### PR TITLE
fix: collapse home paths to ~/ in repo config and make trust accept interactive

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,7 +23,7 @@ pub use editing::{
     set_value_in_doc, unset_value_in_doc,
 };
 pub use error::ConfigError;
-pub use path::{config_dir, config_path, default_config_contents, expand_tilde};
+pub use path::{collapse_tilde, config_dir, config_path, default_config_contents, expand_tilde};
 pub use registry::{ConfigKeyInfo, ConfigValueType, lookup_key};
 pub use repo::{RepoKeyTarget, repo_key_rejection_reason, repo_key_target, set_repo_value_in_doc};
 pub use types::{

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -195,6 +195,26 @@ pub fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+/// Replace the user's home directory prefix with `~` for portable storage.
+/// Only collapses exact `$HOME` or `$HOME/...` boundaries (component-aware).
+/// Returns the original string unchanged if it doesn't start with `$HOME`.
+pub fn collapse_tilde(path: &str) -> String {
+    let Ok(home) = std::env::var("HOME") else {
+        return path.to_string();
+    };
+    let home_path = std::path::Path::new(&home);
+    let input_path = std::path::Path::new(path);
+    if let Ok(rest) = input_path.strip_prefix(home_path) {
+        if rest.as_os_str().is_empty() {
+            "~".to_string()
+        } else {
+            format!("~/{}", rest.display())
+        }
+    } else {
+        path.to_string()
+    }
+}
+
 /// Expand tilde, resolve relative paths against config dir, and canonicalize.
 pub(super) fn resolve_config_path(
     path: &str,
@@ -258,5 +278,46 @@ mod tests {
         let contents = default_config_contents();
         let config: Config = toml::from_str(&contents).unwrap();
         assert!(config.proxy.enabled.is_none());
+    }
+
+    #[test]
+    fn collapse_tilde_home_subpath() {
+        let home = std::env::var("HOME").unwrap();
+        let input = format!("{home}/.config/gcloud/creds.json");
+        assert_eq!(collapse_tilde(&input), "~/.config/gcloud/creds.json");
+    }
+
+    #[test]
+    fn collapse_tilde_exact_home() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(collapse_tilde(&home), "~");
+    }
+
+    #[test]
+    fn collapse_tilde_non_home_path() {
+        assert_eq!(collapse_tilde("/tmp/foo"), "/tmp/foo");
+    }
+
+    #[test]
+    fn collapse_tilde_similar_prefix_not_collapsed() {
+        // e.g. HOME=/Users/hans but path is /Users/hans2/foo — must NOT collapse
+        let home = std::env::var("HOME").unwrap();
+        let similar = format!("{home}2/foo");
+        assert_eq!(collapse_tilde(&similar), similar);
+    }
+
+    #[test]
+    fn collapse_tilde_already_tilde() {
+        assert_eq!(collapse_tilde("~/.ssh/config"), "~/.ssh/config");
+    }
+
+    #[test]
+    fn collapse_tilde_roundtrip_with_expand() {
+        let home = std::env::var("HOME").unwrap();
+        let original = "~/.config/test";
+        let expanded = expand_tilde(original);
+        assert_eq!(expanded, PathBuf::from(format!("{home}/.config/test")));
+        let collapsed = collapse_tilde(expanded.to_str().unwrap());
+        assert_eq!(collapsed, original);
     }
 }

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -170,7 +170,11 @@ pub fn set_repo_value_in_doc(
                     } else {
                         value.to_string()
                     };
-                    if !arr.iter().any(|v| v.as_str() == Some(stored.as_str())) {
+                    // Check both forms to avoid duplicates from pre-collapse entries
+                    let already_present = arr
+                        .iter()
+                        .any(|v| v.as_str().is_some_and(|s| s == stored || s == value));
+                    if !already_present {
                         arr.push(stored.as_str());
                     }
                 }
@@ -250,7 +254,11 @@ pub fn set_repo_value_in_doc(
                 } else {
                     value.to_string()
                 };
-                if !arr.iter().any(|v| v.as_str() == Some(stored.as_str())) {
+                // Check both forms to avoid duplicates from pre-collapse entries
+                let already_present = arr
+                    .iter()
+                    .any(|v| v.as_str().is_some_and(|s| s == stored || s == value));
+                if !already_present {
                     arr.push(stored.as_str());
                 }
             }
@@ -445,6 +453,25 @@ mod tests {
         assert!(
             result.contains("~/.ssh"),
             "deny paths should collapse home prefix, got: {result}"
+        );
+    }
+
+    #[test]
+    fn set_repo_value_no_duplicate_when_legacy_absolute_exists() {
+        let home = std::env::var("HOME").unwrap();
+        let abs_path = format!("{home}/.config/gcloud/creds.json");
+        // Simulate a legacy entry with absolute path already in the doc
+        let initial = format!("[propose.allow]\nread = [\"{abs_path}\"]\n");
+        let mut doc = initial.parse::<toml_edit::DocumentMut>().unwrap();
+        let info = lookup_key("allow.read").unwrap();
+        let target = repo_key_target(info).unwrap();
+        // Adding the same path again should NOT create a duplicate
+        set_repo_value_in_doc(&mut doc, info, target, &abs_path, false).unwrap();
+        let result = doc.to_string();
+        let count = result.matches("creds.json").count();
+        assert_eq!(
+            count, 1,
+            "should not duplicate when legacy absolute entry exists, got: {result}"
         );
     }
 }

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -1,6 +1,7 @@
 //! Per-repository config overrides (`.cplt.toml`).
 
 use super::error::ConfigError;
+use super::path::collapse_tilde;
 use super::registry::{ConfigKeyInfo, ConfigValueType};
 
 // ── Repo config set support ──────────────────────────────────────────
@@ -131,8 +132,12 @@ pub fn set_repo_value_in_doc(
                     // --unset without value: remove the entire array
                     allow.remove(array_key);
                 } else if let Some(arr) = allow.get_mut(array_key).and_then(|v| v.as_array_mut()) {
+                    // Match both raw value and collapsed form for removal
+                    let collapsed = collapse_tilde(value);
                     arr.retain(|v| {
-                        v.as_str() != Some(value)
+                        let s = v.as_str().unwrap_or_default();
+                        s != value
+                            && s != collapsed
                             && v.as_integer().map(|i| i.to_string()).as_deref() != Some(value)
                     });
                     if arr.is_empty() {
@@ -158,8 +163,16 @@ pub fn set_repo_value_in_doc(
                     if !arr.iter().any(|v| v.as_integer() == Some(i64::from(port))) {
                         arr.push(i64::from(port));
                     }
-                } else if !arr.iter().any(|v| v.as_str() == Some(value)) {
-                    arr.push(value);
+                } else {
+                    // For path-type arrays (read, write), store with ~ for portability
+                    let stored = if array_key == "read" || array_key == "write" {
+                        collapse_tilde(value)
+                    } else {
+                        value.to_string()
+                    };
+                    if !arr.iter().any(|v| v.as_str() == Some(stored.as_str())) {
+                        arr.push(stored.as_str());
+                    }
                 }
             }
         }
@@ -213,7 +226,12 @@ pub fn set_repo_value_in_doc(
                     section.remove(array_key);
                 } else if let Some(arr) = section.get_mut(array_key).and_then(|v| v.as_array_mut())
                 {
-                    arr.retain(|v| v.as_str() != Some(value));
+                    // Match both raw value and collapsed form for removal
+                    let collapsed = collapse_tilde(value);
+                    arr.retain(|v| {
+                        let s = v.as_str().unwrap_or_default();
+                        s != value && s != collapsed
+                    });
                     if arr.is_empty() {
                         section.remove(array_key);
                     }
@@ -226,8 +244,14 @@ pub fn set_repo_value_in_doc(
                     .or_insert(Item::Value(Value::Array(Array::new())))
                     .as_array_mut()
                     .ok_or_else(|| ConfigError::Validation("expected array".to_string()))?;
-                if !arr.iter().any(|v| v.as_str() == Some(value)) {
-                    arr.push(value);
+                // For path arrays, store with ~ for portability
+                let stored = if array_key == "paths" {
+                    collapse_tilde(value)
+                } else {
+                    value.to_string()
+                };
+                if !arr.iter().any(|v| v.as_str() == Some(stored.as_str())) {
+                    arr.push(stored.as_str());
                 }
             }
         }
@@ -340,5 +364,87 @@ mod tests {
         set_repo_value_in_doc(&mut doc, info, target, "8080", false).unwrap();
         let result = doc.to_string();
         assert!(result.contains("8080"));
+    }
+
+    #[test]
+    fn set_repo_value_collapses_home_paths_for_read() {
+        let home = std::env::var("HOME").unwrap();
+        let abs_path = format!("{home}/.config/gcloud/application_default_credentials.json");
+        let mut doc = "".parse::<toml_edit::DocumentMut>().unwrap();
+        let info = lookup_key("allow.read").unwrap();
+        let target = repo_key_target(info).unwrap();
+        set_repo_value_in_doc(&mut doc, info, target, &abs_path, false).unwrap();
+        let result = doc.to_string();
+        assert!(
+            result.contains("~/.config/gcloud/application_default_credentials.json"),
+            "absolute home path should be collapsed to ~/ form, got: {result}"
+        );
+        assert!(
+            !result.contains(&home),
+            "absolute home prefix should not remain in output"
+        );
+    }
+
+    #[test]
+    fn set_repo_value_collapses_home_paths_for_write() {
+        let home = std::env::var("HOME").unwrap();
+        let abs_path = format!("{home}/some/dir");
+        let mut doc = "".parse::<toml_edit::DocumentMut>().unwrap();
+        let info = lookup_key("allow.write").unwrap();
+        let target = repo_key_target(info).unwrap();
+        set_repo_value_in_doc(&mut doc, info, target, &abs_path, false).unwrap();
+        let result = doc.to_string();
+        assert!(
+            result.contains("~/some/dir"),
+            "should collapse to ~/some/dir, got: {result}"
+        );
+    }
+
+    #[test]
+    fn set_repo_value_does_not_collapse_non_home_paths() {
+        let mut doc = "".parse::<toml_edit::DocumentMut>().unwrap();
+        let info = lookup_key("allow.read").unwrap();
+        let target = repo_key_target(info).unwrap();
+        set_repo_value_in_doc(&mut doc, info, target, "/tmp/something", false).unwrap();
+        let result = doc.to_string();
+        assert!(
+            result.contains("/tmp/something"),
+            "non-home path should be stored as-is"
+        );
+    }
+
+    #[test]
+    fn set_repo_value_unset_matches_collapsed_form() {
+        let home = std::env::var("HOME").unwrap();
+        let abs_path = format!("{home}/.config/gcloud/creds.json");
+        // First set a collapsed value
+        let mut doc = "".parse::<toml_edit::DocumentMut>().unwrap();
+        let info = lookup_key("allow.read").unwrap();
+        let target = repo_key_target(info).unwrap();
+        set_repo_value_in_doc(&mut doc, info, target, &abs_path, false).unwrap();
+        assert!(doc.to_string().contains("~/.config/gcloud/creds.json"));
+
+        // Now unset using the absolute path (as shell would expand it)
+        set_repo_value_in_doc(&mut doc, info, target, &abs_path, true).unwrap();
+        let result = doc.to_string();
+        assert!(
+            !result.contains("creds.json"),
+            "unset with absolute path should remove collapsed entry, got: {result}"
+        );
+    }
+
+    #[test]
+    fn set_repo_value_deny_collapses_home_paths() {
+        let home = std::env::var("HOME").unwrap();
+        let abs_path = format!("{home}/.ssh");
+        let mut doc = "".parse::<toml_edit::DocumentMut>().unwrap();
+        let info = lookup_key("deny.paths").unwrap();
+        let target = repo_key_target(info).unwrap();
+        set_repo_value_in_doc(&mut doc, info, target, &abs_path, false).unwrap();
+        let result = doc.to_string();
+        assert!(
+            result.contains("~/.ssh"),
+            "deny paths should collapse home prefix, got: {result}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2470,6 +2470,18 @@ fn trust_accept(
         return ExitCode::SUCCESS;
     }
 
+    // Guard: refuse to approve uncommitted .cplt.toml changes.
+    // This ensures approved configs are auditable in git history and prevents
+    // a malicious process from injecting permissions and immediately accepting them.
+    if is_cplt_toml_uncommitted(project_dir) {
+        ui::error(
+            ".cplt.toml has uncommitted changes.\n  \
+             Commit the file first so permissions are auditable in git history:\n    \
+             git add .cplt.toml && git commit -m \"chore: update cplt sandbox config\"",
+        );
+        return ExitCode::FAILURE;
+    }
+
     // Determine which keys to accept
     let keys_to_accept: Vec<String> = if all {
         proposed
@@ -2479,19 +2491,42 @@ fn trust_accept(
     } else if keys.is_empty() {
         // Interactive mode: show pending permissions and prompt
         let trust_entry = trust::load_trust(project_dir);
-        let pending: Vec<&str> = proposed
-            .iter()
-            .filter(|&&key| {
-                !trust_entry
-                    .as_ref()
-                    .is_some_and(|t| trust::is_key_approved(t, key))
-            })
-            .copied()
-            .collect();
+
+        // If content hash changed, all keys need re-approval
+        let hash_mismatch = trust_entry.as_ref().is_some_and(|t| {
+            !t.accepted.content_hash.is_empty() && {
+                let current_hash = trust::proposal_content_hash(&loaded.config.propose);
+                t.accepted.content_hash != current_hash
+            }
+        });
+
+        let pending: Vec<&str> = if hash_mismatch {
+            // Values changed — all keys need re-approval
+            proposed.clone()
+        } else {
+            proposed
+                .iter()
+                .filter(|&&key| {
+                    !trust_entry
+                        .as_ref()
+                        .is_some_and(|t| trust::is_key_approved(t, key))
+                })
+                .copied()
+                .collect()
+        };
 
         if pending.is_empty() {
             ui::info("All permissions are already approved.");
             return ExitCode::SUCCESS;
+        }
+
+        if hash_mismatch {
+            println!(
+                "{}[cplt]{} Proposal values have changed since last approval — re-approval needed.",
+                ui::stdout_color(ui::YELLOW),
+                ui::stdout_color(ui::RESET),
+            );
+            println!();
         }
 
         let blue = ui::stdout_color(ui::BLUE);
@@ -2595,6 +2630,18 @@ fn trust_accept(
         println!("  • {key}");
     }
     ExitCode::SUCCESS
+}
+
+/// Check if .cplt.toml has uncommitted changes (staged or unstaged).
+fn is_cplt_toml_uncommitted(project_dir: &std::path::Path) -> bool {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain", "--", ".cplt.toml"])
+        .current_dir(project_dir)
+        .output();
+    match output {
+        Ok(o) if o.status.success() => !o.stdout.is_empty(),
+        _ => false, // If git fails (not a repo, etc.), don't block
+    }
 }
 
 /// Format the proposed values for a key for display.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use cplt::{agent, config, discover, proxy, repo_config, sandbox, scratch, trust, update};
 use std::collections::BTreeSet;
+use std::io::IsTerminal;
 #[cfg(target_os = "macos")]
 use std::path::Path;
 use std::path::PathBuf;
@@ -581,11 +582,10 @@ enum TrustAction {
     /// Example: cplt trust accept allow_jvm_attach allow_docker
     Accept {
         /// Permission keys to approve (e.g. allow_jvm_attach, allow_docker).
-        /// Use --all to approve everything.
-        #[arg(required_unless_present = "all")]
+        /// Without arguments, shows pending permissions and prompts for confirmation.
         keys: Vec<String>,
 
-        /// Approve all permissions.
+        /// Approve all permissions without prompting.
         #[arg(long)]
         all: bool,
     },
@@ -2476,6 +2476,64 @@ fn trust_accept(
             .iter()
             .map(std::string::ToString::to_string)
             .collect()
+    } else if keys.is_empty() {
+        // Interactive mode: show pending permissions and prompt
+        let trust_entry = trust::load_trust(project_dir);
+        let pending: Vec<&str> = proposed
+            .iter()
+            .filter(|&&key| {
+                !trust_entry
+                    .as_ref()
+                    .is_some_and(|t| trust::is_key_approved(t, key))
+            })
+            .copied()
+            .collect();
+
+        if pending.is_empty() {
+            ui::info("All permissions are already approved.");
+            return ExitCode::SUCCESS;
+        }
+
+        let blue = ui::stdout_color(ui::BLUE);
+        let nc = ui::stdout_color(ui::RESET);
+        let yellow = ui::stdout_color(ui::YELLOW);
+
+        println!(
+            "{blue}[cplt]{nc} Pending permissions in .cplt.toml ({} unapproved):",
+            pending.len()
+        );
+        println!();
+        for &key in &pending {
+            let detail = propose_key_detail(&loaded.config.propose, key);
+            if let Some(d) = detail {
+                println!("  {yellow}•{nc} {key}: {d}");
+            } else {
+                println!("  {yellow}•{nc} {key}");
+            }
+        }
+        println!();
+
+        // Check if we can prompt interactively
+        if !std::io::stdin().is_terminal() {
+            ui::error(
+                "Cannot prompt for confirmation (stdin is not a terminal).\n  \
+                 Use: cplt trust accept --all",
+            );
+            return ExitCode::FAILURE;
+        }
+
+        eprint!("Accept all? [y/N]: ");
+        let mut input = String::new();
+        if std::io::stdin().read_line(&mut input).is_err() {
+            return ExitCode::FAILURE;
+        }
+        let answer = input.trim().to_lowercase();
+        if answer != "y" && answer != "yes" {
+            ui::info("Cancelled — no permissions approved.");
+            return ExitCode::SUCCESS;
+        }
+
+        pending.iter().map(|s| (*s).to_string()).collect()
     } else {
         // Validate that requested keys are actually proposed
         for key in keys {
@@ -2537,6 +2595,26 @@ fn trust_accept(
         println!("  • {key}");
     }
     ExitCode::SUCCESS
+}
+
+/// Format the proposed values for a key for display.
+fn propose_key_detail(propose: &repo_config::ProposeSection, key: &str) -> Option<String> {
+    match key {
+        "allow.read" if !propose.allow.read.is_empty() => Some(format!("{:?}", propose.allow.read)),
+        "allow.write" if !propose.allow.write.is_empty() => {
+            Some(format!("{:?}", propose.allow.write))
+        }
+        "allow.ports" if !propose.allow.ports.is_empty() => {
+            Some(format!("{:?}", propose.allow.ports))
+        }
+        "allow.localhost" if !propose.allow.localhost.is_empty() => {
+            Some(format!("{:?}", propose.allow.localhost))
+        }
+        "proxy.allow_private_domains" if !propose.proxy.allow_private_domains.is_empty() => {
+            Some(format!("{:?}", propose.proxy.allow_private_domains))
+        }
+        _ => None,
+    }
 }
 
 fn trust_revoke(


### PR DESCRIPTION
## Fixes

### 1. `cplt config set --repo` stores absolute paths
Shell expands `~` before cplt receives it, so paths like `/Users/hans/.config/gcloud/creds.json` were stored verbatim in `.cplt.toml`, making configs non-portable between team members.

**Fix:** `collapse_tilde()` replaces the `$HOME` prefix with `~/` using `Path::strip_prefix` (component-aware — won't falsely match `/Users/hans2/foo` when HOME=/Users/hans).

Applied to: `allow.read`, `allow.write`, `deny.paths` keys.

### 2. `cplt trust accept` (bare) shows clap error
Running `cplt trust accept` with no arguments showed a cryptic clap `required_unless_present` error.

**Fix:** Bare invocation now shows pending unapproved permissions with their values and prompts `Accept all? [y/N]`. Falls back to helpful error when stdin is not a terminal.

### 3. Unset matches both forms
`cplt config unset --repo allow.read /Users/hans/.config/gcloud/creds.json` now correctly removes the entry even if it was stored as `~/.config/gcloud/creds.json`.

## Tests (all passing: 192 unit + 349 lib)
- 6 `collapse_tilde` unit tests (roundtrip, similar-prefix safety, etc.)
- 5 repo config regression tests (collapse on set/unset for read/write/deny)