### PR TITLE
fix(linux): resolve terminal hang on Landlock ABI v5+ (kernel >= 6.8)

### DIFF
--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -28,11 +28,22 @@ use std::path::PathBuf;
 // ── Cross-platform types ───────────────────────────────────────
 
 /// Filesystem access flags for a Landlock rule.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FsAccess {
     pub read: bool,
     pub write: bool,
     pub execute: bool,
+    /// Grant `LANDLOCK_ACCESS_FS_IOCTL_DEV` (Landlock ABI v5+, kernel ≥ 6.8).
+    ///
+    /// Required for character and block devices that need `ioctl()` — most
+    /// importantly `/dev/tty` and `/dev/pts/*` for `tcsetattr()` (raw mode).
+    /// Without this flag on ABI v5+, the terminal stays in cooked/echo mode:
+    /// OSC colour-query responses are echoed as visible text and the process
+    /// hangs waiting for a response it already "missed".
+    ///
+    /// For non-device files and directories `IoctlDev` is a no-op; set it
+    /// only on device paths to keep the policy least-privilege.
+    pub ioctl: bool,
 }
 
 /// A filesystem access rule: allow `access` on `path` and its subtree.
@@ -274,9 +285,9 @@ pub(crate) const LINUX_HOME_TOOL_DIRS: &[HomeToolDir] = &[
 ///
 /// Mirrors the macOS SBPL literal file allows in `emit_system_access()`.
 const LINUX_HOME_CONFIG_FILES: &[&str] = &[
-    // Git configuration
+    // Git configuration (includes user-config, attributes, ignore, etc.)
     ".gitconfig",
-    ".config/git/config",
+    ".config/git",
     // GitHub CLI auth (specific files only)
     ".config/gh/hosts.yml",
     ".config/gh/config.yml",
@@ -300,9 +311,10 @@ const DEVICE_FILES: &[&str] = &[
     "/dev/urandom",
     "/dev/zero",
     "/dev/random",
-    "/dev/tty", // Terminal device (interactive tools)
-    "/dev/pts", // Pseudo-terminal devices
-    "/dev/shm", // POSIX shared memory (Node.js, Chromium)
+    "/dev/tty",  // Terminal device (interactive tools)
+    "/dev/ptmx", // PTY master multiplexer — required by forkpty(3)
+    "/dev/pts",  // Pseudo-terminal slave devices
+    "/dev/shm",  // POSIX shared memory (Node.js, Chromium)
 ];
 
 // ── Policy generation (cross-platform, pure logic) ─────────────
@@ -326,6 +338,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
             read: true,
             write: true,
             execute: true,
+            ioctl: false,
         },
     });
 
@@ -337,6 +350,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: false,
                 execute: false,
+                ioctl: false,
             },
         });
     }
@@ -349,6 +363,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: false,
                 execute: true,
+                ioctl: false,
             },
         });
     }
@@ -362,6 +377,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                     read: true,
                     write: dir.write,
                     execute: dir.process_exec || dir.map_exec,
+                    ioctl: false,
                 },
             });
         }
@@ -375,6 +391,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: false,
                 execute: true,
+                ioctl: false,
             },
         });
     }
@@ -387,6 +404,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: false,
                 execute: true,
+                ioctl: false,
             },
         });
     }
@@ -402,6 +420,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: true,
                 execute: true,
+                ioctl: false,
             },
         });
     }
@@ -413,10 +432,14 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
             read: true,
             write: true,
             execute: config.allow_tmp_exec,
+            ioctl: false,
         },
     });
 
-    // ── Device files: read + write (no execute) ──
+    // ── Device files: read + write + ioctl (no execute) ──
+    // ioctl: true grants LANDLOCK_ACCESS_FS_IOCTL_DEV (ABI v5+, kernel ≥ 6.8).
+    // Without it, tcsetattr() on /dev/tty and /dev/pts/* is denied — the
+    // terminal stays in cooked/echo mode and Copilot's TUI hangs.
     for &dev in DEVICE_FILES {
         fs_rules.push(FsRule {
             path: PathBuf::from(dev),
@@ -424,6 +447,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: true,
                 execute: false,
+                ioctl: true,
             },
         });
     }
@@ -435,6 +459,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
             read: true,
             write: false,
             execute: false,
+            ioctl: false,
         },
     });
 
@@ -446,6 +471,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: false,
                 execute: false,
+                ioctl: false,
             },
         });
     }
@@ -458,6 +484,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: true,
                 execute: false,
+                ioctl: false,
             },
         });
     }
@@ -471,6 +498,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                     read: true,
                     write: false,
                     execute: false,
+                    ioctl: false,
                 },
             });
         }
@@ -482,6 +510,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                     read: true,
                     write: true,
                     execute: false,
+                    ioctl: false,
                 },
             });
         }
@@ -498,6 +527,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: false,
                 execute: false,
+                ioctl: false,
             },
         });
     }
@@ -512,6 +542,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: true,
                 execute: true,
+                ioctl: false,
             },
         });
     }
@@ -522,6 +553,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 read: true,
                 write: dir.write,
                 execute: dir.process_exec || dir.map_exec,
+                ioctl: false,
             },
         });
     }
@@ -736,7 +768,6 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
 
     let abi_version = check_availability()?;
     let seccomp_filter = build_seccomp_filter();
-
     if abi_version < ABI::V4 {
         // Check if proxy is configured (proxy_port would have been added to net_rules)
         let has_proxy = policy.net_rules.iter().any(|r| r.port != 443);
@@ -970,6 +1001,14 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
         if access.execute {
             access_flags |= AccessFs::Execute;
+        }
+
+        if access.ioctl && abi_version >= 5 {
+            // Landlock ABI v5 (kernel ≥ 6.8) enforces IOCTL_DEV for character
+            // and block devices. Grant it for device paths so tcsetattr() on
+            // /dev/tty and /dev/pts/* succeeds — without this, raw mode fails,
+            // the terminal stays in cooked/echo mode and Copilot's TUI hangs.
+            access_flags |= AccessFs::IoctlDev;
         }
 
         // Safety: raw_fd was opened in precompute() and is still valid

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -141,13 +141,27 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     "LOGNAME",
     "SHELL",
     "TMPDIR",
-    // Terminal
+    // Terminal — base capabilities
     "TERM",
     "COLORTERM",
     "TERM_PROGRAM",
     "TERM_PROGRAM_VERSION",
     "COLUMNS",
     "LINES",
+    // Terminal multiplexers — without these, Copilot (Node.js/ink) doesn't know it's
+    // inside a multiplexer and sends bare OSC 10/11 color queries. The multiplexer
+    // intercepts the queries but can't deliver the response back to the process,
+    // so the raw response bytes appear on screen and the process hangs.
+    "TMUX",                // tmux: socket path (e.g. /tmp/tmux-1000/default,1234,0)
+    "TMUX_PANE",           // tmux: pane identifier (e.g. %0)
+    "STY",                 // GNU screen: session name
+    "ZELLIJ",              // Zellij: present when running inside Zellij
+    "ZELLIJ_SESSION_NAME", // Zellij: session name
+    // Terminal emulator identification — lets Copilot/Node.js detect color/feature
+    // support without falling back to OSC color queries.
+    "VTE_VERSION",     // GNOME Terminal, Tilix, Terminator (VTE-based)
+    "KITTY_WINDOW_ID", // Kitty terminal
+    "WEZTERM_PANE",    // WezTerm
     // Path
     "PATH",
     // Copilot auth — accepted trade-off: Copilot needs a GitHub token to function.

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -7,7 +7,8 @@ use cplt::discover::copilot_pkg_dir;
 use cplt::is_unsafe_root;
 use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, is_private_ip};
 use cplt::sandbox::{
-    HardeningCategory, ProfileOptions, build_sandbox_env, generate_profile, validate_sbpl_path,
+    HardeningCategory, ProfileOptions, SandboxConfig, build_sandbox_env, generate_policy,
+    generate_profile, validate_sbpl_path,
 };
 
 // ============================================================
@@ -513,6 +514,70 @@ fn profile_allows_tty_ioctl() {
         p.contains("(allow file-ioctl)"),
         "Profile must allow file-ioctl for terminal raw mode"
     );
+}
+
+#[test]
+fn landlock_policy_device_files_have_ioctl() {
+    // Regression test: Landlock ABI v5 (kernel ≥ 6.8) enforces IoctlDev for
+    // character devices. Without IoctlDev on /dev/tty, /dev/ptmx, and /dev/pts,
+    // tcsetattr() and forkpty(3) are denied — the terminal stays in cooked/echo
+    // mode, OSC colour-query responses are echoed as visible text, and Copilot's
+    // TUI hangs. /dev/ptmx is the PTY master multiplexer; ioctl is required for
+    // TIOCGPTN and TIOCSPTLCK (used by forkpty/grantpt/unlockpt).
+    let policy = generate_policy(&SandboxConfig {
+        project_dir: std::path::Path::new("/projects/app"),
+        home_dir: std::path::Path::new("/home/test"),
+        extra_read: &[],
+        extra_write: &[],
+        extra_deny: &[],
+        existing_home_tool_dirs: None,
+        extra_ports: &[],
+        localhost_ports: &[],
+        proxy_port: None,
+        allow_env_files: false,
+        allow_localhost_any: false,
+        scratch_dir: None,
+        allow_tmp_exec: false,
+        copilot_install_dir: None,
+        git_hooks_path: None,
+        allow_gpg_signing: false,
+        allow_jvm_attach: false,
+        allow_docker: false,
+        electron_app_dir: None,
+        agent: cplt::agent::Agent::Copilot,
+        agent_dirs: &[],
+        allow_cache_exec: &[],
+        allow_cache_exec_any: false,
+        allow_browser: false,
+    });
+
+    let device_paths = ["/dev/tty", "/dev/ptmx", "/dev/pts"];
+    for dev in &device_paths {
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == std::path::Path::new(dev))
+            .unwrap_or_else(|| panic!("Device rule for {dev} must exist in Landlock policy"));
+        assert!(
+            rule.access.ioctl,
+            "{dev}: ioctl must be true — tcsetattr() requires IoctlDev on ABI v5+ (kernel ≥ 6.8)"
+        );
+    }
+
+    // Non-device paths must NOT have ioctl set (least-privilege).
+    let non_device_paths = ["/tmp", "/proc/self"];
+    for path in &non_device_paths {
+        if let Some(rule) = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == std::path::Path::new(path))
+        {
+            assert!(
+                !rule.access.ioctl,
+                "{path}: ioctl should be false for non-device paths"
+            );
+        }
+    }
 }
 
 #[test]
@@ -1505,6 +1570,28 @@ fn env_allowlist_includes_new_runtime_vars() {
     assert!(ENV_PREFIX_ALLOWLIST.contains(&"PYENV_"));
     assert!(ENV_PREFIX_ALLOWLIST.contains(&"YARN_"));
     assert!(ENV_PREFIX_ALLOWLIST.contains(&"COREPACK_"));
+}
+
+#[test]
+fn env_allowlist_includes_terminal_multiplexers() {
+    use cplt::sandbox::ENV_ALLOWLIST;
+
+    // tmux — without TMUX set, Node.js/ink sends bare OSC 10/11 color queries
+    // that tmux intercepts but can't deliver back, causing a visible hang.
+    assert!(ENV_ALLOWLIST.contains(&"TMUX"));
+    assert!(ENV_ALLOWLIST.contains(&"TMUX_PANE"));
+
+    // GNU screen
+    assert!(ENV_ALLOWLIST.contains(&"STY"));
+
+    // Zellij
+    assert!(ENV_ALLOWLIST.contains(&"ZELLIJ"));
+    assert!(ENV_ALLOWLIST.contains(&"ZELLIJ_SESSION_NAME"));
+
+    // Terminal emulator identification
+    assert!(ENV_ALLOWLIST.contains(&"VTE_VERSION"));
+    assert!(ENV_ALLOWLIST.contains(&"KITTY_WINDOW_ID"));
+    assert!(ENV_ALLOWLIST.contains(&"WEZTERM_PANE"));
 }
 
 // ============================================================


### PR DESCRIPTION
## Problem

On Linux with kernel >= 6.8 (Landlock ABI v5), running `cplt` with Copilot causes the terminal to clear and display raw OSC escape sequences:

```
```

The process then hangs until Ctrl-C. Reproduced in Konsole, Foot, and other terminals — not tmux-specific.

## Root cause

Landlock ABI v5 introduced `LANDLOCK_ACCESS_FS_IOCTL_DEV`. When `handle_access(AccessFs::from_all(ABI::V5))` is called, the sandbox opts into enforcing it. However, no `PathBeneath` rule ever granted `IoctlDev` for device files — so every `ioctl()` on `/dev/tty` and `/dev/pts/*` was silently denied (`EPERM`).

This causes `tcsetattr()` to fail, keeping the terminal in cooked/echo mode. OSC colour-query responses (sent by Node.js/ink to detect theme colours) are echoed back as visible raw bytes, and the TUI hangs waiting for a clean response via stdin.

Additionally, `/dev/ptmx` was missing from `DEVICE_FILES` entirely, which blocked `forkpty(3)` (requires `TIOCGPTN`/`TIOCSPTLCK` ioctls on the PTY master).

## Fixes

### Commit 1 — Terminal multiplexer env vars
Adds `TMUX`, `STY`, `ZELLIJ`, `VTE_VERSION`, `KITTY_WINDOW_ID`, `WEZTERM_PANE` to `ENV_ALLOWLIST`. Without these, Node.js/ink doesn't know it's inside a multiplexer and sends bare OSC colour queries the multiplexer cannot route back.

### Commit 2 — Landlock IoctlDev for device files
- Adds `ioctl: bool` field to `FsAccess` (default `false`, least-privilege)
- Sets `ioctl: true` only for `DEVICE_FILES`
- In `apply_precomputed()`, adds `AccessFs::IoctlDev` to the access flags when `access.ioctl && abi_version >= 5`
- Adds `/dev/ptmx` to `DEVICE_FILES` with `ioctl: true`
- Broadens `~/.config/git/config` → `~/.config/git/` directory so all git config files are readable