### PR TITLE
feat: add antigravity agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
 ![Linux](https://img.shields.io/badge/platform-Linux-lightgrey)
 
-**Kernel-enforced sandbox for AI coding agents.** Wraps GitHub Copilot CLI, OpenCode, Gemini CLI, Pi, or any shell so agents can write code but cannot steal credentials, push to main, merge PRs, or exfiltrate secrets.
+**Kernel-enforced sandbox for AI coding agents.** Wraps GitHub Copilot CLI, OpenCode, Gemini CLI, Antigravity CLI, Pi, or any shell so agents can write code but cannot steal credentials, push to main, merge PRs, or exfiltrate secrets.
 
 - **macOS**: Apple Seatbelt/SBPL via `sandbox-exec`
 - **Linux**: Landlock LSM + seccomp-BPF (kernel 5.13+; full network filtering on 6.7+)
@@ -122,7 +122,7 @@ For the full security model, threat analysis, and test strategy, see **[SECURITY
 | Environment handling | Allowlist + hardening env injection | More basic pass-through model |
 | Secret file protection | Deny patterns such as `.env*`, `.pem`, `.key` inside the repo | Primarily directory-scoped access |
 | Repo policy | [`.cplt.toml`](docs/configuration.md#per-repo-configuration-cplttoml) with explicit trust/approval flow | No repo-level policy file |
-| Agent support | Copilot, OpenCode, Gemini CLI, [Pi agent](#pi-agent-support), or shell | Codex only |
+| Agent support | Copilot, OpenCode, Gemini CLI, [Antigravity CLI](#antigravity-cli-support), [Pi agent](#pi-agent-support), or shell | Codex only |
 
 cplt is not stronger everywhere. Codex CLI has Linux namespace isolation today, and it already exposes explicit sandbox modes such as read-only and workspace-write. cplt does not yet have that mode matrix.
 
@@ -163,7 +163,7 @@ That matters most for CLI agents and credential exposure:
 | Network proxy | HTTP CONNECT + domain allow/block | HTTP + SOCKS5 + experimental TLS MITM |
 | SSH git | Blocked at kernel (SSH agent socket denied) | Proxied via SOCKS5 |
 | Package manager scripts | Blocked by default (`npm_config_ignore_scripts`) | Not blocked |
-| Agent support | Copilot, OpenCode, Gemini, Pi, Shell | Claude Code |
+| Agent support | Copilot, OpenCode, Gemini, Antigravity, Pi, Shell | Claude Code |
 | Config | TOML (global + per-repo) | JSON (global only) + `--control-fd` live updates |
 | Library API | ❌ Binary only | ✅ Embeddable TypeScript library |
 
@@ -288,7 +288,7 @@ This is the same pattern used by tools like mise, direnv, and starship.
 cplt [OPTIONS] [-- <AGENT_ARGS>...]
 ```
 
-Everything after `--` is passed directly to the agent process (copilot, opencode, or shell).
+Everything after `--` is passed directly to the agent process (copilot, opencode, gemini, antigravity, pi, or shell).
 
 ### File access
 
@@ -494,6 +494,24 @@ cplt --agent gemini --pass-env GEMINI_API_KEY
 - Keychain access is enabled (used for extension integrity verification)
 - OAuth browser flow requires `--allow-browser` for first-time login
 - `--resume`, `--continue`, `--remote`, `--name` flags are Copilot-specific and ignored for Gemini
+
+### Antigravity CLI support
+
+cplt can sandbox [Antigravity CLI](https://github.com/google-antigravity/antigravity-cli). Use `antigravity` as the canonical cplt agent name (aliases `agy` and `agi` are accepted).
+
+```bash
+# Run Antigravity CLI
+cplt --agent antigravity
+
+# Set Antigravity as your default agent
+cplt config set sandbox.agent antigravity
+```
+
+**Security notes for Antigravity:**
+- Antigravity config (`~/.gemini/config/`) and runtime data (`~/.gemini/antigravity-cli/`) are writable in the sandbox
+- Keychain access is enabled (used by OAuth/keyring-based auth)
+- OAuth browser flow requires `--allow-browser` for first-time login
+- `--resume`, `--continue`, `--remote`, `--name` flags are Copilot-specific and ignored for Antigravity
 
 ### Pi agent support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,19 +4,19 @@ This document describes the security architecture of cplt, the threat model it a
 
 ## Supported Agents
 
-cplt sandboxes AI coding agents — currently **GitHub Copilot CLI**, **[OpenCode](https://opencode.ai/)**, **Google Gemini CLI**, and **[Pi](https://github.com/earendil-works/pi)**. All share the same core sandbox infrastructure (deny-default Seatbelt/Landlock profile, env sanitization, scratch dir), with agent-specific adaptations:
+cplt sandboxes AI coding agents — currently **GitHub Copilot CLI**, **[OpenCode](https://opencode.ai/)**, **Google Gemini CLI**, **[Antigravity CLI](https://github.com/google-antigravity/antigravity-cli)**, and **[Pi](https://github.com/earendil-works/pi)**. All share the same core sandbox infrastructure (deny-default Seatbelt/Landlock profile, env sanitization, scratch dir), with agent-specific adaptations:
 
-| Property        | Copilot                             | OpenCode                                                            | Gemini                                    | Pi                                          |
-|-----------------|-------------------------------------|---------------------------------------------------------------------|-------------------------------------------|---------------------------------------------|
-| Auth mechanism  | GitHub token (Keychain, `GH_TOKEN`) | `/connect` device flow → `auth.json`, or API keys                   | Google OAuth (browser) or API key         | API keys (Anthropic, OpenAI, Gemini, etc.)  |
-| Auth in sandbox | Token served via one-time file read (gh guard) or Keychain | Copilot auth stored in data dir; third-party keys need `--pass-env` | OAuth stored in `~/.gemini/`; key needs `--pass-env` | Keys need `--pass-env`             |
-| Config dir      | `~/.copilot` (read/write)           | `~/.config/opencode` (read-only)                                    | `~/.gemini` (read/write)                  | `~/.pi` (read/write)                       |
-| Data dir        | `~/Library/Caches/copilot`          | `~/.local/share/opencode` (write, no exec)                          | N/A (in config dir)                       | `~/.pi/agent/bin` (read + exec)             |
-| State data dir  | N/A                                 | `~/.local/state/opencode` (write, no exec)                          | N/A                                       | N/A                                         |
-| Keychain access | Yes (required for token storage)    | No                                                                  | Yes (extension integrity)                 | No                                          |
-| SEA extraction  | Yes (pre-sandbox)                   | No                                                                  | No                                        | No                                          |
-| Env isolation   | `GH_TOKEN` not injected (one-time file); `COPILOT_*` passed | `GH_TOKEN`, `COPILOT_*` suppressed                                  | `GH_TOKEN`, `COPILOT_*` suppressed        | `GH_TOKEN`, `COPILOT_*` suppressed          |
-| Auto-detected   | Yes (priority 1)                    | Yes (priority 2)                                                    | Yes (priority 3)                          | No (explicit only — name collision risk)    |
+| Property        | Copilot                             | OpenCode                                                            | Gemini                                    | Antigravity                                 | Pi                                          |
+|-----------------|-------------------------------------|---------------------------------------------------------------------|-------------------------------------------|----------------------------------------------|---------------------------------------------|
+| Auth mechanism  | GitHub token (Keychain, `GH_TOKEN`) | `/connect` device flow → `auth.json`, or API keys                   | Google OAuth (browser) or API key         | Google OAuth (browser / keyring session)     | API keys (Anthropic, OpenAI, Gemini, etc.)  |
+| Auth in sandbox | Token served via one-time file read (gh guard) or Keychain | Copilot auth stored in data dir; third-party keys need `--pass-env` | OAuth stored in `~/.gemini/`; key needs `--pass-env` | OAuth/session data stored in `~/.gemini/*` | Keys need `--pass-env`             |
+| Config dir      | `~/.copilot` (read/write)           | `~/.config/opencode` (read-only)                                    | `~/.gemini` (read/write)                  | `~/.gemini/config` (read/write)              | `~/.pi` (read/write)                       |
+| Data dir        | `~/Library/Caches/copilot`          | `~/.local/share/opencode` (write, no exec)                          | N/A (in config dir)                       | `~/.gemini/antigravity-cli` (read/write)     | `~/.pi/agent/bin` (read + exec)             |
+| State data dir  | N/A                                 | `~/.local/state/opencode` (write, no exec)                          | N/A                                       | N/A                                          | N/A                                         |
+| Keychain access | Yes (required for token storage)    | No                                                                  | Yes (extension integrity)                 | Yes (OAuth/keyring flow)                     | No                                          |
+| SEA extraction  | Yes (pre-sandbox)                   | No                                                                  | No                                        | No                                           | No                                          |
+| Env isolation   | `GH_TOKEN` not injected (one-time file); `COPILOT_*` passed | `GH_TOKEN`, `COPILOT_*` suppressed                                  | `GH_TOKEN`, `COPILOT_*` suppressed        | `GH_TOKEN`, `COPILOT_*` suppressed           | `GH_TOKEN`, `COPILOT_*` suppressed          |
+| Auto-detected   | Yes (priority 1)                    | Yes (priority 2)                                                    | Yes (priority 3)                          | Yes (priority 4)                             | No (explicit only — name collision risk)    |
 
 ### OpenCode-specific security notes
 
@@ -33,6 +33,12 @@ cplt sandboxes AI coding agents — currently **GitHub Copilot CLI**, **[OpenCod
 - **API key alternative**: `GEMINI_API_KEY` or `GOOGLE_CLOUD_PROJECT` can be used instead of OAuth — must be passed via `--pass-env`.
 - **Keychain access enabled**: Gemini uses macOS Keychain for extension integrity verification.
 - **Config dir is read/write**: `~/.gemini/` stores auth, settings, sessions, and agents.
+
+### Antigravity-specific security notes
+
+- **OAuth browser flow**: Antigravity uses Google OAuth for login.
+- **Keychain access enabled**: Antigravity relies on macOS keyring/Keychain integration as an authentication trade-off, similar to other OAuth-based agents.
+- **Config/data dirs are read/write**: `~/.gemini/config/` and `~/.gemini/antigravity-cli/`.
 
 ### Pi-specific security notes
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -377,7 +377,7 @@ impl Agent {
                 "Install Gemini CLI: npm i -g @google/gemini-cli, or brew install gemini-cli"
             }
             Agent::Antigravity => {
-                "Install Antigravity CLI: curl -fsSL https://antigravity.google/cli/install.sh | bash"
+                "Install Antigravity CLI: see https://antigravity.google/docs/cli-getting-started"
             }
             Agent::Pi => "Install Pi: npm i -g @earendil-works/pi-coding-agent",
             Agent::Shell => unreachable!("Shell is resolved via $SHELL above"),

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,7 +1,7 @@
 //! Agent abstraction for different AI coding tools.
 //!
 //! cplt can sandbox multiple AI coding agents — currently GitHub Copilot CLI,
-//! OpenCode, Google Gemini CLI, and Pi. Each agent has different binary names,
+//! OpenCode, Google Gemini CLI, Antigravity, and Pi. Each agent has different binary names,
 //! config directories, and runtime requirements, but shares the same core
 //! sandbox infrastructure.
 
@@ -18,6 +18,8 @@ pub enum Agent {
     OpenCode,
     /// Google Gemini CLI — AI coding agent powered by Gemini models.
     Gemini,
+    /// Antigravity CLI (`antigravity` / `agy`).
+    Antigravity,
     /// Pi coding agent (https://github.com/earendil-works/pi).
     Pi,
     /// Plain sandboxed shell — no AI agent, just a secure shell session.
@@ -31,6 +33,7 @@ impl Agent {
             Agent::Copilot => "copilot",
             Agent::OpenCode => "opencode",
             Agent::Gemini => "gemini",
+            Agent::Antigravity => "antigravity",
             Agent::Pi => "pi",
             Agent::Shell => "shell",
         }
@@ -42,6 +45,7 @@ impl Agent {
             Agent::Copilot => "Copilot",
             Agent::OpenCode => "OpenCode",
             Agent::Gemini => "Gemini",
+            Agent::Antigravity => "Antigravity",
             Agent::Pi => "Pi",
             Agent::Shell => "Shell",
         }
@@ -59,7 +63,7 @@ impl Agent {
     pub fn extra_args(&self) -> &'static [&'static str] {
         match self {
             Agent::Copilot => &["--no-auto-update"],
-            Agent::OpenCode | Agent::Gemini | Agent::Pi | Agent::Shell => &[],
+            Agent::OpenCode | Agent::Gemini | Agent::Antigravity | Agent::Pi | Agent::Shell => &[],
         }
     }
 
@@ -68,7 +72,7 @@ impl Agent {
     /// Gemini uses Keychain for extension integrity verification.
     /// OpenCode uses API keys from env vars or config files.
     pub fn needs_keychain(&self) -> bool {
-        matches!(self, Agent::Copilot | Agent::Gemini)
+        matches!(self, Agent::Copilot | Agent::Gemini | Agent::Antigravity)
     }
 
     /// Whether this agent needs access to ~/.copilot directory.
@@ -204,6 +208,26 @@ impl Agent {
                     write_files: vec![],
                 }]
             }
+            Agent::Antigravity => {
+                // Antigravity stores project config under ~/.gemini/config
+                // and runtime/session data under ~/.gemini/antigravity-cli.
+                vec![
+                    AgentDir {
+                        path: home.join(".gemini/config"),
+                        write: true,
+                        map_exec: false,
+                        process_exec: false,
+                        write_files: vec![],
+                    },
+                    AgentDir {
+                        path: home.join(".gemini/antigravity-cli"),
+                        write: true,
+                        map_exec: false,
+                        process_exec: false,
+                        write_files: vec![],
+                    },
+                ]
+            }
             Agent::Pi => {
                 // ~/.pi/agent stores settings, auth, sessions, themes
                 // ~/.pi/agent/bin contains managed tool binaries (fd, rg)
@@ -249,6 +273,8 @@ impl Agent {
             // Gemini uses Google OAuth by default (browser flow, stored in ~/.gemini/).
             // API key or Vertex AI project are alternatives.
             Agent::Gemini => &["GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"],
+            // Antigravity uses Google OAuth with keychain/session storage.
+            Agent::Antigravity => &[],
             // Pi supports multiple LLM providers via API keys.
             Agent::Pi => &[
                 "ANTHROPIC_API_KEY",
@@ -281,7 +307,10 @@ impl Agent {
             return Err(format!("Shell not found: {shell}"));
         }
 
-        let binary_name = self.binary_name();
+        let binary_names: &[&str] = match self {
+            Agent::Antigravity => &["antigravity", "agy"],
+            _ => &[self.binary_name()],
+        };
         let self_exe = std::env::current_exe()
             .ok()
             .and_then(|p| std::fs::canonicalize(&p).ok());
@@ -291,42 +320,45 @@ impl Agent {
         // For Copilot, track editor shims as fallback
         let mut editor_shim: Option<PathBuf> = None;
 
-        for dir in path_var.split(':') {
-            let candidate = PathBuf::from(dir).join(binary_name);
+        for binary_name in binary_names {
+            for dir in path_var.split(':') {
+                let candidate = PathBuf::from(dir).join(binary_name);
 
-            if !candidate.is_file() {
-                continue;
-            }
-
-            // Resolve mise/asdf shims to the real binary to avoid version conflicts
-            // when the project's .tool-versions specifies a different node version.
-            if let Some(real_bin) = resolve_mise_shim(&candidate, binary_name) {
-                if self_exe.as_ref() == Some(&real_bin) {
+                if !candidate.is_file() {
                     continue;
                 }
-                if matches!(self, Agent::Copilot) && is_editor_shim(&real_bin) {
+
+                // Resolve mise/asdf shims to the real binary to avoid version conflicts
+                // when the project's .tool-versions specifies a different node version.
+                if let Some(real_bin) = resolve_mise_shim(&candidate, binary_name) {
+                    if self_exe.as_ref() == Some(&real_bin) {
+                        continue;
+                    }
+                    if matches!(self, Agent::Copilot) && is_editor_shim(&real_bin) {
+                        if editor_shim.is_none() {
+                            editor_shim = Some(real_bin);
+                        }
+                        continue;
+                    }
+                    return Ok(real_bin);
+                }
+
+                let resolved =
+                    std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+                if self_exe.as_ref() == Some(&resolved) {
+                    continue; // skip cplt aliased as this binary
+                }
+
+                // Copilot-specific: prefer standalone over editor shims
+                if matches!(self, Agent::Copilot) && is_editor_shim(&resolved) {
                     if editor_shim.is_none() {
-                        editor_shim = Some(real_bin);
+                        editor_shim = Some(resolved);
                     }
                     continue;
                 }
-                return Ok(real_bin);
-            }
 
-            let resolved = std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
-            if self_exe.as_ref() == Some(&resolved) {
-                continue; // skip cplt aliased as this binary
+                return Ok(resolved);
             }
-
-            // Copilot-specific: prefer standalone over editor shims
-            if matches!(self, Agent::Copilot) && is_editor_shim(&resolved) {
-                if editor_shim.is_none() {
-                    editor_shim = Some(resolved);
-                }
-                continue;
-            }
-
-            return Ok(resolved);
         }
 
         if let Some(shim) = editor_shim {
@@ -344,6 +376,9 @@ impl Agent {
             Agent::Gemini => {
                 "Install Gemini CLI: npm i -g @google/gemini-cli, or brew install gemini-cli"
             }
+            Agent::Antigravity => {
+                "Install Antigravity CLI: curl -fsSL https://antigravity.google/cli/install.sh | bash"
+            }
             Agent::Pi => "Install Pi: npm i -g @earendil-works/pi-coding-agent",
             Agent::Shell => unreachable!("Shell is resolved via $SHELL above"),
         };
@@ -355,7 +390,8 @@ impl Agent {
     }
 
     /// Auto-detect which agent to use based on what's available in PATH.
-    /// Returns Copilot if found (backward compat), else OpenCode, else Gemini.
+    /// Returns Copilot if found (backward compat), else OpenCode, else Gemini,
+    /// else Antigravity.
     /// Returns None if none are found.
     pub fn auto_detect() -> Option<Agent> {
         let path_var = std::env::var("PATH").unwrap_or_default();
@@ -366,6 +402,7 @@ impl Agent {
         let mut found_copilot = false;
         let mut found_opencode = false;
         let mut found_gemini = false;
+        let mut found_antigravity = false;
 
         for dir in path_var.split(':') {
             if !found_copilot {
@@ -398,6 +435,20 @@ impl Agent {
                     }
                 }
             }
+            if !found_antigravity {
+                let antigravity_bin = PathBuf::from(dir).join("antigravity");
+                let agy_bin = PathBuf::from(dir).join("agy");
+                for candidate in [&antigravity_bin, &agy_bin] {
+                    if candidate.is_file() {
+                        let resolved =
+                            std::fs::canonicalize(candidate).unwrap_or_else(|_| candidate.clone());
+                        if self_exe.as_ref() != Some(&resolved) {
+                            found_antigravity = true;
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         if found_copilot {
@@ -406,6 +457,8 @@ impl Agent {
             Some(Agent::OpenCode)
         } else if found_gemini {
             Some(Agent::Gemini)
+        } else if found_antigravity {
+            Some(Agent::Antigravity)
         } else {
             None
         }
@@ -420,10 +473,11 @@ impl FromStr for Agent {
             "copilot" => Ok(Agent::Copilot),
             "opencode" => Ok(Agent::OpenCode),
             "gemini" | "gem" => Ok(Agent::Gemini),
+            "antigravity" | "agy" | "agi" => Ok(Agent::Antigravity),
             "pi" => Ok(Agent::Pi),
             "shell" | "sh" | "bash" | "zsh" => Ok(Agent::Shell),
             _ => Err(format!(
-                "Unknown agent '{s}'. Supported: copilot, opencode, gemini, pi, shell"
+                "Unknown agent '{s}'. Supported: copilot, opencode, gemini, antigravity, pi, shell"
             )),
         }
     }
@@ -559,6 +613,9 @@ mod tests {
         assert_eq!(Agent::from_str("gemini").unwrap(), Agent::Gemini);
         assert_eq!(Agent::from_str("Gemini").unwrap(), Agent::Gemini);
         assert_eq!(Agent::from_str("gem").unwrap(), Agent::Gemini);
+        assert_eq!(Agent::from_str("antigravity").unwrap(), Agent::Antigravity);
+        assert_eq!(Agent::from_str("agi").unwrap(), Agent::Antigravity);
+        assert_eq!(Agent::from_str("agy").unwrap(), Agent::Antigravity);
         assert!(Agent::from_str("unknown").is_err());
     }
 
@@ -578,10 +635,16 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_binary_name() {
+        assert_eq!(Agent::Antigravity.binary_name(), "antigravity");
+    }
+
+    #[test]
     fn copilot_needs_sea_extraction() {
         assert!(Agent::Copilot.needs_sea_extraction());
         assert!(!Agent::OpenCode.needs_sea_extraction());
         assert!(!Agent::Gemini.needs_sea_extraction());
+        assert!(!Agent::Antigravity.needs_sea_extraction());
     }
 
     #[test]
@@ -589,12 +652,14 @@ mod tests {
         assert_eq!(Agent::Copilot.extra_args(), &["--no-auto-update"]);
         assert!(Agent::OpenCode.extra_args().is_empty());
         assert!(Agent::Gemini.extra_args().is_empty());
+        assert!(Agent::Antigravity.extra_args().is_empty());
     }
 
     #[test]
     fn keychain_needs() {
         assert!(Agent::Copilot.needs_keychain());
         assert!(Agent::Gemini.needs_keychain());
+        assert!(Agent::Antigravity.needs_keychain());
         assert!(!Agent::OpenCode.needs_keychain());
     }
 
@@ -664,6 +729,23 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_config_dirs() {
+        let home = Path::new("/Users/test");
+        let dirs = Agent::Antigravity.config_dirs(home);
+        assert_eq!(
+            dirs.len(),
+            2,
+            "should have ~/.gemini config + antigravity-cli"
+        );
+        assert_eq!(dirs[0].path, home.join(".gemini/config"));
+        assert!(dirs[0].write);
+        assert_eq!(dirs[1].path, home.join(".gemini/antigravity-cli"));
+        assert!(dirs[1].write);
+        assert!(!dirs[0].process_exec && !dirs[0].map_exec);
+        assert!(!dirs[1].process_exec && !dirs[1].map_exec);
+    }
+
+    #[test]
     fn copilot_has_no_extra_config_dirs() {
         let home = Path::new("/Users/test");
         let dirs = Agent::Copilot.config_dirs(home);
@@ -688,10 +770,19 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_auth_env_hints() {
+        assert!(
+            Agent::Antigravity.auth_env_hint().is_empty(),
+            "antigravity uses oauth/keychain auth, no env hints"
+        );
+    }
+
+    #[test]
     fn display_names() {
         assert_eq!(format!("{}", Agent::Copilot), "Copilot");
         assert_eq!(format!("{}", Agent::OpenCode), "OpenCode");
         assert_eq!(format!("{}", Agent::Gemini), "Gemini");
+        assert_eq!(format!("{}", Agent::Antigravity), "Antigravity");
         assert_eq!(format!("{}", Agent::Pi), "Pi");
     }
 
@@ -752,8 +843,12 @@ mod tests {
     }
 
     #[test]
-    fn unknown_agent_error_lists_pi() {
+    fn unknown_agent_error_lists_antigravity_and_pi() {
         let err = Agent::from_str("nope").unwrap_err();
+        assert!(
+            err.contains("antigravity"),
+            "error should mention antigravity: {err}"
+        );
         assert!(err.contains("pi"), "error should mention pi: {err}");
     }
 

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -91,7 +91,7 @@ pub fn default_config_contents() -> String {
 # ─── Sandbox behavior ───────────────────────────────────────
 [sandbox]
 # Preferred AI coding agent. Auto-detected from PATH if not set.
-# Supported: copilot, opencode, gemini, pi, shell
+# Supported: copilot, opencode, gemini, antigravity, pi, shell
 # agent = "copilot"
 #
 # Run sandbox-exec validation test on every launch (default: true).

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -153,7 +153,7 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         value_type: ConfigValueType::Str,
         dangerous: false,
         default_display: "",
-        description: "Preferred AI coding agent (copilot, opencode, gemini, pi, shell). Auto-detected from PATH if not set.",
+        description: "Preferred AI coding agent (copilot, opencode, gemini, antigravity, pi, shell). Auto-detected from PATH if not set.",
     },
     ConfigKeyInfo {
         section: "sandbox",

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -211,7 +211,7 @@ pub fn discover_agents() -> Vec<AgentInfo> {
             let (binary_name, path) = binaries
                 .iter()
                 .find_map(|binary| which_resolved(binary).map(|path| (*binary, path)))?;
-            let version = std::process::Command::new(binary_name)
+            let version = std::process::Command::new(&path)
                 .args(*version_args)
                 .output()
                 .ok()

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -194,21 +194,24 @@ pub fn discover_copilot(home_dir: &Path) -> CopilotDiscovery {
 
 // ── Agent discovery ─────────────────────────────────────────────
 
-/// Agents to probe: (display_name, binary_name, version_flag)
-const AGENTS_TO_CHECK: &[(&str, &str, &[&str])] = &[
-    ("Copilot", "copilot", &["--version"]),
-    ("OpenCode", "opencode", &["--version"]),
-    ("Gemini", "gemini", &["--version"]),
-    ("Claude", "claude", &["--version"]),
+/// Agents to probe: (display_name, binary_names, version_flag)
+const AGENTS_TO_CHECK: &[(&str, &[&str], &[&str])] = &[
+    ("Copilot", &["copilot"], &["--version"]),
+    ("OpenCode", &["opencode"], &["--version"]),
+    ("Gemini", &["gemini"], &["--version"]),
+    ("Antigravity", &["antigravity", "agy"], &["--version"]),
+    ("Claude", &["claude"], &["--version"]),
 ];
 
 /// Discover all available AI coding agents in PATH.
 pub fn discover_agents() -> Vec<AgentInfo> {
     AGENTS_TO_CHECK
         .iter()
-        .filter_map(|(name, binary, version_args)| {
-            let path = which_resolved(binary)?;
-            let version = std::process::Command::new(binary)
+        .filter_map(|(name, binaries, version_args)| {
+            let (binary_name, path) = binaries
+                .iter()
+                .find_map(|binary| which_resolved(binary).map(|path| (*binary, path)))?;
+            let version = std::process::Command::new(binary_name)
                 .args(*version_args)
                 .output()
                 .ok()
@@ -226,7 +229,7 @@ pub fn discover_agents() -> Vec<AgentInfo> {
                 });
             Some(AgentInfo {
                 name,
-                binary_name: binary,
+                binary_name,
                 path,
                 version,
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1061,7 +1061,7 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
                              [cplt]   Copilot CLI: brew install --cask copilot-cli\n\
                              [cplt]   OpenCode:    npm i -g opencode-ai\n\
                              [cplt]   Gemini CLI:  npm i -g @google/gemini-cli\n\
-                             [cplt]   Antigravity: curl -fsSL https://antigravity.google/cli/install.sh | bash\n\
+                             [cplt]   Antigravity: https://antigravity.google/docs/cli-getting-started\n\
                              [cplt]   Pi:          npm i -g @earendil-works/pi-coding-agent\n\
                              [cplt] Or specify explicitly: cplt --agent copilot|opencode|gemini|antigravity|pi|shell"
                         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ const LONG_VERSION: &str = match option_env!("CPLT_LONG_VERSION") {
 /// - macOS: Apple Seatbelt/SBPL via sandbox-exec
 /// - Linux: Landlock LSM + seccomp-BPF (kernel 5.13+, full network filtering on 6.7+)
 ///
-/// Supports GitHub Copilot CLI, OpenCode, and Google Gemini CLI. Auto-detects
-/// which agent to use, or specify explicitly with --agent.
+/// Supports GitHub Copilot CLI, OpenCode, Google Gemini CLI, Antigravity CLI,
+/// and Pi. Auto-detects which agent to use, or specify explicitly with --agent.
 ///
 /// Defaults can be saved to ~/.config/cplt/config.toml
 /// so you don't need to pass flags every time. Run `cplt config init` to
@@ -90,7 +90,7 @@ EXAMPLES:
 struct Cli {
     /// Which AI coding agent to sandbox.
     /// Resolved in order: this flag > sandbox.agent config > auto-detect from PATH.
-    /// Supported: copilot, opencode, gemini, pi, shell
+    /// Supported: copilot, opencode, gemini, antigravity, pi, shell
     #[arg(long, value_name = "AGENT")]
     agent: Option<String>,
 
@@ -413,7 +413,7 @@ the attack surface. Prefer --allow-cache-exec with specific subdirs (e.g.,
     // --- Copilot pass-through flags ---
     // These are forwarded directly to the copilot process for convenience,
     // avoiding the need for -- when using common session-level flags.
-    // Ignored when --agent opencode is used.
+    // Ignored when --agent is anything except Copilot.
     /// Resume a previous Copilot session. Use --resume to pick interactively,
     /// or --resume=NAME to resume a specific session by name or ID.
     /// Copilot-only (ignored for other agents).
@@ -1061,8 +1061,9 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
                              [cplt]   Copilot CLI: brew install --cask copilot-cli\n\
                              [cplt]   OpenCode:    npm i -g opencode-ai\n\
                              [cplt]   Gemini CLI:  npm i -g @google/gemini-cli\n\
+                             [cplt]   Antigravity: curl -fsSL https://antigravity.google/cli/install.sh | bash\n\
                              [cplt]   Pi:          npm i -g @earendil-works/pi-coding-agent\n\
-                             [cplt] Or specify explicitly: cplt --agent copilot|opencode|gemini|pi|shell"
+                             [cplt] Or specify explicitly: cplt --agent copilot|opencode|gemini|antigravity|pi|shell"
                         );
                     }
                 }

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -254,6 +254,7 @@ pub const ENV_PREFIX_ALLOWLIST: &[&str] = &[
     "SDKMAN_",         // SDKMAN (Java version manager)
     "TESTCONTAINERS_", // Testcontainers configuration
     "YARN_",           // Yarn Berry config (hardening injection overrides YARN_ENABLE_SCRIPTS)
+    "AGY_",            // Antigravity CLI runtime configuration
 ];
 
 /// Environment variables always stripped, even with --inherit-env.


### PR DESCRIPTION
## Summary
Add first-class support for the **Antigravity CLI** in cplt with canonical agent name `antigravity`.

This makes Antigravity available anywhere cplt currently supports agent selection, while keeping compatibility aliases for upstream binary naming.

## What changed
- Added new agent variant: `Agent::Antigravity`.
- Canonical parsing/config value: `antigravity`.
- Backward-compatible aliases: `agi`, `agy`.
- Binary resolution fallback for Antigravity:
  1. `antigravity`
  2. `agy`
- Added Antigravity config dir permissions:
  - `~/.gemini/config`
  - `~/.gemini/antigravity-cli`
- Enabled Keychain requirement for Antigravity (OAuth/keyring flow).
- Updated supported-agent strings/help text across CLI/config.
- Extended discovery/doctor agent probing to include Antigravity (`antigravity` and `agy`).
- Added `AGY_` env prefix to sandbox env prefix allowlist.
- Updated README with:
  - agent support matrix entries
  - dedicated Antigravity section and usage examples
  - canonical naming guidance (`antigravity` in cplt)

## Behavior notes
- `--agent antigravity` is now the canonical way to run Antigravity in cplt.
- Existing user habits with `--agent agi` / `--agent agy` continue to work.
- Auto-detection now considers Antigravity after Copilot/OpenCode/Gemini.

## Validation
- `mise run check`
