### PR TITLE
feat: add Pi agent support and configurable default agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
 ![Linux](https://img.shields.io/badge/platform-Linux-lightgrey)
 
-Sandbox wrapper for AI coding agents. Runs GitHub Copilot CLI, OpenCode, or a plain shell inside a kernel-level sandbox so the agent can work on your project but cannot access your secrets.
+Sandbox wrapper for AI coding agents. Runs GitHub Copilot CLI, OpenCode, Google Gemini CLI, Pi, or a plain shell inside a kernel-level sandbox so the agent can work on your project but cannot access your secrets.
 
 - **macOS**: Apple Seatbelt/SBPL via `sandbox-exec`
 - **Linux**: Landlock LSM + seccomp-BPF (kernel 5.13+; full network filtering on 6.7+)
@@ -393,6 +393,46 @@ cplt --agent opencode --pass-env OPENAI_API_KEY --pass-env OPENAI_ORG_ID
 - OpenCode data (`~/.local/share/opencode/`) is writable but execution is denied (write+exec prevention)
 - Keychain access is disabled (OpenCode uses its own auth file, not macOS Keychain)
 - `--resume`, `--continue`, `--remote`, `--name` flags are Copilot-specific and ignored for OpenCode
+
+### Gemini CLI support
+
+cplt can sandbox [Google Gemini CLI](https://github.com/google-gemini/gemini-cli). Gemini uses Google OAuth (browser flow) by default, or an API key.
+
+```bash
+# Run Gemini CLI
+cplt --agent gemini
+
+# With API key instead of OAuth
+cplt --agent gemini --pass-env GEMINI_API_KEY
+```
+
+**Security notes for Gemini:**
+- Gemini config/auth (`~/.gemini/`) is writable in the sandbox
+- Keychain access is enabled (used for extension integrity verification)
+- OAuth browser flow requires `--allow-browser` for first-time login
+- `--resume`, `--continue`, `--remote`, `--name` flags are Copilot-specific and ignored for Gemini
+
+### Pi agent support
+
+cplt can sandbox [Pi](https://github.com/earendil-works/pi) (`@earendil-works/pi-coding-agent`). Pi supports multiple LLM providers via API keys.
+
+```bash
+# Run Pi (must be explicit — not auto-detected due to binary name collision risk)
+cplt --agent pi
+
+# Pass your provider API key
+cplt --agent pi --pass-env ANTHROPIC_API_KEY
+
+# Set Pi as your default agent
+cplt config set sandbox.agent pi
+```
+
+**Security notes for Pi:**
+- **Not auto-detected**: the `pi` binary name is too generic and may collide with other tools. Use `--agent pi` or set `sandbox.agent = "pi"` in config
+- **API keys are opt-in**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY` must be explicitly passed via `--pass-env`
+- Pi config/auth (`~/.pi/`) is writable in the sandbox
+- Pi managed binaries (`~/.pi/agent/bin/`) have process-exec permission (for bundled `fd`, `rg`)
+- Keychain access is disabled
 
 ### Shell mode
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,18 +4,19 @@ This document describes the security architecture of cplt, the threat model it a
 
 ## Supported Agents
 
-cplt sandboxes AI coding agents — currently **GitHub Copilot CLI** and **[OpenCode](https://opencode.ai/)** (anomalyco/opencode). OpenCode is [officially supported by GitHub](https://github.blog/changelog/2026-01-16-github-copilot-now-supports-opencode/) as a Copilot client. Both share the same core sandbox infrastructure (deny-default Seatbelt profile, env sanitization, scratch dir), with agent-specific adaptations:
+cplt sandboxes AI coding agents — currently **GitHub Copilot CLI**, **[OpenCode](https://opencode.ai/)**, **Google Gemini CLI**, and **[Pi](https://github.com/earendil-works/pi)**. All share the same core sandbox infrastructure (deny-default Seatbelt/Landlock profile, env sanitization, scratch dir), with agent-specific adaptations:
 
-| Property        | Copilot                             | OpenCode                                                            |
-|-----------------|-------------------------------------|---------------------------------------------------------------------|
-| Auth mechanism  | GitHub token (Keychain, `GH_TOKEN`) | `/connect` device flow → `auth.json`, or API keys                   |
-| Auth in sandbox | Token auto-passed via env allowlist | Copilot auth stored in data dir; third-party keys need `--pass-env` |
-| Config dir      | `~/.copilot` (read/write)           | `~/.config/opencode` (read-only)                                    |
-| Data dir        | `~/Library/Caches/copilot`          | `~/.local/share/opencode` (write, no exec)                          |
-| State data dir  | N/A                                 | `~/.local/state/opencode` (write, no exec)                          |
-| Keychain access | Yes (required for token storage)    | No                                                                  |
-| SEA extraction  | Yes (pre-sandbox)                   | No                                                                  |
-| Env isolation   | `GH_TOKEN`, `COPILOT_*` passed      | `GH_TOKEN`, `COPILOT_*` suppressed                                  |
+| Property        | Copilot                             | OpenCode                                                            | Gemini                                    | Pi                                          |
+|-----------------|-------------------------------------|---------------------------------------------------------------------|-------------------------------------------|---------------------------------------------|
+| Auth mechanism  | GitHub token (Keychain, `GH_TOKEN`) | `/connect` device flow → `auth.json`, or API keys                   | Google OAuth (browser) or API key         | API keys (Anthropic, OpenAI, Gemini, etc.)  |
+| Auth in sandbox | Token auto-passed via env allowlist | Copilot auth stored in data dir; third-party keys need `--pass-env` | OAuth stored in `~/.gemini/`; key needs `--pass-env` | Keys need `--pass-env`             |
+| Config dir      | `~/.copilot` (read/write)           | `~/.config/opencode` (read-only)                                    | `~/.gemini` (read/write)                  | `~/.pi` (read/write)                       |
+| Data dir        | `~/Library/Caches/copilot`          | `~/.local/share/opencode` (write, no exec)                          | N/A (in config dir)                       | `~/.pi/agent/bin` (read + exec)             |
+| State data dir  | N/A                                 | `~/.local/state/opencode` (write, no exec)                          | N/A                                       | N/A                                         |
+| Keychain access | Yes (required for token storage)    | No                                                                  | Yes (extension integrity)                 | No                                          |
+| SEA extraction  | Yes (pre-sandbox)                   | No                                                                  | No                                        | No                                          |
+| Env isolation   | `GH_TOKEN`, `COPILOT_*` passed      | `GH_TOKEN`, `COPILOT_*` suppressed                                  | `GH_TOKEN`, `COPILOT_*` suppressed        | `GH_TOKEN`, `COPILOT_*` suppressed          |
+| Auto-detected   | Yes (priority 1)                    | Yes (priority 2)                                                    | Yes (priority 3)                          | No (explicit only — name collision risk)    |
 
 ### OpenCode-specific security notes
 
@@ -25,6 +26,21 @@ cplt sandboxes AI coding agents — currently **GitHub Copilot CLI** and **[Open
 - **State data dir is write+no-exec**: `~/.local/state/opencode/` (locks, history, statistics) is writable but has both `(deny process-exec)` and `(deny file-map-executable)` to prevent write+exec persistence attacks.
 - **Config dir is read-only**: `~/.config/opencode/opencode.json` and related config are readable but not writable, preventing config tampering across unsandboxed runs.
 - **Copilot env vars isolated**: `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GITHUB_TOKEN`, and all `COPILOT_*` env vars are suppressed for non-Copilot agents. OpenCode's Copilot provider uses its own auth file instead.
+
+### Gemini-specific security notes
+
+- **OAuth browser flow**: Gemini uses Google OAuth by default, requiring `--allow-browser` for first-time login. Auth tokens are stored in `~/.gemini/`.
+- **API key alternative**: `GEMINI_API_KEY` or `GOOGLE_CLOUD_PROJECT` can be used instead of OAuth — must be passed via `--pass-env`.
+- **Keychain access enabled**: Gemini uses macOS Keychain for extension integrity verification.
+- **Config dir is read/write**: `~/.gemini/` stores auth, settings, sessions, and agents.
+
+### Pi-specific security notes
+
+- **Not auto-detected**: the `pi` binary name is generic and may collide with other tools. Pi must be explicitly selected via `--agent pi` or `sandbox.agent = "pi"` in config.
+- **API keys are opt-in**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY` are never passed through by default. Users must explicitly use `--pass-env` for each key.
+- **Config dir is read/write**: `~/.pi/` stores settings, auth, sessions, and themes.
+- **Managed binaries have exec**: `~/.pi/agent/bin/` (bundled `fd`, `rg`) has process-exec permission but is read-only (no write+exec).
+- **Copilot env vars isolated**: `GH_TOKEN`, `GITHUB_TOKEN`, and `COPILOT_*` are suppressed for Pi.
 
 ## Threat Model
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ cplt sandboxes AI coding agents — currently **GitHub Copilot CLI**, **[OpenCod
 - **Not auto-detected**: the `pi` binary name is generic and may collide with other tools. Pi must be explicitly selected via `--agent pi` or `sandbox.agent = "pi"` in config.
 - **API keys are opt-in**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY` are never passed through by default. Users must explicitly use `--pass-env` for each key.
 - **Config dir is read/write**: `~/.pi/` stores settings, auth, sessions, and themes.
-- **Managed binaries have exec**: `~/.pi/agent/bin/` (bundled `fd`, `rg`) has process-exec permission but is read-only (no write+exec).
+- **Managed binaries have exec**: `~/.pi/agent/bin/` (bundled `fd`, `rg`) has process-exec permission with an explicit write deny (prevents write+exec persistence even though the parent `~/.pi/` is writable).
 - **Copilot env vars isolated**: `GH_TOKEN`, `GITHUB_TOKEN`, and `COPILOT_*` are suppressed for Pi.
 
 ## Threat Model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ This creates a commented template at `~/.config/cplt/config.toml`:
 # allow_private_domains = ["intern.nav.no"]  # Allow internal/intranet domains to resolve to private IPs
 
 [sandbox]
+# agent = "copilot"          # Preferred agent: copilot, opencode, gemini, pi, shell (auto-detected if not set)
 # validate = true
 # allow_env_files = false
 # allow_lifecycle_scripts = false

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -18,7 +18,7 @@ pub enum Agent {
     OpenCode,
     /// Google Gemini CLI — AI coding agent powered by Gemini models.
     Gemini,
-    /// Pi coding agent (@earendil-works/pi-coding-agent).
+    /// Pi coding agent (https://github.com/earendil-works/pi).
     Pi,
     /// Plain sandboxed shell — no AI agent, just a secure shell session.
     Shell,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -18,6 +18,8 @@ pub enum Agent {
     OpenCode,
     /// Google Gemini CLI — AI coding agent powered by Gemini models.
     Gemini,
+    /// Pi coding agent (@earendil-works/pi-coding-agent).
+    Pi,
     /// Plain sandboxed shell — no AI agent, just a secure shell session.
     Shell,
 }
@@ -29,6 +31,7 @@ impl Agent {
             Agent::Copilot => "copilot",
             Agent::OpenCode => "opencode",
             Agent::Gemini => "gemini",
+            Agent::Pi => "pi",
             Agent::Shell => "shell",
         }
     }
@@ -39,6 +42,7 @@ impl Agent {
             Agent::Copilot => "Copilot",
             Agent::OpenCode => "OpenCode",
             Agent::Gemini => "Gemini",
+            Agent::Pi => "Pi",
             Agent::Shell => "Shell",
         }
     }
@@ -55,7 +59,7 @@ impl Agent {
     pub fn extra_args(&self) -> &'static [&'static str] {
         match self {
             Agent::Copilot => &["--no-auto-update"],
-            Agent::OpenCode | Agent::Gemini | Agent::Shell => &[],
+            Agent::OpenCode | Agent::Gemini | Agent::Pi | Agent::Shell => &[],
         }
     }
 
@@ -173,6 +177,25 @@ impl Agent {
                     process_exec: false,
                 }]
             }
+            Agent::Pi => {
+                // ~/.pi/agent stores settings, auth, sessions, themes
+                // ~/.pi/agent/bin contains managed tool binaries (fd, rg)
+                vec![
+                    AgentDir {
+                        path: home.join(".pi"),
+                        write: true,
+                        map_exec: false,
+                        process_exec: false,
+                    },
+                    AgentDir {
+                        path: home.join(".pi/agent/bin"),
+                        write: false,
+                        map_exec: false,
+                        // Pi installs managed binaries here (fd, rg)
+                        process_exec: true,
+                    },
+                ]
+            }
         }
     }
 
@@ -197,6 +220,13 @@ impl Agent {
             // Gemini uses Google OAuth by default (browser flow, stored in ~/.gemini/).
             // API key or Vertex AI project are alternatives.
             Agent::Gemini => &["GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"],
+            // Pi supports multiple LLM providers via API keys.
+            Agent::Pi => &[
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "GEMINI_API_KEY",
+                "OPENROUTER_API_KEY",
+            ],
             Agent::Shell => &[],
         }
     }
@@ -270,6 +300,7 @@ impl Agent {
             Agent::Gemini => {
                 "Install Gemini CLI: npm i -g @google/gemini-cli, or brew install gemini-cli"
             }
+            Agent::Pi => "Install Pi: npm i -g @earendil-works/pi-coding-agent",
             Agent::Shell => unreachable!("Shell is resolved via $SHELL above"),
         };
 
@@ -345,9 +376,10 @@ impl FromStr for Agent {
             "copilot" => Ok(Agent::Copilot),
             "opencode" => Ok(Agent::OpenCode),
             "gemini" | "gem" => Ok(Agent::Gemini),
+            "pi" => Ok(Agent::Pi),
             "shell" | "sh" | "bash" | "zsh" => Ok(Agent::Shell),
             _ => Err(format!(
-                "Unknown agent '{s}'. Supported: copilot, opencode, gemini, shell"
+                "Unknown agent '{s}'. Supported: copilot, opencode, gemini, pi, shell"
             )),
         }
     }
@@ -492,5 +524,68 @@ mod tests {
         assert_eq!(format!("{}", Agent::Copilot), "Copilot");
         assert_eq!(format!("{}", Agent::OpenCode), "OpenCode");
         assert_eq!(format!("{}", Agent::Gemini), "Gemini");
+        assert_eq!(format!("{}", Agent::Pi), "Pi");
+    }
+
+    #[test]
+    fn parse_pi_agent() {
+        assert_eq!(Agent::from_str("pi").unwrap(), Agent::Pi);
+        assert_eq!(Agent::from_str("Pi").unwrap(), Agent::Pi);
+        assert_eq!(Agent::from_str("PI").unwrap(), Agent::Pi);
+    }
+
+    #[test]
+    fn pi_binary_name() {
+        assert_eq!(Agent::Pi.binary_name(), "pi");
+    }
+
+    #[test]
+    fn pi_no_sea_extraction() {
+        assert!(!Agent::Pi.needs_sea_extraction());
+    }
+
+    #[test]
+    fn pi_no_extra_args() {
+        assert!(Agent::Pi.extra_args().is_empty());
+    }
+
+    #[test]
+    fn pi_no_keychain() {
+        assert!(!Agent::Pi.needs_keychain());
+    }
+
+    #[test]
+    fn pi_no_copilot_dir() {
+        assert!(!Agent::Pi.needs_copilot_dir());
+    }
+
+    #[test]
+    fn pi_config_dirs() {
+        let home = Path::new("/Users/test");
+        let dirs = Agent::Pi.config_dirs(home);
+        assert_eq!(dirs.len(), 2, "should have ~/.pi and ~/.pi/agent/bin");
+        // Main dir is writable
+        assert_eq!(dirs[0].path, home.join(".pi"));
+        assert!(dirs[0].write);
+        assert!(!dirs[0].process_exec);
+        // Bin dir has process_exec for managed binaries
+        assert_eq!(dirs[1].path, home.join(".pi/agent/bin"));
+        assert!(!dirs[1].write);
+        assert!(dirs[1].process_exec);
+    }
+
+    #[test]
+    fn pi_auth_env_hints() {
+        let hints = Agent::Pi.auth_env_hint();
+        assert!(hints.contains(&"ANTHROPIC_API_KEY"));
+        assert!(hints.contains(&"OPENAI_API_KEY"));
+        assert!(hints.contains(&"GEMINI_API_KEY"));
+        assert!(hints.contains(&"OPENROUTER_API_KEY"));
+    }
+
+    #[test]
+    fn unknown_agent_error_lists_pi() {
+        let err = Agent::from_str("nope").unwrap_err();
+        assert!(err.contains("pi"), "error should mention pi: {err}");
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,7 +1,7 @@
 //! Agent abstraction for different AI coding tools.
 //!
 //! cplt can sandbox multiple AI coding agents — currently GitHub Copilot CLI,
-//! OpenCode, and Google Gemini CLI. Each agent has different binary names,
+//! OpenCode, Google Gemini CLI, and Pi. Each agent has different binary names,
 //! config directories, and runtime requirements, but shares the same core
 //! sandbox infrastructure.
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -315,6 +315,7 @@ impl Config {
             allow_browser,
             scratch_dir,
             quiet,
+            agent: self.sandbox.agent.clone(),
             deny_env: Vec::new(),
         })
     }

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -90,6 +90,10 @@ pub fn default_config_contents() -> String {
 
 # ─── Sandbox behavior ───────────────────────────────────────
 [sandbox]
+# Preferred AI coding agent. Auto-detected from PATH if not set.
+# Supported: copilot, opencode, gemini, pi, shell
+# agent = "copilot"
+#
 # Run sandbox-exec validation test on every launch (default: true).
 # Disable to save ~200ms startup if you trust your config.
 # validate = true

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -147,6 +147,14 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
     // [sandbox]
     ConfigKeyInfo {
         section: "sandbox",
+        key: "agent",
+        value_type: ConfigValueType::Str,
+        dangerous: false,
+        default_display: "",
+        description: "Preferred AI coding agent (copilot, opencode, gemini, pi, shell). Auto-detected from PATH if not set.",
+    },
+    ConfigKeyInfo {
+        section: "sandbox",
         key: "validate",
         value_type: ConfigValueType::Bool,
         dangerous: false,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -100,6 +100,9 @@ pub struct DenyConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct SandboxConfig {
+    /// Preferred AI coding agent (default: auto-detect from PATH).
+    /// Use this instead of always passing --agent on the command line.
+    pub agent: Option<String>,
     /// Run sandbox-exec validation test on startup (default: true).
     pub validate: Option<bool>,
     /// Allow reading .env files and private keys in project dir (default: false).
@@ -182,6 +185,8 @@ pub struct Resolved {
     pub allow_browser: bool,
     pub scratch_dir: bool,
     pub quiet: bool,
+    /// Preferred agent from config (None = auto-detect).
+    pub agent: Option<String>,
     /// Env vars to strip from the sandbox environment (from repo config [deny] section).
     pub deny_env: Vec<String>,
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -17,6 +17,7 @@ const VALID_PROXY_KEYS: &[&str] = &[
 const VALID_ALLOW_KEYS: &[&str] = &["read", "write", "ports", "localhost"];
 const VALID_DENY_KEYS: &[&str] = &["paths"];
 const VALID_SANDBOX_KEYS: &[&str] = &[
+    "agent",
     "validate",
     "allow_env_files",
     "allow_localhost_any",

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ EXAMPLES:
 struct Cli {
     /// Which AI coding agent to sandbox.
     /// Auto-detected from PATH if not specified (prefers copilot, falls back to opencode, then gemini).
-    /// Supported: copilot, opencode, gemini, shell
+    /// Supported: copilot, opencode, gemini, pi, shell
     #[arg(long, value_name = "AGENT")]
     agent: Option<String>,
 
@@ -825,28 +825,37 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
     }
 
     // Resolve which agent to sandbox
+    // Precedence: CLI --agent > config sandbox.agent > auto_detect > error
     let active_agent = match &cli.agent {
         Some(name) => match name.parse::<agent::Agent>() {
             Ok(a) => a,
             Err(e) => bail!("{e}"),
         },
-        None => match agent::Agent::auto_detect() {
-            Some(a) => a,
-            None => {
-                // --print-profile and --doctor don't need a real agent binary.
-                // Default to Copilot so they work without anything installed.
-                if cli.print_profile || cli.doctor {
-                    agent::Agent::Copilot
-                } else {
-                    bail!(
-                        "No supported AI coding agent found in PATH. \
-                         Install one of:\n\
-                         [cplt]   Copilot CLI: brew install --cask copilot-cli\n\
-                         [cplt]   OpenCode:    npm i -g opencode-ai\n\
-                         [cplt] Or specify explicitly: cplt --agent copilot|opencode|shell"
-                    );
+        None => match &resolved.agent {
+            Some(name) => match name.parse::<agent::Agent>() {
+                Ok(a) => a,
+                Err(e) => bail!("Invalid sandbox.agent config value: {e}"),
+            },
+            None => match agent::Agent::auto_detect() {
+                Some(a) => a,
+                None => {
+                    // --print-profile and --doctor don't need a real agent binary.
+                    // Default to Copilot so they work without anything installed.
+                    if cli.print_profile || cli.doctor {
+                        agent::Agent::Copilot
+                    } else {
+                        bail!(
+                            "No supported AI coding agent found in PATH. \
+                             Install one of:\n\
+                             [cplt]   Copilot CLI: brew install --cask copilot-cli\n\
+                             [cplt]   OpenCode:    npm i -g opencode-ai\n\
+                             [cplt]   Gemini CLI:  npm i -g @google/gemini-cli\n\
+                             [cplt]   Pi:          npm i -g @earendil-works/pi-coding-agent\n\
+                             [cplt] Or specify explicitly: cplt --agent copilot|opencode|gemini|pi|shell"
+                        );
+                    }
                 }
-            }
+            },
         },
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ EXAMPLES:
 )]
 struct Cli {
     /// Which AI coding agent to sandbox.
-    /// Auto-detected from PATH if not specified (prefers copilot, falls back to opencode, then gemini).
+    /// Resolved in order: this flag > sandbox.agent config > auto-detect from PATH.
     /// Supported: copilot, opencode, gemini, pi, shell
     #[arg(long, value_name = "AGENT")]
     agent: Option<String>,

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -253,12 +253,20 @@ fn emit_home_access(sb: &mut String, home: &str, agent: Agent, agent_dirs: &[Age
             if dir.map_exec {
                 sbpl!(sb, "(allow file-map-executable (subpath \"{path}\"))");
             }
+            if dir.process_exec {
+                sbpl!(sb, "(allow process-exec (subpath \"{path}\"))");
+            }
             // Explicitly deny exec on writable agent data dirs (write+exec = persistence risk)
             if dir.write && !dir.process_exec {
                 sbpl!(sb, "(deny process-exec (subpath \"{path}\"))");
             }
             if dir.write && !dir.map_exec {
                 sbpl!(sb, "(deny file-map-executable (subpath \"{path}\"))");
+            }
+            // Explicitly deny writes on exec-only dirs (prevents write+exec persistence
+            // even when a parent dir is writable — SBPL uses most-specific match)
+            if !dir.write && dir.process_exec {
+                sbpl!(sb, "(deny file-write* (subpath \"{path}\"))");
             }
         }
         sbpl!(sb);


### PR DESCRIPTION
## Summary

Adds Pi coding agent as a supported agent and introduces a `sandbox.agent` config option for setting a preferred default agent.

### Pi agent (`--agent pi`)

- Sandbox config: `~/.pi` writable, `~/.pi/agent/bin` with process-exec for managed binaries (fd, rg)
- Multi-provider auth hints (Anthropic, OpenAI, Gemini, OpenRouter) — all opt-in via `--pass-env`
- **Not auto-detected** — binary name `pi` has high collision risk with other tools
- Explicit via `--agent pi` or `sandbox.agent = "pi"` in config
- Install: `npm i -g @earendil-works/pi-coding-agent`

### Configurable default agent (`sandbox.agent`)

```toml
[sandbox]
agent = "pi"  # or copilot, opencode, gemini, shell
```

Resolution order: CLI `--agent` > config `sandbox.agent` > auto_detect > error

### Changes

- `src/agent.rs` — `Agent::Pi` variant with full implementation + 9 new tests
- `src/config/types.rs` — `agent: Option<String>` field on `SandboxConfig` + `Resolved`
- `src/config/registry.rs` — `sandbox.agent` key metadata
- `src/config/validation.rs` — added `agent` to valid sandbox keys
- `src/config/loading.rs` — thread agent config through to Resolved
- `src/config/path.rs` — default config template updated
- `src/main.rs` — agent resolution checks config between CLI and auto-detect
- `README.md` — Gemini + Pi agent sections with usage and security notes
- `SECURITY.md` — expanded agent comparison table, Pi/Gemini security notes
- `docs/configuration.md` — `sandbox.agent` option documented

### Testing

All 181 unit + 244 lib tests pass. Clippy clean.

Closes #37