### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/cplt/security/code-scanning/1](https://github.com/navikt/cplt/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (recommended here since there is a single job and all current jobs should share the same minimum access).  
For this workflow, `contents: read` is the best minimal permission and does not change behavior of checkout/build/test steps.

**What to change:**
- File: `.github/workflows/ci.yml`
- Insert directly after the `on:` trigger section (before `env:`), or alternatively before `jobs:`.
- Add:
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
