### PR TITLE
Resolve /proc/self in child after fork before exec

### DIFF
--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -22,9 +22,10 @@
 //! The proxy handles domain-level filtering on both platforms.
 
 use super::policy::{self, HomeToolDir};
+use landlock::PathBeneath;
 use std::fmt::Write as _;
+use std::os::fd::{BorrowedFd, RawFd};
 use std::path::PathBuf;
-
 // ── Cross-platform types ───────────────────────────────────────
 
 /// Filesystem access flags for a Landlock rule.
@@ -102,7 +103,7 @@ pub struct PrecomputedSandbox {
     /// Opened in `precompute()` (parent), used in `apply_precomputed()` (child).
     /// Raw fds (i32) so the struct remains Clone-able. Closed on exec via
     /// `O_CLOEXEC`; the parent leaks them (harmless — ~30 fds, program exits).
-    pub pre_opened_fds: Vec<(i32, FsAccess)>,
+    pub pre_opened_fds: Vec<(RawFd, FsAccess)>,
     /// Paths that must be opened in the child process because they are magic
     /// symlinks that resolve differently per-process (e.g. `/proc/self` resolves
     /// to `/proc/<pid>` — the parent's pid, not the child's).
@@ -984,11 +985,9 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
 /// The seccomp filter application is allocation-free (raw prctl syscall).
 #[cfg(target_os = "linux")]
 pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
-    use std::os::fd::BorrowedFd;
-
     use landlock::{
-        ABI, Access, AccessFs, AccessNet, NetPort, PathBeneath, Ruleset, RulesetAttr,
-        RulesetCreatedAttr, RulesetStatus,
+        ABI, Access, AccessFs, AccessNet, NetPort, Ruleset, RulesetAttr, RulesetCreatedAttr,
+        RulesetStatus,
     };
 
     // Map the detected kernel ABI to the landlock crate's ABI enum.
@@ -1019,66 +1018,26 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
     let mut created = ruleset.create().map_err(std::io::Error::other)?;
 
-    let mut opened_fds = sandbox.pre_opened_fds.clone();
-
-    // Add fds for deferred paths (e.g. /proc/self).
+    // Add filesystem rules for deferred paths (e.g. /proc/self).
     // These are magic symlinks that resolve per-process — opened here in the
     // child so /proc/self resolves to the child's pid, not the parent's.
     for (c_path, access) in &sandbox.deferred_paths {
-        let raw_fd = unsafe { libc::open(c_path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+        let raw_fd: RawFd = unsafe { libc::open(c_path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
         if raw_fd < 0 {
             continue;
         }
-        opened_fds.push((raw_fd, *access))
+        let path_beneath_rule = create_path_beneath_rule(abi_version, &raw_fd, access);
+        created = created
+            .add_rule(path_beneath_rule)
+            .map_err(std::io::Error::other)?;
     }
 
-    // Add filesystem rules using opened file descriptors.
+    // Add filesystem rules using pre-opened file descriptors.
     // No open() or CString allocation — just borrow the raw fd.
-    for &(raw_fd, access) in &opened_fds {
-        let mut access_flags = if access.read {
-            AccessFs::ReadFile | AccessFs::ReadDir
-        } else {
-            landlock::BitFlags::EMPTY
-        };
-
-        if access.write {
-            let mut write_flags = AccessFs::WriteFile
-                | AccessFs::RemoveDir
-                | AccessFs::RemoveFile
-                | AccessFs::MakeDir
-                | AccessFs::MakeReg
-                | AccessFs::MakeSym
-                | AccessFs::MakeFifo
-                | AccessFs::MakeSock;
-            if abi_version >= 2 {
-                // Refer controls rename()/link() across different Landlock
-                // domains. Without it, build tools (cargo, git) that move
-                // files between directories would fail.
-                write_flags |= AccessFs::Refer;
-            }
-            if abi_version >= 3 {
-                write_flags |= AccessFs::Truncate;
-            }
-            access_flags |= write_flags;
-        }
-
-        if access.execute {
-            access_flags |= AccessFs::Execute;
-        }
-
-        if access.ioctl && abi_version >= 5 {
-            // Landlock ABI v5 (kernel ≥ 6.8) enforces IOCTL_DEV for character
-            // and block devices. Grant it for device paths so tcsetattr() on
-            // /dev/tty and /dev/pts/* succeeds — without this, raw mode fails,
-            // the terminal stays in cooked/echo mode and Copilot's TUI hangs.
-            access_flags |= AccessFs::IoctlDev;
-        }
-
-        // Safety: raw_fd was opened in precompute() and is still valid
-        // (O_CLOEXEC keeps it alive until exec, fork inherits it).
-        let fd = unsafe { BorrowedFd::borrow_raw(raw_fd) };
+    for &(raw_fd, access) in &sandbox.pre_opened_fds {
+        let path_beneath_rule = create_path_beneath_rule(abi_version, &raw_fd, &access);
         created = created
-            .add_rule(PathBeneath::new(fd, access_flags))
+            .add_rule(path_beneath_rule)
             .map_err(std::io::Error::other)?;
     }
 
@@ -1104,6 +1063,61 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     apply_seccomp_filter(&sandbox.seccomp_filter)?;
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn create_path_beneath_rule<'fd>(
+    abi_version: u32,
+    raw_fd: &'fd RawFd,
+    access: &FsAccess,
+) -> PathBeneath<BorrowedFd<'fd>> {
+    use std::os::fd::BorrowedFd;
+
+    use landlock::{AccessFs, PathBeneath};
+
+    let mut access_flags = if access.read {
+        AccessFs::ReadFile | AccessFs::ReadDir
+    } else {
+        landlock::BitFlags::EMPTY
+    };
+
+    if access.write {
+        let mut write_flags = AccessFs::WriteFile
+            | AccessFs::RemoveDir
+            | AccessFs::RemoveFile
+            | AccessFs::MakeDir
+            | AccessFs::MakeReg
+            | AccessFs::MakeSym
+            | AccessFs::MakeFifo
+            | AccessFs::MakeSock;
+        if abi_version >= 2 {
+            // Refer controls rename()/link() across different Landlock
+            // domains. Without it, build tools (cargo, git) that move
+            // files between directories would fail.
+            write_flags |= AccessFs::Refer;
+        }
+        if abi_version >= 3 {
+            write_flags |= AccessFs::Truncate;
+        }
+        access_flags |= write_flags;
+    }
+
+    if access.execute {
+        access_flags |= AccessFs::Execute;
+    }
+
+    if access.ioctl && abi_version >= 5 {
+        // Landlock ABI v5 (kernel ≥ 6.8) enforces IOCTL_DEV for character
+        // and block devices. Grant it for device paths so tcsetattr() on
+        // /dev/tty and /dev/pts/* succeeds — without this, raw mode fails,
+        // the terminal stays in cooked/echo mode and Copilot's TUI hangs.
+        access_flags |= AccessFs::IoctlDev;
+    }
+
+    // Safety: raw_fd was opened in precompute() and is still valid
+    // (O_CLOEXEC keeps it alive until exec, fork inherits it).
+    let fd = unsafe { BorrowedFd::borrow_raw(*raw_fd) };
+    PathBeneath::new(fd, access_flags)
 }
 
 /// Apply a pre-built seccomp BPF filter via prctl.

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -1011,10 +1011,12 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     // Add filesystem rules for deferred paths (e.g. /proc/self).
     // These are magic symlinks that resolve per-process — opened here in the
     // child so /proc/self resolves to the child's pid, not the parent's.
+    // Deferred paths should only be used in special cases (such as /proc/self),
+    // and are probably required for proper operation so failing to open is an error.
     for (c_path, access) in &sandbox.deferred_paths {
         let raw_fd: RawFd = unsafe { libc::open(c_path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
         if raw_fd < 0 {
-            continue;
+            return Err(std::io::Error::last_os_error());
         }
         let path_beneath_rule = create_path_beneath_rule(sandbox.abi_version, &raw_fd, access);
         created = created

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -22,10 +22,14 @@
 //! The proxy handles domain-level filtering on both platforms.
 
 use super::policy::{self, HomeToolDir};
-use landlock::PathBeneath;
 use std::fmt::Write as _;
-use std::os::fd::{BorrowedFd, RawFd};
 use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+use landlock::{ABI, PathBeneath};
+#[cfg(target_os = "linux")]
+use std::os::fd::{BorrowedFd, RawFd};
+
 // ── Cross-platform types ───────────────────────────────────────
 
 /// Filesystem access flags for a Landlock rule.
@@ -98,7 +102,7 @@ pub struct LandlockPolicy {
 #[cfg(target_os = "linux")]
 #[derive(Clone)]
 pub struct PrecomputedSandbox {
-    pub abi_version: u32,
+    pub abi_version: ABI,
     /// Pre-opened `O_PATH` file descriptors for Landlock filesystem rules.
     /// Opened in `precompute()` (parent), used in `apply_precomputed()` (child).
     /// Raw fds (i32) so the struct remains Clone-able. Closed on exec via
@@ -718,9 +722,7 @@ pub fn describe_policy(policy: &LandlockPolicy) -> String {
 ///
 /// Called in the parent process during `prepare()` — never in `pre_exec`.
 #[cfg(target_os = "linux")]
-pub fn check_availability() -> Result<landlock::ABI, String> {
-    use landlock::ABI;
-
+pub fn check_availability() -> Result<ABI, String> {
     const ABI_PROBE_ORDER: [ABI; 6] = [ABI::V6, ABI::V5, ABI::V4, ABI::V3, ABI::V2, ABI::V1];
 
     let mut last_error = None;
@@ -746,7 +748,7 @@ pub fn check_availability() -> Result<landlock::ABI, String> {
 }
 
 #[cfg(target_os = "linux")]
-fn probe_abi_candidate(abi: landlock::ABI) -> Result<(), String> {
+fn probe_abi_candidate(abi: ABI) -> Result<(), String> {
     use landlock::{
         Access, AccessFs, AccessNet, CompatLevel, Compatible, Ruleset, RulesetAttr, Scope,
     };
@@ -798,7 +800,6 @@ fn probe_abi_candidate(abi: landlock::ABI) -> Result<(), String> {
 /// cloned into the `pre_exec` closure.
 #[cfg(target_os = "linux")]
 pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> {
-    use landlock::ABI;
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
@@ -845,7 +846,7 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
     let restrict_net_connect = policy.restrict_net_connect;
 
     Ok(PrecomputedSandbox {
-        abi_version: abi_version as u32,
+        abi_version,
         pre_opened_fds,
         deferred_paths,
         net_rules,
@@ -990,25 +991,14 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         RulesetStatus,
     };
 
-    // Map the detected kernel ABI to the landlock crate's ABI enum.
-    let abi = match sandbox.abi_version {
-        1 => ABI::V1,
-        2 => ABI::V2,
-        3 => ABI::V3,
-        4 => ABI::V4,
-        5 => ABI::V5,
-        _ => ABI::V6,
-    };
-    let abi_version = sandbox.abi_version;
-
     let ruleset = Ruleset::default()
-        .handle_access(AccessFs::from_all(abi))
+        .handle_access(AccessFs::from_all(sandbox.abi_version))
         .map_err(std::io::Error::other)?;
 
     // Handle ConnectTcp on ABI v4+ only when network restriction is enabled.
     // When allow_localhost_any is set, we skip this — Landlock cannot
     // distinguish localhost from remote, so we rely on the proxy instead.
-    let ruleset = if abi_version >= 4 && sandbox.restrict_net_connect {
+    let ruleset = if sandbox.abi_version >= ABI::V4 && sandbox.restrict_net_connect {
         ruleset
             .handle_access(AccessNet::ConnectTcp)
             .map_err(std::io::Error::other)?
@@ -1026,7 +1016,7 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
         if raw_fd < 0 {
             continue;
         }
-        let path_beneath_rule = create_path_beneath_rule(abi_version, &raw_fd, access);
+        let path_beneath_rule = create_path_beneath_rule(sandbox.abi_version, &raw_fd, access);
         created = created
             .add_rule(path_beneath_rule)
             .map_err(std::io::Error::other)?;
@@ -1035,14 +1025,14 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
     // Add filesystem rules using pre-opened file descriptors.
     // No open() or CString allocation — just borrow the raw fd.
     for &(raw_fd, access) in &sandbox.pre_opened_fds {
-        let path_beneath_rule = create_path_beneath_rule(abi_version, &raw_fd, &access);
+        let path_beneath_rule = create_path_beneath_rule(sandbox.abi_version, &raw_fd, &access);
         created = created
             .add_rule(path_beneath_rule)
             .map_err(std::io::Error::other)?;
     }
 
     // Add network rules (ABI v4+, only when network restriction is active).
-    if abi_version >= 4 && sandbox.restrict_net_connect {
+    if sandbox.abi_version >= ABI::V4 && sandbox.restrict_net_connect {
         for rule in &sandbox.net_rules {
             created = created
                 .add_rule(NetPort::new(rule.port, AccessNet::ConnectTcp))
@@ -1067,7 +1057,7 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
 #[cfg(target_os = "linux")]
 fn create_path_beneath_rule<'fd>(
-    abi_version: u32,
+    abi_version: ABI,
     raw_fd: &'fd RawFd,
     access: &FsAccess,
 ) -> PathBeneath<BorrowedFd<'fd>> {
@@ -1090,13 +1080,13 @@ fn create_path_beneath_rule<'fd>(
             | AccessFs::MakeSym
             | AccessFs::MakeFifo
             | AccessFs::MakeSock;
-        if abi_version >= 2 {
+        if abi_version >= ABI::V2 {
             // Refer controls rename()/link() across different Landlock
             // domains. Without it, build tools (cargo, git) that move
             // files between directories would fail.
             write_flags |= AccessFs::Refer;
         }
-        if abi_version >= 3 {
+        if abi_version >= ABI::V3 {
             write_flags |= AccessFs::Truncate;
         }
         access_flags |= write_flags;
@@ -1106,7 +1096,7 @@ fn create_path_beneath_rule<'fd>(
         access_flags |= AccessFs::Execute;
     }
 
-    if access.ioctl && abi_version >= 5 {
+    if access.ioctl && abi_version >= ABI::V5 {
         // Landlock ABI v5 (kernel ≥ 6.8) enforces IOCTL_DEV for character
         // and block devices. Grant it for device paths so tcsetattr() on
         // /dev/tty and /dev/pts/* succeeds — without this, raw mode fails,

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -1784,4 +1784,53 @@ mod tests {
             "data dir should NOT be executable"
         );
     }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_self_is_deferred_not_pre_opened() {
+        let policy = LandlockPolicy {
+            fs_rules: vec![
+                FsRule {
+                    path: PathBuf::from("/proc/self"),
+                    access: FsAccess {
+                        read: true,
+                        write: false,
+                        execute: false,
+                        ioctl: false,
+                    },
+                },
+                FsRule {
+                    path: PathBuf::from("/tmp"),
+                    access: FsAccess {
+                        read: true,
+                        write: false,
+                        execute: false,
+                        ioctl: false,
+                    },
+                },
+            ],
+            net_rules: vec![],
+            restrict_net_connect: false,
+        };
+
+        let precomputed = precompute(policy).expect("precompute should succeed");
+
+        assert_eq!(
+            precomputed.deferred_paths.len(),
+            1,
+            "exactly one path should be deferred"
+        );
+        let (c_path, _) = &precomputed.deferred_paths[0];
+        assert_eq!(
+            c_path.to_str().unwrap(),
+            "/proc/self",
+            "/proc/self should be in deferred_paths"
+        );
+
+        assert_eq!(
+            precomputed.pre_opened_fds.len(),
+            1,
+            "/tmp should be pre-opened; /proc/self must not be"
+        );
+    }
 }

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -84,12 +84,16 @@ pub struct LandlockPolicy {
 ///
 /// Everything here is computed in the parent (where allocation and I/O
 /// are safe). The `pre_exec` hook only receives this immutable data and
-/// makes raw syscalls — no allocation, no file I/O.
+/// makes raw syscalls — no allocation, no file I/O, with one exception:
+/// paths in `deferred_paths` are magic symlinks (e.g. `/proc/self`) that
+/// must be opened in the child after fork so they resolve to the child's
+/// pid rather than the parent's.
 ///
 /// File descriptors in `pre_opened_fds` are opened with `O_PATH | O_CLOEXEC`
 /// in `precompute()`. They survive `fork()` and are used by
 /// `apply_precomputed()` via `BorrowedFd` — no `open()` or allocation
-/// in the async-signal-unsafe post-fork context.
+/// in the async-signal-unsafe post-fork context, except for the deferred
+/// paths described above.
 #[cfg(target_os = "linux")]
 #[derive(Clone)]
 pub struct PrecomputedSandbox {
@@ -99,6 +103,12 @@ pub struct PrecomputedSandbox {
     /// Raw fds (i32) so the struct remains Clone-able. Closed on exec via
     /// `O_CLOEXEC`; the parent leaks them (harmless — ~30 fds, program exits).
     pub pre_opened_fds: Vec<(i32, FsAccess)>,
+    /// Paths that must be opened in the child process because they are magic
+    /// symlinks that resolve differently per-process (e.g. `/proc/self` resolves
+    /// to `/proc/<pid>` — the parent's pid, not the child's).
+    /// `CString` allocation happens in `precompute()` (parent, safe).
+    /// The actual `open()` call happens in `apply_precomputed()` (child).
+    pub deferred_paths: Vec<(std::ffi::CString, FsAccess)>,
     pub net_rules: Vec<NetRule>,
     /// Whether to restrict TCP connect at the kernel level.
     pub restrict_net_connect: bool,
@@ -460,12 +470,11 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
         });
     }
 
-    // ── /proc: read-only access to the proc filesystem; /proc/self is a magic symlink
-    // that resolves per-process, so pre-opening /proc/self in the parent would give
-    // the parent's pid directory, not the child's. Granting /proc read access covers
-    // /proc/self/cgroup, /proc/self/exe, /proc/self/maps, and similar needs. ──
+    // ── /proc/self: Node.js reads /proc/self/exe, /proc/self/maps, /proc/self/cgroup ──
+    // This path is a magic symlink resolved per-process. It is deferred to the
+    // child in apply_precomputed() where it resolves to the correct pid.
     fs_rules.push(FsRule {
-        path: PathBuf::from("/proc"),
+        path: PathBuf::from("/proc/self"),
         access: FsAccess {
             read: true,
             write: false,
@@ -779,6 +788,11 @@ fn probe_abi_candidate(abi: landlock::ABI) -> Result<(), String> {
 /// `CString` allocation for path conversion happens safely in the parent.
 /// The child's `pre_exec` hook receives only raw fd numbers.
 ///
+/// Exception: paths that are magic symlinks (e.g. `/proc/self`) cannot
+/// be resolved in the parent because they would yield the parent's pid.
+/// These are stored in `deferred_paths` and opened with a single `open()`
+/// call in the child after fork.
+///
 /// Called once in `prepare()`. The returned `PrecomputedSandbox` is
 /// cloned into the `pre_exec` closure.
 #[cfg(target_os = "linux")]
@@ -808,10 +822,17 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
 
     // Pre-open all filesystem paths in the parent process.
     // This avoids CString allocation and open() calls in pre_exec.
+    // Paths under /proc/self are magic symlinks that resolve to /proc/<pid> —
+    // the parent's pid, not the child's. Defer those to apply_precomputed().
     let mut pre_opened_fds = Vec::new();
+    let mut deferred_paths = Vec::new();
     for rule in &policy.fs_rules {
         let c_path = CString::new(rule.path.as_os_str().as_bytes())
             .map_err(|_| format!("Path contains null byte: {}", rule.path.display()))?;
+        if rule.path.starts_with("/proc/self") {
+            deferred_paths.push((c_path, rule.access));
+            continue;
+        }
         let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
         if fd >= 0 {
             pre_opened_fds.push((fd, rule.access));
@@ -825,6 +846,7 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
     Ok(PrecomputedSandbox {
         abi_version: abi_version as u32,
         pre_opened_fds,
+        deferred_paths,
         net_rules,
         restrict_net_connect,
         seccomp_filter,
@@ -955,6 +977,10 @@ fn build_seccomp_filter() -> Vec<BpfInstruction> {
 /// 3. This is the same risk profile as any Rust program using
 ///    Command::spawn() with pre_exec in a multi-threaded context.
 ///
+/// Deferred paths (magic symlinks like `/proc/self`) also require one
+/// `open()` call per path in the child.
+/// The risk profile is the same as the heap allocation above.
+///
 /// The seccomp filter application is allocation-free (raw prctl syscall).
 #[cfg(target_os = "linux")]
 pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
@@ -993,9 +1019,22 @@ pub fn apply_precomputed(sandbox: &PrecomputedSandbox) -> std::io::Result<()> {
 
     let mut created = ruleset.create().map_err(std::io::Error::other)?;
 
-    // Add filesystem rules using pre-opened file descriptors.
+    let mut opened_fds = sandbox.pre_opened_fds.clone();
+
+    // Add fds for deferred paths (e.g. /proc/self).
+    // These are magic symlinks that resolve per-process — opened here in the
+    // child so /proc/self resolves to the child's pid, not the parent's.
+    for (c_path, access) in &sandbox.deferred_paths {
+        let raw_fd = unsafe { libc::open(c_path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+        if raw_fd < 0 {
+            continue;
+        }
+        opened_fds.push((raw_fd, *access))
+    }
+
+    // Add filesystem rules using opened file descriptors.
     // No open() or CString allocation — just borrow the raw fd.
-    for &(raw_fd, access) in &sandbox.pre_opened_fds {
+    for &(raw_fd, access) in &opened_fds {
         let mut access_flags = if access.read {
             AccessFs::ReadFile | AccessFs::ReadDir
         } else {
@@ -1575,7 +1614,7 @@ mod tests {
     }
 
     #[test]
-    fn proc_is_readonly() {
+    fn proc_self_is_readonly() {
         let project = PathBuf::from("/home/user/project");
         let home = PathBuf::from("/home/user");
         let config = test_config(&project, &home);
@@ -1584,8 +1623,8 @@ mod tests {
         let rule = policy
             .fs_rules
             .iter()
-            .find(|r| r.path == Path::new("/proc"))
-            .expect("/proc should be in rules");
+            .find(|r| r.path == Path::new("/proc/self"))
+            .expect("/proc/self should be in rules");
         assert!(rule.access.read);
         assert!(!rule.access.write);
         assert!(!rule.access.execute);

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -460,9 +460,12 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
         });
     }
 
-    // ── /proc/self: Node.js reads /proc/self/exe, /proc/self/maps ──
+    // ── /proc: read-only access to the proc filesystem; /proc/self is a magic symlink
+    // that resolves per-process, so pre-opening /proc/self in the parent would give
+    // the parent's pid directory, not the child's. Granting /proc read access covers
+    // /proc/self/cgroup, /proc/self/exe, /proc/self/maps, and similar needs. ──
     fs_rules.push(FsRule {
-        path: PathBuf::from("/proc/self"),
+        path: PathBuf::from("/proc"),
         access: FsAccess {
             read: true,
             write: false,
@@ -1572,7 +1575,7 @@ mod tests {
     }
 
     #[test]
-    fn proc_self_is_readonly() {
+    fn proc_is_readonly() {
         let project = PathBuf::from("/home/user/project");
         let home = PathBuf::from("/home/user");
         let config = test_config(&project, &home);
@@ -1581,8 +1584,8 @@ mod tests {
         let rule = policy
             .fs_rules
             .iter()
-            .find(|r| r.path == Path::new("/proc/self"))
-            .expect("/proc/self should be in rules");
+            .find(|r| r.path == Path::new("/proc"))
+            .expect("/proc should be in rules");
         assert!(rule.access.read);
         assert!(!rule.access.write);
         assert!(!rule.access.execute);


### PR DESCRIPTION
/proc/self is a "magic" symlink that always points to the current process. The problem is that landlock doesn't work on symlinks, so the setup would resolve the symlink to the current process, and then the child is spawned inside the sandbox and access is granted to the parent process instead of the child.

Resolving the symlink in pre_exec allows correctly resolving the symlink.