### PR TITLE
fix: emit sensitive project file denies after all user allows

### DIFF
--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -116,7 +116,7 @@ pub fn generate_profile(opts: &ProfileOptions) -> String {
 
     emit_header(&mut sb, &project);
     emit_process_rules(&mut sb);
-    emit_project_access(&mut sb, &project, opts.allow_env_files);
+    emit_project_access(&mut sb, &project);
     emit_home_access(&mut sb, &home, opts.agent, opts.agent_dirs);
     emit_git_hooks(&mut sb, opts.git_hooks_path);
     emit_system_access(&mut sb, &home, opts.allow_browser, allow_chromium_runtime);
@@ -153,6 +153,10 @@ pub fn generate_profile(opts: &ProfileOptions) -> String {
         opts.proxy_port,
         opts.localhost_ports,
     );
+    // Sensitive project file denies MUST come after all user-configured allows.
+    // SBPL uses last-match-wins, so a user allow like `allow.read = ["~/Repos"]`
+    // would override the .env deny if emitted before it.
+    emit_sensitive_project_denies(&mut sb, opts.allow_env_files);
 
     sb
 }
@@ -197,7 +201,7 @@ fn emit_process_rules(sb: &mut String) {
     sbpl!(sb);
 }
 
-fn emit_project_access(sb: &mut String, project: &str, allow_env_files: bool) {
+fn emit_project_access(sb: &mut String, project: &str) {
     // Project directory — full access
     // file-map-executable needed for native Node addons in node_modules
     // (e.g. @next/swc-*, sharp, better-sqlite3 loaded via dlopen)
@@ -225,11 +229,16 @@ fn emit_project_access(sb: &mut String, project: &str, allow_env_files: bool) {
     sbpl!(sb, ";; Repo config — deny write to prevent tampering");
     sbpl!(sb, "(deny file-write* (literal \"{project}/.cplt.toml\"))");
     sbpl!(sb);
+}
 
+fn emit_sensitive_project_denies(sb: &mut String, allow_env_files: bool) {
     // Sensitive project files — deny read AND write of .env*, .pem, .key etc.
     // Read deny: prevents exfiltration of secrets via HTTPS.
     // Write deny: prevents deletion/overwrite of secrets (rm, truncate).
-    // Placed after the project allow so deny wins (more specific filter).
+    // Emitted AFTER all user-configured allows so these denies win via
+    // last-match-wins. A user allow like `allow.read = ["~/Repos"]` must
+    // not override the .env deny just because the project dir happens to
+    // be under ~/Repos.
     if !allow_env_files {
         sbpl!(
             sb,

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -156,7 +156,7 @@ pub fn generate_profile(opts: &ProfileOptions) -> String {
     // Sensitive project file denies MUST come after all user-configured allows.
     // SBPL uses last-match-wins, so a user allow like `allow.read = ["~/Repos"]`
     // would override the .env deny if emitted before it.
-    emit_sensitive_project_denies(&mut sb, opts.allow_env_files);
+    emit_sensitive_project_denies(&mut sb, &project, opts.allow_env_files);
 
     sb
 }
@@ -210,13 +210,19 @@ fn emit_project_access(sb: &mut String, project: &str) {
     sbpl!(sb, "(allow file-write* (subpath \"{project}\"))");
     sbpl!(sb, "(allow file-map-executable (subpath \"{project}\"))");
     sbpl!(sb);
+}
+
+fn emit_sensitive_project_denies(sb: &mut String, project: &str, allow_env_files: bool) {
+    // All security-critical project denies are emitted LAST in the profile.
+    // SBPL uses last-match-wins, so these must come after all user-configured
+    // allows (e.g. `allow.write = ["~/Repos"]`) to guarantee they cannot be
+    // overridden by broad parent-path allows.
 
     // Git persistence prevention — deny writes to files that execute outside the sandbox.
     // .git/hooks/ — post-checkout, pre-push etc. run outside sandbox on next git operation
     // .git/config — core.hooksPath can redirect hooks to /tmp, bypassing the hooks deny;
     //               url.*.insteadOf can hijack git remotes; include.path loads arbitrary config
     // .gitmodules — submodule URLs are a supply chain vector (git submodule update clones them)
-    // These denies are more specific than the project allow, so they win (SBPL specificity).
     sbpl!(sb, ";; Git persistence prevention");
     sbpl!(sb, "(deny file-write* (subpath \"{project}/.git/hooks\"))");
     sbpl!(sb, "(deny file-write* (literal \"{project}/.git/config\"))");
@@ -229,16 +235,10 @@ fn emit_project_access(sb: &mut String, project: &str) {
     sbpl!(sb, ";; Repo config — deny write to prevent tampering");
     sbpl!(sb, "(deny file-write* (literal \"{project}/.cplt.toml\"))");
     sbpl!(sb);
-}
 
-fn emit_sensitive_project_denies(sb: &mut String, allow_env_files: bool) {
     // Sensitive project files — deny read AND write of .env*, .pem, .key etc.
     // Read deny: prevents exfiltration of secrets via HTTPS.
     // Write deny: prevents deletion/overwrite of secrets (rm, truncate).
-    // Emitted AFTER all user-configured allows so these denies win via
-    // last-match-wins. A user allow like `allow.read = ["~/Repos"]` must
-    // not override the .env deny just because the project dir happens to
-    // be under ~/Repos.
     if !allow_env_files {
         sbpl!(
             sb,

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1387,6 +1387,52 @@ fn profile_env_deny_comes_after_project_allow() {
     );
 }
 
+#[test]
+fn profile_env_deny_comes_after_user_allows() {
+    let p = generate_profile(&ProfileOptions {
+        project_dir: std::path::Path::new("/projects/app"),
+        home_dir: std::path::Path::new("/Users/test"),
+        extra_read: &[std::path::PathBuf::from("/projects")],
+        extra_write: &[],
+        extra_deny: &[],
+        existing_home_tool_dirs: None,
+        extra_ports: &[],
+        localhost_ports: &[],
+        proxy_port: None,
+        allow_env_files: false,
+        allow_localhost_any: false,
+        scratch_dir: None,
+        allow_tmp_exec: false,
+        copilot_install_dir: None,
+        java_home: None,
+        git_hooks_path: None,
+        allow_gpg_signing: false,
+        allow_jvm_attach: false,
+        allow_docker: false,
+        electron_app_dir: None,
+        agent: cplt::agent::Agent::Copilot,
+        agent_dirs: &[],
+        allow_cache_exec: &[],
+        allow_cache_exec_any: false,
+        allow_browser: false,
+    });
+    let user_allow = p
+        .find("(allow file-read* (subpath \"/projects\"))")
+        .unwrap();
+    let env_deny = p.find(r#"(deny file-read* (regex #"/\.env$"))"#).unwrap();
+    let env_dot_deny = p
+        .find(r#"(deny file-read* (regex #"/\.env\..*"))"#)
+        .unwrap();
+    assert!(
+        env_deny > user_allow,
+        "env deny must come AFTER user allow for SBPL last-match-wins"
+    );
+    assert!(
+        env_dot_deny > user_allow,
+        ".env.* deny must come AFTER user allow for SBPL last-match-wins"
+    );
+}
+
 // ============================================================
 // Allow-localhost-any
 // ============================================================

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1393,7 +1393,7 @@ fn profile_env_deny_comes_after_user_allows() {
         project_dir: std::path::Path::new("/projects/app"),
         home_dir: std::path::Path::new("/Users/test"),
         extra_read: &[std::path::PathBuf::from("/projects")],
-        extra_write: &[],
+        extra_write: &[std::path::PathBuf::from("/projects")],
         extra_deny: &[],
         existing_home_tool_dirs: None,
         extra_ports: &[],
@@ -1416,20 +1416,56 @@ fn profile_env_deny_comes_after_user_allows() {
         allow_cache_exec_any: false,
         allow_browser: false,
     });
-    let user_allow = p
+    let user_read_allow = p
         .find("(allow file-read* (subpath \"/projects\"))")
         .unwrap();
+    let user_write_allow = p
+        .find("(allow file-write* (subpath \"/projects\"))")
+        .unwrap();
+
+    // .env denies must come after user allows
     let env_deny = p.find(r#"(deny file-read* (regex #"/\.env$"))"#).unwrap();
     let env_dot_deny = p
         .find(r#"(deny file-read* (regex #"/\.env\..*"))"#)
         .unwrap();
     assert!(
-        env_deny > user_allow,
+        env_deny > user_read_allow,
         "env deny must come AFTER user allow for SBPL last-match-wins"
     );
     assert!(
-        env_dot_deny > user_allow,
+        env_dot_deny > user_read_allow,
         ".env.* deny must come AFTER user allow for SBPL last-match-wins"
+    );
+
+    // Git persistence denies must come after user write allows
+    let hooks_deny = p
+        .find("(deny file-write* (subpath \"/projects/app/.git/hooks\"))")
+        .unwrap();
+    let git_config_deny = p
+        .find("(deny file-write* (literal \"/projects/app/.git/config\"))")
+        .unwrap();
+    let gitmodules_deny = p
+        .find("(deny file-write* (literal \"/projects/app/.gitmodules\"))")
+        .unwrap();
+    let cplt_toml_deny = p
+        .find("(deny file-write* (literal \"/projects/app/.cplt.toml\"))")
+        .unwrap();
+
+    assert!(
+        hooks_deny > user_write_allow,
+        ".git/hooks deny must come AFTER user write allow for SBPL last-match-wins"
+    );
+    assert!(
+        git_config_deny > user_write_allow,
+        ".git/config deny must come AFTER user write allow for SBPL last-match-wins"
+    );
+    assert!(
+        gitmodules_deny > user_write_allow,
+        ".gitmodules deny must come AFTER user write allow for SBPL last-match-wins"
+    );
+    assert!(
+        cplt_toml_deny > user_write_allow,
+        ".cplt.toml deny must come AFTER user write allow for SBPL last-match-wins"
     );
 }
 


### PR DESCRIPTION
## Fix: Emit sensitive project file denies after all user-configured allows
### Bug
When a user configured `allow.read = ["~/Repos"]` in `~/.config/cplt/config.toml`, `.env` files inside projects under `~/Repos` became readable.
**Root cause:** SBPL (macOS Seatbelt) uses last-match-wins semantics. The `.env`/`.pem`/`.key` deny rules were emitted early in the profile (inside `emit_project_access`), while user-configured `allow.read` paths were emitted later by `emit_user_allows`. The later allow overrode the earlier deny.
### Fix
Extract sensitive project file denies into a new `emit_sensitive_project_denies()` function and call it at the **very end** of `generate_profile()`, after all allows (including user-configured paths).
### New rule ordering
... all allows first (project, home, tools, user-configured) ...
... other denies (git hooks, dotfiles, etc.) ...
... network rules ...
(deny file-read*  (regex #"/\.env$"))      ← LAST, so it wins
(deny file-write* (regex #"/\.env$"))
(deny file-read*  (regex #"/\.env\..*"))
...
### Test
Added `profile_env_deny_comes_after_user_allows` which creates a profile with `extra_read: ["/projects"]` and asserts that `.env` deny rules appear **after** the user allow in the generated SBPL string.
### Files changed
- `src/sandbox_profile.rs` — extract denies, move call to end
- `tests/unit_tests.rs` — regression test