### PR TITLE
Correctly detect sandbox ABI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/utils.rs
 src/test/
 tests/test_new.py
 .DS_Store
+.idea

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -9,7 +9,6 @@
 //! All checks are read-only, local (no network), and fast (<500ms total).
 
 use std::path::{Path, PathBuf};
-
 use crate::sandbox::{DENIED_DOTFILES, DENIED_FILES};
 
 // ── Result types ────────────────────────────────────────────────
@@ -532,24 +531,24 @@ fn print_sandbox_mechanism_status() -> bool {
     }
     #[cfg(target_os = "linux")]
     {
-        let ok = match std::fs::read_to_string("/sys/kernel/security/landlock/abi_version") {
-            Ok(s) => {
-                let abi = s.trim();
-                eprintln!("  {GREEN}✓{NC} Landlock: ABI v{abi}");
-                if let Ok(v) = abi.parse::<u32>()
-                    && v < 4
-                {
+        use crate::sandbox::landlock_mod::check_availability;
+        use landlock::ABI;
+
+        let ok = match check_availability() {
+            Ok(abi_version) => {
+                eprintln!("  {GREEN}✓{NC} Landlock: ABI v{abi_version}");
+                if abi_version < ABI::V4 {
                     eprintln!(
                         "  {YELLOW}⚠{NC} Landlock ABI < v4: TCP port filtering unavailable (kernel < 6.7)"
                     );
                     eprintln!("      Network security provided by proxy only.");
                 }
                 true
-            }
+            },
             Err(_) => {
                 eprintln!("  {RED}✗{NC} Landlock: not available");
                 eprintln!("      Requires Linux 5.13+ with Landlock enabled.");
-                eprintln!("      Check: cat /sys/kernel/security/lsm");
+                eprintln!("      Check: cat /sys/kernel/security/lsm (should include 'landlock')");
                 false
             }
         };

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -8,8 +8,8 @@
 //!
 //! All checks are read-only, local (no network), and fast (<500ms total).
 
-use std::path::{Path, PathBuf};
 use crate::sandbox::{DENIED_DOTFILES, DENIED_FILES};
+use std::path::{Path, PathBuf};
 
 // ── Result types ────────────────────────────────────────────────
 
@@ -544,7 +544,7 @@ fn print_sandbox_mechanism_status() -> bool {
                     eprintln!("      Network security provided by proxy only.");
                 }
                 true
-            },
+            }
             Err(_) => {
                 eprintln!("  {RED}✗{NC} Landlock: not available");
                 eprintln!("      Requires Linux 5.13+ with Landlock enabled.");

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -647,10 +647,11 @@ pub fn describe_policy(policy: &LandlockPolicy) -> String {
 
 // ── Linux-only: Landlock kernel application ────────────────────
 
-/// Check Landlock availability and return the ABI version.
+/// Check Landlock availability and return the highest supported ABI version.
 ///
-/// Reads `/sys/kernel/security/landlock/abi_version` to determine
-/// which Landlock features the running kernel supports.
+/// Probes the kernel by attempting to create a Ruleset for each ABI level
+/// (V6 down to V1) with `HardRequirement` compatibility. Returns the highest
+/// ABI that the kernel successfully supports.
 ///
 /// Called in the parent process during `prepare()` — never in `pre_exec`.
 #[cfg(target_os = "linux")]
@@ -671,7 +672,7 @@ pub fn check_availability() -> Result<landlock::ABI, String> {
 
     match last_error {
         None => {
-            panic!("This should be impossible")
+            unreachable!("ABI_PROBE_ORDER is non-empty")
         }
         Some(e) => Err(format!(
             "Landlock is not available on this system: {e}\n\
@@ -729,9 +730,9 @@ fn probe_abi_candidate(abi: landlock::ABI) -> Result<(), String> {
 /// cloned into the `pre_exec` closure.
 #[cfg(target_os = "linux")]
 pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> {
+    use landlock::ABI;
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use landlock::ABI;
 
     let abi_version = check_availability()?;
     let seccomp_filter = build_seccomp_filter();
@@ -906,8 +907,8 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     use std::os::fd::BorrowedFd;
 
     use landlock::{
-        Access, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr, RulesetCreatedAttr,
-        RulesetStatus, ABI,
+        ABI, Access, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr,
+        RulesetCreatedAttr, RulesetStatus,
     };
 
     // Map the detected kernel ABI to the landlock crate's ABI enum.
@@ -916,7 +917,8 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         2 => ABI::V2,
         3 => ABI::V3,
         4 => ABI::V4,
-        _ => ABI::V5,
+        5 => ABI::V5,
+        _ => ABI::V6,
     };
     let abi_version = sandbox.abi_version;
 

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -21,10 +21,9 @@
 //! cannot. Use `--with-proxy` on Linux for localhost SSRF protection.
 //! The proxy handles domain-level filtering on both platforms.
 
+use super::policy::{self, HomeToolDir};
 use std::fmt::Write as _;
 use std::path::PathBuf;
-
-use super::policy::{self, HomeToolDir};
 
 // ── Cross-platform types ───────────────────────────────────────
 
@@ -655,25 +654,64 @@ pub fn describe_policy(policy: &LandlockPolicy) -> String {
 ///
 /// Called in the parent process during `prepare()` — never in `pre_exec`.
 #[cfg(target_os = "linux")]
-pub fn check_availability() -> Result<u32, String> {
-    match std::fs::read_to_string("/sys/kernel/security/landlock/abi_version") {
-        Ok(s) => {
-            let version: u32 = s
-                .trim()
-                .parse()
-                .map_err(|e| format!("Invalid Landlock ABI version: {e}"))?;
-            if version < 1 {
-                Err("Landlock ABI version 0 is not supported".to_string())
-            } else {
-                Ok(version)
+pub fn check_availability() -> Result<landlock::ABI, String> {
+    use landlock::ABI;
+
+    const ABI_PROBE_ORDER: [ABI; 6] = [ABI::V6, ABI::V5, ABI::V4, ABI::V3, ABI::V2, ABI::V1];
+
+    let mut last_error = None;
+    for &abi in &ABI_PROBE_ORDER {
+        match probe_abi_candidate(abi) {
+            Ok(()) => return Ok(abi),
+            Err(err) => {
+                last_error = Some(format!("ABI {:?}: {}", abi, err));
             }
         }
-        Err(e) => Err(format!(
+    }
+
+    match last_error {
+        None => {
+            panic!("This should be impossible")
+        }
+        Some(e) => Err(format!(
             "Landlock is not available on this system: {e}\n\
              Requires Linux 5.13+ with Landlock enabled in the kernel.\n\
              Check: cat /sys/kernel/security/lsm (should include 'landlock')"
         )),
     }
+}
+
+#[cfg(target_os = "linux")]
+fn probe_abi_candidate(abi: landlock::ABI) -> Result<(), String> {
+    use landlock::{
+        Access, AccessFs, AccessNet, CompatLevel, Compatible, Ruleset, RulesetAttr, Scope,
+    };
+
+    let mut ruleset = Ruleset::default().set_compatibility(CompatLevel::HardRequirement);
+
+    ruleset = ruleset
+        .handle_access(AccessFs::from_all(abi))
+        .map_err(|e| format!("filesystem access probe failed: {}", e))?;
+
+    let handled_net = AccessNet::from_all(abi);
+    if !handled_net.is_empty() {
+        ruleset = ruleset
+            .handle_access(handled_net)
+            .map_err(|e| format!("network access probe failed: {}", e))?;
+    }
+
+    let scopes = Scope::from_all(abi);
+    if !scopes.is_empty() {
+        ruleset = ruleset
+            .scope(scopes)
+            .map_err(|e| format!("scope probe failed: {}", e))?;
+    }
+
+    ruleset
+        .create()
+        .map_err(|e| format!("ruleset creation probe failed: {}", e))?;
+
+    Ok(())
 }
 
 /// Pre-compute all sandbox data in the parent process.
@@ -693,11 +731,12 @@ pub fn check_availability() -> Result<u32, String> {
 pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
+    use landlock::ABI;
 
     let abi_version = check_availability()?;
     let seccomp_filter = build_seccomp_filter();
 
-    if abi_version < 4 {
+    if abi_version < ABI::V4 {
         // Check if proxy is configured (proxy_port would have been added to net_rules)
         let has_proxy = policy.net_rules.iter().any(|r| r.port != 443);
         if has_proxy {
@@ -730,7 +769,7 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
     let net_rules = policy.net_rules.clone();
 
     Ok(PrecomputedSandbox {
-        abi_version,
+        abi_version: abi_version as u32,
         pre_opened_fds,
         net_rules,
         seccomp_filter,
@@ -867,8 +906,8 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     use std::os::fd::BorrowedFd;
 
     use landlock::{
-        ABI, Access, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr,
-        RulesetCreatedAttr, RulesetStatus,
+        Access, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr, RulesetCreatedAttr,
+        RulesetStatus, ABI,
     };
 
     // Map the detected kernel ABI to the landlock crate's ABI enum.


### PR DESCRIPTION
This pull request improves the detection and handling of the Landlock Linux sandboxing ABI version. Instead of relying on parsing a version number from a file, the code now actively probes for the highest supported ABI version by attempting to create a ruleset with each candidate ABI. This makes the detection more robust and future-proof. The changes also clarify user-facing messages and update internal logic to work with the new approach.

**Landlock ABI detection improvements:**

* Replaced simple file-based ABI version check with an active probing mechanism (`check_availability`), which attempts to create a ruleset for each supported ABI version in descending order and selects the highest one that succeeds. This ensures accurate detection of supported features and compatibility with future kernel versions.
* Updated code to use the `landlock::ABI` enum instead of raw `u32` for ABI versioning, improving code clarity and type safety. [[1]](diffhunk://#diff-58147069c997828caa54c1fccf75e57da25a14df4bfef7e6b7bd281ffaa73965L658-R716) [[2]](diffhunk://#diff-58147069c997828caa54c1fccf75e57da25a14df4bfef7e6b7bd281ffaa73965R732-R739) [[3]](diffhunk://#diff-58147069c997828caa54c1fccf75e57da25a14df4bfef7e6b7bd281ffaa73965L733-R772) [[4]](diffhunk://#diff-58147069c997828caa54c1fccf75e57da25a14df4bfef7e6b7bd281ffaa73965L880-R920)

**User-facing improvements:**

* Enhanced error message when Landlock is not available to clarify that `/sys/kernel/security/lsm` should include 'landlock'.

**Code organization and clarity:**

* Rearranged import statements for consistency and readability in `src/discover.rs` and `src/sandbox_landlock.rs`. [[1]](diffhunk://#diff-9f9238babfe468ba6d7263dbc11dd9cb5d9ac11d890d2ddf2885f2914b632356L11-R12) [[2]](diffhunk://#diff-58147069c997828caa54c1fccf75e57da25a14df4bfef7e6b7bd281ffaa73965R24-L28)
* Updated logic in `print_sandbox_mechanism_status` to use the new ABI probing mechanism and improved the warning for ABI versions < v4.