### PR TITLE
Add state data dir for opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,16 +230,16 @@ By default, `cplt` sanitizes the child environment — only safe variables pass 
 
 **What passes through:**
 
-| Category | Examples | How |
-|---|---|---|
-| Core system | `HOME`, `USER`, `PATH`, `SHELL`, `TMPDIR`, `LANG` | Explicit allowlist |
-| Terminal | `TERM`, `COLORTERM`, `TERM_PROGRAM` | Explicit allowlist |
-| Editor | `EDITOR`, `VISUAL`, `PAGER` | Explicit allowlist |
-| Auth tokens | `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN` | Explicit allowlist (needed for Copilot) |
-| Copilot config | `COPILOT_DEBUG`, `COPILOT_*` | Prefix allowlist |
-| Language runtimes | `NODE_*`, `GOPATH`, `CARGO_HOME`, `JAVA_HOME`, `VIRTUAL_ENV`, `PYTHONPATH` | Explicit allowlist |
-| Tool managers | `NVM_*`, `PYENV_*`, `MISE_*`, `SDKMAN_*`, `COREPACK_*`, `YARN_*` | Prefix allowlist |
-| XDG dirs | `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME` | Explicit allowlist |
+| Category          | Examples                                                                   | How                                     |
+|-------------------|----------------------------------------------------------------------------|-----------------------------------------|
+| Core system       | `HOME`, `USER`, `PATH`, `SHELL`, `TMPDIR`, `LANG`                          | Explicit allowlist                      |
+| Terminal          | `TERM`, `COLORTERM`, `TERM_PROGRAM`                                        | Explicit allowlist                      |
+| Editor            | `EDITOR`, `VISUAL`, `PAGER`                                                | Explicit allowlist                      |
+| Auth tokens       | `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`                         | Explicit allowlist (needed for Copilot) |
+| Copilot config    | `COPILOT_DEBUG`, `COPILOT_*`                                               | Prefix allowlist                        |
+| Language runtimes | `NODE_*`, `GOPATH`, `CARGO_HOME`, `JAVA_HOME`, `VIRTUAL_ENV`, `PYTHONPATH` | Explicit allowlist                      |
+| Tool managers     | `NVM_*`, `PYENV_*`, `MISE_*`, `SDKMAN_*`, `COREPACK_*`, `YARN_*`           | Prefix allowlist                        |
+| XDG dirs          | `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`     | Explicit allowlist                      |
 
 **Prefix allowlist with secret-suffix protection:** Variables matching allowed prefixes (e.g. `COPILOT_*`, `YARN_*`) are passed through *unless* they end with a secret-bearing suffix: `_TOKEN`, `_AUTH`, `_SECRET`, `_SECRET_KEY`, `_KEY`, `_PASSWORD`, or `_CREDENTIALS`. For example, `COPILOT_DEBUG` passes through but `COPILOT_API_KEY` is blocked.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,21 +6,23 @@ This document describes the security architecture of cplt, the threat model it a
 
 cplt sandboxes AI coding agents — currently **GitHub Copilot CLI** and **[OpenCode](https://opencode.ai/)** (anomalyco/opencode). OpenCode is [officially supported by GitHub](https://github.blog/changelog/2026-01-16-github-copilot-now-supports-opencode/) as a Copilot client. Both share the same core sandbox infrastructure (deny-default Seatbelt profile, env sanitization, scratch dir), with agent-specific adaptations:
 
-| Property | Copilot | OpenCode |
-|---|---|---|
-| Auth mechanism | GitHub token (Keychain, `GH_TOKEN`) | `/connect` device flow → `auth.json`, or API keys |
+| Property        | Copilot                             | OpenCode                                                            |
+|-----------------|-------------------------------------|---------------------------------------------------------------------|
+| Auth mechanism  | GitHub token (Keychain, `GH_TOKEN`) | `/connect` device flow → `auth.json`, or API keys                   |
 | Auth in sandbox | Token auto-passed via env allowlist | Copilot auth stored in data dir; third-party keys need `--pass-env` |
-| Config dir | `~/.copilot` (read/write) | `~/.config/opencode` (read-only) |
-| Data dir | `~/Library/Caches/copilot` | `~/.local/share/opencode` (write, no exec) |
-| Keychain access | Yes (required for token storage) | No |
-| SEA extraction | Yes (pre-sandbox) | No |
-| Env isolation | `GH_TOKEN`, `COPILOT_*` passed | `GH_TOKEN`, `COPILOT_*` suppressed |
+| Config dir      | `~/.copilot` (read/write)           | `~/.config/opencode` (read-only)                                    |
+| Data dir        | `~/Library/Caches/copilot`          | `~/.local/share/opencode` (write, no exec)                          |
+| State data dir  | N/A                                 | `~/.local/state/opencode` (write, no exec)                          |
+| Keychain access | Yes (required for token storage)    | No                                                                  |
+| SEA extraction  | Yes (pre-sandbox)                   | No                                                                  |
+| Env isolation   | `GH_TOKEN`, `COPILOT_*` passed      | `GH_TOKEN`, `COPILOT_*` suppressed                                  |
 
 ### OpenCode-specific security notes
 
 - **Copilot provider support**: OpenCode can authenticate with your GitHub Copilot subscription via `/connect` device flow. The token is stored in `~/.local/share/opencode/auth.json` — no environment variables needed. This works out of the box in the sandbox.
 - **Third-party API keys are opt-in**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and other provider keys are never passed through by default. Users must explicitly use `--pass-env` for each key. This prevents accidental exposure of credentials to a sandboxed process.
 - **Data dir is write+no-exec**: `~/.local/share/opencode/` (sessions, auth, SQLite DB) is writable but has both `(deny process-exec)` and `(deny file-map-executable)` to prevent write+exec persistence attacks.
+- **State data dir is write+no-exec**: `~/.local/state/opencode/` (locks, history, statistics) is writable but has both `(deny process-exec)` and `(deny file-map-executable)` to prevent write+exec persistence attacks.
 - **Config dir is read-only**: `~/.config/opencode/opencode.json` and related config are readable but not writable, preventing config tampering across unsandboxed runs.
 - **Copilot env vars isolated**: `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`, and all `COPILOT_*` env vars are suppressed for non-Copilot agents. OpenCode's Copilot provider uses its own auth file instead.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -436,8 +436,8 @@ mod tests {
     fn opencode_config_dirs_xdg_default() {
         let home = Path::new("/Users/test");
         let dirs = Agent::OpenCode.config_dirs(home);
-        assert!(dirs.len() >= 2, "should have config + data dirs");
-        // Config dir is read-only, data dir is writable
+        assert!(dirs.len() >= 2, "should have config + data + state dirs");
+        // Config dir is read-only, data dir and state dir are writable
         let config_dir = dirs
             .iter()
             .find(|d| d.path.to_str().unwrap().contains("config"))
@@ -446,9 +446,14 @@ mod tests {
             .iter()
             .find(|d| d.path.to_str().unwrap().contains("share"))
             .unwrap();
+        let state_dir = dirs
+            .iter()
+            .find(|d| d.path.to_str().unwrap().contains("state"))
+            .unwrap();
         assert!(!config_dir.write, "config dir should be read-only");
         assert!(data_dir.write, "data dir should be writable");
-        // Neither should be executable
+        assert!(state_dir.write, "state data dir should be writable");
+        // None should be executable
         assert!(dirs.iter().all(|d| !d.process_exec && !d.map_exec));
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -138,6 +138,13 @@ impl Agent {
                     .unwrap_or_else(|| home.join(".local/share"));
                 let data_dir = data_base.join("opencode");
 
+                // Respect XDG_STATE_HOME for state data dir (locks, history, statistics)
+                let state_base = std::env::var("XDG_STATE_HOME")
+                    .ok()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| home.join(".local/state"));
+                let state_dir = state_base.join("opencode");
+
                 vec![
                     AgentDir {
                         path: config_dir,
@@ -150,6 +157,13 @@ impl Agent {
                         write: true,
                         map_exec: false,
                         // Explicitly deny exec on writable data dir
+                        process_exec: false,
+                    },
+                    AgentDir {
+                        path: state_dir,
+                        write: true,
+                        map_exec: false,
+                        // Explicitly deny exec on writable state data dir
                         process_exec: false,
                     },
                 ]

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -1645,6 +1645,12 @@ mod tests {
                 map_exec: false,
                 process_exec: false,
             },
+            crate::agent::AgentDir {
+                path: home.join(".local/state/opencode"),
+                write: true,
+                map_exec: false,
+                process_exec: false,
+            },
         ];
         let mut config = test_config(&project, &home);
         config.agent = crate::agent::Agent::OpenCode;
@@ -1669,6 +1675,18 @@ mod tests {
         assert!(
             !data_rule.access.execute,
             "data dir should NOT be executable"
+        );
+
+        let state_rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == home.join(".local/state/opencode"))
+            .expect("OpenCode state data dir should be in rules");
+        assert!(state_rule.access.read);
+        assert!(state_rule.access.write, "state data dir should be writable");
+        assert!(
+            !state_rule.access.execute,
+            "state data dir should NOT be executable"
         );
     }
 

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -172,6 +172,7 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     // XDG directories
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
     "XDG_CACHE_HOME",
     "XDG_RUNTIME_DIR",
     // Node.js


### PR DESCRIPTION
OpenCode seems to work without it (not crashing), but some features might be degraded or unavailable. Adding it makes sense.