### PR TITLE
refactor: introduce platform-agnostic sandbox API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,3 +128,59 @@ jobs:
       - name: Run all Linux tests
         if: steps.landlock.outputs.available == 'true'
         run: cargo test --verbose
+
+  # Build test binaries on PRs — downloadable from the workflow run page.
+  # Lets testers try changes without installing the Rust toolchain.
+  build-test-binaries:
+    if: github.event_name == 'pull_request'
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # ratchet:dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache@v5.0.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: pr-build-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: pr-build-${{ matrix.target }}-
+
+      - name: Build release binary
+        run: |
+          SHORT_SHA="${{ github.event.pull_request.head.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          VERSION="pr${{ github.event.pull_request.number }}-${SHORT_SHA}"
+          CPLT_LONG_VERSION="$VERSION" cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../cplt-${{ matrix.target }}.tar.gz cplt
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
+        with:
+          name: cplt-${{ matrix.target }}
+          path: cplt-${{ matrix.target }}.tar.gz
+          retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,10 +103,28 @@ jobs:
           restore-keys: Linux-integration-cargo-
 
       - name: Verify Landlock availability
+        id: landlock
         run: |
           echo "Kernel: $(uname -r)"
-          echo "LSM: $(cat /sys/kernel/security/lsm)"
+
+          if [ ! -r /sys/kernel/security/lsm ]; then
+            echo "Landlock integration tests skipped: /sys/kernel/security/lsm not available"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          lsm="$(cat /sys/kernel/security/lsm)"
+          echo "LSM: $lsm"
+
+          if [ ! -r /sys/kernel/security/landlock/abi_version ]; then
+            echo "Landlock integration tests skipped: Landlock ABI not available"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Landlock ABI: $(cat /sys/kernel/security/landlock/abi_version)"
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
       - name: Run all Linux tests
+        if: steps.landlock.outputs.available == 'true'
         run: cargo test --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,3 +79,34 @@ jobs:
 
       - name: Run all tests
         run: cargo test --verbose
+
+  # Linux integration tests — Landlock kernel enforcement (requires Linux 5.13+)
+  linux-integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # ratchet:dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache@v5.0.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: Linux-integration-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: Linux-integration-cargo-
+
+      - name: Verify Landlock availability
+        run: |
+          echo "Kernel: $(uname -r)"
+          echo "LSM: $(cat /sys/kernel/security/lsm)"
+          echo "Landlock ABI: $(cat /sys/kernel/security/landlock/abi_version)"
+
+      - name: Run all Linux tests
+        run: cargo test --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,23 +103,34 @@ jobs:
           restore-keys: Linux-integration-cargo-
 
       - name: Verify Landlock availability
+        id: landlock
         run: |
           echo "Kernel: $(uname -r)"
 
           if [ ! -r /sys/kernel/security/lsm ]; then
-            echo "::error::Landlock integration tests require /sys/kernel/security/lsm"
-            exit 1
+            echo "::warning::securityfs not readable — Landlock tests will be skipped by require_landlock!()"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           lsm="$(cat /sys/kernel/security/lsm)"
           echo "LSM: $lsm"
 
+          if ! printf '%s\n' "$lsm" | grep -qw landlock; then
+            echo "::warning::Landlock not in LSM list — tests will be skipped by require_landlock!()"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ ! -r /sys/kernel/security/landlock/abi_version ]; then
-            echo "::error::Landlock ABI not available — runner kernel too old or Landlock disabled"
-            exit 1
+            echo "::warning::Landlock in LSM but abi_version not readable (securityfs may not be fully mounted)"
+            echo "::warning::Tests will still run — require_landlock!() skips individual tests at runtime"
+            echo "available=partial" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "Landlock ABI: $(cat /sys/kernel/security/landlock/abi_version)"
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
       - name: Run all Linux tests
         run: cargo test --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,30 +103,25 @@ jobs:
           restore-keys: Linux-integration-cargo-
 
       - name: Verify Landlock availability
-        id: landlock
         run: |
           echo "Kernel: $(uname -r)"
 
           if [ ! -r /sys/kernel/security/lsm ]; then
-            echo "Landlock integration tests skipped: /sys/kernel/security/lsm not available"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Landlock integration tests require /sys/kernel/security/lsm"
+            exit 1
           fi
 
           lsm="$(cat /sys/kernel/security/lsm)"
           echo "LSM: $lsm"
 
           if [ ! -r /sys/kernel/security/landlock/abi_version ]; then
-            echo "Landlock integration tests skipped: Landlock ABI not available"
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Landlock ABI not available — runner kernel too old or Landlock disabled"
+            exit 1
           fi
 
           echo "Landlock ABI: $(cat /sys/kernel/security/landlock/abi_version)"
-          echo "available=true" >> "$GITHUB_OUTPUT"
 
       - name: Run all Linux tests
-        if: steps.landlock.outputs.available == 'true'
         run: cargo test --verbose
 
   # Build test binaries on PRs — downloadable from the workflow run page.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       id-token: write
@@ -33,7 +33,13 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
+            os: macos-latest
           - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
         with:
@@ -118,16 +124,25 @@ jobs:
             echo "body<<RELEASE_EOF"
             echo "## cplt"
             echo ""
-            echo "macOS Seatbelt sandbox wrapper for GitHub Copilot CLI."
+            echo "Sandbox wrapper for GitHub Copilot CLI."
+            echo ""
+            echo "- **macOS**: Seatbelt/SBPL via sandbox-exec"
+            echo "- **Linux**: Landlock LSM + seccomp-BPF (kernel 5.13+)"
             echo ""
             echo "### Installation"
             echo ""
             echo '```bash'
-            echo "# Apple Silicon (M1/M2/M3/M4)"
+            echo "# macOS — Apple Silicon (M1/M2/M3/M4)"
             echo "curl -fsSL https://github.com/navikt/cplt/releases/download/${{ steps.version.outputs.tag }}/cplt-aarch64-apple-darwin.tar.gz | tar xz"
             echo ""
-            echo "# Intel Mac"
+            echo "# macOS — Intel"
             echo "curl -fsSL https://github.com/navikt/cplt/releases/download/${{ steps.version.outputs.tag }}/cplt-x86_64-apple-darwin.tar.gz | tar xz"
+            echo ""
+            echo "# Linux — x86_64"
+            echo "curl -fsSL https://github.com/navikt/cplt/releases/download/${{ steps.version.outputs.tag }}/cplt-x86_64-unknown-linux-gnu.tar.gz | tar xz"
+            echo ""
+            echo "# Linux — ARM64"
+            echo "curl -fsSL https://github.com/navikt/cplt/releases/download/${{ steps.version.outputs.tag }}/cplt-aarch64-unknown-linux-gnu.tar.gz | tar xz"
             echo '```'
             echo ""
             if [ -n "$PREV_TAG" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Always run `mise run check` at the end of a coding session.
 - `src/sandbox_profile.rs` — SBPL profile generation (`generate_profile`, `ProfileOptions`)
 - `src/sandbox_env.rs` — environment variable construction (`build_sandbox_env`)
 - `src/sandbox_exec.rs` — sandbox execution, validation, signal forwarding
+- `src/sandbox_landlock.rs` — Landlock LSM + seccomp-BPF (cross-platform policy, Linux-only enforcement)
 - `src/scratch.rs` — per-session scratch directory with TMPDIR redirect
 - `src/config.rs` — config file parsing, CLI/config merging, `Resolved` struct
 - `src/discover.rs` — runtime environment probing (`--doctor`)
@@ -41,6 +42,7 @@ Always run `mise run check` at the end of a coding session.
 - `src/proxy.rs` + `src/proxy/` — CONNECT proxy, domain blocking
 - `tests/unit_tests.rs` — cross-platform unit tests (137 tests)
 - `tests/integration.rs` — macOS sandbox-exec kernel-level tests (37 tests)
+- `tests/integration_linux.rs` — Linux Landlock+seccomp kernel-level tests (24 tests)
 - `tests/e2e.rs` — end-to-end with compiled binary + smoke tests (67 tests)
 - `tests/e2e_projects.rs` — e2e tests with realistic project scaffolding (37 tests)
 - `src/agent.rs` — includes 10 agent unit tests (in lib tests)
@@ -55,6 +57,7 @@ Test suites and where they can run:
 | `mise run test:unit`    | unit_tests     | ✅         | ✅       | ✅       | None                          |
 | `mise run test:lib`     | lib (modules)  | ✅         | ✅       | ✅       | None                          |
 | `mise run test:integration` | integration | ✅         | ❌       | ✅       | macOS `sandbox-exec`          |
+| `mise run test:integration-linux` | integration_linux | ❌ | ✅  | ❌       | Linux with Landlock (5.13+)   |
 | `mise run test:e2e`     | e2e            | ✅         | ❌       | ✅       | macOS + `copilot` in PATH     |
 | `mise run test:e2e-projects` | e2e_projects | ✅      | ❌       | ✅       | macOS `sandbox-exec`          |
 | `mise run test:e2e-live`| e2e (ignored)  | ❌         | ❌       | ⚠️       | macOS + Copilot auth + network|
@@ -63,7 +66,9 @@ Test suites and where they can run:
 
 - **check** runs fmt, clippy, unit_tests, and lib tests — safe inside sandbox, CI, anywhere
 - **unit_tests** + **lib** are cross-platform — use `check` on Linux CI or inside sandbox
-- **integration**, **e2e**, **e2e_projects** all require macOS with `sandbox-exec`
+- **integration** requires macOS with `sandbox-exec`
+- **integration_linux** requires Linux with Landlock (kernel 5.13+)
+- **e2e**, **e2e_projects** require macOS with `sandbox-exec`
 - **e2e-live** (6 smoke tests) need real Copilot auth and network — not for regular CI
 - All suites except **e2e-live** run fine inside the cplt sandbox
 
@@ -71,24 +76,24 @@ Test suites and where they can run:
 
 The four tiers validate different properties — all are needed:
 
-1. **Unit tests** verify SBPL profile string generation: the profile text contains the
-   correct allow/deny rules, env vars are filtered properly, config merging works.
+1. **Unit tests** verify profile/policy generation: SBPL profile text and Landlock policy
+   contain the correct allow/deny rules, env vars are filtered properly, config merging works.
    Fast and cross-platform, but do not prove the kernel actually enforces anything.
-2. **Integration tests** verify kernel enforcement: run a real command inside
-   `sandbox-exec` and assert it is denied or allowed. This is the ground truth for
-   security properties — if a unit test says "deny" but integration passes, the rule
-   is broken.
+2. **Integration tests** verify kernel enforcement: run a real command inside the sandbox
+   (macOS: `sandbox-exec`, Linux: Landlock+seccomp) and assert it is denied or allowed.
+   This is the ground truth for security properties.
 3. **E2E tests** verify the full binary pipeline: CLI arg parsing → profile generation →
-   sandbox-exec invocation → exit code. Catches wiring bugs between modules.
+   sandbox invocation → exit code. Catches wiring bugs between modules.
 4. **E2E project tests** verify realistic developer workflows (git, node, python, rust
    file ops, config files) work correctly inside the sandbox. Catches real-world
    breakage that synthetic tests miss.
 
 **Which tier to use:**
-- Adding/changing a sandbox rule → unit test for the SBPL string + integration test for kernel enforcement
+- Adding/changing a sandbox rule → unit test for the policy string + integration test for kernel enforcement
 - Adding a config option → unit test for merge logic in `config.rs`
 - Adding env var filtering → unit test in `unit_tests.rs`
 - Fixing a real-world breakage → e2e_projects test reproducing the scenario
+- Adding a Landlock rule → unit test in `sandbox_landlock.rs` + test in `integration_linux.rs`
 
 ## Security constraints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,33 @@ name = "cplt"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "landlock",
  "libc",
  "serde",
  "serde_json",
  "tempfile",
  "toml",
  "toml_edit",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -220,6 +241,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -396,6 +428,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +124,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
  "toml_edit",
 ]
@@ -115,6 +134,50 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -129,13 +192,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -151,10 +222,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -163,10 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -185,6 +290,31 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -256,6 +386,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,10 +457,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -341,6 +542,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ strip = true
 lto = true
 
 [dev-dependencies]
+tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cplt"
 version = "0.0.0"
 edition = "2024"
-description = "macOS Seatbelt sandbox wrapper for GitHub Copilot CLI"
+description = "Sandbox wrapper for GitHub Copilot CLI (macOS Seatbelt, Linux Landlock)"
 license = "MIT"
 
 [dependencies]
@@ -12,6 +12,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"
 toml_edit = "0.25"
+
+# Linux-only: Landlock LSM crate (only compiled and linked on Linux).
+# Run `cargo update` with network access to populate the lockfile.
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ cplt config set sandbox.quiet --unset
 └──────────────────────────────────┘
 ```
 
-**Security model**: deny-by-default filesystem with kernel enforcement. Network is restricted to port 443 (HTTPS) by default (use `--allow-port` for extras). SSH agent access and localhost outbound are blocked at the kernel level. The profile generator auto-discovers your environment (`--doctor`) and only includes tool directories that actually exist on disk — fewer rules means a tighter sandbox.
+**Security model**: deny-by-default filesystem with kernel enforcement. On macOS and Linux with kernel 6.7+ (Landlock ABI v4), network is restricted to port 443 (HTTPS) by default (use `--allow-port` for extras). On older Linux kernels, network restriction is provided by the CONNECT proxy (enabled by default). SSH agent access and localhost outbound are blocked at the kernel level (macOS) or via the proxy (Linux). The profile generator auto-discovers your environment (`--doctor`) and only includes tool directories that actually exist on disk — fewer rules means a tighter sandbox.
 
 Platform-specific details:
 - **macOS**: Seatbelt/SBPL profile generated and passed to `sandbox-exec`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Sandbox wrapper for AI coding agents. Runs GitHub Copilot CLI, OpenCode, or a plain shell inside a kernel-level sandbox so the agent can work on your project but cannot access your secrets.
 
 - **macOS**: Apple Seatbelt/SBPL via `sandbox-exec`
-- **Linux**: Landlock LSM + seccomp-BPF (kernel 5.13+)
+- **Linux**: Landlock LSM + seccomp-BPF (kernel 5.13+; full network filtering on 6.7+)
 
 ![cplt banner](./assets/cplt.png)
 
@@ -1104,7 +1104,9 @@ Only port 443 is allowed by default. Services on other ports need `--allow-port`
 
 - **Kernel 5.13+ required** — Landlock LSM must be enabled (`cat /sys/kernel/security/lsm`)
 - **TCP port filtering requires kernel 6.7+** — older kernels get filesystem-only enforcement; network security via proxy only
-- **Landlock cannot deny subpaths within allowed paths** — different granularity than Seatbelt
+- **Landlock cannot deny subpaths within allowed paths** — unlike macOS Seatbelt, Landlock cannot deny `.env` reads or `.git/hooks` writes *inside* the project directory at the kernel level. Defense-in-depth comes from the proxy (blocks exfiltration) and env hardening (`GIT_CONFIG_NOSYSTEM`, etc.)
+- **`--deny-path` has no effect** — Landlock is allowlist-only; a runtime warning is emitted
+- **Some macOS flags are not applicable** — `--allow-docker`, `--allow-jvm-attach`, `--allow-cache-exec` emit warnings and are ignored on Linux
 - **No audit logs** — `--show-denials` is macOS-only; use `strace -f -e trace=file,network` for debugging
 - **Auth scoped to env + gh CLI** — no D-Bus/Secret Service integration for v1
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 [![Release](https://github.com/navikt/cplt/actions/workflows/release.yaml/badge.svg)](https://github.com/navikt/cplt/actions/workflows/release.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
+![Linux](https://img.shields.io/badge/platform-Linux-lightgrey)
 
-macOS Seatbelt sandbox wrapper for AI coding agents. Runs GitHub Copilot CLI, OpenCode, or a plain shell inside Apple's kernel-level sandbox (`sandbox-exec`) so the agent can work on your project but cannot access your secrets.
+Sandbox wrapper for AI coding agents. Runs GitHub Copilot CLI, OpenCode, or a plain shell inside a kernel-level sandbox so the agent can work on your project but cannot access your secrets.
+
+- **macOS**: Apple Seatbelt/SBPL via `sandbox-exec`
+- **Linux**: Landlock LSM + seccomp-BPF (kernel 5.13+)
 
 ![cplt banner](./assets/cplt.png)
-
-> **macOS only** — uses Apple's Seatbelt framework (the same mechanism App Store apps run under).
 
 ## Table of contents
 
@@ -100,15 +102,23 @@ brew install navikt/tap/cplt
 
 ### Pre-compiled binary
 
-Download the latest release for your Mac:
+Download the latest release for your platform:
 
 ```bash
-# Apple Silicon (M1/M2/M3/M4)
+# macOS — Apple Silicon (M1/M2/M3/M4)
 curl -fsSL https://github.com/navikt/cplt/releases/latest/download/cplt-aarch64-apple-darwin.tar.gz | tar xz
 sudo mv cplt /usr/local/bin/
 
-# Intel Mac
+# macOS — Intel
 curl -fsSL https://github.com/navikt/cplt/releases/latest/download/cplt-x86_64-apple-darwin.tar.gz | tar xz
+sudo mv cplt /usr/local/bin/
+
+# Linux — x86_64
+curl -fsSL https://github.com/navikt/cplt/releases/latest/download/cplt-x86_64-unknown-linux-gnu.tar.gz | tar xz
+sudo mv cplt /usr/local/bin/
+
+# Linux — ARM64
+curl -fsSL https://github.com/navikt/cplt/releases/latest/download/cplt-aarch64-unknown-linux-gnu.tar.gz | tar xz
 sudo mv cplt /usr/local/bin/
 ```
 
@@ -560,27 +570,37 @@ cplt config set sandbox.quiet --unset
 
 ```
 ┌──────────────────────────────────┐
-│  cplt (Rust binary)   │
-│  ┌───────────┐  ┌─────────────┐ │
-│  │ Profile    │  │ CONNECT     │ │
-│  │ Generator  │  │ Proxy       │ │
-│  │ (SBPL)     │  │ (optional)  │ │
-│  └─────┬─────┘  └─────────────┘ │
-│        │                         │
+│  cplt (Rust binary)              │
+│  ┌───────────┐  ┌─────────────┐  │
+│  │ Policy    │  │ CONNECT     │  │
+│  │ Generator │  │ Proxy       │  │
+│  └─────┬─────┘  │ (optional)  │  │
+│        │        └─────────────┘  │
 │        ▼                         │
-│  sandbox-exec (Apple kernel)     │
+│  ┌─────────────┬────────────┐    │
+│  │   macOS     │   Linux    │    │
+│  │  Seatbelt   │  Landlock  │    │
+│  │  sandbox-   │  + seccomp │    │
+│  │  exec       │  pre_exec  │    │
+│  └─────────────┴────────────┘    │
 │        │                         │
 │        ▼                         │
 │  copilot (sandboxed)             │
 │  ├── All child processes         │
 │  ├── Cannot read ~/.ssh          │
 │  ├── Network port-restricted     │
-│  ├── SSH agent blocked            │
+│  ├── SSH agent blocked           │
 │  └── Filesystem = primary ctrl   │
 └──────────────────────────────────┘
 ```
 
-**Security model**: deny-by-default filesystem with kernel enforcement. Network is restricted to port 443 (HTTPS) by default (use `--allow-port` for extras). SSH agent access and localhost outbound are blocked at the kernel level. The profile generator auto-discovers your environment (`--doctor`) and only includes tool directories that actually exist on disk — fewer rules means a tighter sandbox. See [SECURITY.md](SECURITY.md) for the full threat model, defense layers, and honest gaps.
+**Security model**: deny-by-default filesystem with kernel enforcement. Network is restricted to port 443 (HTTPS) by default (use `--allow-port` for extras). SSH agent access and localhost outbound are blocked at the kernel level. The profile generator auto-discovers your environment (`--doctor`) and only includes tool directories that actually exist on disk — fewer rules means a tighter sandbox.
+
+Platform-specific details:
+- **macOS**: Seatbelt/SBPL profile generated and passed to `sandbox-exec`
+- **Linux**: Landlock LSM rules + seccomp-BPF filter applied via `pre_exec` (kernel 5.13+, TCP port filtering on 6.7+)
+
+See [SECURITY.md](SECURITY.md) for the full threat model, defense layers, and honest gaps.
 
 ## Security
 
@@ -1074,11 +1094,23 @@ Only port 443 is allowed by default. Services on other ports need `--allow-port`
 
 ## Limitations
 
-- **macOS only** — uses `sandbox-exec` (deprecated but functional, used by Chromium and VS Code)
-- **No TLS inspection** — the proxy sees domain names (via CONNECT) but not request bodies
-- **No network filtering** — SBPL doesn't support domain-based or port-based filtering for outbound TCP
-- **Keychain access required** — Copilot stores auth tokens in macOS Keychain
+### macOS
+
 - **`sandbox-exec` is deprecated** — Apple has not removed it but may in future macOS versions
+- **SBPL has no domain-based filtering** — the optional CONNECT proxy provides domain blocking
+- **Keychain access required** — Copilot stores auth tokens in macOS Keychain
+
+### Linux
+
+- **Kernel 5.13+ required** — Landlock LSM must be enabled (`cat /sys/kernel/security/lsm`)
+- **TCP port filtering requires kernel 6.7+** — older kernels get filesystem-only enforcement; network security via proxy only
+- **Landlock cannot deny subpaths within allowed paths** — different granularity than Seatbelt
+- **No audit logs** — `--show-denials` is macOS-only; use `strace -f -e trace=file,network` for debugging
+- **Auth scoped to env + gh CLI** — no D-Bus/Secret Service integration for v1
+
+### Both platforms
+
+- **No TLS inspection** — the proxy sees domain names (via CONNECT) but not request bodies
 
 For known attack vectors, out-of-scope threats, and prior art, see [SECURITY.md](SECURITY.md).
 
@@ -1099,6 +1131,8 @@ Please open an issue before starting large changes. All PRs must pass CI (fmt, c
 - [SECURITY.md](SECURITY.md) — Full security model, threat analysis, test strategy, and prior art
 - [Apple sandbox-exec(1)](https://keith.github.io/xcode-man-pages/sandbox-exec.1.html)
 - [Chromium Seatbelt V2 Design](https://chromium.googlesource.com/chromium/src/sandbox/+show/refs/heads/main/mac/seatbelt_sandbox_design.md)
+- [Landlock LSM documentation](https://docs.kernel.org/userspace-api/landlock.html)
+- [seccomp-BPF documentation](https://www.kernel.org/doc/html/latest/userspace-api/seccomp_filter.html)
 - [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
 - [michaelneale/agent-seatbelt-sandbox](https://github.com/michaelneale/agent-seatbelt-sandbox)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,36 +30,38 @@ cplt assumes the sandboxed agent is **untrusted** — executing arbitrary code s
 
 | Threat | Example | Defense layer |
 |---|---|---|
-| **Credential theft** | Read `~/.ssh/id_ed25519`, `~/.aws/credentials` | Seatbelt file deny rules |
+| **Credential theft** | Read `~/.ssh/id_ed25519`, `~/.aws/credentials` | Seatbelt deny rules (macOS) / Landlock deny (Linux) |
 | **Data exfiltration** | POST secrets to `https://evil.com/collect` | Filesystem isolation (credentials unreadable) |
-| **Secret file access** | Read `~/.netrc`, `~/.npmrc`, `~/.vault-token` | Seatbelt file deny rules |
+| **Secret file access** | Read `~/.netrc`, `~/.npmrc`, `~/.vault-token` | Seatbelt deny rules (macOS) / Landlock deny (Linux) |
 | **DNS rebinding SSRF** | Domain resolves to `127.0.0.1` after check | Post-DNS-resolution IP validation; `--allow-private-domain` opt-in bypass for explicitly trusted internal domains |
-| **Sandbox profile injection** | Path with `\n(allow file-read* (subpath "/"))` | SBPL path character validation |
+| **Sandbox profile injection** | Path with `\n(allow file-read* (subpath "/"))` | SBPL path character validation (macOS) |
 | **Temp file symlink attack** | Symlink at predictable `/tmp/cplt.sb` | Unique filename + `O_CREAT\|O_EXCL` |
-| **Write-then-exec in /tmp** | Drop binary in `/tmp`, execute it | `deny process-exec` + `deny file-map-executable` on `/tmp` and `/var/folders`; `--scratch-dir` provides a safe alternative |
+| **Write-then-exec in /tmp** | Drop binary in `/tmp`, execute it | Seatbelt deny (macOS) / Landlock deny (Linux); `--scratch-dir` provides safe alternative |
 | **Cloud metadata access** | Fetch `169.254.169.254` or CGNAT range | Comprehensive private IP blocklist |
-| **Cross-project access** | Read files outside project directory | Seatbelt subpath restrictions |
+| **Cross-project access** | Read files outside project directory | Seatbelt subpath (macOS) / Landlock ruleset (Linux) |
 | **Process-group escape** | Kill parent, children continue unsandboxed | `setpgid` + signal forwarding |
 | **Env var credential theft** | Read `AWS_SECRET_ACCESS_KEY` from env | `env_clear()` + safe allowlist |
 | **Persistence via native modules** | Replace `keytar.node` with malware | Deny writes to `~/.copilot/pkg` |
 | **Git hook injection** | Write post-checkout hook that runs outside sandbox | Deny writes to `.git/hooks/` and global `core.hooksPath` dir |
-| **Git config hijacking** | Set `core.hooksPath=/tmp/evil` or URL redirect | Deny writes to `.git/config`; global hooks path validated (under `$HOME`, depth ≥3) |
+| **Git config hijacking** | Set `core.hooksPath=/tmp/evil` or URL redirect | Deny writes to `.git/config`; global hooks path validated |
 | **Submodule supply chain** | Modify `.gitmodules` to point to malicious repo | Deny writes to `.gitmodules` |
+| **Syscall abuse** | `ptrace`, `mount`, `kexec_load` | seccomp-BPF filter (Linux) |
 
 ### Out of scope
 
 - **TLS interception** — the proxy sees CONNECT targets (hostname:port) but not request bodies or responses
-- **macOS kernel exploits** — we rely on Apple's Seatbelt enforcement being correct
-- **Keychain isolation** — Copilot requires Keychain access for auth; this is an accepted trade-off. `mach-lookup` is blanket because Node.js needs it for DNS, Security framework, and system services. Scoping to individual service names is impractical (undocumented, version-dependent).
-- **sandbox-exec deprecation** — Apple marks it deprecated but has not removed it; Chromium and VS Code still use it
+- **Kernel exploits** — we rely on Apple's Seatbelt (macOS) and Landlock/seccomp (Linux) enforcement being correct
+- **Keychain isolation** (macOS) — Copilot requires Keychain access for auth; this is an accepted trade-off. `mach-lookup` is blanket because Node.js needs it for DNS, Security framework, and system services.
+- **sandbox-exec deprecation** (macOS) — Apple marks it deprecated but has not removed it; Chromium and VS Code still use it
+- **Landlock subpath limitations** (Linux) — Landlock cannot deny access to subpaths within allowed directories. If a parent directory is allowed, all children are allowed. This means certain fine-grained macOS rules (e.g., deny `.config/gh/extensions` while allowing `.config/gh/hosts.yml`) cannot be replicated on Linux.
 - **Code quality** — the sandbox cannot judge whether code written by Copilot contains backdoors; that's a code review problem
 - **`~/.config/gh/hosts.yml` token** — contains the user's GitHub OAuth token. Copilot needs *a* GitHub token to function (via env var or this file). The token is readable inside the sandbox. If this is a concern, set `GH_TOKEN` env var (passes through allowlist) and add `--deny-path ~/.config/gh` to block the file.
-- **Interpreter-based temp execution** — the sandbox blocks *direct* exec from `/tmp` (Mach-O binaries, dlopen), but cannot block `bash /tmp/evil.sh` or `node /tmp/evil.js` because the exec target is the interpreter (`/bin/bash`, `/usr/bin/node`), not the script file. Sandboxing interpreters would break Copilot.
+- **Interpreter-based temp execution** — the sandbox blocks *direct* exec from `/tmp` (Mach-O/ELF binaries, dlopen), but cannot block `bash /tmp/evil.sh` or `node /tmp/evil.js` because the exec target is the interpreter (`/bin/bash`, `/usr/bin/node`), not the script file. Sandboxing interpreters would break Copilot.
 - **`.vscode/` project configs** — the agent can write `.vscode/tasks.json`, `launch.json`, and `settings.json` which VS Code may auto-execute outside the sandbox. This is an IDE trust boundary issue, not a sandbox scope issue. Mitigation: review `.vscode/` changes in `git diff` before committing; set `"task.autoRunTasks": "off"` in VS Code.
-- **Write+exec in home cache dirs** — `~/.gradle`, `~/.m2`, `~/Library/pnpm` have both write and exec permissions. Build tools need write for dependency downloads and exec for build plugins. A rogue agent could write a malicious JAR to `~/.m2` or a Gradle plugin to `~/.gradle`, but the executed code would still be sandboxed. `~/Library/Caches` is broadly allowed for dev tool caches (go-build, Homebrew, pip, etc.), but browser and app caches (Chrome, Firefox, Discord, etc.) are denied via regex prefix rules — no allowlist maintenance needed for new dev tools. `--allow-cache-exec <SUBDIR>` opts into the same write+exec trade-off for the named subdir (e.g. `ms-playwright`, `pnpm/dlx`): a rogue agent could write a binary there and execute it, but execution remains sandboxed. Prefer `--allow-cache-exec <SUBDIR>` over `--allow-cache-exec-any`, which opens the entire `~/Library/Caches` tree.
+- **Write+exec in home cache dirs** — `~/.gradle`, `~/.m2`, `~/Library/pnpm` (macOS) / `~/.local/share/pnpm` (Linux) have both write and exec permissions. Build tools need write for dependency downloads and exec for build plugins. A rogue agent could write a malicious JAR to `~/.m2` or a Gradle plugin to `~/.gradle`, but the executed code would still be sandboxed. `~/Library/Caches` (macOS) is broadly allowed for dev tool caches (go-build, Homebrew, pip, etc.), but browser and app caches (Chrome, Firefox, Discord, etc.) are denied via regex prefix rules — no allowlist maintenance needed for new dev tools. `--allow-cache-exec <SUBDIR>` opts into the same write+exec trade-off for the named subdir (e.g. `ms-playwright`, `pnpm/dlx`): a rogue agent could write a binary there and execute it, but execution remains sandboxed. Prefer `--allow-cache-exec <SUBDIR>` over `--allow-cache-exec-any`, which opens the entire `~/Library/Caches` tree.
 - **Project build scripts** — the agent can modify `Makefile`, `package.json` scripts, `build.gradle`, `.github/workflows/`, etc. These are legitimate Copilot targets and cannot be blocked. The risk is mitigated by code review (git diff) before running builds or committing.
-- **POSIX shared memory** — `ipc-posix-shm-*` is allowed because Node.js needs it for DNS and system queries. An agent could theoretically use SHM as an IPC channel to processes outside the sandbox, but this requires a cooperating process already running on the machine.
-- **DNS tunneling** — DNS queries go through macOS mDNSResponder Unix socket. Seatbelt offers no per-query filtering; it's all-or-nothing. Blocking DNS breaks everything. Bandwidth is ~15 KB/s max, requires attacker-controlled authoritative DNS, and is detectable with network monitoring.
+- **POSIX shared memory** (macOS) — `ipc-posix-shm-*` is allowed because Node.js needs it for DNS and system queries. An agent could theoretically use SHM as an IPC channel to processes outside the sandbox, but this requires a cooperating process already running on the machine.
+- **DNS tunneling** — DNS queries are unrestricted on both platforms. Bandwidth is ~15 KB/s max, requires attacker-controlled authoritative DNS, and is detectable with network monitoring.
 
 ## Real-World Attack Landscape (2025–2026)
 
@@ -324,6 +326,88 @@ When `--scratch-dir` is enabled, cplt creates a per-session directory at `~/Libr
 ### Layer 2: CONNECT Proxy (Logging and Domain Filtering)
 
 A localhost CONNECT proxy intercepts all outbound traffic by default. `HTTP_PROXY`/`HTTPS_PROXY` and `NODE_USE_ENV_PROXY=1` are injected into the sandbox environment, routing traffic from Copilot CLI (Node.js), `gh` (Go), `curl`, and any other tool through the proxy. Use `--no-proxy` to disable.
+
+### Layer 1L: Landlock + seccomp Kernel Sandbox (Linux)
+
+On Linux, kernel-level enforcement uses two complementary mechanisms:
+
+#### Landlock LSM (filesystem + network)
+
+[Landlock](https://docs.kernel.org/userspace-api/landlock.html) is a stacking LSM that provides unprivileged, process-level access control. Rules are additive within a ruleset — access not explicitly granted is denied.
+
+**ABI version support:**
+
+| ABI | Kernel | Capabilities |
+|-----|--------|-------------|
+| v1  | 5.13+  | Filesystem access control |
+| v2  | 5.19+  | + file refer (cross-directory rename) |
+| v3  | 6.2+   | + file truncate |
+| v4  | 6.7+   | + TCP port filtering (bind + connect) |
+| v5  | 6.10+  | + ioctl on character devices |
+
+cplt requires ABI v1 minimum. On ABI < v4, network security relies on the CONNECT proxy only (Landlock cannot filter TCP ports). On ABI v4+, Landlock denies all TCP connections except to explicitly allowed ports.
+
+**Key differences from Seatbelt:**
+
+| Property | Seatbelt (macOS) | Landlock (Linux) |
+|----------|-----------------|------------------|
+| Granularity | Path regex, file-level deny | Path-based, directory-level allow |
+| Default | deny-by-default | deny-by-default |
+| Subpath deny | ✅ Can deny subpaths within allowed dirs | ❌ Cannot deny within allowed paths |
+| Network | Port-based (all ABIs) | Port-based (ABI v4+ only) |
+| Audit logs | Full Seatbelt violation log | None (no audit mode) |
+| Privilege | Requires `sandbox-exec` (deprecated) | Unprivileged (any user) |
+
+**Pre-exec safety:** Because the proxy thread makes the process multi-threaded, Landlock rules and seccomp filters are pre-computed in the parent process (`PrecomputedSandbox`) and applied in the child's `pre_exec` callback using only async-signal-safe raw syscalls.
+
+#### seccomp-BPF (syscall filtering)
+
+A BPF filter blocks dangerous syscalls that could be used to escape the sandbox or escalate privileges:
+
+| Blocked syscall | Reason |
+|----------------|--------|
+| `ptrace` | Prevents debugging/injecting into other processes |
+| `mount`, `umount2` | Prevents filesystem namespace manipulation |
+| `pivot_root`, `chroot` | Prevents root filesystem escape |
+| `unshare` | Prevents creating new namespaces |
+| `setns` | Prevents entering other namespaces |
+| `reboot` | Prevents system disruption |
+| `kexec_load`, `kexec_file_load` | Prevents kernel replacement |
+| `init_module`, `finit_module`, `delete_module` | Prevents kernel module manipulation |
+| `perf_event_open` | Prevents performance monitoring-based side channels |
+| `process_vm_readv`, `process_vm_writev` | Prevents cross-process memory access |
+| `userfaultfd` | Prevents use-after-free exploitation primitive |
+| `bpf` | Prevents loading arbitrary BPF programs |
+| `add_key`, `keyctl`, `request_key` | Prevents kernel keyring manipulation |
+| `io_uring_setup`, `io_uring_enter`, `io_uring_register` | io_uring has a large attack surface |
+| `move_mount`, `open_tree`, `mount_setattr`, `fsopen`, `fsconfig`, `fsmount`, `fspick` | Prevents mount API v2 manipulation |
+| `landlock_create_ruleset`, `landlock_add_rule`, `landlock_restrict_self` | Prevents self-modification of sandbox |
+
+The filter uses `SECCOMP_RET_ERRNO` (returns EPERM) rather than `SECCOMP_RET_KILL` to avoid crashing on legitimate probes.
+
+#### Protected paths (Linux)
+
+The same credential directories are denied as on macOS:
+
+- `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.azure`, `~/.kube`, `~/.docker`, `~/.nais`
+- `~/.password-store`, `~/.config/gcloud`, `~/.config/op`, `~/.terraform.d`
+- `~/.netrc`, `~/.npmrc`, `~/.pypirc`, `~/.gem/credentials`, `~/.vault-token`
+
+Linux-specific tool directories use XDG-style paths:
+
+| Directory | Permissions | Rationale |
+|-----------|------------|-----------|
+| `~/.cache` | read+write | XDG cache dir (pip, go-build, etc.) |
+| `~/.local/share/pnpm` | read+write+exec | pnpm global store |
+| `~/.local/bin` | read+exec | User-installed binaries |
+| `~/.local/share/mise` | read+write+exec | mise tool installations |
+
+#### Linux-specific limitations
+
+1. **No `--show-denials`**: Landlock has no audit logging. Use `strace` for debugging.
+2. **No subpath deny**: Cannot deny `~/.config/gh/extensions` while allowing `~/.config/gh/hosts.yml` — the entire directory must be allowed or denied.
+3. **No auth integration**: Linux v1 supports env token + `gh auth` only (no D-Bus/Secret Service).
+4. **Copilot extraction**: The macOS SEA extraction path is unknown on Linux — `ensure_copilot_extracted()` is skipped.
 
 The proxy provides:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -133,7 +133,7 @@ A curated blocklist of these domains is included in [`blocked-domains.txt`](bloc
 - A compromised agent CAN make HTTPS requests to attacker-controlled servers on port 443
 - A compromised agent CANNOT exfiltrate cloud credentials from env vars (env is sanitized; only safe allowlist passes through)
 - A compromised agent CAN exfiltrate project source code and Copilot auth tokens
-- A compromised agent CANNOT connect to local services (localhost is blocked)
+- A compromised agent CANNOT connect to local services (localhost is blocked on macOS; on Linux, use `--with-proxy` — see [Linux-specific limitations](#linux-specific-limitations))
 - A compromised agent CANNOT use loaded SSH keys (unix socket is blocked)
 - A compromised agent CANNOT connect on non-standard ports (e.g., 8080, 3000) unless `--allow-port` is used
 - A compromised agent CANNOT exfiltrate SSH keys, cloud credentials, or npm tokens (kernel-blocked from reading them)
@@ -405,6 +405,7 @@ Linux-specific tool directories use XDG-style paths:
 2. **No subpath deny**: Cannot deny `~/.config/gh/extensions` while allowing `~/.config/gh/hosts.yml` — the entire directory must be allowed or denied.
 3. **No auth integration**: Linux v1 supports env token + `gh auth` only (no D-Bus/Secret Service).
 4. **Copilot extraction**: The macOS SEA extraction path is unknown on Linux — `ensure_copilot_extracted()` is skipped.
+5. **No localhost isolation at kernel level**: Landlock network rules are port-based only — they cannot distinguish `localhost:443` from `remote:443`. On macOS, Seatbelt blocks localhost outbound separately. On Linux, use `--with-proxy` for localhost SSRF protection (the proxy resolves DNS and blocks private IPs).
 
 The proxy provides:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -374,7 +374,7 @@ cplt requires ABI v1 minimum. On ABI < v4, network security relies on the CONNEC
 | Audit logs | Full Seatbelt violation log | None (no audit mode) |
 | Privilege | Requires `sandbox-exec` (deprecated) | Unprivileged (any user) |
 
-**Pre-exec safety:** Because the proxy thread makes the process multi-threaded, Landlock rules and seccomp filters are pre-computed in the parent process (`PrecomputedSandbox`) and applied in the child's `pre_exec` callback using only async-signal-safe raw syscalls.
+**Pre-exec safety:** The proxy thread makes the process multi-threaded before `fork`. Landlock rules are pre-computed in the parent process (`PrecomputedSandbox`), and the seccomp filter is installed via raw syscall. The Landlock crate performs small heap allocations in `pre_exec` which is technically not async-signal-safe, but works reliably in practice (the proxy thread is blocked in I/O syscalls during fork, minimizing allocator contention).
 
 #### seccomp-BPF (syscall filtering)
 
@@ -383,6 +383,7 @@ A BPF filter blocks dangerous syscalls that could be used to escape the sandbox 
 | Blocked syscall | Reason |
 |----------------|--------|
 | `ptrace` | Prevents debugging/injecting into other processes |
+| `process_vm_readv`, `process_vm_writev` | Prevents cross-process memory access |
 | `mount`, `umount2` | Prevents filesystem namespace manipulation |
 | `pivot_root`, `chroot` | Prevents root filesystem escape |
 | `unshare` | Prevents creating new namespaces |
@@ -393,6 +394,10 @@ A BPF filter blocks dangerous syscalls that could be used to escape the sandbox 
 | `swapon`, `swapoff` | Prevents swap manipulation |
 | `personality` | Prevents ABI personality changes |
 | `add_key`, `keyctl`, `request_key` | Prevents kernel keyring manipulation |
+| `io_uring_setup`, `io_uring_enter`, `io_uring_register` | Prevents io_uring (bypass of seccomp/Landlock) |
+| `userfaultfd` | Prevents userfaultfd exploitation |
+| `perf_event_open` | Prevents perf-based side channels |
+| `bpf` | Prevents BPF program loading |
 | `iopl`, `ioperm` | Prevents I/O port access (x86_64 only) |
 | `modify_ldt` | Prevents LDT modification (x86_64 only) |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ cplt assumes the sandboxed agent is **untrusted** — executing arbitrary code s
 | **Write-then-exec in /tmp** | Drop binary in `/tmp`, execute it | Seatbelt deny (macOS) / Landlock deny (Linux); `--scratch-dir` provides safe alternative |
 | **Cloud metadata access** | Fetch `169.254.169.254` or CGNAT range | Comprehensive private IP blocklist |
 | **Cross-project access** | Read files outside project directory | Seatbelt subpath (macOS) / Landlock ruleset (Linux) |
-| **Process-group escape** | Kill parent, children continue unsandboxed | `setpgid` + signal forwarding |
+| **Process-group escape** | Kill parent, children continue unsandboxed | Signal forwarding (SIGTERM, SIGHUP) |
 | **Env var credential theft** | Read `AWS_SECRET_ACCESS_KEY` from env | `env_clear()` + safe allowlist |
 | **Persistence via native modules** | Replace `keytar.node` with malware | Deny writes to `~/.copilot/pkg` |
 | **Git hook injection** | Write post-checkout hook that runs outside sandbox | Deny writes to `.git/hooks/` and global `core.hooksPath` dir |
@@ -372,16 +372,13 @@ A BPF filter blocks dangerous syscalls that could be used to escape the sandbox 
 | `unshare` | Prevents creating new namespaces |
 | `setns` | Prevents entering other namespaces |
 | `reboot` | Prevents system disruption |
-| `kexec_load`, `kexec_file_load` | Prevents kernel replacement |
+| `kexec_load` | Prevents kernel replacement |
 | `init_module`, `finit_module`, `delete_module` | Prevents kernel module manipulation |
-| `perf_event_open` | Prevents performance monitoring-based side channels |
-| `process_vm_readv`, `process_vm_writev` | Prevents cross-process memory access |
-| `userfaultfd` | Prevents use-after-free exploitation primitive |
-| `bpf` | Prevents loading arbitrary BPF programs |
+| `swapon`, `swapoff` | Prevents swap manipulation |
+| `personality` | Prevents ABI personality changes |
 | `add_key`, `keyctl`, `request_key` | Prevents kernel keyring manipulation |
-| `io_uring_setup`, `io_uring_enter`, `io_uring_register` | io_uring has a large attack surface |
-| `move_mount`, `open_tree`, `mount_setattr`, `fsopen`, `fsconfig`, `fsmount`, `fspick` | Prevents mount API v2 manipulation |
-| `landlock_create_ruleset`, `landlock_add_rule`, `landlock_restrict_self` | Prevents self-modification of sandbox |
+| `iopl`, `ioperm` | Prevents I/O port access (x86_64 only) |
+| `modify_ldt` | Prevents LDT modification (x86_64 only) |
 
 The filter uses `SECCOMP_RET_ERRNO` (returns EPERM) rather than `SECCOMP_RET_KILL` to avoid crashing on legitimate probes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,10 +42,26 @@ cplt assumes the sandboxed agent is **untrusted** — executing arbitrary code s
 | **Process-group escape** | Kill parent, children continue unsandboxed | Signal forwarding (SIGTERM, SIGHUP) |
 | **Env var credential theft** | Read `AWS_SECRET_ACCESS_KEY` from env | `env_clear()` + safe allowlist |
 | **Persistence via native modules** | Replace `keytar.node` with malware | Deny writes to `~/.copilot/pkg` |
-| **Git hook injection** | Write post-checkout hook that runs outside sandbox | Deny writes to `.git/hooks/` and global `core.hooksPath` dir |
-| **Git config hijacking** | Set `core.hooksPath=/tmp/evil` or URL redirect | Deny writes to `.git/config`; global hooks path validated |
-| **Submodule supply chain** | Modify `.gitmodules` to point to malicious repo | Deny writes to `.gitmodules` |
+| **Git hook injection** | Write post-checkout hook that runs outside sandbox | Seatbelt deny rules (macOS); env hardening `GIT_CONFIG_NOSYSTEM` + proxy exfiltration blocking (Linux — project-internal `.git/hooks` is writable) |
+| **Git config hijacking** | Set `core.hooksPath=/tmp/evil` or URL redirect | Seatbelt deny rules (macOS); env hardening (Linux — `.git/config` writable within project, but proxy blocks redirected fetches) |
+| **Submodule supply chain** | Modify `.gitmodules` to point to malicious repo | Seatbelt deny rules (macOS); proxy domain filtering (Linux — `.gitmodules` writable within project) |
 | **Syscall abuse** | `ptrace`, `mount`, `kexec_load` | seccomp-BPF filter (Linux) |
+
+### Platform enforcement comparison
+
+| Protection | macOS (Seatbelt) | Linux (Landlock + seccomp) |
+|---|---|---|
+| Credential files (~/.ssh, ~/.aws) | ✅ Kernel deny | ✅ Not in ruleset (deny-by-default) |
+| Project .env file reads | ✅ Kernel deny | ⚠️ Proxy blocks exfiltration |
+| .git/hooks write in project | ✅ Kernel deny | ⚠️ Env hardening (GIT_CONFIG_NOSYSTEM) |
+| .git/config write in project | ✅ Kernel deny | ⚠️ Env hardening + proxy |
+| Network: outbound port filtering | ✅ Kernel (all versions) | ✅ Kernel (6.7+) / ⚠️ Proxy only (<6.7) |
+| Network: localhost isolation | ✅ Kernel deny | ⚠️ Proxy domain filtering |
+| Exec from /tmp | ✅ Kernel deny | ✅ Landlock deny |
+| Dangerous syscalls | N/A (Seatbelt covers) | ✅ seccomp-BPF |
+| --deny-path | ✅ Kernel deny | ❌ No effect (warned) |
+
+Legend: ✅ = kernel-enforced, ⚠️ = defense-in-depth (proxy/env), ❌ = not available
 
 ### Out of scope
 

--- a/mise.toml
+++ b/mise.toml
@@ -60,8 +60,20 @@ description = "Run live smoke tests — requires macOS + Copilot auth + network"
 run = "cargo test --test e2e -- --ignored"
 
 [tasks."test:all"]
-description = "Run all test suites except live smoke tests (macOS only)"
+description = "Run all test suites except live smoke tests (platform-aware)"
 depends = ["test:unit", "test:lib", "test:integration", "test:e2e", "test:e2e-projects"]
+
+[tasks."test:integration-linux"]
+description = "Run Linux Landlock integration tests — requires Linux with Landlock"
+run = "cargo test --test integration_linux"
+
+[tasks."test:e2e-linux"]
+description = "Run Linux E2E tests — requires Linux with compiled binary"
+run = "cargo test --test e2e_linux"
+
+[tasks."test:e2e-projects-linux"]
+description = "Run Linux project workflow tests — requires Linux with Landlock"
+run = "cargo test --test e2e_projects_linux"
 
 [tasks.check]
 description = "Run all checks (fmt, clippy, test) — works inside sandbox"
@@ -75,7 +87,12 @@ depends = ["check", "build:release"]
 description = "Build and install cplt to /usr/local/bin"
 run = """
 export CPLT_LONG_VERSION="$(date -u +%Y.%m.%d-%H%M%S)-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)$(git diff --quiet HEAD 2>/dev/null || echo '-dirty')"
-cargo build --release && sudo cp target/release/cplt /usr/local/bin/cplt && sudo /usr/bin/xattr -cr /usr/local/bin/cplt && sudo codesign --force --sign - /usr/local/bin/cplt
+cargo build --release
+sudo cp target/release/cplt /usr/local/bin/cplt
+if [[ "$(uname)" == "Darwin" ]]; then
+  sudo /usr/bin/xattr -cr /usr/local/bin/cplt
+  sudo codesign --force --sign - /usr/local/bin/cplt
+fi
 """
 
 [tasks.clean]

--- a/mise.toml
+++ b/mise.toml
@@ -67,14 +67,6 @@ depends = ["test:unit", "test:lib", "test:integration", "test:e2e", "test:e2e-pr
 description = "Run Linux Landlock integration tests — requires Linux with Landlock"
 run = "cargo test --test integration_linux"
 
-[tasks."test:e2e-linux"]
-description = "Run Linux E2E tests — requires Linux with compiled binary"
-run = "cargo test --test e2e_linux"
-
-[tasks."test:e2e-projects-linux"]
-description = "Run Linux project workflow tests — requires Linux with Landlock"
-run = "cargo test --test e2e_projects_linux"
-
 [tasks.check]
 description = "Run all checks (fmt, clippy, test) — works inside sandbox"
 depends = ["fmt:check", "clippy", "test:unit", "test:lib"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -629,6 +629,7 @@ impl Resolved {
             );
         }
         if agent.needs_keychain() {
+            #[cfg(target_os = "macos")]
             eprintln!(
                 "{blue}[cplt]{nc}    Keychain:      {green}allowed{nc}     {dim}~/Library/Keychains{nc}"
             );
@@ -865,13 +866,14 @@ pub fn default_config_contents() -> String {
 # inherit_env = false
 #
 # Enable per-session scratch directory for TMPDIR redirect (default: true).
-# Creates ~/Library/Caches/cplt/tmp/{session}/ with write+exec permissions
+# Creates ~/.cache/cplt/tmp/{session}/ (Linux) or
+# ~/Library/Caches/cplt/tmp/{session}/ (macOS) with write+exec permissions
 # so tools like `go test`, `mise` inline tasks, and `node-gyp` can work.
 # Cleaned up automatically on exit.
 # scratch_dir = true
 #
 # DANGEROUS: Allow process execution from system temp directories.
-# Re-enables exec from /private/tmp and /private/var/folders.
+# Re-enables exec from /tmp (Linux) or /private/tmp, /private/var/folders (macOS).
 # Prefer scratch_dir which creates a controlled executable temp dir.
 # allow_tmp_exec = false
 #

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -105,7 +105,11 @@ pub fn discover_auth(home_dir: &Path) -> AuthDiscovery {
 
     let gh_config_exists = home_dir.join(".config/gh/hosts.yml").exists();
 
+    // macOS Keychain CLI — not applicable on Linux.
+    #[cfg(target_os = "macos")]
     let security_cli_exists = Path::new("/usr/bin/security").exists();
+    #[cfg(not(target_os = "macos"))]
+    let security_cli_exists = false;
 
     let keytar_nodes = find_native_modules(home_dir, "keytar.node");
 
@@ -185,7 +189,7 @@ const TOOLS_TO_CHECK: &[&str] = &[
     "gh", "git", "node", "mise", "cargo", "python3", "java", "go", "gradle", "yarn", "pnpm",
 ];
 
-use crate::sandbox::HOME_TOOL_DIRS;
+use crate::sandbox::home_tool_dirs;
 
 pub fn discover_tools(home_dir: &Path) -> ToolDiscovery {
     let tools: Vec<ToolInfo> = TOOLS_TO_CHECK
@@ -203,7 +207,7 @@ pub fn discover_tools(home_dir: &Path) -> ToolDiscovery {
         .map(PathBuf::from)
         .find(|p| p.exists());
 
-    let existing_home_tool_dirs: Vec<String> = HOME_TOOL_DIRS
+    let existing_home_tool_dirs: Vec<String> = home_tool_dirs()
         .iter()
         // Writable cache dirs are always included: tools create them on first use,
         // and the profile must permit the write that creates the directory.
@@ -235,7 +239,12 @@ pub fn discover_paths(home_dir: &Path, project_dir: &Path) -> PathDiscovery {
         .collect();
 
     let copilot_dir_exists = home_dir.join(".copilot").exists();
+
+    // macOS-only: Keychain and Security framework database.
+    #[cfg(target_os = "macos")]
     let keychains_dir_exists = home_dir.join("Library/Keychains").exists();
+    #[cfg(not(target_os = "macos"))]
+    let keychains_dir_exists = false;
 
     let is_git_repo = std::process::Command::new("git")
         .args(["rev-parse", "--git-dir"])
@@ -245,7 +254,10 @@ pub fn discover_paths(home_dir: &Path, project_dir: &Path) -> PathDiscovery {
         .status()
         .is_ok_and(|s| s.success());
 
+    #[cfg(target_os = "macos")]
     let security_db_exists = Path::new("/private/var/db/mds").exists();
+    #[cfg(not(target_os = "macos"))]
+    let security_db_exists = false;
 
     PathDiscovery {
         existing_denied_dirs,
@@ -303,6 +315,7 @@ impl Discovery {
         } else {
             eprintln!("  {YELLOW}⚠{NC} gh CLI: no config found (~/.config/gh/hosts.yml)");
         }
+        #[cfg(target_os = "macos")]
         if self.auth.security_cli_exists {
             eprintln!("  {GREEN}✓{NC} Keychain CLI: /usr/bin/security exists");
         } else {
@@ -368,7 +381,7 @@ impl Discovery {
                 self.tools.existing_home_tool_dirs.join(", ~/")
             );
         }
-        let missing_dirs: Vec<&str> = HOME_TOOL_DIRS
+        let missing_dirs: Vec<&str> = home_tool_dirs()
             .iter()
             .map(|d| d.path)
             .filter(|p| !self.tools.existing_home_tool_dirs.iter().any(|e| e == p))
@@ -395,13 +408,16 @@ impl Discovery {
             eprintln!("  {RED}✗{NC} ~/.copilot not found — Copilot CLI may not be installed");
             critical_ok = false;
         }
-        if self.paths.keychains_dir_exists {
-            eprintln!("  {GREEN}✓{NC} ~/Library/Keychains exists");
-        } else {
-            eprintln!("  {YELLOW}⚠{NC} ~/Library/Keychains not found");
-        }
-        if self.paths.security_db_exists {
-            eprintln!("  {GREEN}✓{NC} /private/var/db/mds exists (Security framework)");
+        #[cfg(target_os = "macos")]
+        {
+            if self.paths.keychains_dir_exists {
+                eprintln!("  {GREEN}✓{NC} ~/Library/Keychains exists");
+            } else {
+                eprintln!("  {YELLOW}⚠{NC} ~/Library/Keychains not found");
+            }
+            if self.paths.security_db_exists {
+                eprintln!("  {GREEN}✓{NC} /private/var/db/mds exists (Security framework)");
+            }
         }
 
         let n_denied =
@@ -428,6 +444,50 @@ impl Discovery {
                 "  {GREEN}✓{NC} Protected ({n_denied} found): {}",
                 all.join(", ")
             );
+        }
+        eprintln!();
+
+        // Sandbox mechanism section
+        eprintln!("{BOLD}{BLUE}[doctor]{NC} {BOLD}Sandbox mechanism{NC}");
+        #[cfg(target_os = "macos")]
+        {
+            let sandbox_exec_exists = Path::new("/usr/bin/sandbox-exec").exists();
+            if sandbox_exec_exists {
+                eprintln!("  {GREEN}✓{NC} Seatbelt: /usr/bin/sandbox-exec available");
+            } else {
+                eprintln!("  {RED}✗{NC} Seatbelt: /usr/bin/sandbox-exec not found");
+                critical_ok = false;
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            match std::fs::read_to_string("/sys/kernel/security/landlock/abi_version") {
+                Ok(s) => {
+                    let abi = s.trim();
+                    eprintln!("  {GREEN}✓{NC} Landlock: ABI v{abi}");
+                    if let Ok(v) = abi.parse::<u32>() {
+                        if v < 4 {
+                            eprintln!(
+                                "  {YELLOW}⚠{NC} Landlock ABI < v4: TCP port filtering unavailable (kernel < 6.7)"
+                            );
+                            eprintln!("      Network security provided by proxy only.");
+                        }
+                    }
+                }
+                Err(_) => {
+                    eprintln!("  {RED}✗{NC} Landlock: not available");
+                    eprintln!("      Requires Linux 5.13+ with Landlock enabled.");
+                    eprintln!("      Check: cat /sys/kernel/security/lsm");
+                    critical_ok = false;
+                }
+            }
+            if let Ok(uname) = std::process::Command::new("uname").arg("-r").output() {
+                if uname.status.success() {
+                    let kernel = String::from_utf8_lossy(&uname.stdout);
+                    eprintln!("  {GREEN}✓{NC} Kernel: {}", kernel.trim());
+                }
+            }
+            eprintln!("  {GREEN}✓{NC} seccomp: available (built-in on modern kernels)");
         }
         eprintln!();
 

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -106,10 +106,7 @@ pub fn discover_auth(home_dir: &Path) -> AuthDiscovery {
     let gh_config_exists = home_dir.join(".config/gh/hosts.yml").exists();
 
     // macOS Keychain CLI — not applicable on Linux.
-    #[cfg(target_os = "macos")]
-    let security_cli_exists = Path::new("/usr/bin/security").exists();
-    #[cfg(not(target_os = "macos"))]
-    let security_cli_exists = false;
+    let security_cli_exists = probe_security_cli();
 
     let keytar_nodes = find_native_modules(home_dir, "keytar.node");
 
@@ -241,10 +238,7 @@ pub fn discover_paths(home_dir: &Path, project_dir: &Path) -> PathDiscovery {
     let copilot_dir_exists = home_dir.join(".copilot").exists();
 
     // macOS-only: Keychain and Security framework database.
-    #[cfg(target_os = "macos")]
-    let keychains_dir_exists = home_dir.join("Library/Keychains").exists();
-    #[cfg(not(target_os = "macos"))]
-    let keychains_dir_exists = false;
+    let keychains_dir_exists = probe_keychains_dir(home_dir);
 
     let is_git_repo = std::process::Command::new("git")
         .args(["rev-parse", "--git-dir"])
@@ -254,10 +248,7 @@ pub fn discover_paths(home_dir: &Path, project_dir: &Path) -> PathDiscovery {
         .status()
         .is_ok_and(|s| s.success());
 
-    #[cfg(target_os = "macos")]
-    let security_db_exists = Path::new("/private/var/db/mds").exists();
-    #[cfg(not(target_os = "macos"))]
-    let security_db_exists = false;
+    let security_db_exists = probe_security_db();
 
     PathDiscovery {
         existing_denied_dirs,
@@ -315,12 +306,7 @@ impl Discovery {
         } else {
             eprintln!("  {YELLOW}⚠{NC} gh CLI: no config found (~/.config/gh/hosts.yml)");
         }
-        #[cfg(target_os = "macos")]
-        if self.auth.security_cli_exists {
-            eprintln!("  {GREEN}✓{NC} Keychain CLI: /usr/bin/security exists");
-        } else {
-            eprintln!("  {YELLOW}⚠{NC} Keychain CLI: /usr/bin/security not found");
-        }
+        print_keychain_status(self.auth.security_cli_exists);
         if !self.auth.keytar_nodes.is_empty() {
             eprintln!("  {GREEN}✓{NC} keytar.node: found in ~/.copilot/pkg/");
         } else {
@@ -408,17 +394,10 @@ impl Discovery {
             eprintln!("  {RED}✗{NC} ~/.copilot not found — Copilot CLI may not be installed");
             critical_ok = false;
         }
-        #[cfg(target_os = "macos")]
-        {
-            if self.paths.keychains_dir_exists {
-                eprintln!("  {GREEN}✓{NC} ~/Library/Keychains exists");
-            } else {
-                eprintln!("  {YELLOW}⚠{NC} ~/Library/Keychains not found");
-            }
-            if self.paths.security_db_exists {
-                eprintln!("  {GREEN}✓{NC} /private/var/db/mds exists (Security framework)");
-            }
-        }
+        print_macos_path_status(
+            self.paths.keychains_dir_exists,
+            self.paths.security_db_exists,
+        );
 
         let n_denied =
             self.paths.existing_denied_dirs.len() + self.paths.existing_denied_files.len();
@@ -449,45 +428,8 @@ impl Discovery {
 
         // Sandbox mechanism section
         eprintln!("{BOLD}{BLUE}[doctor]{NC} {BOLD}Sandbox mechanism{NC}");
-        #[cfg(target_os = "macos")]
-        {
-            let sandbox_exec_exists = Path::new("/usr/bin/sandbox-exec").exists();
-            if sandbox_exec_exists {
-                eprintln!("  {GREEN}✓{NC} Seatbelt: /usr/bin/sandbox-exec available");
-            } else {
-                eprintln!("  {RED}✗{NC} Seatbelt: /usr/bin/sandbox-exec not found");
-                critical_ok = false;
-            }
-        }
-        #[cfg(target_os = "linux")]
-        {
-            match std::fs::read_to_string("/sys/kernel/security/landlock/abi_version") {
-                Ok(s) => {
-                    let abi = s.trim();
-                    eprintln!("  {GREEN}✓{NC} Landlock: ABI v{abi}");
-                    if let Ok(v) = abi.parse::<u32>()
-                        && v < 4
-                    {
-                        eprintln!(
-                            "  {YELLOW}⚠{NC} Landlock ABI < v4: TCP port filtering unavailable (kernel < 6.7)"
-                        );
-                        eprintln!("      Network security provided by proxy only.");
-                    }
-                }
-                Err(_) => {
-                    eprintln!("  {RED}✗{NC} Landlock: not available");
-                    eprintln!("      Requires Linux 5.13+ with Landlock enabled.");
-                    eprintln!("      Check: cat /sys/kernel/security/lsm");
-                    critical_ok = false;
-                }
-            }
-            if let Ok(uname) = std::process::Command::new("uname").arg("-r").output()
-                && uname.status.success()
-            {
-                let kernel = String::from_utf8_lossy(&uname.stdout);
-                eprintln!("  {GREEN}✓{NC} Kernel: {}", kernel.trim());
-            }
-            eprintln!("  {GREEN}✓{NC} seccomp: available (built-in on modern kernels)");
+        if !print_sandbox_mechanism_status() {
+            critical_ok = false;
         }
         eprintln!();
 
@@ -499,6 +441,126 @@ impl Discovery {
         }
 
         critical_ok
+    }
+}
+
+// ── Platform-specific probes ────────────────────────────────────
+//
+// Named functions keep cfg blocks out of the discovery logic above.
+
+/// Check if macOS Keychain CLI exists. Always false on other platforms.
+fn probe_security_cli() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        Path::new("/usr/bin/security").exists()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Check if macOS Keychain directory exists. Always false on other platforms.
+fn probe_keychains_dir(home_dir: &Path) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        home_dir.join("Library/Keychains").exists()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = home_dir;
+        false
+    }
+}
+
+/// Check if macOS Security framework database exists. Always false on other platforms.
+fn probe_security_db() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        Path::new("/private/var/db/mds").exists()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Print Keychain CLI status in doctor output (macOS only, no-op on Linux).
+fn print_keychain_status(security_cli_exists: bool) {
+    #[cfg(target_os = "macos")]
+    if security_cli_exists {
+        eprintln!("  {GREEN}✓{NC} Keychain CLI: /usr/bin/security exists");
+    } else {
+        eprintln!("  {YELLOW}⚠{NC} Keychain CLI: /usr/bin/security not found");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = security_cli_exists;
+    }
+}
+
+/// Print macOS-specific path status (keychains, security db). No-op on Linux.
+fn print_macos_path_status(keychains_dir_exists: bool, security_db_exists: bool) {
+    #[cfg(target_os = "macos")]
+    {
+        if keychains_dir_exists {
+            eprintln!("  {GREEN}✓{NC} ~/Library/Keychains exists");
+        } else {
+            eprintln!("  {YELLOW}⚠{NC} ~/Library/Keychains not found");
+        }
+        if security_db_exists {
+            eprintln!("  {GREEN}✓{NC} /private/var/db/mds exists (Security framework)");
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (keychains_dir_exists, security_db_exists);
+    }
+}
+
+/// Print sandbox mechanism status and return true if mechanism is available.
+fn print_sandbox_mechanism_status() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        let sandbox_exec_exists = Path::new("/usr/bin/sandbox-exec").exists();
+        if sandbox_exec_exists {
+            eprintln!("  {GREEN}✓{NC} Seatbelt: /usr/bin/sandbox-exec available");
+        } else {
+            eprintln!("  {RED}✗{NC} Seatbelt: /usr/bin/sandbox-exec not found");
+        }
+        sandbox_exec_exists
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let ok = match std::fs::read_to_string("/sys/kernel/security/landlock/abi_version") {
+            Ok(s) => {
+                let abi = s.trim();
+                eprintln!("  {GREEN}✓{NC} Landlock: ABI v{abi}");
+                if let Ok(v) = abi.parse::<u32>()
+                    && v < 4
+                {
+                    eprintln!(
+                        "  {YELLOW}⚠{NC} Landlock ABI < v4: TCP port filtering unavailable (kernel < 6.7)"
+                    );
+                    eprintln!("      Network security provided by proxy only.");
+                }
+                true
+            }
+            Err(_) => {
+                eprintln!("  {RED}✗{NC} Landlock: not available");
+                eprintln!("      Requires Linux 5.13+ with Landlock enabled.");
+                eprintln!("      Check: cat /sys/kernel/security/lsm");
+                false
+            }
+        };
+        if let Ok(uname) = std::process::Command::new("uname").arg("-r").output()
+            && uname.status.success()
+        {
+            let kernel = String::from_utf8_lossy(&uname.stdout);
+            eprintln!("  {GREEN}✓{NC} Kernel: {}", kernel.trim());
+        }
+        eprintln!("  {GREEN}✓{NC} seccomp: available (built-in on modern kernels)");
+        ok
     }
 }
 

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -465,13 +465,13 @@ impl Discovery {
                 Ok(s) => {
                     let abi = s.trim();
                     eprintln!("  {GREEN}✓{NC} Landlock: ABI v{abi}");
-                    if let Ok(v) = abi.parse::<u32>() {
-                        if v < 4 {
-                            eprintln!(
-                                "  {YELLOW}⚠{NC} Landlock ABI < v4: TCP port filtering unavailable (kernel < 6.7)"
-                            );
-                            eprintln!("      Network security provided by proxy only.");
-                        }
+                    if let Ok(v) = abi.parse::<u32>()
+                        && v < 4
+                    {
+                        eprintln!(
+                            "  {YELLOW}⚠{NC} Landlock ABI < v4: TCP port filtering unavailable (kernel < 6.7)"
+                        );
+                        eprintln!("      Network security provided by proxy only.");
                     }
                 }
                 Err(_) => {
@@ -481,11 +481,11 @@ impl Discovery {
                     critical_ok = false;
                 }
             }
-            if let Ok(uname) = std::process::Command::new("uname").arg("-r").output() {
-                if uname.status.success() {
-                    let kernel = String::from_utf8_lossy(&uname.stdout);
-                    eprintln!("  {GREEN}✓{NC} Kernel: {}", kernel.trim());
-                }
+            if let Ok(uname) = std::process::Command::new("uname").arg("-r").output()
+                && uname.status.success()
+            {
+                let kernel = String::from_utf8_lossy(&uname.stdout);
+                eprintln!("  {GREEN}✓{NC} Kernel: {}", kernel.trim());
             }
             eprintln!("  {GREEN}✓{NC} seccomp: available (built-in on modern kernels)");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,15 @@ const LONG_VERSION: &str = match option_env!("CPLT_LONG_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 
-/// Run AI coding agents inside a macOS sandbox.
+/// Run AI coding agents inside a kernel-level sandbox.
 ///
 /// The agent can read and write your project files, but cannot access your
 /// SSH keys, cloud credentials, or other secrets. The sandbox is enforced
-/// by the macOS kernel — the agent (and any process it spawns) cannot bypass it.
+/// by the OS kernel — the agent (and any process it spawns) cannot bypass it.
+///
+/// Platform enforcement:
+/// - macOS: Apple Seatbelt/SBPL via sandbox-exec
+/// - Linux: Landlock LSM + seccomp-BPF (kernel 5.13+, full network filtering on 6.7+)
 ///
 /// Supports GitHub Copilot CLI, OpenCode, and Google Gemini CLI. Auto-detects
 /// which agent to use, or specify explicitly with --agent.
@@ -569,14 +573,6 @@ fn main() -> ExitCode {
     // Handle --doctor: run diagnostics and exit (works on all platforms)
     if cli.doctor {
         return run_doctor();
-    }
-
-    // Linux sandbox is not yet implemented — gate at runtime until Landlock backend lands.
-    // Uses cfg!() instead of #[cfg()] so the compiler still type-checks the code below
-    // on Linux without triggering unreachable-code warnings.
-    if cfg!(not(target_os = "macos")) {
-        error("Linux sandbox support is not yet implemented (see issue #16)");
-        return ExitCode::FAILURE;
     }
 
     // Load config file and merge with CLI flags

--- a/src/main.rs
+++ b/src/main.rs
@@ -1088,6 +1088,7 @@ fn main() -> ExitCode {
 
     // --show-denials: stream macOS sandbox denial logs in the background.
     // Landlock does not produce kernel audit logs, so this is macOS-only.
+    #[allow(unused_mut)] // mut needed on macOS where denial_proc is assigned
     let mut denial_proc: Option<std::process::Child> = None;
     if cli.show_denials {
         #[cfg(target_os = "macos")]
@@ -1713,6 +1714,7 @@ fn shell_install() -> ExitCode {
         }
     }
 }
+
 
 /// Ensure Copilot's bundled package is extracted before entering the sandbox.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -863,8 +863,9 @@ fn main() -> ExitCode {
     let git_hooks_path = discover::git_hooks_path(&home_dir);
 
     // Discover Electron app bundle when Copilot CLI is installed via VS Code.
-    // The shim invokes VS Code's Electron runtime, which needs dyld access to
-    // load Electron Framework from within the .app bundle.
+    // macOS-only: the shim invokes VS Code's Electron runtime, which needs
+    // dyld access to load Electron Framework from within the .app bundle.
+    #[cfg(target_os = "macos")]
     let electron_app_dir = if active_agent == agent::Agent::Copilot {
         agent_bin_result
             .as_ref()
@@ -873,6 +874,8 @@ fn main() -> ExitCode {
     } else {
         None
     };
+    #[cfg(not(target_os = "macos"))]
+    let electron_app_dir: Option<std::path::PathBuf> = None;
 
     // Compute agent-specific sandbox directories
     let agent_dirs = active_agent.config_dirs(&home_dir);
@@ -1039,7 +1042,7 @@ fn main() -> ExitCode {
 
     // Ensure Copilot's bundled runtime is extracted before entering the sandbox.
     // Writes to copilot/pkg are denied inside the sandbox (write-then-exec defense),
-    // so extraction must happen here, outside. macOS-only: SEA extraction is an
+    // so extraction must happen here, outside. macOS-only: SEA extraction is a
     // macOS Copilot packaging detail. Skipped for other agents.
     #[cfg(target_os = "macos")]
     if active_agent.needs_sea_extraction() {
@@ -1051,7 +1054,10 @@ fn main() -> ExitCode {
         match sandbox::preflight(&prepared) {
             Ok(()) => {
                 if !resolved.quiet {
+                    #[cfg(target_os = "macos")]
                     ok("Sandbox profile validated ✓");
+                    #[cfg(target_os = "linux")]
+                    ok("Landlock sandbox ready ✓");
                 }
             }
             Err(e) => {
@@ -1080,25 +1086,36 @@ fn main() -> ExitCode {
         active_agent.display_name()
     ));
 
-    // --show-denials: stream macOS sandbox denial logs in the background
+    // --show-denials: stream macOS sandbox denial logs in the background.
+    // Landlock does not produce kernel audit logs, so this is macOS-only.
     let mut denial_proc = None;
     if cli.show_denials {
-        info("Streaming sandbox denial logs (--show-denials)...");
-        match std::process::Command::new("log")
-            .args([
-                "stream",
-                "--predicate",
-                "eventMessage CONTAINS \"Sandbox\" AND eventMessage CONTAINS \"deny\"",
-                "--info",
-                "--style",
-                "compact",
-            ])
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .spawn()
+        #[cfg(target_os = "macos")]
         {
-            Ok(child) => denial_proc = Some(child),
-            Err(e) => warn(&format!("Could not start denial log stream: {e}")),
+            info("Streaming sandbox denial logs (--show-denials)...");
+            match std::process::Command::new("log")
+                .args([
+                    "stream",
+                    "--predicate",
+                    "eventMessage CONTAINS \"Sandbox\" AND eventMessage CONTAINS \"deny\"",
+                    "--info",
+                    "--style",
+                    "compact",
+                ])
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .spawn()
+            {
+                Ok(child) => denial_proc = Some(child),
+                Err(e) => warn(&format!("Could not start denial log stream: {e}")),
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            warn(
+                "--show-denials is not available on Linux: Landlock does not produce kernel audit logs.",
+            );
+            info("Use `strace -f -e trace=file,network` for filesystem/network debugging.");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -559,7 +559,7 @@ fn main() -> ExitCode {
         };
     }
 
-    // Platform check: cplt currently supports macOS (Seatbelt) and Linux (planned: Landlock).
+    // Platform check: cplt supports macOS (Seatbelt) and Linux (Landlock).
     // Other platforms (Windows, FreeBSD, etc.) are not supported.
     if cfg!(not(any(target_os = "macos", target_os = "linux"))) {
         error("cplt requires macOS or Linux");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1751,22 +1751,6 @@ fn start_denial_stream() -> Option<std::process::Child> {
     }
 }
 
-/// Parse the Copilot CLI version from `copilot --version` output.
-///
-/// Returns e.g. `"1.0.24"` from `"GitHub Copilot CLI 1.0.24.\n..."`.
-#[cfg(target_os = "macos")]
-fn get_copilot_version(copilot_bin: &Path) -> Option<String> {
-    let output = std::process::Command::new(copilot_bin)
-        .arg("--version")
-        .output()
-        .ok()?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout
-        .split_whitespace()
-        .find(|s| s.starts_with(|c: char| c.is_ascii_digit()))
-        .map(|s| s.trim_end_matches('.').to_string())
-}
-
 /// Ensure Copilot's bundled package is extracted before entering the sandbox.
 ///
 /// Copilot CLI (SEA binary) extracts its runtime into

--- a/src/main.rs
+++ b/src/main.rs
@@ -865,17 +865,7 @@ fn main() -> ExitCode {
     // Discover Electron app bundle when Copilot CLI is installed via VS Code.
     // macOS-only: the shim invokes VS Code's Electron runtime, which needs
     // dyld access to load Electron Framework from within the .app bundle.
-    #[cfg(target_os = "macos")]
-    let electron_app_dir = if active_agent == agent::Agent::Copilot {
-        agent_bin_result
-            .as_ref()
-            .ok()
-            .and_then(|p| discover::discover_electron_app(p))
-    } else {
-        None
-    };
-    #[cfg(not(target_os = "macos"))]
-    let electron_app_dir: Option<std::path::PathBuf> = None;
+    let electron_app_dir = discover_electron_app_dir(&agent_bin_result, active_agent);
 
     // Compute agent-specific sandbox directories
     let agent_dirs = active_agent.config_dirs(&home_dir);
@@ -1054,10 +1044,7 @@ fn main() -> ExitCode {
         match sandbox::preflight(&prepared) {
             Ok(()) => {
                 if !resolved.quiet {
-                    #[cfg(target_os = "macos")]
-                    ok("Sandbox profile validated ✓");
-                    #[cfg(target_os = "linux")]
-                    ok("Landlock sandbox ready ✓");
+                    print_preflight_ok();
                 }
             }
             Err(e) => {
@@ -1086,38 +1073,11 @@ fn main() -> ExitCode {
         active_agent.display_name()
     ));
 
-    // --show-denials: stream macOS sandbox denial logs in the background.
-    // Landlock does not produce kernel audit logs, so this is macOS-only.
+    // --show-denials: stream sandbox denial logs in the background.
     #[allow(unused_mut)] // mut needed on macOS where denial_proc is assigned
     let mut denial_proc: Option<std::process::Child> = None;
     if cli.show_denials {
-        #[cfg(target_os = "macos")]
-        {
-            info("Streaming sandbox denial logs (--show-denials)...");
-            match std::process::Command::new("log")
-                .args([
-                    "stream",
-                    "--predicate",
-                    "eventMessage CONTAINS \"Sandbox\" AND eventMessage CONTAINS \"deny\"",
-                    "--info",
-                    "--style",
-                    "compact",
-                ])
-                .stdout(std::process::Stdio::inherit())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-            {
-                Ok(child) => denial_proc = Some(child),
-                Err(e) => warn(&format!("Could not start denial log stream: {e}")),
-            }
-        }
-        #[cfg(target_os = "linux")]
-        {
-            warn(
-                "--show-denials is not available on Linux: Landlock does not produce kernel audit logs.",
-            );
-            info("Use `strace -f -e trace=file,network` for filesystem/network debugging.");
-        }
+        denial_proc = start_denial_stream();
     }
 
     eprintln!("{YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{NC}");
@@ -1715,6 +1675,97 @@ fn shell_install() -> ExitCode {
     }
 }
 
+// ── Platform-specific helpers ─────────────────────────────────
+//
+// Named functions with cfg-gated bodies keep the run() function
+// free of inline #[cfg] blocks.
+
+/// Discover the VS Code Electron app bundle containing Copilot's shim (macOS only).
+///
+/// On Linux, Copilot doesn't use Electron app bundles, so this always returns `None`.
+/// Skipped for non-Copilot agents.
+fn discover_electron_app_dir(
+    agent_bin_result: &Result<PathBuf, String>,
+    agent: agent::Agent,
+) -> Option<std::path::PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        if agent != agent::Agent::Copilot {
+            return None;
+        }
+        agent_bin_result
+            .as_ref()
+            .ok()
+            .and_then(|p| discover::discover_electron_app(p))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (agent_bin_result, agent);
+        None
+    }
+}
+
+/// Print the preflight success message appropriate for this platform.
+fn print_preflight_ok() {
+    #[cfg(target_os = "macos")]
+    ok("Sandbox profile validated ✓");
+    #[cfg(target_os = "linux")]
+    ok("Landlock sandbox ready ✓");
+}
+
+/// Start streaming sandbox denial logs (macOS only).
+///
+/// On macOS, spawns `log stream` filtering for Sandbox deny events.
+/// On Linux, prints a hint about `strace` since Landlock has no audit logs.
+fn start_denial_stream() -> Option<std::process::Child> {
+    #[cfg(target_os = "macos")]
+    {
+        info("Streaming sandbox denial logs (--show-denials)...");
+        match std::process::Command::new("log")
+            .args([
+                "stream",
+                "--predicate",
+                "eventMessage CONTAINS \"Sandbox\" AND eventMessage CONTAINS \"deny\"",
+                "--info",
+                "--style",
+                "compact",
+            ])
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+        {
+            Ok(child) => Some(child),
+            Err(e) => {
+                warn(&format!("Could not start denial log stream: {e}"));
+                None
+            }
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        warn(
+            "--show-denials is not available on Linux: Landlock does not produce kernel audit logs.",
+        );
+        info("Use `strace -f -e trace=file,network` for filesystem/network debugging.");
+        None
+    }
+}
+
+/// Parse the Copilot CLI version from `copilot --version` output.
+///
+/// Returns e.g. `"1.0.24"` from `"GitHub Copilot CLI 1.0.24.\n..."`.
+#[cfg(target_os = "macos")]
+fn get_copilot_version(copilot_bin: &Path) -> Option<String> {
+    let output = std::process::Command::new(copilot_bin)
+        .arg("--version")
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .split_whitespace()
+        .find(|s| s.starts_with(|c: char| c.is_ascii_digit()))
+        .map(|s| s.trim_end_matches('.').to_string())
+}
 
 /// Ensure Copilot's bundled package is extracted before entering the sandbox.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -1088,7 +1088,7 @@ fn main() -> ExitCode {
 
     // --show-denials: stream macOS sandbox denial logs in the background.
     // Landlock does not produce kernel audit logs, so this is macOS-only.
-    let mut denial_proc = None;
+    let mut denial_proc: Option<std::process::Child> = None;
     if cli.show_denials {
         #[cfg(target_os = "macos")]
         {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -44,7 +44,8 @@ mod profile;
 
 pub use policy::{
     DENIED_DOTFILES, DENIED_FILES, ENV_ALLOWLIST, ENV_PREFIX_ALLOWLIST, HARDENING_ENV_VARS,
-    HOME_TOOL_DIRS, HardeningCategory, HardeningEnvVar, HomeToolDir, validate_sbpl_path,
+    HOME_TOOL_DIRS, HardeningCategory, HardeningEnvVar, HomeToolDir, home_tool_dirs,
+    validate_sbpl_path,
 };
 
 // SBPL profile generation — kept public for unit tests.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -155,82 +155,13 @@ impl PreparedSandbox {
 /// - A path contains characters that could cause profile injection (macOS)
 /// - The platform does not support sandboxing
 pub fn prepare(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
-    #[cfg(target_os = "macos")]
-    {
-        // Validate all paths for SBPL injection safety.
-        validate_config_paths(config)?;
-
-        let profile_text = profile::generate_profile(&profile::ProfileOptions {
-            project_dir: config.project_dir,
-            home_dir: config.home_dir,
-            extra_read: config.extra_read,
-            extra_write: config.extra_write,
-            extra_deny: config.extra_deny,
-            existing_home_tool_dirs: config.existing_home_tool_dirs,
-            extra_ports: config.extra_ports,
-            localhost_ports: config.localhost_ports,
-            proxy_port: config.proxy_port,
-            allow_env_files: config.allow_env_files,
-            allow_localhost_any: config.allow_localhost_any,
-            scratch_dir: config.scratch_dir,
-            allow_tmp_exec: config.allow_tmp_exec,
-            copilot_install_dir: config.copilot_install_dir,
-            git_hooks_path: config.git_hooks_path,
-            allow_gpg_signing: config.allow_gpg_signing,
-            allow_jvm_attach: config.allow_jvm_attach,
-            allow_docker: config.allow_docker,
-            electron_app_dir: config.electron_app_dir,
-            agent: config.agent,
-            agent_dirs: config.agent_dirs,
-            allow_cache_exec: config.allow_cache_exec,
-            allow_cache_exec_any: config.allow_cache_exec_any,
-        });
-
-        Ok(PreparedSandbox {
-            project_dir: config.project_dir.to_path_buf(),
-            home_dir: config.home_dir.to_path_buf(),
-            profile_text,
-            scratch_dir: config.scratch_dir.map(Path::to_path_buf),
-            proxy_port: config.proxy_port,
-            agent: config.agent,
-        })
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        // Warn about config options that Linux cannot enforce at kernel level.
-        if !config.extra_deny.is_empty() {
-            eprintln!(
-                "\x1b[0;33m[cplt]\x1b[0m --deny-path has no effect on Linux: \
-                 Landlock cannot deny subpaths within allowed directories. \
-                 Proxy and env hardening provide defense-in-depth."
-            );
-        }
-
-        let policy = landlock_mod::generate_policy(config);
-        let profile_text = landlock_mod::describe_policy(&policy);
-
-        // Pre-compute everything in the parent process.
-        // ABI check, BPF construction, and all allocation happens here.
-        // The pre_exec hook only makes raw syscalls.
-        let precomputed = landlock_mod::precompute(policy)?;
-
-        Ok(PreparedSandbox {
-            project_dir: config.project_dir.to_path_buf(),
-            home_dir: config.home_dir.to_path_buf(),
-            profile_text,
-            scratch_dir: config.scratch_dir.map(Path::to_path_buf),
-            proxy_port: config.proxy_port,
-            agent: config.agent,
-            precomputed,
-        })
-    }
+    prepare_impl(config)
 }
 
 /// Human-readable representation of the sandbox policy.
 ///
 /// On macOS, returns the SBPL profile text (useful for `--print-profile`).
-/// On Linux (future), returns a formatted Landlock rule summary.
+/// On Linux, returns a formatted Landlock rule summary.
 pub fn describe(sandbox: &PreparedSandbox) -> &str {
     &sandbox.profile_text
 }
@@ -240,22 +171,9 @@ pub fn describe(sandbox: &PreparedSandbox) -> &str {
 /// On macOS, writes the profile to a temp file and runs `/usr/bin/true`
 /// inside `sandbox-exec` to confirm enforcement is active.
 ///
-/// On Linux, checks Landlock ABI availability and kernel version.
+/// On Linux, this is a no-op (ABI checks happen during prepare).
 pub fn preflight(sandbox: &PreparedSandbox) -> Result<(), String> {
-    #[cfg(target_os = "macos")]
-    {
-        let profile_path = write_temp_profile(&sandbox.profile_text)?;
-        let result = exec::validate(&profile_path, &sandbox.project_dir, &sandbox.home_dir);
-        let _ = std::fs::remove_file(&profile_path);
-        result
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        // ABI check and warnings already done in prepare()/precompute().
-        let _ = sandbox;
-        Ok(())
-    }
+    exec::preflight(sandbox)
 }
 
 /// Execute a command inside the sandbox, forwarding signals to the child.
@@ -266,7 +184,6 @@ pub fn preflight(sandbox: &PreparedSandbox) -> Result<(), String> {
 ///
 /// Environment handling is controlled by `extra_pass_env`, `inherit_env`,
 /// and `disabled_categories` — see [`build_sandbox_env()`] for details.
-#[allow(clippy::too_many_arguments)]
 pub fn exec_sandboxed(
     sandbox: &PreparedSandbox,
     copilot_bin: &Path,
@@ -275,48 +192,87 @@ pub fn exec_sandboxed(
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
 ) -> u8 {
-    #[cfg(target_os = "macos")]
-    {
-        let profile_path = match write_temp_profile(&sandbox.profile_text) {
-            Ok(p) => p,
-            Err(e) => {
-                eprintln!("\x1b[0;31m[cplt]\x1b[0m {e}");
-                return 1;
-            }
-        };
+    exec::exec(
+        sandbox,
+        copilot_bin,
+        copilot_args,
+        extra_pass_env,
+        inherit_env,
+        disabled_categories,
+    )
+}
 
-        let exit_code = exec::exec(
-            copilot_bin,
-            &profile_path,
-            &sandbox.project_dir,
-            &sandbox.home_dir,
-            copilot_args,
-            extra_pass_env,
-            inherit_env,
-            disabled_categories,
-            sandbox.scratch_dir.as_deref(),
-            sandbox.proxy_port,
-            sandbox.agent,
+
+// ── Platform-specific prepare implementations ─────────────────
+
+#[cfg(target_os = "macos")]
+fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
+    validate_config_paths(config)?;
+
+    let profile_text = profile::generate_profile(&profile::ProfileOptions {
+        project_dir: config.project_dir,
+        home_dir: config.home_dir,
+        extra_read: config.extra_read,
+        extra_write: config.extra_write,
+        extra_deny: config.extra_deny,
+        existing_home_tool_dirs: config.existing_home_tool_dirs,
+        extra_ports: config.extra_ports,
+        localhost_ports: config.localhost_ports,
+        proxy_port: config.proxy_port,
+        allow_env_files: config.allow_env_files,
+        allow_localhost_any: config.allow_localhost_any,
+        scratch_dir: config.scratch_dir,
+        allow_tmp_exec: config.allow_tmp_exec,
+        copilot_install_dir: config.copilot_install_dir,
+        git_hooks_path: config.git_hooks_path,
+        allow_gpg_signing: config.allow_gpg_signing,
+        allow_jvm_attach: config.allow_jvm_attach,
+        allow_docker: config.allow_docker,
+        electron_app_dir: config.electron_app_dir,
+        agent: config.agent,
+        agent_dirs: config.agent_dirs,
+        allow_cache_exec: config.allow_cache_exec,
+        allow_cache_exec_any: config.allow_cache_exec_any,
+    });
+
+    Ok(PreparedSandbox {
+        project_dir: config.project_dir.to_path_buf(),
+        home_dir: config.home_dir.to_path_buf(),
+        profile_text,
+        scratch_dir: config.scratch_dir.map(Path::to_path_buf),
+        proxy_port: config.proxy_port,
+        agent: config.agent,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
+    // Warn about config options that Linux cannot enforce at kernel level.
+    if !config.extra_deny.is_empty() {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m --deny-path has no effect on Linux: \
+             Landlock cannot deny subpaths within allowed directories. \
+             Proxy and env hardening provide defense-in-depth."
         );
-
-        let _ = std::fs::remove_file(&profile_path);
-        exit_code
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        exec::exec_linux(
-            copilot_bin,
-            &sandbox.project_dir,
-            copilot_args,
-            extra_pass_env,
-            inherit_env,
-            disabled_categories,
-            sandbox.scratch_dir.as_deref(),
-            sandbox.proxy_port,
-            &sandbox.precomputed,
-        )
-    }
+    let policy = landlock_mod::generate_policy(config);
+    let profile_text = landlock_mod::describe_policy(&policy);
+
+    // Pre-compute everything in the parent process.
+    // ABI check, BPF construction, and all allocation happens here.
+    // The pre_exec hook only makes raw syscalls.
+    let precomputed = landlock_mod::precompute(policy)?;
+
+    Ok(PreparedSandbox {
+        project_dir: config.project_dir.to_path_buf(),
+        home_dir: config.home_dir.to_path_buf(),
+        profile_text,
+        scratch_dir: config.scratch_dir.map(Path::to_path_buf),
+        proxy_port: config.proxy_port,
+        agent: config.agent,
+        precomputed,
+    })
 }
 
 // ── Internal helpers (macOS only) ──────────────────────────────
@@ -385,37 +341,4 @@ fn validate_config_paths(config: &SandboxConfig) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-/// Write SBPL profile text to a temp file with secure creation (macOS only).
-///
-/// Uses O_CREAT|O_EXCL (create_new) to prevent symlink-following attacks,
-/// and mode 0600 to restrict read access.
-#[cfg(target_os = "macos")]
-fn write_temp_profile(profile_text: &str) -> Result<PathBuf, String> {
-    use std::io::Write as _;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let path = std::env::temp_dir().join(format!(
-        "cplt-{}-{}.sb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
-
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(&path)
-        .map_err(|e| format!("Cannot create sandbox profile: {e}"))?;
-
-    file.write_all(profile_text.as_bytes()).map_err(|e| {
-        let _ = std::fs::remove_file(&path);
-        format!("Cannot write sandbox profile: {e}")
-    })?;
-
-    Ok(path)
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -202,7 +202,6 @@ pub fn exec_sandboxed(
     )
 }
 
-
 // ── Platform-specific prepare implementations ─────────────────
 
 #[cfg(target_os = "macos")]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,7 +4,7 @@
 //!
 //! The sandbox uses different kernel enforcement mechanisms per platform:
 //! - **macOS**: Seatbelt/SBPL via `sandbox-exec`
-//! - **Linux**: Landlock LSM + seccomp-BPF (planned — see issue #16)
+//! - **Linux**: Landlock LSM + seccomp-BPF
 //!
 //! The public API is platform-agnostic:
 //! - [`prepare()`] validates configuration and compiles it into a [`PreparedSandbox`]
@@ -14,8 +14,8 @@
 //!
 //! Platform-specific details are handled by internal modules:
 //! - `profile`: SBPL profile generation (macOS — also compiled cross-platform for testing)
-//! - `exec`: `sandbox-exec` invocation (macOS runtime only)
-//! - Future: `landlock`, `seccomp` modules for Linux
+//! - `exec`: sandbox-exec (macOS) / Landlock+seccomp (Linux) invocation
+//! - `landlock_mod`: Landlock rule generation (cross-platform) and application (Linux)
 //!
 //! # Submodule layout
 //!
@@ -31,6 +31,8 @@ use crate::agent::{Agent, AgentDir};
 mod env;
 #[path = "sandbox_exec.rs"]
 mod exec;
+#[path = "sandbox_landlock.rs"]
+pub(crate) mod landlock_mod;
 #[path = "sandbox_policy.rs"]
 mod policy;
 #[path = "sandbox_profile.rs"]
@@ -52,6 +54,12 @@ pub use profile::{ProfileOptions, generate_profile};
 
 // Environment construction — already platform-agnostic.
 pub use env::{SandboxEnv, build_sandbox_env};
+
+// Landlock policy types — cross-platform for testing.
+pub use landlock_mod::{
+    BLOCKED_SYSCALL_NAMES, FsAccess, FsRule, LandlockPolicy, NetRule, describe_policy,
+    generate_policy,
+};
 
 // ── Platform-agnostic sandbox API ──────────────────────────────
 
@@ -105,8 +113,7 @@ pub struct SandboxConfig<'a> {
 /// A validated, platform-specific sandbox ready for execution.
 ///
 /// Created by [`prepare()`]. On macOS this contains the compiled SBPL
-/// profile text. On Linux (future) it will contain the Landlock ruleset
-/// and seccomp filter configuration.
+/// profile text. On Linux it contains the Landlock ruleset configuration.
 ///
 /// Use [`describe()`] for a human-readable representation,
 /// [`preflight()`] to verify the mechanism works, and
@@ -115,11 +122,15 @@ pub struct PreparedSandbox {
     project_dir: PathBuf,
     home_dir: PathBuf,
     /// macOS: SBPL profile text.
-    /// Linux: human-readable policy summary (future).
+    /// Linux: human-readable Landlock policy summary.
     profile_text: String,
     scratch_dir: Option<PathBuf>,
     proxy_port: Option<u16>,
     agent: Agent,
+    /// Landlock + seccomp pre-computed sandbox data (Linux only).
+    /// Built in the parent process; applied in pre_exec.
+    #[cfg(target_os = "linux")]
+    precomputed: landlock_mod::PrecomputedSandbox,
 }
 
 impl PreparedSandbox {
@@ -137,55 +148,82 @@ impl PreparedSandbox {
 /// Validate configuration and compile it into a platform-specific sandbox.
 ///
 /// On macOS, this generates an SBPL profile and validates all paths for
-/// SBPL injection safety. On Linux (future), this will build a Landlock
-/// ruleset.
+/// SBPL injection safety. On Linux, this builds a Landlock policy.
 ///
 /// Returns an error if:
-/// - A path contains characters that could cause profile injection
-/// - The platform does not support sandboxing (yet)
+/// - A path contains characters that could cause profile injection (macOS)
+/// - The platform does not support sandboxing
 pub fn prepare(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
-    // Validate all paths that will be interpolated into the sandbox profile.
-    // On macOS, SBPL uses string interpolation — characters like `"`, `;`, `(`
-    // could break or inject rules. This validation is centralized here so
-    // callers don't need to know about backend-specific injection risks.
-    validate_config_paths(config)?;
+    #[cfg(target_os = "macos")]
+    {
+        // Validate all paths for SBPL injection safety.
+        validate_config_paths(config)?;
 
-    // Generate platform-specific sandbox profile.
-    // Currently macOS-only; Linux will use Landlock ruleset builder.
-    let profile_text = profile::generate_profile(&profile::ProfileOptions {
-        project_dir: config.project_dir,
-        home_dir: config.home_dir,
-        extra_read: config.extra_read,
-        extra_write: config.extra_write,
-        extra_deny: config.extra_deny,
-        existing_home_tool_dirs: config.existing_home_tool_dirs,
-        extra_ports: config.extra_ports,
-        localhost_ports: config.localhost_ports,
-        proxy_port: config.proxy_port,
-        allow_env_files: config.allow_env_files,
-        allow_localhost_any: config.allow_localhost_any,
-        scratch_dir: config.scratch_dir,
-        allow_tmp_exec: config.allow_tmp_exec,
-        copilot_install_dir: config.copilot_install_dir,
-        git_hooks_path: config.git_hooks_path,
-        allow_gpg_signing: config.allow_gpg_signing,
-        allow_jvm_attach: config.allow_jvm_attach,
-        allow_docker: config.allow_docker,
-        electron_app_dir: config.electron_app_dir,
-        agent: config.agent,
-        agent_dirs: config.agent_dirs,
-        allow_cache_exec: config.allow_cache_exec,
-        allow_cache_exec_any: config.allow_cache_exec_any,
-    });
+        let profile_text = profile::generate_profile(&profile::ProfileOptions {
+            project_dir: config.project_dir,
+            home_dir: config.home_dir,
+            extra_read: config.extra_read,
+            extra_write: config.extra_write,
+            extra_deny: config.extra_deny,
+            existing_home_tool_dirs: config.existing_home_tool_dirs,
+            extra_ports: config.extra_ports,
+            localhost_ports: config.localhost_ports,
+            proxy_port: config.proxy_port,
+            allow_env_files: config.allow_env_files,
+            allow_localhost_any: config.allow_localhost_any,
+            scratch_dir: config.scratch_dir,
+            allow_tmp_exec: config.allow_tmp_exec,
+            copilot_install_dir: config.copilot_install_dir,
+            git_hooks_path: config.git_hooks_path,
+            allow_gpg_signing: config.allow_gpg_signing,
+            allow_jvm_attach: config.allow_jvm_attach,
+            allow_docker: config.allow_docker,
+            electron_app_dir: config.electron_app_dir,
+            agent: config.agent,
+            agent_dirs: config.agent_dirs,
+            allow_cache_exec: config.allow_cache_exec,
+            allow_cache_exec_any: config.allow_cache_exec_any,
+        });
 
-    Ok(PreparedSandbox {
-        project_dir: config.project_dir.to_path_buf(),
-        home_dir: config.home_dir.to_path_buf(),
-        profile_text,
-        scratch_dir: config.scratch_dir.map(Path::to_path_buf),
-        proxy_port: config.proxy_port,
-        agent: config.agent,
-    })
+        Ok(PreparedSandbox {
+            project_dir: config.project_dir.to_path_buf(),
+            home_dir: config.home_dir.to_path_buf(),
+            profile_text,
+            scratch_dir: config.scratch_dir.map(Path::to_path_buf),
+            proxy_port: config.proxy_port,
+            agent: config.agent,
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Warn about config options that Linux cannot enforce at kernel level.
+        if !config.extra_deny.is_empty() {
+            eprintln!(
+                "\x1b[0;33m[cplt]\x1b[0m --deny-path has no effect on Linux: \
+                 Landlock cannot deny subpaths within allowed directories. \
+                 Proxy and env hardening provide defense-in-depth."
+            );
+        }
+
+        let policy = landlock_mod::generate_policy(config);
+        let profile_text = landlock_mod::describe_policy(&policy);
+
+        // Pre-compute everything in the parent process.
+        // ABI check, BPF construction, and all allocation happens here.
+        // The pre_exec hook only makes raw syscalls.
+        let precomputed = landlock_mod::precompute(policy)?;
+
+        Ok(PreparedSandbox {
+            project_dir: config.project_dir.to_path_buf(),
+            home_dir: config.home_dir.to_path_buf(),
+            profile_text,
+            scratch_dir: config.scratch_dir.map(Path::to_path_buf),
+            proxy_port: config.proxy_port,
+            agent: config.agent,
+            precomputed,
+        })
+    }
 }
 
 /// Human-readable representation of the sandbox policy.
@@ -201,19 +239,29 @@ pub fn describe(sandbox: &PreparedSandbox) -> &str {
 /// On macOS, writes the profile to a temp file and runs `/usr/bin/true`
 /// inside `sandbox-exec` to confirm enforcement is active.
 ///
-/// On Linux (future), checks Landlock ABI availability and kernel version.
+/// On Linux, checks Landlock ABI availability and kernel version.
 pub fn preflight(sandbox: &PreparedSandbox) -> Result<(), String> {
-    let profile_path = write_temp_profile(&sandbox.profile_text)?;
-    let result = exec::validate(&profile_path, &sandbox.project_dir, &sandbox.home_dir);
-    let _ = std::fs::remove_file(&profile_path);
-    result
+    #[cfg(target_os = "macos")]
+    {
+        let profile_path = write_temp_profile(&sandbox.profile_text)?;
+        let result = exec::validate(&profile_path, &sandbox.project_dir, &sandbox.home_dir);
+        let _ = std::fs::remove_file(&profile_path);
+        result
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // ABI check and warnings already done in prepare()/precompute().
+        let _ = sandbox;
+        Ok(())
+    }
 }
 
 /// Execute a command inside the sandbox, forwarding signals to the child.
 ///
 /// Handles platform-specific sandbox setup internally:
 /// - macOS: writes SBPL profile to temp file, invokes `sandbox-exec`
-/// - Linux (future): applies Landlock ruleset + seccomp filter, then `execvp`
+/// - Linux: applies Landlock ruleset + seccomp filter via `pre_exec`
 ///
 /// Environment handling is controlled by `extra_pass_env`, `inherit_env`,
 /// and `disabled_categories` — see [`build_sandbox_env()`] for details.
@@ -226,39 +274,60 @@ pub fn exec_sandboxed(
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
 ) -> u8 {
-    let profile_path = match write_temp_profile(&sandbox.profile_text) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("\x1b[0;31m[cplt]\x1b[0m {e}");
-            return 1;
-        }
-    };
+    #[cfg(target_os = "macos")]
+    {
+        let profile_path = match write_temp_profile(&sandbox.profile_text) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("\x1b[0;31m[cplt]\x1b[0m {e}");
+                return 1;
+            }
+        };
 
-    let exit_code = exec::exec(
-        copilot_bin,
-        &profile_path,
-        &sandbox.project_dir,
-        &sandbox.home_dir,
-        copilot_args,
-        extra_pass_env,
-        inherit_env,
-        disabled_categories,
-        sandbox.scratch_dir.as_deref(),
-        sandbox.proxy_port,
-        sandbox.agent,
-    );
+        let exit_code = exec::exec(
+            copilot_bin,
+            &profile_path,
+            &sandbox.project_dir,
+            &sandbox.home_dir,
+            copilot_args,
+            extra_pass_env,
+            inherit_env,
+            disabled_categories,
+            sandbox.scratch_dir.as_deref(),
+            sandbox.proxy_port,
+            sandbox.agent,
+        );
 
-    let _ = std::fs::remove_file(&profile_path);
-    exit_code
+        let _ = std::fs::remove_file(&profile_path);
+        exit_code
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        exec::exec_linux(
+            copilot_bin,
+            &sandbox.project_dir,
+            copilot_args,
+            extra_pass_env,
+            inherit_env,
+            disabled_categories,
+            sandbox.scratch_dir.as_deref(),
+            sandbox.proxy_port,
+            &sandbox.precomputed,
+        )
+    }
 }
 
-// ── Internal helpers ───────────────────────────────────────────
+// ── Internal helpers (macOS only) ──────────────────────────────
 
 /// Validate all paths in a [`SandboxConfig`] for backend-specific injection.
 ///
 /// On macOS, SBPL profiles use string interpolation — paths containing
 /// `"`, `;`, `(`, etc. could inject malicious rules. This validates every
 /// path that will be interpolated into the profile.
+///
+/// Linux uses Landlock's fd-based API which is immune to path injection.
+#[cfg(target_os = "macos")]
 fn validate_config_paths(config: &SandboxConfig) -> Result<(), String> {
     policy::validate_sbpl_path(config.project_dir).map_err(|e| format!("Project dir: {e}"))?;
     policy::validate_sbpl_path(config.home_dir).map_err(|e| format!("Home dir: {e}"))?;
@@ -317,10 +386,11 @@ fn validate_config_paths(config: &SandboxConfig) -> Result<(), String> {
     Ok(())
 }
 
-/// Write SBPL profile text to a temp file with secure creation.
+/// Write SBPL profile text to a temp file with secure creation (macOS only).
 ///
 /// Uses O_CREAT|O_EXCL (create_new) to prevent symlink-following attacks,
 /// and mode 0600 to restrict read access.
+#[cfg(target_os = "macos")]
 fn write_temp_profile(profile_text: &str) -> Result<PathBuf, String> {
     use std::io::Write as _;
     use std::os::unix::fs::OpenOptionsExt;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -58,7 +58,7 @@ pub use env::{SandboxEnv, build_sandbox_env};
 
 // Landlock policy types — cross-platform for testing.
 pub use landlock_mod::{
-    BLOCKED_SYSCALL_NAMES, FsAccess, FsRule, LandlockPolicy, NetRule, describe_policy,
+    FsAccess, FsRule, LandlockPolicy, NetRule, blocked_syscall_names, describe_policy,
     generate_policy,
 };
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -255,6 +255,13 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
              Proxy and env hardening provide defense-in-depth."
         );
     }
+    if !config.allow_env_files {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m allow_env_files=false is not fully enforceable on Linux: \
+             Landlock grants the project directory full read access, so .env files \
+             within it remain readable. Differs from macOS Seatbelt behavior."
+        );
+    }
 
     let policy = landlock_mod::generate_policy(config);
     let profile_text = landlock_mod::describe_policy(&policy);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -272,6 +272,24 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
              Use --with-proxy for localhost SSRF protection."
         );
     }
+    if config.allow_docker {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m --allow-docker has no effect on Linux: \
+             Docker socket access is not yet implemented in the Landlock backend."
+        );
+    }
+    if config.allow_jvm_attach {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m --allow-jvm-attach has no effect on Linux: \
+             JVM attach socket patterns are macOS-specific."
+        );
+    }
+    if !config.allow_cache_exec.is_empty() || config.allow_cache_exec_any {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m --allow-cache-exec has no effect on Linux: \
+             ~/Library/Caches is a macOS-specific path."
+        );
+    }
 
     let policy = landlock_mod::generate_policy(config);
     let profile_text = landlock_mod::describe_policy(&policy);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -261,6 +261,17 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
              within it remain readable. Differs from macOS Seatbelt behavior."
         );
     }
+    // Landlock network rules are port-based, not address-based — localhost
+    // cannot be distinguished from remote hosts at the kernel level.
+    if config.proxy_port.is_none()
+        && (!config.localhost_ports.is_empty() || config.allow_localhost_any)
+    {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m Localhost protection limited on Linux without proxy: \
+             Landlock cannot distinguish localhost from remote hosts. \
+             Use --with-proxy for localhost SSRF protection."
+        );
+    }
 
     let policy = landlock_mod::generate_policy(config);
     let profile_text = landlock_mod::describe_policy(&policy);

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -1,8 +1,6 @@
 use std::path::{Path, PathBuf};
 
-#[cfg(target_os = "macos")]
 use super::env::build_sandbox_env;
-#[cfg(target_os = "macos")]
 use super::policy::HardeningCategory;
 use crate::agent::Agent;
 

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use super::env::build_sandbox_env;
 use super::policy::HardeningCategory;
@@ -35,58 +36,29 @@ fn compute_mise_ignored_paths(project_dir: &Path, home: &Path) -> Vec<PathBuf> {
     ignored
 }
 
-/// Validate the profile by running a simple command inside the sandbox.
-#[cfg(target_os = "macos")]
-pub fn validate(profile_path: &Path, _project_dir: &Path, _home_dir: &Path) -> Result<(), String> {
-    let output = std::process::Command::new("sandbox-exec")
-        .arg("-f")
-        .arg(profile_path)
-        .arg("/usr/bin/true")
-        .output()
-        .map_err(|e| format!("Failed to run sandbox-exec: {e}"))?;
+// ── Shared command setup ──────────────────────────────────────
 
-    if output.status.success() {
-        Ok(())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!(
-            "sandbox-exec exited with {}: {stderr}",
-            output.status
-        ))
-    }
-}
-
-/// Execute copilot inside the sandbox, forwarding signals to the child process group.
+/// Configure environment, proxy, and common args on a sandboxed Command.
 ///
-/// Environment handling:
-/// - Default (inherit_env=false): env_clear() + allowlist only. Cloud credentials,
-///   npm tokens, database URLs, etc. are stripped. Use `extra_pass_env` for extras.
-/// - Legacy (inherit_env=true): all env vars inherited, only SSH_AUTH_SOCK and
-///   color vars are stripped. Use only when the default breaks something.
-/// - Security hardening env vars are injected unless their category is disabled.
-#[cfg(target_os = "macos")]
+/// Both macOS (Seatbelt) and Linux (Landlock) paths call this to apply the
+/// identical env filtering, proxy routing, and recursion guard.
 #[allow(clippy::too_many_arguments)]
-pub fn exec(
-    copilot_bin: &Path,
-    profile_path: &Path,
-    project_dir: &Path,
-    home: &Path,
+fn configure_command(
+    cmd: &mut Command,
     copilot_args: &[String],
+    project_dir: &Path,
+    home_dir: &Path,
     extra_pass_env: &[String],
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
     scratch_dir: Option<&Path>,
     proxy_port: Option<u16>,
     agent: Agent,
-) -> u8 {
-    let mut cmd = std::process::Command::new("sandbox-exec");
-    cmd.arg("-f").arg(profile_path).arg(copilot_bin);
-
+) {
     for arg in copilot_args {
         cmd.arg(arg);
     }
 
-    // Set working directory to project
     cmd.current_dir(project_dir);
 
     // Build and apply environment
@@ -114,27 +86,20 @@ pub fn exec(
         }
     }
 
+    // Tell mise to ignore config files in ancestor directories that the sandbox blocks.
+    let ignored = compute_mise_ignored_paths(project_dir, home_dir);
+    if !ignored.is_empty() {
+        let paths: Vec<String> = ignored.iter().map(|p| p.to_string_lossy().into_owned()).collect();
+        cmd.env("MISE_IGNORED_CONFIG_PATHS", paths.join(":"));
+    }
+
     // Recursion guard: if copilot somehow re-invokes cplt (e.g. via symlink),
     // cplt will see this and bail before launching another sandbox.
     cmd.env("__CPLT_WRAPPED", "1");
 
-    // Tell mise to skip config files in ancestor directories the sandbox can't read.
-    // Without this, mise fails with EPERM when traversing parent dirs for .tool-versions.
-    if !extra_pass_env
-        .iter()
-        .any(|v| v == "MISE_IGNORED_CONFIG_PATHS")
-    {
-        let ignored = compute_mise_ignored_paths(project_dir, home);
-        if !ignored.is_empty() {
-            let paths: Vec<&str> = ignored.iter().filter_map(|p| p.to_str()).collect();
-            cmd.env("MISE_IGNORED_CONFIG_PATHS", paths.join(":"));
-        }
-    }
-
     // When proxy is enabled, tell Node.js (bundled in Copilot CLI) to route
     // traffic through our CONNECT proxy. NODE_USE_ENV_PROXY is required for
     // Node.js ≥24.5.0 to honor HTTP_PROXY/HTTPS_PROXY natively.
-    // Both cases are set for compatibility with non-Node tools (curl, gh, etc).
     if let Some(port) = proxy_port {
         let proxy_url = format!("http://127.0.0.1:{port}");
         cmd.env("NODE_USE_ENV_PROXY", "1");
@@ -143,14 +108,16 @@ pub fn exec(
         cmd.env("http_proxy", &proxy_url);
         cmd.env("https_proxy", &proxy_url);
         // Exclude loopback from proxying — MCP servers, dev servers, etc.
-        // on localhost should connect directly, not through our CONNECT proxy.
         cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
         cmd.env("no_proxy", "localhost,127.0.0.1,::1");
     }
+}
 
-    // Child inherits our process group — terminal signals (Ctrl+C)
-    // reach both parent and child naturally. No setpgid/tcsetpgrp needed.
-    //
+/// Spawn a sandboxed command, forward signals, and wait for exit.
+///
+/// Handles SIGTTOU/SIGTTIN suppression (Node.js terminal raw mode),
+/// SIGTERM/SIGHUP forwarding to the child, and cleanup on exit.
+fn spawn_and_wait(cmd: &mut Command) -> u8 {
     // Ignore SIGTTOU/SIGTTIN — copilot (Node.js) may manipulate terminal
     // settings (raw mode), and when the child exits the terminal state can
     // cause these signals to be sent to us.
@@ -162,7 +129,7 @@ pub fn exec(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("\x1b[0;31m[cplt]\x1b[0m Failed to start sandbox-exec: {e}");
+            eprintln!("\x1b[0;31m[cplt]\x1b[0m Failed to start sandboxed process: {e}");
             return 1;
         }
     };
@@ -183,7 +150,6 @@ pub fn exec(
         }
     };
 
-    // Restore default signal handling
     unsafe {
         libc::signal(libc::SIGTTOU, libc::SIG_DFL);
         libc::signal(libc::SIGTTIN, libc::SIG_DFL);
@@ -206,7 +172,6 @@ fn install_signal_forwarding(child_pid: i32) {
                 libc::kill(pid, sig);
             }
         }
-        // Reset to default — second signal kills us immediately
         unsafe {
             libc::signal(sig, libc::SIG_DFL);
         }
@@ -224,122 +189,151 @@ fn install_signal_forwarding(child_pid: i32) {
     }
 }
 
-/// Execute copilot inside a Landlock + seccomp sandbox (Linux only).
+// ── macOS: Seatbelt / sandbox-exec ────────────────────────────
+
+/// Verify the SBPL profile works by running `/usr/bin/true` inside sandbox-exec.
+#[cfg(target_os = "macos")]
+pub fn preflight(sandbox: &super::PreparedSandbox) -> Result<(), String> {
+    let profile_path = write_temp_profile(&sandbox.profile_text)?;
+    let output = Command::new("sandbox-exec")
+        .arg("-f")
+        .arg(&profile_path)
+        .arg("/usr/bin/true")
+        .output()
+        .map_err(|e| format!("Failed to run sandbox-exec: {e}"));
+    let _ = std::fs::remove_file(&profile_path);
+
+    let output = output?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!(
+            "sandbox-exec exited with {}: {stderr}",
+            output.status
+        ))
+    }
+}
+
+/// Execute copilot inside the macOS Seatbelt sandbox.
 ///
-/// The sandbox is applied via a `pre_exec` hook that runs in the child
-/// process between fork() and exec(). This ensures only the child is
-/// restricted — the parent (cplt) keeps full access.
-///
-/// The pre_exec hook:
-/// 1. Applies the Landlock ruleset (filesystem + network restrictions)
-/// 2. Applies the seccomp filter (blocks dangerous syscalls)
-/// 3. Both are irreversible — the child cannot remove them
-#[cfg(target_os = "linux")]
-#[allow(clippy::too_many_arguments)]
-pub fn exec_linux(
+/// Writes the SBPL profile to a temp file, invokes `sandbox-exec`, and
+/// cleans up the profile file on exit.
+#[cfg(target_os = "macos")]
+pub fn exec(
+    sandbox: &super::PreparedSandbox,
     copilot_bin: &Path,
-    project_dir: &Path,
     copilot_args: &[String],
     extra_pass_env: &[String],
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
-    scratch_dir: Option<&Path>,
-    proxy_port: Option<u16>,
-    precomputed: &super::landlock_mod::PrecomputedSandbox,
 ) -> u8 {
-    use std::os::unix::process::CommandExt as _;
-
-    let mut cmd = std::process::Command::new(copilot_bin);
-
-    // Prevent Copilot from trying to auto-update inside the sandbox.
-    cmd.arg("--no-auto-update");
-
-    for arg in copilot_args {
-        cmd.arg(arg);
-    }
-
-    cmd.current_dir(project_dir);
-
-    // Build and apply environment (same as macOS path)
-    let parent_env: Vec<(String, String)> = std::env::vars().collect();
-    let sandbox_env = build_sandbox_env(
-        &parent_env,
-        extra_pass_env,
-        inherit_env,
-        disabled_categories,
-        scratch_dir,
-    );
-
-    if sandbox_env.clear_first {
-        cmd.env_clear();
-        for (key, val) in &sandbox_env.vars {
-            cmd.env(key, val);
-        }
-    } else {
-        for var in &sandbox_env.remove {
-            cmd.env_remove(var);
-        }
-        for (key, val) in &sandbox_env.vars {
-            cmd.env(key, val);
-        }
-    }
-
-    // Recursion guard
-    cmd.env("__CPLT_WRAPPED", "1");
-
-    // Proxy setup (same as macOS)
-    if let Some(port) = proxy_port {
-        let proxy_url = format!("http://127.0.0.1:{port}");
-        cmd.env("NODE_USE_ENV_PROXY", "1");
-        cmd.env("HTTP_PROXY", &proxy_url);
-        cmd.env("HTTPS_PROXY", &proxy_url);
-        cmd.env("http_proxy", &proxy_url);
-        cmd.env("https_proxy", &proxy_url);
-        cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
-        cmd.env("no_proxy", "localhost,127.0.0.1,::1");
-    }
-
-    // Terminal signal handling (same as macOS)
-    unsafe {
-        libc::signal(libc::SIGTTOU, libc::SIG_IGN);
-        libc::signal(libc::SIGTTIN, libc::SIG_IGN);
-    }
-
-    // Apply pre-computed sandbox in the child process, between fork and exec.
-    // All allocation and I/O was done in the parent — the closure only makes
-    // raw syscalls via the Landlock crate and prctl for seccomp.
-    let sandbox = precomputed.clone();
-    unsafe {
-        cmd.pre_exec(move || super::landlock_mod::apply_precomputed(&sandbox));
-    }
-
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
+    let profile_path = match write_temp_profile(&sandbox.profile_text) {
+        Ok(p) => p,
         Err(e) => {
-            eprintln!("\x1b[0;31m[cplt]\x1b[0m Failed to start sandboxed process: {e}");
+            eprintln!("\x1b[0;31m[cplt]\x1b[0m {e}");
             return 1;
         }
     };
 
-    let child_pid = child.id() as i32;
-    install_signal_forwarding(child_pid);
+    let mut cmd = Command::new("sandbox-exec");
+    cmd.arg("-f").arg(&profile_path).arg(copilot_bin);
 
-    let status = match child.wait() {
-        Ok(status) => status.code().unwrap_or(1) as u8,
-        Err(e) => {
-            eprintln!("\x1b[0;31m[cplt]\x1b[0m Error waiting for child: {e}");
-            unsafe {
-                libc::kill(child_pid, libc::SIGTERM);
-            }
-            1
-        }
-    };
+    configure_command(
+        &mut cmd,
+        copilot_args,
+        &sandbox.project_dir,
+        &sandbox.home_dir,
+        extra_pass_env,
+        inherit_env,
+        disabled_categories,
+        sandbox.scratch_dir.as_deref(),
+        sandbox.proxy_port,
+        sandbox.agent,
+    );
 
-    // Restore default signal handling
+    let exit_code = spawn_and_wait(&mut cmd);
+    let _ = std::fs::remove_file(&profile_path);
+    exit_code
+}
+
+/// Write SBPL profile text to a temp file with secure creation.
+///
+/// Uses O_CREAT|O_EXCL (create_new) to prevent symlink-following attacks,
+/// and mode 0600 to restrict read access.
+#[cfg(target_os = "macos")]
+fn write_temp_profile(profile_text: &str) -> Result<std::path::PathBuf, String> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let path = std::env::temp_dir().join(format!(
+        "cplt-{}-{}.sb",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|e| format!("Cannot create sandbox profile: {e}"))?;
+
+    file.write_all(profile_text.as_bytes()).map_err(|e| {
+        let _ = std::fs::remove_file(&path);
+        format!("Cannot write sandbox profile: {e}")
+    })?;
+
+    Ok(path)
+}
+
+// ── Linux: Landlock + seccomp ─────────────────────────────────
+
+/// Verify Landlock sandbox readiness (no-op: ABI already checked in prepare).
+#[cfg(target_os = "linux")]
+pub fn preflight(_sandbox: &super::PreparedSandbox) -> Result<(), String> {
+    Ok(())
+}
+
+/// Execute copilot inside a Landlock + seccomp sandbox.
+///
+/// The sandbox is applied via a `pre_exec` hook that runs in the child
+/// process between fork() and exec(). All allocation and I/O was done
+/// in the parent via `precompute()` — the hook only makes raw syscalls.
+#[cfg(target_os = "linux")]
+pub fn exec(
+    sandbox: &super::PreparedSandbox,
+    copilot_bin: &Path,
+    copilot_args: &[String],
+    extra_pass_env: &[String],
+    inherit_env: bool,
+    disabled_categories: &[HardeningCategory],
+) -> u8 {
+    use std::os::unix::process::CommandExt as _;
+
+    let mut cmd = Command::new(copilot_bin);
+
+    configure_command(
+        &mut cmd,
+        copilot_args,
+        &sandbox.project_dir,
+        &sandbox.home_dir,
+        extra_pass_env,
+        inherit_env,
+        disabled_categories,
+        sandbox.scratch_dir.as_deref(),
+        sandbox.proxy_port,
+        sandbox.agent,
+    );
+
+    // Apply pre-computed sandbox in the child process, between fork and exec.
+    let precomputed = sandbox.precomputed.clone();
     unsafe {
-        libc::signal(libc::SIGTTOU, libc::SIG_DFL);
-        libc::signal(libc::SIGTTIN, libc::SIG_DFL);
+        cmd.pre_exec(move || super::landlock_mod::apply_precomputed(&precomputed));
     }
 
-    status
+    spawn_and_wait(&mut cmd)
 }

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
+#[cfg(target_os = "macos")]
 use super::env::build_sandbox_env;
+#[cfg(target_os = "macos")]
 use super::policy::HardeningCategory;
 use crate::agent::Agent;
 
@@ -36,6 +38,7 @@ fn compute_mise_ignored_paths(project_dir: &Path, home: &Path) -> Vec<PathBuf> {
 }
 
 /// Validate the profile by running a simple command inside the sandbox.
+#[cfg(target_os = "macos")]
 pub fn validate(profile_path: &Path, _project_dir: &Path, _home_dir: &Path) -> Result<(), String> {
     let output = std::process::Command::new("sandbox-exec")
         .arg("-f")
@@ -63,6 +66,7 @@ pub fn validate(profile_path: &Path, _project_dir: &Path, _home_dir: &Path) -> R
 /// - Legacy (inherit_env=true): all env vars inherited, only SSH_AUTH_SOCK and
 ///   color vars are stripped. Use only when the default breaks something.
 /// - Security hardening env vars are injected unless their category is disabled.
+#[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 pub fn exec(
     copilot_bin: &Path,

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -89,7 +89,10 @@ fn configure_command(
     // Tell mise to ignore config files in ancestor directories that the sandbox blocks.
     let ignored = compute_mise_ignored_paths(project_dir, home_dir);
     if !ignored.is_empty() {
-        let paths: Vec<String> = ignored.iter().map(|p| p.to_string_lossy().into_owned()).collect();
+        let paths: Vec<String> = ignored
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
         cmd.env("MISE_IGNORED_CONFIG_PATHS", paths.join(":"));
     }
 

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -110,9 +110,15 @@ fn configure_command(
         cmd.env("HTTPS_PROXY", &proxy_url);
         cmd.env("http_proxy", &proxy_url);
         cmd.env("https_proxy", &proxy_url);
-        // Exclude loopback from proxying — MCP servers, dev servers, etc.
-        cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
-        cmd.env("no_proxy", "localhost,127.0.0.1,::1");
+        // On macOS, exclude loopback from proxying — Seatbelt enforces localhost
+        // isolation at the kernel level, and MCP servers/dev servers need direct access.
+        // On Linux, do NOT exclude localhost — the proxy is the only mechanism to
+        // mediate/deny loopback connections (Landlock cannot filter by IP).
+        #[cfg(target_os = "macos")]
+        {
+            cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
+            cmd.env("no_proxy", "localhost,127.0.0.1,::1");
+        }
     }
 }
 
@@ -333,6 +339,11 @@ pub fn exec(
     );
 
     // Apply pre-computed sandbox in the child process, between fork and exec.
+    // Safety: The proxy thread is running (multi-threaded at fork), making this
+    // technically not async-signal-safe. The Landlock crate performs small heap
+    // allocations internally. This works reliably in practice because the proxy
+    // thread is blocked in I/O syscalls during fork, minimizing allocator lock
+    // contention. See SECURITY.md "Pre-exec safety" for full analysis.
     let precomputed = sandbox.precomputed.clone();
     unsafe {
         cmd.pre_exec(move || super::landlock_mod::apply_precomputed(&precomputed));

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -221,3 +221,123 @@ fn install_signal_forwarding(child_pid: i32) {
         );
     }
 }
+
+/// Execute copilot inside a Landlock + seccomp sandbox (Linux only).
+///
+/// The sandbox is applied via a `pre_exec` hook that runs in the child
+/// process between fork() and exec(). This ensures only the child is
+/// restricted — the parent (cplt) keeps full access.
+///
+/// The pre_exec hook:
+/// 1. Applies the Landlock ruleset (filesystem + network restrictions)
+/// 2. Applies the seccomp filter (blocks dangerous syscalls)
+/// 3. Both are irreversible — the child cannot remove them
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+pub fn exec_linux(
+    copilot_bin: &Path,
+    project_dir: &Path,
+    copilot_args: &[String],
+    extra_pass_env: &[String],
+    inherit_env: bool,
+    disabled_categories: &[HardeningCategory],
+    scratch_dir: Option<&Path>,
+    proxy_port: Option<u16>,
+    precomputed: &super::landlock_mod::PrecomputedSandbox,
+) -> u8 {
+    use std::os::unix::process::CommandExt as _;
+
+    let mut cmd = std::process::Command::new(copilot_bin);
+
+    // Prevent Copilot from trying to auto-update inside the sandbox.
+    cmd.arg("--no-auto-update");
+
+    for arg in copilot_args {
+        cmd.arg(arg);
+    }
+
+    cmd.current_dir(project_dir);
+
+    // Build and apply environment (same as macOS path)
+    let parent_env: Vec<(String, String)> = std::env::vars().collect();
+    let sandbox_env = build_sandbox_env(
+        &parent_env,
+        extra_pass_env,
+        inherit_env,
+        disabled_categories,
+        scratch_dir,
+    );
+
+    if sandbox_env.clear_first {
+        cmd.env_clear();
+        for (key, val) in &sandbox_env.vars {
+            cmd.env(key, val);
+        }
+    } else {
+        for var in &sandbox_env.remove {
+            cmd.env_remove(var);
+        }
+        for (key, val) in &sandbox_env.vars {
+            cmd.env(key, val);
+        }
+    }
+
+    // Recursion guard
+    cmd.env("__CPLT_WRAPPED", "1");
+
+    // Proxy setup (same as macOS)
+    if let Some(port) = proxy_port {
+        let proxy_url = format!("http://127.0.0.1:{port}");
+        cmd.env("NODE_USE_ENV_PROXY", "1");
+        cmd.env("HTTP_PROXY", &proxy_url);
+        cmd.env("HTTPS_PROXY", &proxy_url);
+        cmd.env("http_proxy", &proxy_url);
+        cmd.env("https_proxy", &proxy_url);
+        cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
+        cmd.env("no_proxy", "localhost,127.0.0.1,::1");
+    }
+
+    // Terminal signal handling (same as macOS)
+    unsafe {
+        libc::signal(libc::SIGTTOU, libc::SIG_IGN);
+        libc::signal(libc::SIGTTIN, libc::SIG_IGN);
+    }
+
+    // Apply pre-computed sandbox in the child process, between fork and exec.
+    // All allocation and I/O was done in the parent — the closure only makes
+    // raw syscalls via the Landlock crate and prctl for seccomp.
+    let sandbox = precomputed.clone();
+    unsafe {
+        cmd.pre_exec(move || super::landlock_mod::apply_precomputed(&sandbox));
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("\x1b[0;31m[cplt]\x1b[0m Failed to start sandboxed process: {e}");
+            return 1;
+        }
+    };
+
+    let child_pid = child.id() as i32;
+    install_signal_forwarding(child_pid);
+
+    let status = match child.wait() {
+        Ok(status) => status.code().unwrap_or(1) as u8,
+        Err(e) => {
+            eprintln!("\x1b[0;31m[cplt]\x1b[0m Error waiting for child: {e}");
+            unsafe {
+                libc::kill(child_pid, libc::SIGTERM);
+            }
+            1
+        }
+    };
+
+    // Restore default signal handling
+    unsafe {
+        libc::signal(libc::SIGTTOU, libc::SIG_DFL);
+        libc::signal(libc::SIGTTIN, libc::SIG_DFL);
+    }
+
+    status
+}

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -903,8 +903,9 @@ fn apply_seccomp_filter(filter: &[BpfInstruction]) -> std::io::Result<()> {
 }
 
 /// Names of blocked syscalls for display/testing purposes.
-/// Matches the order in `apply_seccomp()`.
-pub const BLOCKED_SYSCALL_NAMES: &[&str] = &[
+/// Cross-architecture names only — x86_64-specific syscalls are appended
+/// via `blocked_syscall_names()` to match `build_seccomp_filter()`.
+const BLOCKED_SYSCALL_NAMES_COMMON: &[&str] = &[
     "ptrace",
     "mount",
     "umount2",
@@ -919,14 +920,22 @@ pub const BLOCKED_SYSCALL_NAMES: &[&str] = &[
     "reboot",
     "swapon",
     "swapoff",
-    "iopl",
-    "ioperm",
-    "modify_ldt",
     "personality",
     "keyctl",
     "request_key",
     "add_key",
 ];
+
+/// Return the full list of blocked syscall names for the current architecture.
+pub fn blocked_syscall_names() -> Vec<&'static str> {
+    #[allow(unused_mut)]
+    let mut names = BLOCKED_SYSCALL_NAMES_COMMON.to_vec();
+    #[cfg(target_arch = "x86_64")]
+    {
+        names.extend_from_slice(&["iopl", "ioperm", "modify_ldt"]);
+    }
+    names
+}
 
 // ── Tests (cross-platform) ─────────────────────────────────────
 
@@ -1349,9 +1358,11 @@ mod tests {
 
     #[test]
     fn blocked_syscall_names_not_empty() {
+        let names = blocked_syscall_names();
         assert!(
-            BLOCKED_SYSCALL_NAMES.len() >= 20,
-            "should block at least 20 dangerous syscalls"
+            names.len() >= 18,
+            "should block at least 18 dangerous syscalls, got {}",
+            names.len()
         );
     }
 

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -737,19 +737,19 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
     let ruleset = Ruleset::default()
         .handle_access(AccessFs::from_all(abi))
-        .map_err(|e| std::io::Error::other(e))?;
+        .map_err(std::io::Error::other)?;
 
     // Always handle ConnectTcp on ABI v4+ — even with empty rules this means
     // "deny all TCP connect" (deny-by-default for network).
     let ruleset = if abi_version >= 4 {
         ruleset
             .handle_access(AccessNet::ConnectTcp)
-            .map_err(|e| std::io::Error::other(e))?
+            .map_err(std::io::Error::other)?
     } else {
         ruleset
     };
 
-    let mut created = ruleset.create().map_err(|e| std::io::Error::other(e))?;
+    let mut created = ruleset.create().map_err(std::io::Error::other)?;
 
     // Add filesystem rules.
     for rule in &sandbox.policy.fs_rules {
@@ -782,7 +782,7 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         if let Ok(fd) = PathFd::new(&rule.path) {
             created = created
                 .add_rule(PathBeneath::new(fd, access))
-                .map_err(|e| std::io::Error::other(e))?;
+                .map_err(std::io::Error::other)?;
         }
     }
 
@@ -791,14 +791,12 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         for rule in &sandbox.policy.net_rules {
             created = created
                 .add_rule(NetPort::new(rule.port, AccessNet::ConnectTcp))
-                .map_err(|e| std::io::Error::other(e))?;
+                .map_err(std::io::Error::other)?;
         }
     }
 
     // Apply Landlock — this is irreversible.
-    let status = created
-        .restrict_self()
-        .map_err(|e| std::io::Error::other(e))?;
+    let status = created.restrict_self().map_err(std::io::Error::other)?;
 
     if status.ruleset == RulesetStatus::NotEnforced {
         return Err(std::io::Error::other(

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -66,11 +66,21 @@ pub struct LandlockPolicy {
 /// Everything here is computed in the parent (where allocation and I/O
 /// are safe). The `pre_exec` hook only receives this immutable data and
 /// makes raw syscalls — no allocation, no file I/O.
+///
+/// File descriptors in `pre_opened_fds` are opened with `O_PATH | O_CLOEXEC`
+/// in `precompute()`. They survive `fork()` and are used by
+/// `apply_precomputed()` via `BorrowedFd` — no `open()` or allocation
+/// in the async-signal-unsafe post-fork context.
 #[cfg(target_os = "linux")]
 #[derive(Clone)]
 pub struct PrecomputedSandbox {
     pub abi_version: u32,
-    pub policy: LandlockPolicy,
+    /// Pre-opened `O_PATH` file descriptors for Landlock filesystem rules.
+    /// Opened in `precompute()` (parent), used in `apply_precomputed()` (child).
+    /// Raw fds (i32) so the struct remains Clone-able. Closed on exec via
+    /// `O_CLOEXEC`; the parent leaks them (harmless — ~30 fds, program exits).
+    pub pre_opened_fds: Vec<(i32, FsAccess)>,
+    pub net_rules: Vec<NetRule>,
     pub seccomp_filter: Vec<BpfInstruction>,
 }
 
@@ -466,15 +476,23 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
     });
 
     // ── Network rules (requires ABI v4+, kernel 6.7+) ──
-    let mut net_rules = Vec::new();
-    if let Some(port) = config.proxy_port {
+    // Always allow HTTPS (443) — Copilot needs it to reach GitHub APIs.
+    // This mirrors the macOS SBPL profile which allows outbound 443.
+    let mut net_rules = vec![NetRule { port: 443 }];
+    if let Some(port) = config.proxy_port
+        && !net_rules.iter().any(|r| r.port == port)
+    {
         net_rules.push(NetRule { port });
     }
     for &port in config.extra_ports {
-        net_rules.push(NetRule { port });
+        if !net_rules.iter().any(|r| r.port == port) {
+            net_rules.push(NetRule { port });
+        }
     }
     for &port in config.localhost_ports {
-        net_rules.push(NetRule { port });
+        if !net_rules.iter().any(|r| r.port == port) {
+            net_rules.push(NetRule { port });
+        }
     }
 
     // Denied dotfiles and denied files are handled by simply NOT adding
@@ -613,10 +631,17 @@ pub fn check_availability() -> Result<u32, String> {
 /// issues when forking a multi-threaded process (the proxy thread may
 /// be running).
 ///
+/// File descriptors are opened here with `O_PATH | O_CLOEXEC`. The
+/// `CString` allocation for path conversion happens safely in the parent.
+/// The child's `pre_exec` hook receives only raw fd numbers.
+///
 /// Called once in `prepare()`. The returned `PrecomputedSandbox` is
 /// cloned into the `pre_exec` closure.
 #[cfg(target_os = "linux")]
 pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
     let abi_version = check_availability()?;
     let seccomp_filter = build_seccomp_filter();
 
@@ -627,9 +652,25 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
         );
     }
 
+    // Pre-open all filesystem paths in the parent process.
+    // This avoids CString allocation and open() calls in pre_exec.
+    let mut pre_opened_fds = Vec::new();
+    for rule in &policy.fs_rules {
+        let c_path = CString::new(rule.path.as_os_str().as_bytes())
+            .map_err(|_| format!("Path contains null byte: {}", rule.path.display()))?;
+        let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+        if fd >= 0 {
+            pre_opened_fds.push((fd, rule.access));
+        }
+        // Skip paths that don't exist (fd < 0) — the tool may not be installed.
+    }
+
+    let net_rules = policy.net_rules.clone();
+
     Ok(PrecomputedSandbox {
         abi_version,
-        policy,
+        pre_opened_fds,
+        net_rules,
         seccomp_filter,
     })
 }
@@ -669,10 +710,10 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
         BpfInstruction { code, jt, jf, k }
     }
 
-    // Blocked syscall numbers (x86_64).
-    // Privilege escalation and system modification syscalls
-    // that a sandboxed code assistant should never need.
-    let blocked: &[u32] = &[
+    // Blocked syscall numbers — privilege escalation and system modification
+    // syscalls that a sandboxed code assistant should never need.
+    // Cross-architecture: only common syscalls here.
+    let mut blocked: Vec<u32> = vec![
         libc::SYS_ptrace as u32,
         libc::SYS_mount as u32,
         libc::SYS_umount2 as u32,
@@ -687,14 +728,19 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
         libc::SYS_reboot as u32,
         libc::SYS_swapon as u32,
         libc::SYS_swapoff as u32,
-        libc::SYS_iopl as u32,
-        libc::SYS_ioperm as u32,
-        libc::SYS_modify_ldt as u32,
         libc::SYS_personality as u32,
         libc::SYS_keyctl as u32,
         libc::SYS_request_key as u32,
         libc::SYS_add_key as u32,
     ];
+
+    // x86_64-only syscalls — these don't exist on aarch64.
+    #[cfg(target_arch = "x86_64")]
+    {
+        blocked.push(libc::SYS_iopl as u32);
+        blocked.push(libc::SYS_ioperm as u32);
+        blocked.push(libc::SYS_modify_ldt as u32);
+    }
 
     let mut filter = Vec::with_capacity(blocked.len() * 2 + 2);
 
@@ -702,7 +748,7 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
     filter.push(stmt(BPF_LD | BPF_W | BPF_ABS, NR_OFFSET));
 
     // For each blocked syscall: compare and jump to EPERM if match
-    for &nr in blocked {
+    for &nr in &blocked {
         filter.push(jump(BPF_JMP | BPF_JEQ | BPF_K, nr, 0, 1));
         filter.push(stmt(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM_VAL));
     }
@@ -715,24 +761,36 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
 
 /// Apply the pre-computed sandbox to the current process.
 ///
-/// Called in the child's `pre_exec` hook — all data is pre-computed,
-/// so this function only makes raw syscalls (no allocation, no I/O).
+/// Called in the child's `pre_exec` hook. All file descriptors are
+/// pre-opened in the parent, and BPF instructions pre-built, so this
+/// function only makes syscalls (Landlock, prctl) — no allocation,
+/// no file I/O, no CString construction.
 ///
 /// # Safety context
 ///
 /// Safe for `pre_exec` because:
 /// - Landlock crate API internally uses only syscalls + stack structs
-/// - PathFd::new() is just open() (async-signal-safe)
+/// - File descriptors are pre-opened in parent (via `precompute()`)
+/// - `BorrowedFd::borrow_raw()` is zero-cost, no allocation
 /// - Seccomp filter is pre-built; only prctl() is called here
 /// - All error messages are static strings (no allocation)
 #[cfg(target_os = "linux")]
 pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
+    use std::os::fd::BorrowedFd;
+
     use landlock::{
-        ABI, Access, AccessFs, AccessNet, NetPort, PathBeneath, PathFd, Ruleset, RulesetAttr,
-        RulesetCreatedAttr, RulesetStatus,
+        ABI, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr, RulesetCreatedAttr,
+        RulesetStatus,
     };
 
-    let abi = ABI::V5;
+    // Map the detected kernel ABI to the landlock crate's ABI enum.
+    let abi = match sandbox.abi_version {
+        1 => ABI::V1,
+        2 => ABI::V2,
+        3 => ABI::V3,
+        4 => ABI::V4,
+        _ => ABI::V5,
+    };
     let abi_version = sandbox.abi_version;
 
     let ruleset = Ruleset::default()
@@ -751,15 +809,16 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
     let mut created = ruleset.create().map_err(std::io::Error::other)?;
 
-    // Add filesystem rules.
-    for rule in &sandbox.policy.fs_rules {
-        let mut access = if rule.access.read {
+    // Add filesystem rules using pre-opened file descriptors.
+    // No open() or CString allocation — just borrow the raw fd.
+    for &(raw_fd, access) in &sandbox.pre_opened_fds {
+        let mut access_flags = if access.read {
             AccessFs::ReadFile | AccessFs::ReadDir
         } else {
             landlock::BitFlags::EMPTY
         };
 
-        if rule.access.write {
+        if access.write {
             let mut write_flags = AccessFs::WriteFile
                 | AccessFs::RemoveDir
                 | AccessFs::RemoveFile
@@ -771,24 +830,24 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
             if abi_version >= 3 {
                 write_flags |= AccessFs::Truncate;
             }
-            access |= write_flags;
+            access_flags |= write_flags;
         }
 
-        if rule.access.execute {
-            access |= AccessFs::Execute;
+        if access.execute {
+            access_flags |= AccessFs::Execute;
         }
 
-        // Skip paths that don't exist — the tool may not be installed.
-        if let Ok(fd) = PathFd::new(&rule.path) {
-            created = created
-                .add_rule(PathBeneath::new(fd, access))
-                .map_err(std::io::Error::other)?;
-        }
+        // Safety: raw_fd was opened in precompute() and is still valid
+        // (O_CLOEXEC keeps it alive until exec, fork inherits it).
+        let fd = unsafe { BorrowedFd::borrow_raw(raw_fd) };
+        created = created
+            .add_rule(PathBeneath::new(fd, access_flags))
+            .map_err(std::io::Error::other)?;
     }
 
     // Add network rules (ABI v4+).
     if abi_version >= 4 {
-        for rule in &sandbox.policy.net_rules {
+        for rule in &sandbox.net_rules {
             created = created
                 .add_rule(NetPort::new(rule.port, AccessNet::ConnectTcp))
                 .map_err(std::io::Error::other)?;

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -779,8 +779,8 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     use std::os::fd::BorrowedFd;
 
     use landlock::{
-        ABI, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr, RulesetCreatedAttr,
-        RulesetStatus,
+        ABI, Access, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr,
+        RulesetCreatedAttr, RulesetStatus,
     };
 
     // Map the detected kernel ABI to the landlock crate's ABI enum.

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -1,0 +1,1334 @@
+//! Landlock LSM sandbox backend for Linux.
+//!
+//! # Cross-platform design
+//!
+//! This module is **always compiled** on all platforms. The rule generation
+//! and description logic is pure Rust with no kernel dependencies, enabling
+//! unit tests to run on macOS. Only the kernel application functions are
+//! behind `#[cfg(target_os = "linux")]`.
+//!
+//! # Security model differences from macOS (Seatbelt)
+//!
+//! Landlock is allowlist-only — it cannot deny access to subpaths within an
+//! allowed directory. On macOS, SBPL can deny `.env` reads and `.git/hooks`
+//! writes inside the project dir at the kernel level. On Linux, these
+//! protections come from the proxy layer (exfiltration blocking) and
+//! environment hardening (GIT_CONFIG overrides), not from filesystem rules.
+//!
+//! Landlock network rules (ABI v4+) are port-based, not address-based.
+//! The proxy handles domain-level filtering on both platforms.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use super::policy::{self, HomeToolDir};
+
+// ── Cross-platform types ───────────────────────────────────────
+
+/// Filesystem access flags for a Landlock rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FsAccess {
+    pub read: bool,
+    pub write: bool,
+    pub execute: bool,
+}
+
+/// A filesystem access rule: allow `access` on `path` and its subtree.
+///
+/// Landlock is deny-by-default — only paths with explicit rules are
+/// accessible. Sensitive paths (`.ssh`, `.gnupg`, etc.) are simply
+/// not added to the ruleset.
+#[derive(Debug, Clone)]
+pub struct FsRule {
+    pub path: PathBuf,
+    pub access: FsAccess,
+}
+
+/// TCP connect rule (requires Landlock ABI v4+, kernel 6.7+).
+#[derive(Debug, Clone, Copy)]
+pub struct NetRule {
+    pub port: u16,
+}
+
+/// Complete Landlock policy compiled from SandboxConfig.
+///
+/// This is a platform-agnostic description of what the Landlock ruleset
+/// will enforce. It's built by [`generate_policy()`] and applied by
+/// [`apply_policy()`] (Linux only).
+#[derive(Debug, Clone)]
+pub struct LandlockPolicy {
+    pub fs_rules: Vec<FsRule>,
+    pub net_rules: Vec<NetRule>,
+}
+
+/// Pre-computed data for sandbox application in the child process.
+///
+/// Everything here is computed in the parent (where allocation and I/O
+/// are safe). The `pre_exec` hook only receives this immutable data and
+/// makes raw syscalls — no allocation, no file I/O.
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+pub struct PrecomputedSandbox {
+    pub abi_version: u32,
+    pub policy: LandlockPolicy,
+    pub seccomp_filter: Vec<BpfInstruction>,
+}
+
+/// A single BPF instruction for the seccomp filter.
+///
+/// Pre-built in the parent, applied via prctl in the child.
+#[cfg(target_os = "linux")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct BpfInstruction {
+    pub code: u16,
+    pub jt: u8,
+    pub jf: u8,
+    pub k: u32,
+}
+
+// ── Linux-specific constants ───────────────────────────────────
+//
+// These mirror the macOS constants in sandbox_policy.rs but with
+// Linux-specific paths. Some duplication with macOS is intentional
+// to keep each platform's paths independent and auditable.
+
+/// System paths that need read access.
+/// Linux equivalent of macOS `SYSTEM_READ_FILES` in sandbox_policy.rs.
+const LINUX_SYSTEM_READ_PATHS: &[&str] = &[
+    "/etc/ssl",
+    "/etc/pki",             // RHEL/Fedora CA certificates
+    "/etc/ca-certificates", // Debian/Ubuntu CA certificates
+    "/etc/resolv.conf",
+    "/etc/hosts",
+    "/etc/nsswitch.conf", // Name service switch (DNS resolution)
+    "/etc/host.conf",     // Resolver configuration
+    "/etc/gai.conf",      // getaddrinfo configuration
+    "/etc/shells",
+    "/etc/passwd",
+    "/etc/localtime",
+    "/etc/ld.so.cache",
+    "/etc/ld.so.conf",
+    "/etc/ld.so.conf.d",
+    "/etc/zshrc",
+    "/etc/bashrc",
+    "/etc/bash.bashrc", // Debian/Ubuntu
+    "/etc/profile",
+    "/etc/profile.d",
+    "/etc/alternatives", // Debian alternatives system
+    "/etc/environment",
+    "/etc/default",
+    "/etc/security", // PAM config (read-only)
+];
+
+/// Tool directories with read + execute access.
+/// Linux equivalent of macOS `TOOL_READ_DIRS` in sandbox_policy.rs.
+const LINUX_TOOL_DIRS: &[&str] = &[
+    "/bin",
+    "/sbin",
+    "/usr/bin",
+    "/usr/sbin",
+    "/usr/lib",
+    "/usr/lib64",
+    "/usr/libexec",
+    "/usr/local",
+    "/usr/share",
+    "/lib",
+    "/lib64",
+    "/snap",               // Ubuntu Snap packages
+    "/run/current-system", // NixOS
+];
+
+/// Home tool directories for Linux.
+///
+/// Shares most entries with macOS HOME_TOOL_DIRS (in sandbox_policy.rs)
+/// but replaces macOS-specific `Library/Caches` and `Library/pnpm` with
+/// their Linux equivalents.
+const LINUX_HOME_TOOL_DIRS: &[HomeToolDir] = &[
+    // ── Shared with macOS (same paths, same permissions) ──
+    HomeToolDir {
+        path: ".local",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".mise",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".nvm",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".pyenv",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".cargo",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".rustup",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".sdkman",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: "go/bin",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".gradle",
+        process_exec: false,
+        map_exec: true,
+        write: true,
+    },
+    HomeToolDir {
+        path: ".m2",
+        process_exec: false,
+        map_exec: true,
+        write: true,
+    },
+    HomeToolDir {
+        path: ".konan",
+        process_exec: false,
+        map_exec: true,
+        write: true,
+    },
+    HomeToolDir {
+        path: "go/pkg",
+        process_exec: false,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".yarn",
+        process_exec: false,
+        map_exec: false,
+        write: true,
+    },
+    // ── Linux-specific (replaces macOS Library/* paths) ──
+    HomeToolDir {
+        path: ".cache",
+        process_exec: false,
+        map_exec: false,
+        write: true,
+    },
+    HomeToolDir {
+        path: ".local/share/pnpm",
+        process_exec: true,
+        map_exec: true,
+        write: true,
+    },
+    // ── Linux-only runtimes ──
+    HomeToolDir {
+        path: ".deno",
+        process_exec: true,
+        map_exec: true,
+        write: true,
+    },
+    HomeToolDir {
+        path: ".bun",
+        process_exec: true,
+        map_exec: true,
+        write: true,
+    },
+];
+
+/// Device and pseudo-filesystem paths that Node.js and common tools need.
+const DEVICE_FILES: &[&str] = &[
+    "/dev/null",
+    "/dev/urandom",
+    "/dev/zero",
+    "/dev/random",
+    "/dev/tty", // Terminal device (interactive tools)
+    "/dev/pts", // Pseudo-terminal devices
+    "/dev/shm", // POSIX shared memory (Node.js, Chromium)
+];
+
+// ── Policy generation (cross-platform, pure logic) ─────────────
+
+/// Generate a Landlock policy from a sandbox configuration.
+///
+/// This is pure logic with no kernel calls — it translates the
+/// platform-agnostic `SandboxConfig` into a set of `FsRule` and
+/// `NetRule` values that describe what the sandbox should allow.
+///
+/// Returns a `LandlockPolicy` that can be applied with `apply_policy()`
+/// on Linux, or described with `describe_policy()` on any platform.
+pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
+    let mut fs_rules = Vec::new();
+    let home = config.home_dir;
+
+    // ── Project directory: full access ──
+    fs_rules.push(FsRule {
+        path: config.project_dir.to_path_buf(),
+        access: FsAccess {
+            read: true,
+            write: true,
+            execute: true,
+        },
+    });
+
+    // ── System read paths ──
+    for &p in LINUX_SYSTEM_READ_PATHS {
+        fs_rules.push(FsRule {
+            path: PathBuf::from(p),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: false,
+            },
+        });
+    }
+
+    // ── Tool directories: read + execute ──
+    for &p in LINUX_TOOL_DIRS {
+        fs_rules.push(FsRule {
+            path: PathBuf::from(p),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: true,
+            },
+        });
+    }
+
+    // ── Home tool directories (filtered by discovery) ──
+    for dir in LINUX_HOME_TOOL_DIRS {
+        if should_include_tool_dir(dir, config) {
+            fs_rules.push(FsRule {
+                path: home.join(dir.path),
+                access: FsAccess {
+                    read: true,
+                    write: dir.write,
+                    execute: dir.process_exec || dir.map_exec,
+                },
+            });
+        }
+    }
+
+    // ── Copilot install directory: read + execute ──
+    if let Some(dir) = config.copilot_install_dir {
+        fs_rules.push(FsRule {
+            path: dir.to_path_buf(),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: true,
+            },
+        });
+    }
+
+    // ── Git hooks path: read + execute ──
+    if let Some(p) = config.git_hooks_path {
+        fs_rules.push(FsRule {
+            path: p.to_path_buf(),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: true,
+            },
+        });
+    }
+
+    // ── Scratch directory: read + write, execute only if allowed ──
+    if let Some(dir) = config.scratch_dir {
+        fs_rules.push(FsRule {
+            path: dir.to_path_buf(),
+            access: FsAccess {
+                read: true,
+                write: true,
+                execute: config.allow_tmp_exec,
+            },
+        });
+    }
+
+    // ── /tmp: read + write, execute only if explicitly allowed ──
+    fs_rules.push(FsRule {
+        path: PathBuf::from("/tmp"),
+        access: FsAccess {
+            read: true,
+            write: true,
+            execute: config.allow_tmp_exec,
+        },
+    });
+
+    // ── Device files: read + write (no execute) ──
+    for &dev in DEVICE_FILES {
+        fs_rules.push(FsRule {
+            path: PathBuf::from(dev),
+            access: FsAccess {
+                read: true,
+                write: true,
+                execute: false,
+            },
+        });
+    }
+
+    // ── /proc/self: Node.js reads /proc/self/exe, /proc/self/maps ──
+    fs_rules.push(FsRule {
+        path: PathBuf::from("/proc/self"),
+        access: FsAccess {
+            read: true,
+            write: false,
+            execute: false,
+        },
+    });
+
+    // ── Extra read paths from config ──
+    for p in config.extra_read {
+        fs_rules.push(FsRule {
+            path: p.clone(),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: false,
+            },
+        });
+    }
+
+    // ── Extra write paths from config ──
+    for p in config.extra_write {
+        fs_rules.push(FsRule {
+            path: p.clone(),
+            access: FsAccess {
+                read: true,
+                write: true,
+                execute: false,
+            },
+        });
+    }
+
+    // ── GPG signing files (read-only subset of ~/.gnupg) ──
+    if config.allow_gpg_signing {
+        for &file in policy::GPG_SIGNING_ALLOW_FILES {
+            fs_rules.push(FsRule {
+                path: home.join(".gnupg").join(file),
+                access: FsAccess {
+                    read: true,
+                    write: false,
+                    execute: false,
+                },
+            });
+        }
+        // gpg-agent and keyboxd sockets (read + write for IPC)
+        for socket in &["S.gpg-agent", "S.keyboxd"] {
+            fs_rules.push(FsRule {
+                path: home.join(".gnupg").join(socket),
+                access: FsAccess {
+                    read: true,
+                    write: true,
+                    execute: false,
+                },
+            });
+        }
+    }
+
+    // ── Home dir itself: read-only for dotfile enumeration ──
+    // Tools like Node.js resolve config by listing $HOME. Grant read
+    // on the home dir itself (not recursively — Landlock is per-dir).
+    fs_rules.push(FsRule {
+        path: home.to_path_buf(),
+        access: FsAccess {
+            read: true,
+            write: false,
+            execute: false,
+        },
+    });
+
+    // ── Copilot config dir: read + write ──
+    // Copilot stores auth tokens and config in ~/.copilot/
+    fs_rules.push(FsRule {
+        path: home.join(".copilot"),
+        access: FsAccess {
+            read: true,
+            write: true,
+            execute: false,
+        },
+    });
+
+    // ── Network rules (requires ABI v4+, kernel 6.7+) ──
+    let mut net_rules = Vec::new();
+    if let Some(port) = config.proxy_port {
+        net_rules.push(NetRule { port });
+    }
+    for &port in config.extra_ports {
+        net_rules.push(NetRule { port });
+    }
+    for &port in config.localhost_ports {
+        net_rules.push(NetRule { port });
+    }
+
+    // Denied dotfiles and denied files are handled by simply NOT adding
+    // them to the ruleset — Landlock is deny-by-default.
+    //
+    // Note: This means we cannot deny subpaths within an allowed tree
+    // (e.g. .env files inside the project dir). Those protections come
+    // from the proxy (blocks exfiltration) and env hardening (blocks
+    // hook injection). See module-level doc comment.
+
+    LandlockPolicy {
+        fs_rules,
+        net_rules,
+    }
+}
+
+/// Check if a home tool directory should be included based on discovery data.
+fn should_include_tool_dir(dir: &HomeToolDir, config: &super::SandboxConfig) -> bool {
+    match &config.existing_home_tool_dirs {
+        Some(existing) => existing.iter().any(|e| e == dir.path),
+        None => true,
+    }
+}
+
+/// Human-readable summary of the Landlock policy for `--print-profile`.
+pub fn describe_policy(policy: &LandlockPolicy) -> String {
+    let mut out = String::new();
+    out.push_str("# Landlock filesystem policy (deny-by-default)\n");
+    out.push_str("# Only listed paths are accessible. Everything else is denied.\n\n");
+
+    let mut full = Vec::new();
+    let mut read_exec = Vec::new();
+    let mut read_write = Vec::new();
+    let mut read_only = Vec::new();
+    let mut write_only = Vec::new();
+
+    for rule in &policy.fs_rules {
+        let a = &rule.access;
+        match (a.read, a.write, a.execute) {
+            (true, true, true) => full.push(&rule.path),
+            (true, false, true) => read_exec.push(&rule.path),
+            (true, true, false) => read_write.push(&rule.path),
+            (true, false, false) => read_only.push(&rule.path),
+            (false, true, false) => write_only.push(&rule.path),
+            _ => {} // other combinations are unusual
+        }
+    }
+
+    if !full.is_empty() {
+        out.push_str("## Full access (read + write + execute)\n");
+        for p in &full {
+            let _ = writeln!(out, "  {}", p.display());
+        }
+        out.push('\n');
+    }
+    if !read_exec.is_empty() {
+        out.push_str("## Read + execute\n");
+        for p in &read_exec {
+            let _ = writeln!(out, "  {}", p.display());
+        }
+        out.push('\n');
+    }
+    if !read_write.is_empty() {
+        out.push_str("## Read + write\n");
+        for p in &read_write {
+            let _ = writeln!(out, "  {}", p.display());
+        }
+        out.push('\n');
+    }
+    if !read_only.is_empty() {
+        out.push_str("## Read only\n");
+        for p in &read_only {
+            let _ = writeln!(out, "  {}", p.display());
+        }
+        out.push('\n');
+    }
+    if !write_only.is_empty() {
+        out.push_str("## Write only\n");
+        for p in &write_only {
+            let _ = writeln!(out, "  {}", p.display());
+        }
+        out.push('\n');
+    }
+
+    if !policy.net_rules.is_empty() {
+        out.push_str("## Network (TCP connect, requires kernel 6.7+ / ABI v4)\n");
+        for rule in &policy.net_rules {
+            let _ = writeln!(out, "  port {}", rule.port);
+        }
+        out.push('\n');
+    }
+
+    out.push_str("# Note: Landlock is allowlist-only. Paths not listed above are denied.\n");
+    out.push_str(
+        "# Intra-project deny rules (.env, .pem, .git/hooks) are enforced by\n\
+         # environment hardening and proxy filtering, not filesystem rules.\n",
+    );
+
+    out
+}
+
+// ── Linux-only: Landlock kernel application ────────────────────
+
+/// Check Landlock availability and return the ABI version.
+///
+/// Reads `/sys/kernel/security/landlock/abi_version` to determine
+/// which Landlock features the running kernel supports.
+///
+/// Called in the parent process during `prepare()` — never in `pre_exec`.
+#[cfg(target_os = "linux")]
+pub fn check_availability() -> Result<u32, String> {
+    match std::fs::read_to_string("/sys/kernel/security/landlock/abi_version") {
+        Ok(s) => {
+            let version: u32 = s
+                .trim()
+                .parse()
+                .map_err(|e| format!("Invalid Landlock ABI version: {e}"))?;
+            if version < 1 {
+                Err("Landlock ABI version 0 is not supported".to_string())
+            } else {
+                Ok(version)
+            }
+        }
+        Err(e) => Err(format!(
+            "Landlock is not available on this system: {e}\n\
+             Requires Linux 5.13+ with Landlock enabled in the kernel.\n\
+             Check: cat /sys/kernel/security/lsm (should include 'landlock')"
+        )),
+    }
+}
+
+/// Pre-compute all sandbox data in the parent process.
+///
+/// This does all I/O and allocation before fork(), so the `pre_exec`
+/// hook only needs to make raw syscalls. This avoids async-signal-safety
+/// issues when forking a multi-threaded process (the proxy thread may
+/// be running).
+///
+/// Called once in `prepare()`. The returned `PrecomputedSandbox` is
+/// cloned into the `pre_exec` closure.
+#[cfg(target_os = "linux")]
+pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> {
+    let abi_version = check_availability()?;
+    let seccomp_filter = build_seccomp_filter();
+
+    if abi_version < 4 {
+        eprintln!(
+            "\x1b[0;33m[cplt]\x1b[0m Landlock ABI v{abi_version} (kernel < 6.7): \
+             TCP port filtering unavailable. Network security provided by proxy only."
+        );
+    }
+
+    Ok(PrecomputedSandbox {
+        abi_version,
+        policy,
+        seccomp_filter,
+    })
+}
+
+/// Build the seccomp BPF filter program in the parent process.
+///
+/// Returns a Vec of BPF instructions ready to be passed to prctl()
+/// in the child. No allocation needed in pre_exec.
+#[cfg(target_os = "linux")]
+fn build_seccomp_filter() -> Vec<BpfInstruction> {
+    // BPF constants
+    const BPF_LD: u16 = 0x00;
+    const BPF_W: u16 = 0x00;
+    const BPF_ABS: u16 = 0x20;
+    const BPF_JMP: u16 = 0x05;
+    const BPF_JEQ: u16 = 0x10;
+    const BPF_K: u16 = 0x00;
+    const BPF_RET: u16 = 0x06;
+
+    const SECCOMP_RET_ALLOW: u32 = 0x7fff_0000;
+    const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
+    const EPERM_VAL: u32 = 1;
+
+    // Offset of `nr` field in seccomp_data struct
+    const NR_OFFSET: u32 = 0;
+
+    const fn stmt(code: u16, k: u32) -> BpfInstruction {
+        BpfInstruction {
+            code,
+            jt: 0,
+            jf: 0,
+            k,
+        }
+    }
+
+    const fn jump(code: u16, k: u32, jt: u8, jf: u8) -> BpfInstruction {
+        BpfInstruction { code, jt, jf, k }
+    }
+
+    // Blocked syscall numbers (x86_64).
+    // Privilege escalation and system modification syscalls
+    // that a sandboxed code assistant should never need.
+    let blocked: &[u32] = &[
+        libc::SYS_ptrace as u32,
+        libc::SYS_mount as u32,
+        libc::SYS_umount2 as u32,
+        libc::SYS_unshare as u32,
+        libc::SYS_setns as u32,
+        libc::SYS_pivot_root as u32,
+        libc::SYS_chroot as u32,
+        libc::SYS_kexec_load as u32,
+        libc::SYS_init_module as u32,
+        libc::SYS_finit_module as u32,
+        libc::SYS_delete_module as u32,
+        libc::SYS_reboot as u32,
+        libc::SYS_swapon as u32,
+        libc::SYS_swapoff as u32,
+        libc::SYS_iopl as u32,
+        libc::SYS_ioperm as u32,
+        libc::SYS_modify_ldt as u32,
+        libc::SYS_personality as u32,
+        libc::SYS_keyctl as u32,
+        libc::SYS_request_key as u32,
+        libc::SYS_add_key as u32,
+    ];
+
+    let mut filter = Vec::with_capacity(blocked.len() * 2 + 2);
+
+    // Load syscall number from seccomp_data.nr
+    filter.push(stmt(BPF_LD | BPF_W | BPF_ABS, NR_OFFSET));
+
+    // For each blocked syscall: compare and jump to EPERM if match
+    for &nr in blocked {
+        filter.push(jump(BPF_JMP | BPF_JEQ | BPF_K, nr, 0, 1));
+        filter.push(stmt(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM_VAL));
+    }
+
+    // Default: allow
+    filter.push(stmt(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
+
+    filter
+}
+
+/// Apply the pre-computed sandbox to the current process.
+///
+/// Called in the child's `pre_exec` hook — all data is pre-computed,
+/// so this function only makes raw syscalls (no allocation, no I/O).
+///
+/// # Safety context
+///
+/// Safe for `pre_exec` because:
+/// - Landlock crate API internally uses only syscalls + stack structs
+/// - PathFd::new() is just open() (async-signal-safe)
+/// - Seccomp filter is pre-built; only prctl() is called here
+/// - All error messages are static strings (no allocation)
+#[cfg(target_os = "linux")]
+pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
+    use landlock::{
+        ABI, Access, AccessFs, AccessNet, NetPort, PathBeneath, PathFd, Ruleset, RulesetAttr,
+        RulesetCreatedAttr, RulesetStatus,
+    };
+
+    let abi = ABI::V5;
+    let abi_version = sandbox.abi_version;
+
+    let mut ruleset = Ruleset::default()
+        .handle_access(AccessFs::from_all(abi))
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    // Always handle ConnectTcp on ABI v4+ — even with empty rules this means
+    // "deny all TCP connect" (deny-by-default for network).
+    if abi_version >= 4 {
+        ruleset
+            .handle_access(AccessNet::ConnectTcp)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    }
+
+    let mut created = ruleset
+        .create()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    // Add filesystem rules.
+    for rule in &sandbox.policy.fs_rules {
+        let mut access = if rule.access.read {
+            AccessFs::ReadFile | AccessFs::ReadDir
+        } else {
+            landlock::BitFlags::EMPTY
+        };
+
+        if rule.access.write {
+            let mut write_flags = AccessFs::WriteFile
+                | AccessFs::RemoveDir
+                | AccessFs::RemoveFile
+                | AccessFs::MakeDir
+                | AccessFs::MakeReg
+                | AccessFs::MakeSym
+                | AccessFs::MakeFifo
+                | AccessFs::MakeSock;
+            if abi_version >= 3 {
+                write_flags |= AccessFs::Truncate;
+            }
+            access |= write_flags;
+        }
+
+        if rule.access.execute {
+            access |= AccessFs::Execute;
+        }
+
+        // Skip paths that don't exist — the tool may not be installed.
+        if let Ok(fd) = PathFd::new(&rule.path) {
+            created
+                .add_rule(PathBeneath::new(fd, access))
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        }
+    }
+
+    // Add network rules (ABI v4+).
+    if abi_version >= 4 {
+        for rule in &sandbox.policy.net_rules {
+            created
+                .add_rule(NetPort::new(rule.port, AccessNet::ConnectTcp))
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        }
+    }
+
+    // Apply Landlock — this is irreversible.
+    let status = created
+        .restrict_self()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    if status.ruleset == RulesetStatus::NotEnforced {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Landlock rules were not enforced by the kernel",
+        ));
+    }
+
+    // Apply pre-built seccomp filter.
+    apply_seccomp_filter(&sandbox.seccomp_filter)?;
+
+    Ok(())
+}
+
+/// Apply a pre-built seccomp BPF filter via prctl.
+///
+/// The filter must be constructed by `build_seccomp_filter()` in the
+/// parent process. This function only makes one syscall.
+#[cfg(target_os = "linux")]
+fn apply_seccomp_filter(filter: &[BpfInstruction]) -> std::io::Result<()> {
+    #[repr(C)]
+    struct SockFprog {
+        len: libc::c_ushort,
+        filter: *const BpfInstruction,
+    }
+
+    let prog = SockFprog {
+        len: filter.len() as libc::c_ushort,
+        filter: filter.as_ptr(),
+    };
+
+    // PR_SET_NO_NEW_PRIVS is already set by Landlock's restrict_self().
+    let ret = unsafe {
+        libc::prctl(
+            libc::PR_SET_SECCOMP,
+            libc::SECCOMP_MODE_FILTER,
+            &prog as *const SockFprog,
+        )
+    };
+
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
+/// Names of blocked syscalls for display/testing purposes.
+/// Matches the order in `apply_seccomp()`.
+pub const BLOCKED_SYSCALL_NAMES: &[&str] = &[
+    "ptrace",
+    "mount",
+    "umount2",
+    "unshare",
+    "setns",
+    "pivot_root",
+    "chroot",
+    "kexec_load",
+    "init_module",
+    "finit_module",
+    "delete_module",
+    "reboot",
+    "swapon",
+    "swapoff",
+    "iopl",
+    "ioperm",
+    "modify_ldt",
+    "personality",
+    "keyctl",
+    "request_key",
+    "add_key",
+];
+
+// ── Tests (cross-platform) ─────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// Build a minimal SandboxConfig for testing.
+    fn test_config<'a>(
+        project_dir: &'a Path,
+        home_dir: &'a Path,
+    ) -> super::super::SandboxConfig<'a> {
+        super::super::SandboxConfig {
+            project_dir,
+            home_dir,
+            extra_read: &[],
+            extra_write: &[],
+            extra_deny: &[],
+            existing_home_tool_dirs: None,
+            extra_ports: &[],
+            localhost_ports: &[],
+            proxy_port: None,
+            allow_env_files: false,
+            allow_localhost_any: false,
+            scratch_dir: None,
+            allow_tmp_exec: false,
+            copilot_install_dir: None,
+            git_hooks_path: None,
+            allow_gpg_signing: false,
+            electron_app_dir: None,
+        }
+    }
+
+    #[test]
+    fn project_dir_gets_full_access() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == project)
+            .expect("project dir should be in rules");
+        assert!(rule.access.read);
+        assert!(rule.access.write);
+        assert!(rule.access.execute);
+    }
+
+    #[test]
+    fn denied_dotfiles_not_in_ruleset() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        for dotfile in policy::DENIED_DOTFILES {
+            let path = home.join(dotfile);
+            let found = policy.fs_rules.iter().any(|r| r.path == path);
+            assert!(!found, "denied dotfile {dotfile} should NOT be in ruleset");
+        }
+    }
+
+    #[test]
+    fn denied_files_not_in_ruleset() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        for file in policy::DENIED_FILES {
+            let path = home.join(file);
+            let found = policy.fs_rules.iter().any(|r| r.path == path);
+            assert!(!found, "denied file {file} should NOT be in ruleset");
+        }
+    }
+
+    #[test]
+    fn system_read_paths_are_readonly() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        for &p in LINUX_SYSTEM_READ_PATHS {
+            let rule = policy
+                .fs_rules
+                .iter()
+                .find(|r| r.path == Path::new(p))
+                .unwrap_or_else(|| panic!("system path {p} should be in rules"));
+            assert!(rule.access.read, "{p} should have read");
+            assert!(!rule.access.write, "{p} should NOT have write");
+            assert!(!rule.access.execute, "{p} should NOT have execute");
+        }
+    }
+
+    #[test]
+    fn tool_dirs_have_read_and_execute() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        for &p in LINUX_TOOL_DIRS {
+            let rule = policy
+                .fs_rules
+                .iter()
+                .find(|r| r.path == Path::new(p))
+                .unwrap_or_else(|| panic!("tool dir {p} should be in rules"));
+            assert!(rule.access.read, "{p} should have read");
+            assert!(!rule.access.write, "{p} should NOT have write");
+            assert!(rule.access.execute, "{p} should have execute");
+        }
+    }
+
+    #[test]
+    fn home_tool_dirs_permissions_match() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        for dir in LINUX_HOME_TOOL_DIRS {
+            let path = home.join(dir.path);
+            let rule = policy
+                .fs_rules
+                .iter()
+                .find(|r| r.path == path)
+                .unwrap_or_else(|| panic!("home tool dir {} should be in rules", dir.path));
+            assert!(rule.access.read, "{} should have read", dir.path);
+            assert_eq!(rule.access.write, dir.write, "{} write mismatch", dir.path);
+            assert_eq!(
+                rule.access.execute,
+                dir.process_exec || dir.map_exec,
+                "{} execute mismatch",
+                dir.path
+            );
+        }
+    }
+
+    #[test]
+    fn scratch_dir_gets_write_and_conditional_exec() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let scratch = PathBuf::from("/home/user/.cache/cplt/tmp/session-1");
+
+        let mut config = test_config(&project, &home);
+        config.scratch_dir = Some(&scratch);
+        config.allow_tmp_exec = false;
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == scratch)
+            .expect("scratch dir should be in rules");
+        assert!(rule.access.read);
+        assert!(rule.access.write);
+        assert!(
+            !rule.access.execute,
+            "exec should be off when allow_tmp_exec=false"
+        );
+
+        config.allow_tmp_exec = true;
+        let policy = generate_policy(&config);
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == scratch)
+            .expect("scratch dir should be in rules");
+        assert!(
+            rule.access.execute,
+            "exec should be on when allow_tmp_exec=true"
+        );
+    }
+
+    #[test]
+    fn extra_read_paths_added() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let extra = vec![PathBuf::from("/mnt/data")];
+        let mut config = test_config(&project, &home);
+        config.extra_read = &extra;
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == Path::new("/mnt/data"))
+            .expect("extra read path should be in rules");
+        assert!(rule.access.read);
+        assert!(!rule.access.write);
+        assert!(!rule.access.execute);
+    }
+
+    #[test]
+    fn extra_write_paths_added() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let extra = vec![PathBuf::from("/mnt/output")];
+        let mut config = test_config(&project, &home);
+        config.extra_write = &extra;
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == Path::new("/mnt/output"))
+            .expect("extra write path should be in rules");
+        assert!(rule.access.read);
+        assert!(rule.access.write);
+    }
+
+    #[test]
+    fn proxy_port_added_to_net_rules() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let mut config = test_config(&project, &home);
+        config.proxy_port = Some(8080);
+        let policy = generate_policy(&config);
+
+        assert!(policy.net_rules.iter().any(|r| r.port == 8080));
+    }
+
+    #[test]
+    fn extra_ports_added_to_net_rules() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let ports = vec![443, 8443];
+        let mut config = test_config(&project, &home);
+        config.extra_ports = &ports;
+        let policy = generate_policy(&config);
+
+        assert!(policy.net_rules.iter().any(|r| r.port == 443));
+        assert!(policy.net_rules.iter().any(|r| r.port == 8443));
+    }
+
+    #[test]
+    fn localhost_ports_in_net_rules() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let ports = vec![3000, 5173];
+        let mut config = test_config(&project, &home);
+        config.localhost_ports = &ports;
+        let policy = generate_policy(&config);
+
+        assert!(policy.net_rules.iter().any(|r| r.port == 3000));
+        assert!(policy.net_rules.iter().any(|r| r.port == 5173));
+    }
+
+    #[test]
+    fn discovery_filtering_limits_home_tool_dirs() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let existing = vec![".cargo".to_string(), ".nvm".to_string()];
+        let mut config = test_config(&project, &home);
+        config.existing_home_tool_dirs = Some(&existing);
+        let policy = generate_policy(&config);
+
+        // .cargo and .nvm should be present
+        assert!(
+            policy
+                .fs_rules
+                .iter()
+                .any(|r| r.path == home.join(".cargo"))
+        );
+        assert!(policy.fs_rules.iter().any(|r| r.path == home.join(".nvm")));
+
+        // .pyenv should NOT be present (not in discovery list)
+        assert!(
+            !policy
+                .fs_rules
+                .iter()
+                .any(|r| r.path == home.join(".pyenv"))
+        );
+    }
+
+    #[test]
+    fn gpg_signing_adds_specific_files() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let mut config = test_config(&project, &home);
+        config.allow_gpg_signing = true;
+        let policy = generate_policy(&config);
+
+        // Public key files should be read-only
+        let pubring = home.join(".gnupg/pubring.kbx");
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == pubring)
+            .expect("pubring.kbx should be in rules");
+        assert!(rule.access.read);
+        assert!(!rule.access.write);
+
+        // Agent socket should be read+write
+        let socket = home.join(".gnupg/S.gpg-agent");
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == socket)
+            .expect("gpg-agent socket should be in rules");
+        assert!(rule.access.read);
+        assert!(rule.access.write);
+    }
+
+    #[test]
+    fn gpg_signing_off_excludes_gnupg() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        let gnupg_rules: Vec<_> = policy
+            .fs_rules
+            .iter()
+            .filter(|r| r.path.starts_with(home.join(".gnupg")))
+            .collect();
+        assert!(
+            gnupg_rules.is_empty(),
+            "gnupg paths should not be in rules when gpg signing is off"
+        );
+    }
+
+    #[test]
+    fn copilot_install_dir_gets_read_exec() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let install_dir = PathBuf::from("/home/user/.cache/copilot/pkg/linux-x64");
+        let mut config = test_config(&project, &home);
+        config.copilot_install_dir = Some(&install_dir);
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == install_dir)
+            .expect("copilot install dir should be in rules");
+        assert!(rule.access.read);
+        assert!(!rule.access.write);
+        assert!(rule.access.execute);
+    }
+
+    #[test]
+    fn tmp_no_exec_by_default() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == Path::new("/tmp"))
+            .expect("/tmp should be in rules");
+        assert!(rule.access.read);
+        assert!(rule.access.write);
+        assert!(
+            !rule.access.execute,
+            "/tmp should not have execute by default"
+        );
+    }
+
+    #[test]
+    fn device_files_have_read_write() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        for &dev in DEVICE_FILES {
+            let rule = policy
+                .fs_rules
+                .iter()
+                .find(|r| r.path == Path::new(dev))
+                .unwrap_or_else(|| panic!("device {dev} should be in rules"));
+            assert!(rule.access.read, "{dev} should have read");
+            assert!(rule.access.write, "{dev} should have write");
+            assert!(!rule.access.execute, "{dev} should NOT have execute");
+        }
+    }
+
+    #[test]
+    fn proc_self_is_readonly() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == Path::new("/proc/self"))
+            .expect("/proc/self should be in rules");
+        assert!(rule.access.read);
+        assert!(!rule.access.write);
+        assert!(!rule.access.execute);
+    }
+
+    #[test]
+    fn describe_policy_includes_all_sections() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let mut config = test_config(&project, &home);
+        config.proxy_port = Some(8080);
+        let policy = generate_policy(&config);
+        let desc = describe_policy(&policy);
+
+        assert!(desc.contains("deny-by-default"));
+        assert!(desc.contains("Full access"));
+        assert!(desc.contains("/home/user/project"));
+        assert!(desc.contains("Read + execute"));
+        assert!(desc.contains("Read only"));
+        assert!(desc.contains("Network"));
+        assert!(desc.contains("port 8080"));
+        assert!(desc.contains("allowlist-only"));
+    }
+
+    #[test]
+    fn blocked_syscall_names_not_empty() {
+        assert!(
+            BLOCKED_SYSCALL_NAMES.len() >= 20,
+            "should block at least 20 dangerous syscalls"
+        );
+    }
+
+    #[test]
+    fn home_dir_itself_is_readable() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == home)
+            .expect("home dir should be in rules");
+        assert!(rule.access.read);
+        assert!(!rule.access.write);
+        assert!(!rule.access.execute);
+    }
+
+    #[test]
+    fn copilot_config_dir_is_writable() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let config = test_config(&project, &home);
+        let policy = generate_policy(&config);
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == home.join(".copilot"))
+            .expect(".copilot dir should be in rules");
+        assert!(rule.access.read);
+        assert!(rule.access.write);
+    }
+}

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -735,17 +735,19 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     let abi = ABI::V5;
     let abi_version = sandbox.abi_version;
 
-    let mut ruleset = Ruleset::default()
+    let ruleset = Ruleset::default()
         .handle_access(AccessFs::from_all(abi))
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     // Always handle ConnectTcp on ABI v4+ — even with empty rules this means
     // "deny all TCP connect" (deny-by-default for network).
-    if abi_version >= 4 {
+    let ruleset = if abi_version >= 4 {
         ruleset
             .handle_access(AccessNet::ConnectTcp)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    }
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+    } else {
+        ruleset
+    };
 
     let mut created = ruleset
         .create()
@@ -780,7 +782,7 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
         // Skip paths that don't exist — the tool may not be installed.
         if let Ok(fd) = PathFd::new(&rule.path) {
-            created
+            created = created
                 .add_rule(PathBeneath::new(fd, access))
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         }
@@ -789,7 +791,7 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     // Add network rules (ABI v4+).
     if abi_version >= 4 {
         for rule in &sandbox.policy.net_rules {
-            created
+            created = created
                 .add_rule(NetPort::new(rule.port, AccessNet::ConnectTcp))
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         }

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -144,7 +144,7 @@ const LINUX_TOOL_DIRS: &[&str] = &[
 /// Shares most entries with macOS HOME_TOOL_DIRS (in sandbox_policy.rs)
 /// but replaces macOS-specific `Library/Caches` and `Library/pnpm` with
 /// their Linux equivalents.
-const LINUX_HOME_TOOL_DIRS: &[HomeToolDir] = &[
+pub(crate) const LINUX_HOME_TOOL_DIRS: &[HomeToolDir] = &[
     // ── Shared with macOS (same paths, same permissions) ──
     HomeToolDir {
         path: ".local",

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -737,21 +737,19 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
     let ruleset = Ruleset::default()
         .handle_access(AccessFs::from_all(abi))
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(|e| std::io::Error::other(e))?;
 
     // Always handle ConnectTcp on ABI v4+ — even with empty rules this means
     // "deny all TCP connect" (deny-by-default for network).
     let ruleset = if abi_version >= 4 {
         ruleset
             .handle_access(AccessNet::ConnectTcp)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+            .map_err(|e| std::io::Error::other(e))?
     } else {
         ruleset
     };
 
-    let mut created = ruleset
-        .create()
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let mut created = ruleset.create().map_err(|e| std::io::Error::other(e))?;
 
     // Add filesystem rules.
     for rule in &sandbox.policy.fs_rules {
@@ -784,7 +782,7 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         if let Ok(fd) = PathFd::new(&rule.path) {
             created = created
                 .add_rule(PathBeneath::new(fd, access))
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(|e| std::io::Error::other(e))?;
         }
     }
 
@@ -793,18 +791,17 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         for rule in &sandbox.policy.net_rules {
             created = created
                 .add_rule(NetPort::new(rule.port, AccessNet::ConnectTcp))
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(|e| std::io::Error::other(e))?;
         }
     }
 
     // Apply Landlock — this is irreversible.
     let status = created
         .restrict_self()
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        .map_err(|e| std::io::Error::other(e))?;
 
     if status.ruleset == RulesetStatus::NotEnforced {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        return Err(std::io::Error::other(
             "Landlock rules were not enforced by the kernel",
         ));
     }

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -832,10 +832,19 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
 /// Called in the child's `pre_exec` hook. File descriptors are pre-opened
 /// and BPF instructions pre-built in the parent via `precompute()`.
 ///
-/// Note: The Landlock crate API does heap-allocate internally (Ruleset,
-/// add_rule, etc.). In practice this is safe because our fork happens
-/// before any proxy thread starts, so no mutex contention. The seccomp
-/// filter application is allocation-free (raw prctl syscall).
+/// # Safety (async-signal-safety)
+///
+/// The Landlock crate API does heap-allocate internally (Ruleset, add_rule,
+/// etc.). This runs after fork() in a multi-threaded process (the proxy
+/// thread is running). Strictly, heap allocation in pre_exec is not
+/// async-signal-safe. In practice this is safe because:
+/// 1. The proxy thread spends nearly all time blocked in I/O syscalls
+///    (epoll_wait/recv/send), not holding the allocator lock.
+/// 2. The Landlock allocations are small and fast (~microseconds).
+/// 3. This is the same risk profile as any Rust program using
+///    Command::spawn() with pre_exec in a multi-threaded context.
+///
+/// The seccomp filter application is allocation-free (raw prctl syscall).
 #[cfg(target_os = "linux")]
 pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     use std::os::fd::BorrowedFd;

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -265,10 +265,14 @@ pub(crate) const LINUX_HOME_TOOL_DIRS: &[HomeToolDir] = &[
     },
 ];
 
-/// Individual home config files that tools need read access to.
+/// Individual home config files (and select config directories) that tools
+/// need read access to.
 ///
-/// These are specific files, NOT directories — Landlock PathBeneath
-/// on a directory would grant recursive access to the entire subtree.
+/// File entries grant access to a single file. Directory entries (e.g.
+/// `.config/mise`) grant recursive read access to the subtree — this is
+/// acceptable because these directories contain only tool configuration,
+/// not secrets.
+///
 /// Mirrors the macOS SBPL literal file allows in `emit_system_access()`.
 const LINUX_HOME_CONFIG_FILES: &[&str] = &[
     // Git configuration
@@ -279,7 +283,7 @@ const LINUX_HOME_CONFIG_FILES: &[&str] = &[
     ".config/gh/config.yml",
     // Tool version managers
     ".tool-versions",
-    // mise config (tool versions, no secrets)
+    // mise config directory (tool versions, env settings — no secrets)
     ".config/mise",
     // Shell startup (tools source these for PATH)
     ".bashrc",
@@ -388,14 +392,17 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
         });
     }
 
-    // ── Scratch directory: read + write, execute only if allowed ──
+    // ── Scratch directory: read + write + execute (always) ──
+    // The scratch dir is the controlled alternative to /tmp for compile-then-exec
+    // workflows (e.g. node-gyp, cargo). Execute is always allowed here regardless
+    // of allow_tmp_exec, which controls only system temp dirs like /tmp.
     if let Some(dir) = config.scratch_dir {
         fs_rules.push(FsRule {
             path: dir.to_path_buf(),
             access: FsAccess {
                 read: true,
                 write: true,
-                execute: config.allow_tmp_exec,
+                execute: true,
             },
         });
     }
@@ -691,10 +698,20 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
     let seccomp_filter = build_seccomp_filter();
 
     if abi_version < 4 {
-        eprintln!(
-            "\x1b[0;33m[cplt]\x1b[0m Landlock ABI v{abi_version} (kernel < 6.7): \
-             TCP port filtering unavailable. Network security provided by proxy only."
-        );
+        // Check if proxy is configured (proxy_port would have been added to net_rules)
+        let has_proxy = policy.net_rules.iter().any(|r| r.port != 443);
+        if has_proxy {
+            eprintln!(
+                "\x1b[0;33m[cplt]\x1b[0m Landlock ABI v{abi_version} (kernel < 6.7): \
+                 TCP port filtering unavailable. Network security provided by proxy only."
+            );
+        } else {
+            eprintln!(
+                "\x1b[0;31m[cplt]\x1b[0m WARNING: Landlock ABI v{abi_version} (kernel < 6.7) \
+                 and no proxy configured — outbound network is UNRESTRICTED. \
+                 Use --with-proxy or upgrade to kernel 6.7+ for network isolation."
+            );
+        }
     }
 
     // Pre-open all filesystem paths in the parent process.
@@ -1170,11 +1187,14 @@ mod tests {
     }
 
     #[test]
-    fn scratch_dir_gets_write_and_conditional_exec() {
+    fn scratch_dir_always_has_exec() {
         let project = PathBuf::from("/home/user/project");
         let home = PathBuf::from("/home/user");
         let scratch = PathBuf::from("/home/user/.cache/cplt/tmp/session-1");
 
+        // Scratch dir should always have exec, regardless of allow_tmp_exec.
+        // The scratch dir is the controlled alternative to /tmp for
+        // compile-then-exec workflows (node-gyp, cargo).
         let mut config = test_config(&project, &home);
         config.scratch_dir = Some(&scratch);
         config.allow_tmp_exec = false;
@@ -1188,20 +1208,8 @@ mod tests {
         assert!(rule.access.read);
         assert!(rule.access.write);
         assert!(
-            !rule.access.execute,
-            "exec should be off when allow_tmp_exec=false"
-        );
-
-        config.allow_tmp_exec = true;
-        let policy = generate_policy(&config);
-        let rule = policy
-            .fs_rules
-            .iter()
-            .find(|r| r.path == scratch)
-            .expect("scratch dir should be in rules");
-        assert!(
             rule.access.execute,
-            "exec should be on when allow_tmp_exec=true"
+            "scratch dir should always have exec (independent of allow_tmp_exec)"
         );
     }
 

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -16,6 +16,9 @@
 //! environment hardening (GIT_CONFIG overrides), not from filesystem rules.
 //!
 //! Landlock network rules (ABI v4+) are port-based, not address-based.
+//! This means port 443 allows connecting to ANY host on that port, including
+//! localhost. On macOS, Seatbelt can deny localhost separately, but Landlock
+//! cannot. Use `--with-proxy` on Linux for localhost SSRF protection.
 //! The proxy handles domain-level filtering on both platforms.
 
 use std::fmt::Write as _;
@@ -262,6 +265,32 @@ pub(crate) const LINUX_HOME_TOOL_DIRS: &[HomeToolDir] = &[
     },
 ];
 
+/// Individual home config files that tools need read access to.
+///
+/// These are specific files, NOT directories — Landlock PathBeneath
+/// on a directory would grant recursive access to the entire subtree.
+/// Mirrors the macOS SBPL literal file allows in `emit_system_access()`.
+const LINUX_HOME_CONFIG_FILES: &[&str] = &[
+    // Git configuration
+    ".gitconfig",
+    ".config/git/config",
+    // GitHub CLI auth (specific files only)
+    ".config/gh/hosts.yml",
+    ".config/gh/config.yml",
+    // Tool version managers
+    ".tool-versions",
+    // mise config (tool versions, no secrets)
+    ".config/mise",
+    // Shell startup (tools source these for PATH)
+    ".bashrc",
+    ".zshrc",
+    ".profile",
+    ".bash_profile",
+    ".zprofile",
+    // Node.js REPL history
+    ".node_repl_history",
+];
+
 /// Device and pseudo-filesystem paths that Node.js and common tools need.
 const DEVICE_FILES: &[&str] = &[
     "/dev/null",
@@ -452,28 +481,44 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
         }
     }
 
-    // ── Home dir itself: read-only for dotfile enumeration ──
-    // Tools like Node.js resolve config by listing $HOME. Grant read
-    // on the home dir itself (not recursively — Landlock is per-dir).
-    fs_rules.push(FsRule {
-        path: home.to_path_buf(),
-        access: FsAccess {
-            read: true,
-            write: false,
-            execute: false,
-        },
-    });
+    // ── Home config files: individual read-only rules ──
+    // Landlock PathBeneath rules are always recursive — a rule on $HOME
+    // would grant read to the entire home tree including ~/.ssh, ~/.gnupg.
+    // Instead, enumerate the specific config files/dirs that tools need.
+    for &file in LINUX_HOME_CONFIG_FILES {
+        fs_rules.push(FsRule {
+            path: home.join(file),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: false,
+            },
+        });
+    }
 
-    // ── Copilot config dir: read + write ──
-    // Copilot stores auth tokens and config in ~/.copilot/
-    fs_rules.push(FsRule {
-        path: home.join(".copilot"),
-        access: FsAccess {
-            read: true,
-            write: true,
-            execute: false,
-        },
-    });
+    // ── Agent-specific directories ──
+    if config.agent.needs_copilot_dir() {
+        // Copilot config — auth tokens, settings, native modules.
+        // Execute needed for dlopen() of native .node addons (keytar, pty, computer).
+        fs_rules.push(FsRule {
+            path: home.join(".copilot"),
+            access: FsAccess {
+                read: true,
+                write: true,
+                execute: true,
+            },
+        });
+    }
+    for dir in config.agent_dirs {
+        fs_rules.push(FsRule {
+            path: dir.path.clone(),
+            access: FsAccess {
+                read: true,
+                write: dir.write,
+                execute: dir.process_exec || dir.map_exec,
+            },
+        });
+    }
 
     // ── Network rules (requires ABI v4+, kernel 6.7+) ──
     // Always allow HTTPS (443) — Copilot needs it to reach GitHub APIs.
@@ -679,6 +724,9 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
 ///
 /// Returns a Vec of BPF instructions ready to be passed to prctl()
 /// in the child. No allocation needed in pre_exec.
+///
+/// Security: The filter validates `seccomp_data.arch` first to prevent
+/// bypass via 32-bit compat syscall ABI (e.g. `int 0x80` on x86_64).
 #[cfg(target_os = "linux")]
 fn build_seccomp_filter() -> Vec<BpfInstruction> {
     // BPF constants
@@ -694,8 +742,15 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
     const SECCOMP_RET_ERRNO: u32 = 0x0005_0000;
     const EPERM_VAL: u32 = 1;
 
-    // Offset of `nr` field in seccomp_data struct
+    // seccomp_data field offsets
     const NR_OFFSET: u32 = 0;
+    const ARCH_OFFSET: u32 = 4;
+
+    // Expected architecture audit values
+    #[cfg(target_arch = "x86_64")]
+    const EXPECTED_ARCH: u32 = 0xC000_003E; // AUDIT_ARCH_X86_64
+    #[cfg(target_arch = "aarch64")]
+    const EXPECTED_ARCH: u32 = 0xC000_00B7; // AUDIT_ARCH_AARCH64
 
     const fn stmt(code: u16, k: u32) -> BpfInstruction {
         BpfInstruction {
@@ -712,9 +767,10 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
 
     // Blocked syscall numbers — privilege escalation and system modification
     // syscalls that a sandboxed code assistant should never need.
-    // Cross-architecture: only common syscalls here.
     let mut blocked: Vec<u32> = vec![
         libc::SYS_ptrace as u32,
+        libc::SYS_process_vm_readv as u32,
+        libc::SYS_process_vm_writev as u32,
         libc::SYS_mount as u32,
         libc::SYS_umount2 as u32,
         libc::SYS_unshare as u32,
@@ -732,6 +788,12 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
         libc::SYS_keyctl as u32,
         libc::SYS_request_key as u32,
         libc::SYS_add_key as u32,
+        libc::SYS_io_uring_setup as u32,
+        libc::SYS_io_uring_enter as u32,
+        libc::SYS_io_uring_register as u32,
+        libc::SYS_userfaultfd as u32,
+        libc::SYS_perf_event_open as u32,
+        libc::SYS_bpf as u32,
     ];
 
     // x86_64-only syscalls — these don't exist on aarch64.
@@ -742,9 +804,15 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
         blocked.push(libc::SYS_modify_ldt as u32);
     }
 
-    let mut filter = Vec::with_capacity(blocked.len() * 2 + 2);
+    let mut filter = Vec::with_capacity(blocked.len() * 2 + 4);
 
-    // Load syscall number from seccomp_data.nr
+    // Step 1: Validate architecture — prevent bypass via compat syscall ABI.
+    // If arch doesn't match, return EPERM for all syscalls.
+    filter.push(stmt(BPF_LD | BPF_W | BPF_ABS, ARCH_OFFSET));
+    filter.push(jump(BPF_JMP | BPF_JEQ | BPF_K, EXPECTED_ARCH, 1, 0));
+    filter.push(stmt(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM_VAL));
+
+    // Step 2: Load syscall number and check against blocklist.
     filter.push(stmt(BPF_LD | BPF_W | BPF_ABS, NR_OFFSET));
 
     // For each blocked syscall: compare and jump to EPERM if match
@@ -761,19 +829,13 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
 
 /// Apply the pre-computed sandbox to the current process.
 ///
-/// Called in the child's `pre_exec` hook. All file descriptors are
-/// pre-opened in the parent, and BPF instructions pre-built, so this
-/// function only makes syscalls (Landlock, prctl) — no allocation,
-/// no file I/O, no CString construction.
+/// Called in the child's `pre_exec` hook. File descriptors are pre-opened
+/// and BPF instructions pre-built in the parent via `precompute()`.
 ///
-/// # Safety context
-///
-/// Safe for `pre_exec` because:
-/// - Landlock crate API internally uses only syscalls + stack structs
-/// - File descriptors are pre-opened in parent (via `precompute()`)
-/// - `BorrowedFd::borrow_raw()` is zero-cost, no allocation
-/// - Seccomp filter is pre-built; only prctl() is called here
-/// - All error messages are static strings (no allocation)
+/// Note: The Landlock crate API does heap-allocate internally (Ruleset,
+/// add_rule, etc.). In practice this is safe because our fork happens
+/// before any proxy thread starts, so no mutex contention. The seccomp
+/// filter application is allocation-free (raw prctl syscall).
 #[cfg(target_os = "linux")]
 pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     use std::os::fd::BorrowedFd;
@@ -827,6 +889,12 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
                 | AccessFs::MakeSym
                 | AccessFs::MakeFifo
                 | AccessFs::MakeSock;
+            if abi_version >= 2 {
+                // Refer controls rename()/link() across different Landlock
+                // domains. Without it, build tools (cargo, git) that move
+                // files between directories would fail.
+                write_flags |= AccessFs::Refer;
+            }
             if abi_version >= 3 {
                 write_flags |= AccessFs::Truncate;
             }
@@ -907,6 +975,8 @@ fn apply_seccomp_filter(filter: &[BpfInstruction]) -> std::io::Result<()> {
 /// via `blocked_syscall_names()` to match `build_seccomp_filter()`.
 const BLOCKED_SYSCALL_NAMES_COMMON: &[&str] = &[
     "ptrace",
+    "process_vm_readv",
+    "process_vm_writev",
     "mount",
     "umount2",
     "unshare",
@@ -924,6 +994,12 @@ const BLOCKED_SYSCALL_NAMES_COMMON: &[&str] = &[
     "keyctl",
     "request_key",
     "add_key",
+    "io_uring_setup",
+    "io_uring_enter",
+    "io_uring_register",
+    "userfaultfd",
+    "perf_event_open",
+    "bpf",
 ];
 
 /// Return the full list of blocked syscall names for the current architecture.
@@ -1363,31 +1439,40 @@ mod tests {
     fn blocked_syscall_names_not_empty() {
         let names = blocked_syscall_names();
         assert!(
-            names.len() >= 18,
-            "should block at least 18 dangerous syscalls, got {}",
+            names.len() >= 26,
+            "should block at least 26 dangerous syscalls, got {}",
             names.len()
         );
     }
 
     #[test]
-    fn home_dir_itself_is_readable() {
+    fn home_config_files_are_readable() {
         let project = PathBuf::from("/home/user/project");
         let home = PathBuf::from("/home/user");
         let config = test_config(&project, &home);
         let policy = generate_policy(&config);
 
-        let rule = policy
-            .fs_rules
-            .iter()
-            .find(|r| r.path == home)
-            .expect("home dir should be in rules");
-        assert!(rule.access.read);
-        assert!(!rule.access.write);
-        assert!(!rule.access.execute);
+        for &file in LINUX_HOME_CONFIG_FILES {
+            let path = home.join(file);
+            let rule = policy
+                .fs_rules
+                .iter()
+                .find(|r| r.path == path)
+                .unwrap_or_else(|| panic!("home config file {file} should be in rules"));
+            assert!(rule.access.read, "{file} should have read");
+            assert!(!rule.access.write, "{file} should NOT have write");
+            assert!(!rule.access.execute, "{file} should NOT have execute");
+        }
+
+        // $HOME itself must NOT be in the ruleset (would grant recursive read)
+        assert!(
+            !policy.fs_rules.iter().any(|r| r.path == home),
+            "$HOME must not have a blanket rule (Landlock is recursive)"
+        );
     }
 
     #[test]
-    fn copilot_config_dir_is_writable() {
+    fn copilot_config_dir_is_writable_and_executable() {
         let project = PathBuf::from("/home/user/project");
         let home = PathBuf::from("/home/user");
         let config = test_config(&project, &home);
@@ -1400,5 +1485,70 @@ mod tests {
             .expect(".copilot dir should be in rules");
         assert!(rule.access.read);
         assert!(rule.access.write);
+        assert!(
+            rule.access.execute,
+            ".copilot needs execute for native .node module dlopen()"
+        );
+    }
+
+    #[test]
+    fn copilot_dir_absent_for_non_copilot_agent() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let mut config = test_config(&project, &home);
+        config.agent = crate::agent::Agent::OpenCode;
+        let policy = generate_policy(&config);
+
+        assert!(
+            !policy
+                .fs_rules
+                .iter()
+                .any(|r| r.path == home.join(".copilot")),
+            ".copilot should NOT be in rules for non-Copilot agent"
+        );
+    }
+
+    #[test]
+    fn agent_dirs_added_to_policy() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let agent_dirs = vec![
+            crate::agent::AgentDir {
+                path: home.join(".config/opencode"),
+                write: false,
+                map_exec: false,
+                process_exec: false,
+            },
+            crate::agent::AgentDir {
+                path: home.join(".local/share/opencode"),
+                write: true,
+                map_exec: false,
+                process_exec: false,
+            },
+        ];
+        let mut config = test_config(&project, &home);
+        config.agent = crate::agent::Agent::OpenCode;
+        config.agent_dirs = &agent_dirs;
+        let policy = generate_policy(&config);
+
+        let config_rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == home.join(".config/opencode"))
+            .expect("OpenCode config dir should be in rules");
+        assert!(config_rule.access.read);
+        assert!(!config_rule.access.write, "config dir should be read-only");
+
+        let data_rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == home.join(".local/share/opencode"))
+            .expect("OpenCode data dir should be in rules");
+        assert!(data_rule.access.read);
+        assert!(data_rule.access.write, "data dir should be writable");
+        assert!(
+            !data_rule.access.execute,
+            "data dir should NOT be executable"
+        );
     }
 }

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -1043,9 +1043,12 @@ mod tests {
             git_hooks_path: None,
             allow_gpg_signing: false,
             allow_jvm_attach: false,
+            allow_docker: false,
             electron_app_dir: None,
             agent: crate::agent::Agent::Copilot,
             agent_dirs: &[],
+            allow_cache_exec: &[],
+            allow_cache_exec_any: false,
         }
     }
 

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -966,7 +966,10 @@ mod tests {
             copilot_install_dir: None,
             git_hooks_path: None,
             allow_gpg_signing: false,
+            allow_jvm_attach: false,
             electron_app_dir: None,
+            agent: crate::agent::Agent::Copilot,
+            agent_dirs: &[],
         }
     }
 

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -441,6 +441,25 @@ pub const HOME_TOOL_DIRS: &[HomeToolDir] = &[
     },
 ];
 
+/// Return the platform-appropriate home tool directory list.
+///
+/// macOS uses `HOME_TOOL_DIRS` (includes `Library/Caches`, `Library/pnpm`).
+/// Linux uses `LINUX_HOME_TOOL_DIRS` (includes `.cache`, `.local/share/pnpm`).
+pub fn home_tool_dirs() -> &'static [HomeToolDir] {
+    #[cfg(target_os = "macos")]
+    {
+        HOME_TOOL_DIRS
+    }
+    #[cfg(target_os = "linux")]
+    {
+        super::landlock_mod::LINUX_HOME_TOOL_DIRS
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        HOME_TOOL_DIRS
+    }
+}
+
 /// Validate that a path is safe for interpolation into SBPL profile strings.
 /// Returns an error if the path contains characters that could break or inject SBPL rules.
 pub fn validate_sbpl_path(path: &Path) -> Result<(), String> {

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, SystemTime};
 const SCRATCH_BASE: &str = "Library/Caches/cplt/tmp";
 
 /// Base directory for scratch dirs, relative to $HOME.
-/// Follows XDG Base Directory spec (`$XDG_CACHE_HOME` defaults to `~/.cache`).
+/// Uses `~/.cache` (does not read `$XDG_CACHE_HOME` — sandbox env is filtered).
 #[cfg(not(target_os = "macos"))]
 const SCRATCH_BASE: &str = ".cache/cplt/tmp";
 

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -337,8 +337,8 @@ mod tests {
 
     #[test]
     fn scratch_dir_rejects_ancestor_symlink() {
-        // If ~/Library/Caches/cplt is a symlink to /tmp/evil, the scratch dir
-        // would escape into /tmp. The canonicalize + prefix check must catch this.
+        // If the scratch base ancestor is a symlink, the scratch dir
+        // would escape. The canonicalize + prefix check must catch this.
         let tmp = std::env::temp_dir().join("cplt-test-ancestor-symlink");
         let _ = std::fs::remove_dir_all(&tmp);
         let evil_target = tmp.join("evil-target");

--- a/src/update.rs
+++ b/src/update.rs
@@ -157,15 +157,10 @@ pub fn perform_update(tag: &str, current_version: &str) -> Result<String, String
         .map_err(|e| format!("Cannot determine current binary path: {e}"))?;
     let target_path = std::fs::canonicalize(&current_exe).unwrap_or(current_exe);
 
-    // 5. Stage: set permissions and sign BEFORE replacing
+    // 5. Stage: set permissions and platform-specific postprocessing
     eprintln!("  Preparing binary...");
     set_executable(&new_binary)?;
-    // xattr and codesign are macOS-specific (Gatekeeper requirements)
-    #[cfg(target_os = "macos")]
-    {
-        let _ = run_xattr(&new_binary);
-        let _ = run_codesign(&new_binary);
-    }
+    postprocess_binary(&new_binary);
 
     // 6. Atomic rename
     let staged = target_path.with_extension("new");
@@ -182,11 +177,7 @@ pub fn perform_update(tag: &str, current_version: &str) -> Result<String, String
 
     // Copy permissions/signing to staged location too
     set_executable(&staged)?;
-    #[cfg(target_os = "macos")]
-    {
-        let _ = run_xattr(&staged);
-        let _ = run_codesign(&staged);
-    }
+    postprocess_binary(&staged);
 
     std::fs::rename(&staged, &target_path).map_err(|e| {
         let _ = std::fs::remove_file(&staged);
@@ -402,19 +393,11 @@ fn curl_download(url: &str, dest: &Path, version: &str) -> Result<(), String> {
     }
 }
 
-/// Compute SHA256 hash of a file using /usr/bin/shasum.
+/// Compute SHA256 hash of a file using the platform's hash utility.
+///
+/// macOS uses `/usr/bin/shasum -a 256`, Linux uses `sha256sum`.
 fn compute_sha256(path: &Path) -> Result<String, String> {
-    #[cfg(target_os = "macos")]
-    let output = Command::new("/usr/bin/shasum")
-        .args(["-a", "256", &path.to_string_lossy()])
-        .output()
-        .map_err(|e| format!("Cannot run shasum: {e}"))?;
-
-    #[cfg(not(target_os = "macos"))]
-    let output = Command::new("sha256sum")
-        .arg(path.to_string_lossy().to_string())
-        .output()
-        .map_err(|e| format!("Cannot run sha256sum: {e}"))?;
+    let output = sha256_command(path)?;
 
     if !output.status.success() {
         return Err("SHA256 computation failed".to_string());
@@ -426,6 +409,22 @@ fn compute_sha256(path: &Path) -> Result<String, String> {
         .next()
         .map(|h| h.to_lowercase())
         .ok_or_else(|| "Cannot parse shasum output".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn sha256_command(path: &Path) -> Result<std::process::Output, String> {
+    Command::new("/usr/bin/shasum")
+        .args(["-a", "256", &path.to_string_lossy()])
+        .output()
+        .map_err(|e| format!("Cannot run shasum: {e}"))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn sha256_command(path: &Path) -> Result<std::process::Output, String> {
+    Command::new("sha256sum")
+        .arg(path.to_string_lossy().to_string())
+        .output()
+        .map_err(|e| format!("Cannot run sha256sum: {e}"))
 }
 
 /// Validate archive contents before extraction.
@@ -512,6 +511,22 @@ fn set_executable(path: &Path) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
         .map_err(|e| format!("Cannot set permissions: {e}"))
+}
+
+/// Apply platform-specific binary postprocessing after download.
+///
+/// On macOS, removes quarantine attributes and ad-hoc code signs the binary
+/// (required by Gatekeeper). On Linux, this is a no-op.
+fn postprocess_binary(path: &Path) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = run_xattr(path);
+        let _ = run_codesign(path);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = path;
+    }
 }
 
 /// Remove macOS quarantine extended attributes.

--- a/src/update.rs
+++ b/src/update.rs
@@ -412,7 +412,7 @@ fn compute_sha256(path: &Path) -> Result<String, String> {
 
     #[cfg(not(target_os = "macos"))]
     let output = Command::new("sha256sum")
-        .arg(&path.to_string_lossy().to_string())
+        .arg(path.to_string_lossy().to_string())
         .output()
         .map_err(|e| format!("Cannot run sha256sum: {e}"))?;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -160,9 +160,12 @@ pub fn perform_update(tag: &str, current_version: &str) -> Result<String, String
     // 5. Stage: set permissions and sign BEFORE replacing
     eprintln!("  Preparing binary...");
     set_executable(&new_binary)?;
-    // xattr and codesign are best-effort (may not be needed in all contexts)
-    let _ = run_xattr(&new_binary);
-    let _ = run_codesign(&new_binary);
+    // xattr and codesign are macOS-specific (Gatekeeper requirements)
+    #[cfg(target_os = "macos")]
+    {
+        let _ = run_xattr(&new_binary);
+        let _ = run_codesign(&new_binary);
+    }
 
     // 6. Atomic rename
     let staged = target_path.with_extension("new");
@@ -179,8 +182,11 @@ pub fn perform_update(tag: &str, current_version: &str) -> Result<String, String
 
     // Copy permissions/signing to staged location too
     set_executable(&staged)?;
-    let _ = run_xattr(&staged);
-    let _ = run_codesign(&staged);
+    #[cfg(target_os = "macos")]
+    {
+        let _ = run_xattr(&staged);
+        let _ = run_codesign(&staged);
+    }
 
     std::fs::rename(&staged, &target_path).map_err(|e| {
         let _ = std::fs::remove_file(&staged);
@@ -214,9 +220,20 @@ pub fn is_homebrew_managed() -> bool {
     }
 }
 
-/// Construct the asset filename for the current architecture.
+/// Construct the asset filename for the current platform and architecture.
 pub fn asset_name(arch: &str) -> String {
-    format!("cplt-{arch}-apple-darwin.tar.gz")
+    #[cfg(target_os = "macos")]
+    {
+        format!("cplt-{arch}-apple-darwin.tar.gz")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        format!("cplt-{arch}-unknown-linux-gnu.tar.gz")
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        format!("cplt-{arch}-apple-darwin.tar.gz")
+    }
 }
 
 /// Check if a string looks like a cplt version.
@@ -387,10 +404,17 @@ fn curl_download(url: &str, dest: &Path, version: &str) -> Result<(), String> {
 
 /// Compute SHA256 hash of a file using /usr/bin/shasum.
 fn compute_sha256(path: &Path) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
     let output = Command::new("/usr/bin/shasum")
         .args(["-a", "256", &path.to_string_lossy()])
         .output()
-        .map_err(|e| format!("Cannot run /usr/bin/shasum: {e}"))?;
+        .map_err(|e| format!("Cannot run shasum: {e}"))?;
+
+    #[cfg(not(target_os = "macos"))]
+    let output = Command::new("sha256sum")
+        .arg(&path.to_string_lossy().to_string())
+        .output()
+        .map_err(|e| format!("Cannot run sha256sum: {e}"))?;
 
     if !output.status.success() {
         return Err("SHA256 computation failed".to_string());
@@ -491,6 +515,8 @@ fn set_executable(path: &Path) -> Result<(), String> {
 }
 
 /// Remove macOS quarantine extended attributes.
+/// Remove quarantine attribute (macOS only — required for Gatekeeper).
+#[cfg(target_os = "macos")]
 fn run_xattr(path: &Path) -> Result<(), String> {
     let output = Command::new("/usr/bin/xattr")
         .args(["-cr", &path.to_string_lossy()])
@@ -504,7 +530,8 @@ fn run_xattr(path: &Path) -> Result<(), String> {
     }
 }
 
-/// Ad-hoc code sign the binary (required for macOS Gatekeeper).
+/// Ad-hoc code sign the binary (macOS only — required for Gatekeeper).
+#[cfg(target_os = "macos")]
 fn run_codesign(path: &Path) -> Result<(), String> {
     let output = Command::new("/usr/bin/codesign")
         .args(["--force", "--sign", "-", &path.to_string_lossy()])
@@ -657,13 +684,30 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn asset_name_aarch64() {
         assert_eq!(asset_name("aarch64"), "cplt-aarch64-apple-darwin.tar.gz");
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn asset_name_x86_64() {
         assert_eq!(asset_name("x86_64"), "cplt-x86_64-apple-darwin.tar.gz");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn asset_name_aarch64_linux() {
+        assert_eq!(
+            asset_name("aarch64"),
+            "cplt-aarch64-unknown-linux-gnu.tar.gz"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn asset_name_x86_64_linux() {
+        assert_eq!(asset_name("x86_64"), "cplt-x86_64-unknown-linux-gnu.tar.gz");
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -408,7 +408,7 @@ fn compute_sha256(path: &Path) -> Result<String, String> {
         .split_whitespace()
         .next()
         .map(|h| h.to_lowercase())
-        .ok_or_else(|| "Cannot parse shasum output".to_string())
+        .ok_or_else(|| "Cannot parse hash output".to_string())
 }
 
 #[cfg(target_os = "macos")]
@@ -421,7 +421,13 @@ fn sha256_command(path: &Path) -> Result<std::process::Output, String> {
 
 #[cfg(not(target_os = "macos"))]
 fn sha256_command(path: &Path) -> Result<std::process::Output, String> {
-    Command::new("sha256sum")
+    // Try /usr/bin/sha256sum first, fall back to PATH lookup.
+    let bin = if std::path::Path::new("/usr/bin/sha256sum").exists() {
+        "/usr/bin/sha256sum"
+    } else {
+        "sha256sum"
+    };
+    Command::new(bin)
         .arg(path.to_string_lossy().to_string())
         .output()
         .map_err(|e| format!("Cannot run sha256sum: {e}"))

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1,0 +1,503 @@
+//! Linux Landlock integration tests.
+//!
+//! These tests verify kernel-level enforcement of the Landlock sandbox.
+//! They ONLY run on Linux — skipped on macOS via `#[cfg(target_os = "linux")]`.
+//!
+//! Test tiers:
+//! - Filesystem enforcement (read, write, deny of sensitive paths)
+//! - Attack vector coverage (symlinks, hardlinks, rename across boundary)
+//! - Network port filtering (ABI v4+)
+//! - seccomp syscall blocking
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    // ── Landlock ABI detection ─────────────────────────────────────
+
+    fn landlock_abi_version() -> Option<u32> {
+        fs::read_to_string("/sys/kernel/security/landlock/abi_version")
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+    }
+
+    /// Skip guard — call at the top of tests that require Landlock.
+    macro_rules! require_landlock {
+        () => {
+            require_landlock!(1);
+        };
+        ($min_abi:expr) => {
+            match landlock_abi_version() {
+                Some(v) if v >= $min_abi => {}
+                Some(v) => {
+                    eprintln!("SKIPPED: need Landlock ABI v{}, have v{v}", $min_abi);
+                    return;
+                }
+                None => {
+                    eprintln!("SKIPPED: Landlock not available on this kernel");
+                    return;
+                }
+            }
+        };
+    }
+
+    // ── Test helpers ───────────────────────────────────────────────
+
+    /// Create a temporary project directory for testing.
+    fn create_test_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        fs::write(dir.path().join("test.txt"), "hello from project").unwrap();
+        dir
+    }
+
+    fn home_dir() -> PathBuf {
+        PathBuf::from(std::env::var("HOME").expect("HOME not set"))
+    }
+
+    /// Path to the built binary.
+    fn binary_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
+    }
+
+    /// Run a shell command inside the cplt sandbox and return (exit_code, stdout, stderr).
+    fn run_sandboxed(project_dir: &Path, script: &str) -> (i32, String, String) {
+        let output = Command::new(binary_path())
+            .args([
+                "--no-validate",
+                "--quiet",
+                "-C",
+                &project_dir.to_string_lossy(),
+                "--",
+                "sh",
+                "-c",
+                script,
+            ])
+            .env("HOME", home_dir())
+            .output()
+            .expect("Failed to execute cplt");
+
+        (
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        )
+    }
+
+    /// Run a shell command inside the sandbox with extra flags.
+    fn run_sandboxed_with_flags(
+        project_dir: &Path,
+        extra_flags: &[&str],
+        script: &str,
+    ) -> (i32, String, String) {
+        let dir_str = project_dir.to_string_lossy().into_owned();
+        let mut args: Vec<&str> = vec!["--no-validate", "--quiet", "-C", &dir_str];
+        args.extend_from_slice(extra_flags);
+        args.extend_from_slice(&["--", "sh", "-c", script]);
+
+        let output = Command::new(binary_path())
+            .args(&args)
+            .env("HOME", home_dir())
+            .output()
+            .expect("Failed to execute cplt");
+
+        (
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        )
+    }
+
+    // ── Filesystem enforcement tests ──────────────────────────────
+
+    #[test]
+    fn landlock_allows_project_file_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, stdout, _) = run_sandboxed(project.path(), "cat test.txt");
+        assert_eq!(code, 0, "Should be able to read project files");
+        assert!(stdout.contains("hello from project"));
+    }
+
+    #[test]
+    fn landlock_allows_project_file_write() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, _, _) = run_sandboxed(
+            project.path(),
+            "echo 'new content' > new_file.txt && cat new_file.txt",
+        );
+        assert_eq!(code, 0, "Should be able to write to project dir");
+    }
+
+    #[test]
+    fn landlock_blocks_ssh_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let ssh_dir = home_dir().join(".ssh");
+        if !ssh_dir.exists() {
+            fs::create_dir_all(&ssh_dir).ok();
+            fs::write(ssh_dir.join("test_key"), "secret").ok();
+        }
+        let (code, _, stderr) = run_sandboxed(project.path(), "cat ~/.ssh/test_key 2>&1 || true");
+        // Either the file doesn't exist or access is denied — both are acceptable
+        assert!(
+            code != 0 || stderr.contains("Permission denied") || stderr.contains("denied"),
+            "Should not be able to read ~/.ssh"
+        );
+    }
+
+    #[test]
+    fn landlock_blocks_aws_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let aws_dir = home_dir().join(".aws");
+        if !aws_dir.exists() {
+            eprintln!("SKIPPED: ~/.aws does not exist");
+            return;
+        }
+        let (code, stdout, _) = run_sandboxed(project.path(), "cat ~/.aws/credentials 2>&1");
+        assert!(
+            code != 0 || stdout.contains("Permission denied"),
+            "Should not be able to read ~/.aws/credentials"
+        );
+    }
+
+    #[test]
+    fn landlock_blocks_kube_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let kube_dir = home_dir().join(".kube");
+        if !kube_dir.exists() {
+            eprintln!("SKIPPED: ~/.kube does not exist");
+            return;
+        }
+        let (code, stdout, _) = run_sandboxed(project.path(), "cat ~/.kube/config 2>&1");
+        assert!(
+            code != 0 || stdout.contains("Permission denied"),
+            "Should not be able to read ~/.kube/config"
+        );
+    }
+
+    #[test]
+    fn landlock_blocks_docker_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let docker_dir = home_dir().join(".docker");
+        if !docker_dir.exists() {
+            eprintln!("SKIPPED: ~/.docker does not exist");
+            return;
+        }
+        let (code, stdout, _) = run_sandboxed(project.path(), "cat ~/.docker/config.json 2>&1");
+        assert!(
+            code != 0 || stdout.contains("Permission denied"),
+            "Should not be able to read ~/.docker/config.json"
+        );
+    }
+
+    #[test]
+    fn landlock_allows_system_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, _, _) = run_sandboxed(project.path(), "cat /etc/resolv.conf > /dev/null");
+        assert_eq!(code, 0, "Should be able to read system files");
+    }
+
+    #[test]
+    fn landlock_blocks_etc_write() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, _, _) =
+            run_sandboxed(project.path(), "echo 'evil' > /etc/cplt-test 2>/dev/null");
+        assert_ne!(code, 0, "Should not be able to write to /etc");
+    }
+
+    #[test]
+    fn landlock_allows_dev_null() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, _, _) = run_sandboxed(project.path(), "echo test > /dev/null");
+        assert_eq!(code, 0, "Should be able to write to /dev/null");
+    }
+
+    #[test]
+    fn landlock_allows_dev_urandom() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, _, _) = run_sandboxed(project.path(), "head -c 16 /dev/urandom > /dev/null");
+        assert_eq!(code, 0, "Should be able to read /dev/urandom");
+    }
+
+    #[test]
+    fn landlock_blocks_gnupg_read() {
+        require_landlock!();
+        let project = create_test_project();
+        let gnupg_dir = home_dir().join(".gnupg");
+        if !gnupg_dir.exists() {
+            eprintln!("SKIPPED: ~/.gnupg does not exist");
+            return;
+        }
+        let (code, stdout, _) = run_sandboxed(project.path(), "ls ~/.gnupg 2>&1");
+        assert!(
+            code != 0 || stdout.contains("Permission denied"),
+            "Should not be able to list ~/.gnupg"
+        );
+    }
+
+    // ── Attack vector tests ───────────────────────────────────────
+
+    #[test]
+    fn landlock_blocks_symlink_escape() {
+        require_landlock!();
+        let project = create_test_project();
+        // Create a symlink inside the project that points to a denied path
+        let (code, stdout, _) = run_sandboxed(
+            project.path(),
+            "ln -sf ~/.ssh/id_rsa symlink_test && cat symlink_test 2>&1",
+        );
+        assert!(
+            code != 0 || stdout.contains("Permission denied") || stdout.contains("No such file"),
+            "Should not be able to read denied paths via symlink"
+        );
+    }
+
+    #[test]
+    fn landlock_restriction_inherited_by_child() {
+        require_landlock!();
+        let project = create_test_project();
+        // Spawn a nested shell — restrictions should still apply
+        let (code, stdout, _) = run_sandboxed(
+            project.path(),
+            "bash -c 'bash -c \"cat ~/.ssh/id_rsa 2>&1\"'",
+        );
+        assert!(
+            code != 0 || stdout.contains("Permission denied") || stdout.contains("No such file"),
+            "Child processes should inherit sandbox restrictions"
+        );
+    }
+
+    #[test]
+    fn landlock_allows_scratch_dir_write() {
+        require_landlock!();
+        let project = create_test_project();
+        let (code, _, _) = run_sandboxed_with_flags(
+            project.path(),
+            &["--scratch-dir"],
+            "echo 'test' > \"$TMPDIR/test_file\" && cat \"$TMPDIR/test_file\"",
+        );
+        assert_eq!(code, 0, "Should be able to write to scratch dir");
+    }
+
+    #[test]
+    fn landlock_allows_scratch_dir_exec() {
+        require_landlock!();
+        let project = create_test_project();
+        let script = r#"
+            cat > "$TMPDIR/hello.sh" << 'EOF'
+#!/bin/sh
+echo "hello from scratch"
+EOF
+            chmod +x "$TMPDIR/hello.sh"
+            "$TMPDIR/hello.sh"
+        "#;
+        let (code, stdout, _) =
+            run_sandboxed_with_flags(project.path(), &["--scratch-dir"], script);
+        assert_eq!(code, 0, "Should be able to execute from scratch dir");
+        assert!(stdout.contains("hello from scratch"));
+    }
+
+    // ── seccomp enforcement tests ─────────────────────────────────
+
+    #[test]
+    fn seccomp_blocks_ptrace() {
+        require_landlock!();
+        let project = create_test_project();
+        // Try to ptrace ourselves — should fail with EPERM
+        let script = r#"
+            python3 -c "
+import ctypes, ctypes.util, errno, os, sys
+libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
+ret = libc.ptrace(0, 0, 0, 0)  # PTRACE_TRACEME
+err = ctypes.get_errno()
+if ret == -1 and err == errno.EPERM:
+    print('BLOCKED')
+    sys.exit(0)
+else:
+    print(f'ALLOWED ret={ret} errno={err}')
+    sys.exit(1)
+" 2>/dev/null || echo "BLOCKED"
+        "#;
+        let (code, stdout, _) = run_sandboxed(project.path(), script);
+        assert!(
+            stdout.contains("BLOCKED"),
+            "seccomp should block ptrace: code={code}, stdout={stdout}"
+        );
+    }
+
+    #[test]
+    fn seccomp_allows_normal_operations() {
+        require_landlock!();
+        let project = create_test_project();
+        // Normal operations should work fine
+        let (code, _, _) = run_sandboxed(
+            project.path(),
+            "echo test > output.txt && cat output.txt && rm output.txt",
+        );
+        assert_eq!(code, 0, "Normal read/write/fork/exec should work");
+    }
+
+    // ── Network tests (ABI v4+) ───────────────────────────────────
+
+    #[test]
+    fn landlock_blocks_outbound_tcp() {
+        require_landlock!(4);
+        let project = create_test_project();
+        // Try to connect to a random port — should fail
+        let (code, _, _) = run_sandboxed(
+            project.path(),
+            "bash -c 'echo > /dev/tcp/127.0.0.1/12345' 2>/dev/null",
+        );
+        assert_ne!(code, 0, "Outbound TCP to arbitrary port should be blocked");
+    }
+
+    // ── E2E binary tests ──────────────────────────────────────────
+
+    #[test]
+    fn binary_shows_help() {
+        let output = Command::new(binary_path())
+            .arg("--help")
+            .output()
+            .expect("Failed to run cplt --help");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("sandbox") || stdout.contains("cplt"));
+    }
+
+    #[test]
+    fn binary_shows_version() {
+        let output = Command::new(binary_path())
+            .arg("--version")
+            .output()
+            .expect("Failed to run cplt --version");
+        assert!(output.status.success());
+    }
+
+    #[test]
+    fn binary_print_profile_shows_landlock() {
+        require_landlock!();
+        let project = create_test_project();
+        let output = Command::new(binary_path())
+            .args(["--print-profile", "-C", &project.path().to_string_lossy()])
+            .env("HOME", home_dir())
+            .output()
+            .expect("Failed to run cplt --print-profile");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("Landlock") || stdout.contains("landlock"),
+            "Print profile should mention Landlock on Linux"
+        );
+    }
+
+    // ── E2E project workflow tests ────────────────────────────────
+
+    #[test]
+    fn project_git_workflow() {
+        require_landlock!();
+        let project = create_test_project();
+        let script = r#"
+            git init . &&
+            git config user.email "test@test.com" &&
+            git config user.name "Test" &&
+            echo "hello" > file.txt &&
+            git add file.txt &&
+            git -c commit.gpgSign=false commit -m "init" &&
+            git log --oneline
+        "#;
+        let (code, stdout, _) = run_sandboxed(project.path(), script);
+        assert_eq!(code, 0, "Git workflow should work inside sandbox");
+        assert!(stdout.contains("init"));
+    }
+
+    #[test]
+    fn project_env_vars_sanitized() {
+        require_landlock!();
+        let project = create_test_project();
+        // Set a dangerous env var and verify it's stripped
+        let output = Command::new(binary_path())
+            .args([
+                "--no-validate",
+                "--quiet",
+                "-C",
+                &project.path().to_string_lossy(),
+                "--",
+                "sh",
+                "-c",
+                "echo \"AWS=$AWS_SECRET_ACCESS_KEY\"",
+            ])
+            .env("HOME", home_dir())
+            .env("AWS_SECRET_ACCESS_KEY", "super-secret-key")
+            .output()
+            .expect("Failed to execute cplt");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("super-secret-key"),
+            "AWS_SECRET_ACCESS_KEY should be stripped from env"
+        );
+    }
+
+    #[test]
+    fn project_home_secrets_blocked() {
+        require_landlock!();
+        let project = create_test_project();
+        // Try to read various sensitive paths
+        let script = r#"
+            fail=0
+            for path in ~/.ssh ~/.gnupg ~/.aws ~/.azure ~/.kube ~/.docker ~/.nais; do
+                if [ -d "$path" ] && ls "$path" 2>/dev/null; then
+                    echo "FAIL: could list $path"
+                    fail=1
+                fi
+            done
+            exit $fail
+        "#;
+        let (code, _, _) = run_sandboxed(project.path(), script);
+        // If all paths don't exist, that's also fine (code 0 means none were accessible)
+        assert_eq!(
+            code, 0,
+            "Should not be able to list sensitive home directories"
+        );
+    }
+
+    #[test]
+    fn project_dotenv_blocked_by_default() {
+        require_landlock!();
+        let project = create_test_project();
+        // Create .env files and verify they can't be read
+        fs::write(project.path().join(".env"), "SECRET=value").unwrap();
+        fs::write(project.path().join(".env.local"), "LOCAL_SECRET=value").unwrap();
+
+        let (code, stdout, _) = run_sandboxed(project.path(), "cat .env 2>&1");
+        assert!(
+            code != 0 || stdout.contains("Permission denied"),
+            ".env should be blocked by default"
+        );
+    }
+
+    #[test]
+    fn project_cache_dir_writable() {
+        require_landlock!();
+        let project = create_test_project();
+        let cache_dir = home_dir().join(".cache");
+        if !cache_dir.exists() {
+            fs::create_dir_all(&cache_dir).ok();
+        }
+        let (code, _, _) = run_sandboxed(
+            project.path(),
+            "mkdir -p ~/.cache/cplt-test && echo ok > ~/.cache/cplt-test/probe && rm -rf ~/.cache/cplt-test",
+        );
+        assert_eq!(code, 0, "~/.cache should be writable");
+    }
+}

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -140,11 +140,14 @@ mod linux_tests {
             fs::create_dir_all(&ssh_dir).ok();
             fs::write(ssh_dir.join("test_key"), "secret").ok();
         }
-        let (code, _, stderr) = run_sandboxed(project.path(), "cat ~/.ssh/test_key 2>&1 || true");
-        // Either the file doesn't exist or access is denied — both are acceptable
+        let (code, stdout, stderr) =
+            run_sandboxed(project.path(), "cat ~/.ssh/test_key 2>&1 || true");
+        // With 2>&1, the denial message goes to stdout. code is 0 due to || true.
         assert!(
-            code != 0 || stderr.contains("Permission denied") || stderr.contains("denied"),
-            "Should not be able to read ~/.ssh"
+            stdout.contains("Permission denied")
+                || stdout.contains("denied")
+                || stdout.contains("No such file"),
+            "Should not be able to read ~/.ssh — stdout: {stdout}, stderr: {stderr}"
         );
     }
 
@@ -471,17 +474,23 @@ else:
     }
 
     #[test]
-    fn project_dotenv_blocked_by_default() {
+    fn project_dotenv_readable_in_allowed_tree() {
         require_landlock!();
         let project = create_test_project();
-        // Create .env files and verify they can't be read
+        // Landlock cannot deny subpaths within an allowed directory.
+        // On Linux, .env files inside the project tree remain readable.
+        // Protection comes from the proxy (blocks exfiltration) and
+        // env hardening (blocks hook injection), not filesystem rules.
         fs::write(project.path().join(".env"), "SECRET=value").unwrap();
-        fs::write(project.path().join(".env.local"), "LOCAL_SECRET=value").unwrap();
 
-        let (code, stdout, _) = run_sandboxed(project.path(), "cat .env 2>&1");
+        let (code, stdout, _) = run_sandboxed(project.path(), "cat .env");
+        assert_eq!(
+            code, 0,
+            ".env inside the allowed project tree is readable on Linux (Landlock limitation)"
+        );
         assert!(
-            code != 0 || stdout.contains("Permission denied"),
-            ".env should be blocked by default"
+            stdout.contains("SECRET=value"),
+            "Expected to read .env contents from the allowed project tree"
         );
     }
 

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -140,7 +140,7 @@ mod linux_tests {
             fs::create_dir_all(&ssh_dir).ok();
             fs::write(ssh_dir.join("test_key"), "secret").ok();
         }
-        let (code, stdout, stderr) =
+        let (_code, stdout, stderr) =
             run_sandboxed(project.path(), "cat ~/.ssh/test_key 2>&1 || true");
         // With 2>&1, the denial message goes to stdout. code is 0 due to || true.
         assert!(

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -135,19 +135,33 @@ mod linux_tests {
     fn landlock_blocks_ssh_read() {
         require_landlock!();
         let project = create_test_project();
-        let ssh_dir = home_dir().join(".ssh");
-        if !ssh_dir.exists() {
-            fs::create_dir_all(&ssh_dir).ok();
-            fs::write(ssh_dir.join("test_key"), "secret").ok();
-        }
-        let (_code, stdout, stderr) =
-            run_sandboxed(project.path(), "cat ~/.ssh/test_key 2>&1 || true");
-        // With 2>&1, the denial message goes to stdout. code is 0 due to || true.
+        // Create a temp dir to use as HOME with a .ssh directory,
+        // ensuring the test is hermetic and doesn't touch the real $HOME.
+        let fake_home = tempfile::tempdir().expect("Failed to create temp home");
+        let ssh_dir = fake_home.path().join(".ssh");
+        fs::create_dir_all(&ssh_dir).unwrap();
+        fs::write(ssh_dir.join("test_key"), "secret").unwrap();
+
+        let output = Command::new(binary_path())
+            .args([
+                "--no-validate",
+                "--quiet",
+                "-C",
+                &project.path().to_string_lossy(),
+                "--",
+                "sh",
+                "-c",
+                "cat ~/.ssh/test_key 2>&1",
+            ])
+            .env("HOME", fake_home.path())
+            .output()
+            .expect("Failed to execute cplt");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let code = output.status.code().unwrap_or(-1);
         assert!(
-            stdout.contains("Permission denied")
-                || stdout.contains("denied")
-                || stdout.contains("No such file"),
-            "Should not be able to read ~/.ssh — stdout: {stdout}, stderr: {stderr}"
+            code != 0 || stdout.contains("Permission denied"),
+            "Should not be able to read ~/.ssh — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -254,14 +268,33 @@ mod linux_tests {
     fn landlock_blocks_symlink_escape() {
         require_landlock!();
         let project = create_test_project();
-        // Create a symlink inside the project that points to a denied path
-        let (code, stdout, _) = run_sandboxed(
-            project.path(),
-            "ln -sf ~/.ssh/id_rsa symlink_test && cat symlink_test 2>&1",
-        );
+        // Use a fake HOME with a real .ssh/test_key file to ensure
+        // "No such file" isn't masking a missing target.
+        let fake_home = tempfile::tempdir().expect("Failed to create temp home");
+        let ssh_dir = fake_home.path().join(".ssh");
+        fs::create_dir_all(&ssh_dir).unwrap();
+        fs::write(ssh_dir.join("test_key"), "secret_key_data").unwrap();
+
+        let output = Command::new(binary_path())
+            .args([
+                "--no-validate",
+                "--quiet",
+                "-C",
+                &project.path().to_string_lossy(),
+                "--",
+                "sh",
+                "-c",
+                "ln -sf ~/.ssh/test_key symlink_test && cat symlink_test 2>&1",
+            ])
+            .env("HOME", fake_home.path())
+            .output()
+            .expect("Failed to execute cplt");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let code = output.status.code().unwrap_or(-1);
         assert!(
-            code != 0 || stdout.contains("Permission denied") || stdout.contains("No such file"),
-            "Should not be able to read denied paths via symlink"
+            code != 0 || stdout.contains("Permission denied"),
+            "Should not be able to read denied paths via symlink — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -269,14 +302,32 @@ mod linux_tests {
     fn landlock_restriction_inherited_by_child() {
         require_landlock!();
         let project = create_test_project();
-        // Spawn a nested shell — restrictions should still apply
-        let (code, stdout, _) = run_sandboxed(
-            project.path(),
-            "bash -c 'bash -c \"cat ~/.ssh/id_rsa 2>&1\"'",
-        );
+        // Use a fake HOME with a real .ssh/test_key to confirm enforcement.
+        let fake_home = tempfile::tempdir().expect("Failed to create temp home");
+        let ssh_dir = fake_home.path().join(".ssh");
+        fs::create_dir_all(&ssh_dir).unwrap();
+        fs::write(ssh_dir.join("test_key"), "secret_key_data").unwrap();
+
+        let output = Command::new(binary_path())
+            .args([
+                "--no-validate",
+                "--quiet",
+                "-C",
+                &project.path().to_string_lossy(),
+                "--",
+                "sh",
+                "-c",
+                "bash -c 'bash -c \"cat ~/.ssh/test_key 2>&1\"'",
+            ])
+            .env("HOME", fake_home.path())
+            .output()
+            .expect("Failed to execute cplt");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let code = output.status.code().unwrap_or(-1);
         assert!(
-            code != 0 || stdout.contains("Permission denied") || stdout.contains("No such file"),
-            "Child processes should inherit sandbox restrictions"
+            code != 0 || stdout.contains("Permission denied"),
+            "Child processes should inherit sandbox restrictions — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -316,6 +367,18 @@ EOF
     fn seccomp_blocks_ptrace() {
         require_landlock!();
         let project = create_test_project();
+
+        // Skip if python3 is not available — can't test ptrace without it.
+        let has_python = Command::new("python3")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !has_python {
+            eprintln!("SKIPPED: python3 not available for ptrace test");
+            return;
+        }
+
         // Try to ptrace ourselves — should fail with EPERM
         let script = r#"
             python3 -c "
@@ -329,7 +392,7 @@ if ret == -1 and err == errno.EPERM:
 else:
     print(f'ALLOWED ret={ret} errno={err}')
     sys.exit(1)
-" 2>/dev/null || echo "BLOCKED"
+"
         "#;
         let (code, stdout, _) = run_sandboxed(project.path(), script);
         assert!(

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -12,7 +12,6 @@
 #[cfg(target_os = "linux")]
 mod linux_tests {
     use std::fs;
-    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::Command;
 

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -517,22 +517,46 @@ else:
     fn project_home_secrets_blocked() {
         require_landlock!();
         let project = create_test_project();
-        // Try to read various sensitive paths
+        // Create a hermetic fake HOME with sensitive directories populated.
+        // This ensures the test doesn't pass vacuously when dirs don't exist.
+        let fake_home = tempfile::tempdir().expect("Failed to create temp home");
+        for dir in &[".ssh", ".gnupg", ".aws", ".azure", ".kube", ".docker"] {
+            let path = fake_home.path().join(dir);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("secret"), "sensitive-data").unwrap();
+        }
+
         let script = r#"
             fail=0
-            for path in ~/.ssh ~/.gnupg ~/.aws ~/.azure ~/.kube ~/.docker ~/.nais; do
-                if [ -d "$path" ] && ls "$path" 2>/dev/null; then
-                    echo "FAIL: could list $path"
+            for path in ~/.ssh ~/.gnupg ~/.aws ~/.azure ~/.kube ~/.docker; do
+                if cat "$path/secret" 2>/dev/null; then
+                    echo "FAIL: could read $path/secret"
                     fail=1
                 fi
             done
             exit $fail
         "#;
-        let (code, _, _) = run_sandboxed(project.path(), script);
-        // If all paths don't exist, that's also fine (code 0 means none were accessible)
+
+        let output = Command::new(binary_path())
+            .args([
+                "--no-validate",
+                "--quiet",
+                "-C",
+                &project.path().to_string_lossy(),
+                "--",
+                "sh",
+                "-c",
+                script,
+            ])
+            .env("HOME", fake_home.path())
+            .output()
+            .expect("Failed to execute cplt");
+
+        let code = output.status.code().unwrap_or(-1);
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert_eq!(
             code, 0,
-            "Should not be able to list sensitive home directories"
+            "Should not be able to read sensitive home directories — stdout: {stdout}"
         );
     }
 

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -65,12 +65,14 @@ mod linux_tests {
     fn run_sandboxed(project_dir: &Path, script: &str) -> (i32, String, String) {
         let output = Command::new(binary_path())
             .args([
+                "--yes",
                 "--no-validate",
                 "--quiet",
+                "--agent",
+                "shell",
                 "-C",
                 &project_dir.to_string_lossy(),
                 "--",
-                "sh",
                 "-c",
                 script,
             ])
@@ -92,9 +94,17 @@ mod linux_tests {
         script: &str,
     ) -> (i32, String, String) {
         let dir_str = project_dir.to_string_lossy().into_owned();
-        let mut args: Vec<&str> = vec!["--no-validate", "--quiet", "-C", &dir_str];
+        let mut args: Vec<&str> = vec![
+            "--yes",
+            "--no-validate",
+            "--quiet",
+            "--agent",
+            "shell",
+            "-C",
+            &dir_str,
+        ];
         args.extend_from_slice(extra_flags);
-        args.extend_from_slice(&["--", "sh", "-c", script]);
+        args.extend_from_slice(&["--", "-c", script]);
 
         let output = Command::new(binary_path())
             .args(&args)
@@ -144,12 +154,14 @@ mod linux_tests {
 
         let output = Command::new(binary_path())
             .args([
+                "--yes",
                 "--no-validate",
                 "--quiet",
+                "--agent",
+                "shell",
                 "-C",
                 &project.path().to_string_lossy(),
                 "--",
-                "sh",
                 "-c",
                 "cat ~/.ssh/test_key 2>&1",
             ])
@@ -277,12 +289,14 @@ mod linux_tests {
 
         let output = Command::new(binary_path())
             .args([
+                "--yes",
                 "--no-validate",
                 "--quiet",
+                "--agent",
+                "shell",
                 "-C",
                 &project.path().to_string_lossy(),
                 "--",
-                "sh",
                 "-c",
                 "ln -sf ~/.ssh/test_key symlink_test && cat symlink_test 2>&1",
             ])
@@ -310,12 +324,14 @@ mod linux_tests {
 
         let output = Command::new(binary_path())
             .args([
+                "--yes",
                 "--no-validate",
                 "--quiet",
+                "--agent",
+                "shell",
                 "-C",
                 &project.path().to_string_lossy(),
                 "--",
-                "sh",
                 "-c",
                 "bash -c 'bash -c \"cat ~/.ssh/test_key 2>&1\"'",
             ])
@@ -492,12 +508,14 @@ else:
         // Set a dangerous env var and verify it's stripped
         let output = Command::new(binary_path())
             .args([
+                "--yes",
                 "--no-validate",
                 "--quiet",
+                "--agent",
+                "shell",
                 "-C",
                 &project.path().to_string_lossy(),
                 "--",
-                "sh",
                 "-c",
                 "echo \"AWS=$AWS_SECRET_ACCESS_KEY\"",
             ])
@@ -539,12 +557,14 @@ else:
 
         let output = Command::new(binary_path())
             .args([
+                "--yes",
                 "--no-validate",
                 "--quiet",
+                "--agent",
+                "shell",
                 "-C",
                 &project.path().to_string_lossy(),
                 "--",
-                "sh",
                 "-c",
                 script,
             ])

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -121,6 +121,61 @@ mod linux_tests {
 
     // ── Filesystem enforcement tests ──────────────────────────────
 
+    /// Run a shell command inside the sandbox with a custom HOME directory.
+    fn run_sandboxed_home(project_dir: &Path, home: &Path, script: &str) -> (i32, String, String) {
+        let output = Command::new(binary_path())
+            .args([
+                "--yes",
+                "--no-validate",
+                "--quiet",
+                "--agent",
+                "shell",
+                "-C",
+                &project_dir.to_string_lossy(),
+                "--",
+                "-c",
+                script,
+            ])
+            .env("HOME", home)
+            .output()
+            .expect("Failed to execute cplt");
+
+        (
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        )
+    }
+
+    /// Create a fake HOME with populated sensitive directories for hermetic testing.
+    fn create_fake_home_with_secrets() -> tempfile::TempDir {
+        let fake_home = tempfile::tempdir().expect("Failed to create temp home");
+        for dir in &[".ssh", ".gnupg", ".aws", ".azure", ".kube", ".docker"] {
+            let path = fake_home.path().join(dir);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("secret"), "sensitive-data").unwrap();
+        }
+        // Create specific credential files that tests check
+        fs::write(
+            fake_home.path().join(".aws/credentials"),
+            "[default]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n",
+        )
+        .unwrap();
+        fs::write(
+            fake_home.path().join(".kube/config"),
+            "apiVersion: v1\nclusters:\n- cluster:\n    server: https://k8s.example.com\n",
+        )
+        .unwrap();
+        fs::write(
+            fake_home.path().join(".docker/config.json"),
+            r#"{"auths":{"registry.example.com":{"auth":"dGVzdDp0ZXN0"}}}"#,
+        )
+        .unwrap();
+        // Also create .cache for cache-writable tests
+        fs::create_dir_all(fake_home.path().join(".cache")).unwrap();
+        fake_home
+    }
+
     #[test]
     fn landlock_allows_project_file_read() {
         require_landlock!();
@@ -181,15 +236,15 @@ mod linux_tests {
     fn landlock_blocks_aws_read() {
         require_landlock!();
         let project = create_test_project();
-        let aws_dir = home_dir().join(".aws");
-        if !aws_dir.exists() {
-            eprintln!("SKIPPED: ~/.aws does not exist");
-            return;
-        }
-        let (code, stdout, _) = run_sandboxed(project.path(), "cat ~/.aws/credentials 2>&1");
+        let fake_home = create_fake_home_with_secrets();
+        let (code, stdout, _) = run_sandboxed_home(
+            project.path(),
+            fake_home.path(),
+            "cat ~/.aws/credentials 2>&1",
+        );
         assert!(
             code != 0 || stdout.contains("Permission denied"),
-            "Should not be able to read ~/.aws/credentials"
+            "Should not be able to read ~/.aws/credentials — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -197,15 +252,12 @@ mod linux_tests {
     fn landlock_blocks_kube_read() {
         require_landlock!();
         let project = create_test_project();
-        let kube_dir = home_dir().join(".kube");
-        if !kube_dir.exists() {
-            eprintln!("SKIPPED: ~/.kube does not exist");
-            return;
-        }
-        let (code, stdout, _) = run_sandboxed(project.path(), "cat ~/.kube/config 2>&1");
+        let fake_home = create_fake_home_with_secrets();
+        let (code, stdout, _) =
+            run_sandboxed_home(project.path(), fake_home.path(), "cat ~/.kube/config 2>&1");
         assert!(
             code != 0 || stdout.contains("Permission denied"),
-            "Should not be able to read ~/.kube/config"
+            "Should not be able to read ~/.kube/config — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -213,15 +265,15 @@ mod linux_tests {
     fn landlock_blocks_docker_read() {
         require_landlock!();
         let project = create_test_project();
-        let docker_dir = home_dir().join(".docker");
-        if !docker_dir.exists() {
-            eprintln!("SKIPPED: ~/.docker does not exist");
-            return;
-        }
-        let (code, stdout, _) = run_sandboxed(project.path(), "cat ~/.docker/config.json 2>&1");
+        let fake_home = create_fake_home_with_secrets();
+        let (code, stdout, _) = run_sandboxed_home(
+            project.path(),
+            fake_home.path(),
+            "cat ~/.docker/config.json 2>&1",
+        );
         assert!(
             code != 0 || stdout.contains("Permission denied"),
-            "Should not be able to read ~/.docker/config.json"
+            "Should not be able to read ~/.docker/config.json — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -262,15 +314,12 @@ mod linux_tests {
     fn landlock_blocks_gnupg_read() {
         require_landlock!();
         let project = create_test_project();
-        let gnupg_dir = home_dir().join(".gnupg");
-        if !gnupg_dir.exists() {
-            eprintln!("SKIPPED: ~/.gnupg does not exist");
-            return;
-        }
-        let (code, stdout, _) = run_sandboxed(project.path(), "ls ~/.gnupg 2>&1");
+        let fake_home = create_fake_home_with_secrets();
+        let (code, stdout, _) =
+            run_sandboxed_home(project.path(), fake_home.path(), "ls ~/.gnupg 2>&1");
         assert!(
             code != 0 || stdout.contains("Permission denied"),
-            "Should not be able to list ~/.gnupg"
+            "Should not be able to list ~/.gnupg — code: {code}, stdout: {stdout}"
         );
     }
 
@@ -435,12 +484,24 @@ else:
     fn landlock_blocks_outbound_tcp() {
         require_landlock!(4);
         let project = create_test_project();
-        // Try to connect to a random port — should fail
-        let (code, _, _) = run_sandboxed(
-            project.path(),
-            "bash -c 'echo > /dev/tcp/127.0.0.1/12345' 2>/dev/null",
+
+        // Start a real listener so we can distinguish "blocked by Landlock" (EPERM)
+        // from "nothing listening" (ECONNREFUSED).
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind test listener");
+        let port = listener.local_addr().unwrap().port();
+
+        // Try to connect to the listening port — should fail with Permission denied
+        let script =
+            format!("bash -c 'echo > /dev/tcp/127.0.0.1/{port}' 2>&1 || echo CONNECT_FAILED");
+        let (code, stdout, _) = run_sandboxed(project.path(), &script);
+        drop(listener);
+
+        // The connection must fail (non-zero exit or explicit failure message)
+        assert!(
+            code != 0 || stdout.contains("CONNECT_FAILED"),
+            "Outbound TCP to port {port} should be blocked by Landlock — code: {code}, stdout: {stdout}"
         );
-        assert_ne!(code, 0, "Outbound TCP to arbitrary port should be blocked");
     }
 
     // ── E2E binary tests ──────────────────────────────────────────
@@ -605,12 +666,10 @@ else:
     fn project_cache_dir_writable() {
         require_landlock!();
         let project = create_test_project();
-        let cache_dir = home_dir().join(".cache");
-        if !cache_dir.exists() {
-            fs::create_dir_all(&cache_dir).ok();
-        }
-        let (code, _, _) = run_sandboxed(
+        let fake_home = create_fake_home_with_secrets();
+        let (code, _, _) = run_sandboxed_home(
             project.path(),
+            fake_home.path(),
             "mkdir -p ~/.cache/cplt-test && echo ok > ~/.cache/cplt-test/probe && rm -rf ~/.cache/cplt-test",
         );
         assert_eq!(code, 0, "~/.cache should be writable");


### PR DESCRIPTION
Add SandboxConfig, PreparedSandbox, prepare(), describe(), preflight(), and exec_sandboxed() as the unified public API for sandbox operations.

This replaces the scattered SBPL-specific flow in main.rs (5 validate calls, temp file management, direct exec invocation) with a clean pipeline: prepare → describe → preflight → exec_sandboxed.

Key changes:
- sandbox.rs: new types and functions encapsulating the full lifecycle
- main.rs: ~50 lines shorter; no longer knows about SBPL, temp files, or validation internals
- scratch.rs: platform-conditional SCRATCH_BASE (XDG on Linux)
- lib.rs: platform-conditional is_unsafe_root paths
- unit_tests.rs: platform-gated macOS/Linux root rejection tests

The old API (generate_profile, ProfileOptions, validate_sbpl_path, build_sandbox_env) remains public for existing unit tests (131 tests run on Linux CI via SBPL string verification).

Platform gate updated: compiles on both macOS and Linux, but Linux sandbox backend is not yet implemented (runtime error until Phase 2).

Ref: #16