### PR TITLE
feat: add `cplt exec` subcommand for sandboxing arbitrary commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@ cplt doctor                 # check your environment
 cplt -- -p "fix the tests"  # run Copilot in sandbox
 ```
 
-Other agents:
+Other agents and sandbox commands:
 ```bash
 cplt --agent opencode                       # OpenCode (Copilot subscription)
 cplt --agent opencode --pass-env ANTHROPIC_API_KEY  # third-party provider
-cplt --agent shell                          # sandboxed shell (no AI)
+cplt --agent shell                          # interactive sandboxed shell (no AI)
+cplt exec -- npm install                    # sandbox any command directly
+cplt exec -c "npm install && npm test"      # compound commands in sandbox
+alias npm="cplt exec -- npm"               # sandboxed npm for every invocation
 ```
 
 ### Team rollout
@@ -556,14 +559,43 @@ Run a plain sandboxed shell — no AI agent, same security restrictions. Useful 
 # Interactive sandboxed shell (uses $SHELL — fish, zsh, bash)
 cplt --agent shell
 
-# Run a single command inside the sandbox
-cplt --agent shell -- -c 'go test ./...'
-
 # Inspect what's allowed without entering the shell
 cplt --agent shell --print-profile
 ```
 
 The sandbox applies the same deny-by-default rules — filesystem isolation, network restrictions, env sanitization. Shell config directories (fish variables/history, zsh history) are writable.
+
+> **Tip:** To run a single command non-interactively, use [`cplt exec`](#exec-mode) — it is cleaner for scripting and shell aliases than `cplt --agent shell -- -c 'cmd'`.
+
+### Exec mode
+
+<a id="exec-mode"></a>
+
+Run any command inside the sandbox without starting an AI agent. Clean for scripting, piping, and shell aliases — no startup banner, no confirmation prompt.
+
+```bash
+# Sandbox a single command
+cplt exec -- npm install
+cplt exec -- make build
+cplt exec -- go test ./...
+
+# Compound commands via $SHELL -c
+cplt exec -c "npm install && npm test"
+
+# Pass sandbox flags as usual
+cplt exec --allow-lifecycle-scripts -- npm install
+cplt exec --project-dir /path/to/repo -- make build
+cplt exec --with-proxy -- curl https://example.com
+
+# Shell aliases for sandboxed tools
+alias npm="cplt exec -- npm"
+alias node="cplt exec -- node"
+alias python="cplt exec -- python"
+```
+
+All top-level `cplt` flags apply: `--project-dir`, `--allow-read`, `--deny-path`, `--with-proxy`, `--pass-env`, etc.
+
+Use `--no-quiet` to see the full sandbox configuration summary before the command runs.
 
 ### Examples
 
@@ -638,7 +670,8 @@ cplt --pass-env ANTHROPIC_API_KEY
 cplt --agent shell
 
 # Run a one-off command in the sandbox
-cplt --agent shell -- -c 'npm test'
+cplt exec -- npm test
+cplt exec -c "npm install && npm test"
 ```
 
 ## Configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -1298,8 +1298,14 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
 
     // Handle `cplt exec` before consuming cli.command so resolve_context
     // can still borrow &cli after we take the exec-specific fields out.
-    if let Some(Command::Exec { shell_cmd, cmd }) = cli.command.take() {
-        return run_exec_command(&cli, shell_cmd, cmd);
+    // The outer matches! guard ensures we only call take() when the variant
+    // is definitely Exec — without it, take() would consume any subcommand
+    // and leave cli.command = None, silently breaking all other subcommands.
+    #[allow(clippy::collapsible_if)]
+    if matches!(&cli.command, Some(Command::Exec { .. })) {
+        if let Some(Command::Exec { shell_cmd, cmd }) = cli.command.take() {
+            return run_exec_command(&cli, shell_cmd, cmd);
+        }
     }
 
     // Handle subcommands (these don't need macOS or sandbox)
@@ -1887,6 +1893,17 @@ fn resolve_exec_binary(name: &str) -> anyhow::Result<PathBuf> {
         }
         bail!("exec: not a file: {}", canonical.display());
     }
+    // Relative path (e.g. `./vendor-script.sh`) — resolve against cwd, not PATH.
+    if name.contains('/') {
+        let cwd = std::env::current_dir().context("exec: cannot determine current directory")?;
+        let canonical = std::fs::canonicalize(cwd.join(name)).with_context(|| {
+            format!("exec: relative binary not found or not accessible: {name}")
+        })?;
+        if canonical.is_file() {
+            return Ok(canonical);
+        }
+        bail!("exec: not a file: {}", canonical.display());
+    }
     let path_var = std::env::var("PATH").unwrap_or_default();
     for dir in path_var.split(':') {
         let candidate = PathBuf::from(dir).join(name);
@@ -1921,18 +1938,13 @@ fn run_exec_command(
 
     // Resolve the binary and args to pass to the sandbox
     let (exec_bin, exec_args): (PathBuf, Vec<String>) = if let Some(ref shell_c) = shell_cmd {
-        // -c mode: delegate to $SHELL -c "cmd"
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| {
-            if cfg!(target_os = "macos") {
-                "/bin/zsh".to_string()
-            } else {
-                "/bin/sh".to_string()
-            }
-        });
-        (
-            PathBuf::from(shell),
-            vec!["-c".to_string(), shell_c.clone()],
-        )
+        // -c mode: use the same shell as --agent shell for consistent behaviour.
+        // Agent::Shell.resolve_binary() validates $SHELL exists and falls back to
+        // /bin/zsh (macOS) or /bin/bash (Linux) — same fallbacks as the interactive shell.
+        let shell = agent::Agent::Shell
+            .resolve_binary()
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        (shell, vec!["-c".to_string(), shell_c.clone()])
     } else {
         if cmd.is_empty() {
             bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1304,6 +1304,18 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     #[allow(clippy::collapsible_if)]
     if matches!(&cli.command, Some(Command::Exec { .. })) {
         if let Some(Command::Exec { shell_cmd, cmd }) = cli.command.take() {
+            // exec always uses the shell sandbox policy. Default --agent shell
+            // if none is specified so resolve_context doesn't fail when no AI
+            // agent binary is installed.
+            if cli.agent.is_none() {
+                cli.agent = Some("shell".to_string());
+            }
+            // exec defaults to quiet — apply before resolve_context so that
+            // config-loading diagnostics (e.g. "[cplt] Repo config: ...") are
+            // suppressed and don't contaminate scripts/pipes using exec.
+            if !cli.no_quiet {
+                cli.quiet = true;
+            }
             return run_exec_command(&cli, shell_cmd, cmd);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,15 @@ EXAMPLES:
   cplt trust accept allow_jvm_attach allow_docker
     Approve specific permissions from .cplt.toml
 
+  cplt exec -- npm install
+    Run npm install in the sandbox (filesystem/network isolated)
+
+  cplt exec -c \"npm install && npm test\"
+    Run compound shell commands in the sandbox
+
+  alias npm=\"cplt exec -- npm\"
+    Sandboxed npm for every invocation
+
   eval \"$(cplt --shell-setup)\"
     Add to your shell rc so 'copilot' runs the sandboxed version
 "
@@ -522,7 +531,35 @@ enum Command {
     /// and sandbox-critical paths. Exits 0 if all critical checks pass.
     Doctor,
 
-    /// [internal] Evaluate a gh command against the proxy policy.
+    /// Run an arbitrary command inside the sandbox.
+    ///
+    /// Uses the same sandbox as `--agent shell`: filesystem isolation,
+    /// env filtering, network proxy, etc.
+    ///
+    /// stdin/stdout/stderr are passed through transparently.
+    /// Exit code is forwarded from the child process.
+    /// No startup banner or confirmation prompt — clean for piping and aliases.
+    ///
+    /// All top-level cplt flags work: --project-dir, --allow-read, --with-proxy, etc.
+    ///
+    /// EXAMPLES:
+    ///   cplt exec -- npm install
+    ///   cplt exec --allow-lifecycle-scripts -- npm install
+    ///   cplt exec --project-dir /path/to/repo -- make build
+    ///   cplt exec -c "npm install && npm test"
+    ///   alias npm="cplt exec -- npm"
+    Exec {
+        /// Run CMD via the shell interpreter ($SHELL -c CMD).
+        /// Useful for shell built-ins and compound commands.
+        /// Example: cplt exec -c "npm install && npm test"
+        #[arg(short = 'c', value_name = "CMD", conflicts_with = "cmd")]
+        shell_cmd: Option<String>,
+
+        /// The command and its arguments (everything after --).
+        #[arg(last = true, value_name = "CMD")]
+        cmd: Vec<String>,
+    },
+
     ///
     /// Called by the gh wrapper script inside the sandbox. Not intended
     /// for direct use. Evaluates the command, passes through if allowed,
@@ -1241,7 +1278,7 @@ fn start_proxy_if_enabled(
     }
 }
 
-fn run(cli: Cli) -> anyhow::Result<ExitCode> {
+fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     // Handle --init-config
     if cli.init_config {
         return Ok(init_config());
@@ -1256,6 +1293,12 @@ fn run(cli: Cli) -> anyhow::Result<ExitCode> {
     // Handle --shell-install: append setup line to shell rc file
     if cli.shell_install {
         return Ok(shell_install());
+    }
+
+    // Handle `cplt exec` before consuming cli.command so resolve_context
+    // can still borrow &cli after we take the exec-specific fields out.
+    if let Some(Command::Exec { shell_cmd, cmd }) = cli.command.take() {
+        return run_exec_command(&cli, shell_cmd, cmd);
     }
 
     // Handle subcommands (these don't need macOS or sandbox)
@@ -1335,6 +1378,8 @@ fn run(cli: Cli) -> anyhow::Result<ExitCode> {
                     &rules,
                 )
             }
+            // Exec is handled before this match (see above) — unreachable
+            Command::Exec { .. } => unreachable!("Command::Exec handled before this match"),
         });
     }
 
@@ -1817,6 +1862,237 @@ fn run_git_gate(
             }
         },
     }
+}
+
+// ── cplt exec ──────────────────────────────────────────────────────────────
+
+/// Resolve a command name to an absolute binary path.
+///
+/// If `name` is already an absolute path, validate it exists and return it.
+/// Otherwise walk PATH entries (left-to-right) and return the first match.
+/// Unlike `Agent::resolve_binary()`, this does not skip cplt aliases — the
+/// user explicitly asked for this binary.
+fn resolve_exec_binary(name: &str) -> anyhow::Result<PathBuf> {
+    let p = PathBuf::from(name);
+    if p.is_absolute() {
+        // Canonicalize to resolve symlinks and `..` components — consistent with
+        // how other paths are handled, and avoids passing a non-canonical path
+        // to the OS after the sandbox allow-lists have been resolved.
+        let canonical = std::fs::canonicalize(&p).with_context(|| {
+            format!("exec: binary not found or not accessible: {}", p.display())
+        })?;
+        if canonical.is_file() {
+            return Ok(canonical);
+        }
+        bail!("exec: not a file: {}", canonical.display());
+    }
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    for dir in path_var.split(':') {
+        let candidate = PathBuf::from(dir).join(name);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    bail!("exec: '{name}' not found in PATH")
+}
+
+/// Run an arbitrary command inside the sandbox (`cplt exec -- <cmd> [args]`).
+///
+/// Reuses the Agent::Shell sandbox policy. Defaults to quiet+yes so it is
+/// clean for scripting and shell aliases. Pass --no-quiet to show the summary.
+fn run_exec_command(
+    cli: &Cli,
+    shell_cmd: Option<String>,
+    cmd: Vec<String>,
+) -> anyhow::Result<ExitCode> {
+    // Platform check
+    if cfg!(not(any(target_os = "macos", target_os = "linux"))) {
+        bail!("cplt exec requires macOS or Linux");
+    }
+
+    // Recursion guard: block nested exec inside an existing sandbox.
+    if std::env::var("__CPLT_WRAPPED").is_ok() {
+        bail!(
+            "cplt exec: already inside a cplt sandbox (recursion detected). \
+             Run this command outside the sandbox."
+        );
+    }
+
+    // Resolve the binary and args to pass to the sandbox
+    let (exec_bin, exec_args): (PathBuf, Vec<String>) = if let Some(ref shell_c) = shell_cmd {
+        // -c mode: delegate to $SHELL -c "cmd"
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| {
+            if cfg!(target_os = "macos") {
+                "/bin/zsh".to_string()
+            } else {
+                "/bin/sh".to_string()
+            }
+        });
+        (
+            PathBuf::from(shell),
+            vec!["-c".to_string(), shell_c.clone()],
+        )
+    } else {
+        if cmd.is_empty() {
+            bail!(
+                "cplt exec: no command given.\n\
+                 Usage: cplt exec -- <cmd> [args...]\n\
+                 Or:    cplt exec -c \"cmd && cmd\""
+            );
+        }
+        let bin = resolve_exec_binary(&cmd[0])?;
+        (bin, cmd[1..].to_vec())
+    };
+
+    // Resolve config, paths, project dir — same pipeline as the main agent launch
+    let ResolvedContext {
+        mut resolved,
+        config_path,
+        home_dir,
+        project_dir,
+        unapproved_proposals: _,
+        // active_agent from resolve_context is ignored — exec always uses Shell
+        active_agent: _,
+    } = resolve_context(cli)?;
+
+    // exec defaults to quiet+yes (scripting UX). User can override with --no-quiet / --no-yes.
+    if !cli.no_quiet {
+        resolved.quiet = true;
+    }
+    if !cli.no_yes {
+        resolved.yes = true;
+    }
+
+    // Warn about dangerous flags even in quiet mode — exec defaults to quiet,
+    // so these warnings would otherwise be silently swallowed. The main agent
+    // flow only warns inside print_summary (shown when !quiet), but for exec
+    // the user never explicitly chose quiet mode, so we must warn here.
+    if resolved.inherit_env {
+        ui::warn(
+            "exec: --inherit-env is active — all env vars (including credentials) are passed to the sandbox",
+        );
+    }
+    if resolved.allow_docker {
+        ui::warn(
+            "exec: --allow-docker is active — container volume mounts bypass sandbox filesystem restrictions",
+        );
+    }
+    if resolved.allow_tmp_exec {
+        ui::warn("exec: --allow-tmp-exec is active — code execution from /tmp is allowed");
+    }
+
+    // Always use the Shell sandbox policy
+    let active_agent = agent::Agent::Shell;
+
+    let tool_discovery = discover::discover_tools(&home_dir);
+    let existing_home_tool_dirs = tool_discovery.existing_home_tool_dirs;
+    let existing_app_dirs = tool_discovery.existing_app_dirs;
+
+    let scratch_guard = if resolved.scratch_dir {
+        scratch::ScratchDir::gc_stale(&home_dir);
+        match scratch::ScratchDir::create(&home_dir) {
+            Ok(s) => Some(s),
+            Err(e) => bail!("Cannot create scratch dir: {e}"),
+        }
+    } else {
+        None
+    };
+    let scratch_path = scratch_guard.as_ref().map(cplt::scratch::ScratchDir::path);
+
+    let git_hooks_path = discover::git_hooks_path(&home_dir);
+    let git_common_dir = discover::git_common_dir(&home_dir, &project_dir);
+    let java_home_dir = std::env::var("JAVA_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .filter(|p| !crate::is_unsafe_root(p, &home_dir));
+
+    let agent_dirs = active_agent.config_dirs(&home_dir);
+    for dir in &agent_dirs {
+        if !dir.path.exists() {
+            let _ = std::fs::create_dir_all(&dir.path);
+        }
+    }
+
+    let proxy_handle = start_proxy_if_enabled(&mut resolved, cli, config_path.as_ref())?;
+    let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
+
+    let prepared = match sandbox::prepare(&sandbox::SandboxConfig {
+        project_dir: &project_dir,
+        home_dir: &home_dir,
+        extra_read: &resolved.allow_read,
+        extra_write: &resolved.allow_write,
+        extra_deny: &resolved.deny_paths,
+        existing_home_tool_dirs: Some(&existing_home_tool_dirs),
+        existing_app_dirs: Some(&existing_app_dirs),
+        extra_ports: &resolved.allow_ports,
+        localhost_ports: &resolved.allow_localhost,
+        proxy_port: proxy_port_for_profile,
+        allow_env_files: resolved.allow_env_files,
+        allow_localhost_any: resolved.allow_localhost_any,
+        scratch_dir: scratch_path,
+        allow_tmp_exec: resolved.allow_tmp_exec,
+        // exec has no agent install dir to grant special access to
+        copilot_install_dir: None,
+        java_home: java_home_dir.as_deref(),
+        git_hooks_path: git_hooks_path.as_deref(),
+        git_common_dir: git_common_dir.as_deref(),
+        allow_gpg_signing: resolved.allow_gpg_signing,
+        deny_clipboard: resolved.deny_clipboard,
+        allow_jvm_attach: resolved.allow_jvm_attach,
+        allow_docker: resolved.allow_docker,
+        electron_app_dir: None,
+        agent: active_agent,
+        agent_dirs: &agent_dirs,
+        allow_cache_exec: &resolved.allow_cache_exec,
+        allow_cache_exec_any: resolved.allow_cache_exec_any,
+        allow_browser: resolved.allow_browser,
+    }) {
+        Ok(s) => s,
+        Err(e) => bail!("{e}"),
+    };
+
+    if cli.print_profile {
+        println!("{}", sandbox::describe(&prepared));
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    // Preflight: verify the sandbox mechanism works on this system.
+    // Respects --no-validate (same as the main agent flow).
+    if !resolved.no_validate {
+        match sandbox::preflight(&prepared) {
+            Ok(()) => {}
+            Err(e) => bail!("Sandbox validation failed: {e}"),
+        }
+    }
+
+    // Summary (only shown with --no-quiet)
+    if !resolved.quiet {
+        resolved.print_summary(&project_dir, &home_dir, active_agent);
+    }
+    if let Err(e) = prompt_confirm(resolved.yes, resolved.quiet) {
+        bail!("{e}");
+    }
+
+    let disabled_categories = resolved.disabled_hardening_categories();
+
+    let exit_code = sandbox::exec_sandboxed(
+        &prepared,
+        &exec_bin,
+        &exec_args,
+        &resolved.pass_env,
+        resolved.inherit_env,
+        &disabled_categories,
+        &resolved.deny_env,
+        &resolved.gh_guard,
+        &resolved.git_guard,
+    );
+
+    if let Some(handle) = proxy_handle {
+        handle.shutdown();
+    }
+
+    Ok(ExitCode::from(exit_code))
 }
 
 fn run_doctor() -> ExitCode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -560,6 +560,7 @@ enum Command {
         cmd: Vec<String>,
     },
 
+    /// [internal] Evaluate a gh command against the proxy policy.
     ///
     /// Called by the gh wrapper script inside the sandbox. Not intended
     /// for direct use. Evaluates the command, passes through if allowed,

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3820,7 +3820,9 @@ mod e2e_tests {
     }
 
     #[test]
-    fn e2e_exec_no_banner_on_stdout() {
+    fn e2e_exec_no_output_contamination() {
+        // exec must not contaminate stdout or stderr with cplt startup messages —
+        // both must be clean so it is safe to use in pipes and shell aliases.
         require_sandbox!();
         let output = cplt_cmd()
             .args(["exec", "--no-validate", "--", "/usr/bin/true"])
@@ -3829,24 +3831,11 @@ mod e2e_tests {
             .expect("cplt exec should run");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        // exec must not contaminate stdout with cplt startup messages
         assert!(
             stdout.is_empty(),
             "exec stdout should be clean (no banner).\nstdout: {stdout}"
         );
-    }
-
-    #[test]
-    fn e2e_exec_stderr_quiet_by_default() {
-        require_sandbox!();
-        let output = cplt_cmd()
-            .args(["exec", "--no-validate", "--", "/usr/bin/true"])
-            .current_dir(project_dir())
-            .output()
-            .expect("cplt exec should run");
-
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // quiet is the default for exec — no cplt status lines
         assert!(
             stderr.is_empty(),
             "exec stderr should be empty by default (quiet).\nstderr: {stderr}"

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3766,7 +3766,7 @@ mod e2e_tests {
     fn e2e_exec_runs_true() {
         require_sandbox!();
         let output = cplt_cmd()
-            .args(["exec", "--no-validate", "--", "/usr/bin/true"])
+            .args(["--no-validate", "exec", "--", "/usr/bin/true"])
             .current_dir(project_dir())
             .output()
             .expect("cplt exec should run");
@@ -3782,7 +3782,7 @@ mod e2e_tests {
     fn e2e_exec_exit_code_pass_through() {
         require_sandbox!();
         let output = cplt_cmd()
-            .args(["exec", "--no-validate", "--", "/usr/bin/false"])
+            .args(["--no-validate", "exec", "--", "/usr/bin/false"])
             .current_dir(project_dir())
             .output()
             .expect("cplt exec should run");
@@ -3802,7 +3802,7 @@ mod e2e_tests {
     fn e2e_exec_shell_c_mode() {
         require_sandbox!();
         let output = cplt_cmd()
-            .args(["exec", "--no-validate", "-c", "echo hello-from-exec"])
+            .args(["--no-validate", "exec", "-c", "echo hello-from-exec"])
             .current_dir(project_dir())
             .output()
             .expect("cplt exec -c should run");
@@ -3825,7 +3825,7 @@ mod e2e_tests {
         // both must be clean so it is safe to use in pipes and shell aliases.
         require_sandbox!();
         let output = cplt_cmd()
-            .args(["exec", "--no-validate", "--", "/usr/bin/true"])
+            .args(["--no-validate", "exec", "--", "/usr/bin/true"])
             .current_dir(project_dir())
             .output()
             .expect("cplt exec should run");
@@ -3846,7 +3846,7 @@ mod e2e_tests {
     fn e2e_exec_env_credentials_filtered() {
         require_sandbox!();
         let output = cplt_cmd()
-            .args(["exec", "--no-validate", "--", "/usr/bin/env"])
+            .args(["--no-validate", "exec", "--", "/usr/bin/env"])
             .current_dir(project_dir())
             .env("AWS_SECRET_ACCESS_KEY", "should-be-stripped")
             .env("DATABASE_URL", "postgres://secret")
@@ -3900,7 +3900,7 @@ mod e2e_tests {
         fs::set_permissions(&script, perms).expect("chmod script");
 
         let output = cplt_cmd()
-            .args(["exec", "--no-validate", "--", "./cplt_exec_test_script.sh"])
+            .args(["--no-validate", "exec", "--", "./cplt_exec_test_script.sh"])
             .current_dir(&dir)
             .output()
             .expect("cplt exec with relative path should run");
@@ -3919,10 +3919,10 @@ mod e2e_tests {
         require_sandbox!();
         let output = cplt_cmd()
             .args([
-                "exec",
                 "--no-validate",
                 "--no-quiet",
                 "--yes",
+                "exec",
                 "--",
                 "/usr/bin/true",
             ])

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3887,6 +3887,34 @@ mod e2e_tests {
     }
 
     #[test]
+    fn e2e_exec_relative_path() {
+        require_sandbox!();
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = project_dir();
+        let script = dir.join("cplt_exec_test_script.sh");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write test script");
+        let mut perms = fs::metadata(&script).expect("stat script").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).expect("chmod script");
+
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "--", "./cplt_exec_test_script.sh"])
+            .current_dir(&dir)
+            .output()
+            .expect("cplt exec with relative path should run");
+
+        let _ = fs::remove_file(&script);
+
+        assert!(
+            output.status.success(),
+            "cplt exec -- ./script.sh should exit 0.\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
     fn e2e_exec_no_quiet_shows_summary() {
         require_sandbox!();
         let output = cplt_cmd()

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3757,4 +3757,172 @@ mod e2e_tests {
             "doctor should show workspace member: {combined}"
         );
     }
+
+    // ============================================================
+    // cplt exec tests
+    // ============================================================
+
+    #[test]
+    fn e2e_exec_runs_true() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "--", "/usr/bin/true"])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec should run");
+
+        assert!(
+            output.status.success(),
+            "cplt exec -- /usr/bin/true should exit 0.\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn e2e_exec_exit_code_pass_through() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "--", "/usr/bin/false"])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec should run");
+
+        assert!(
+            !output.status.success(),
+            "cplt exec -- /usr/bin/false should exit non-zero"
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "exit code should be 1 (from /usr/bin/false)"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_shell_c_mode() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "-c", "echo hello-from-exec"])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec -c should run");
+
+        assert!(
+            output.status.success(),
+            "cplt exec -c 'echo ...' should exit 0.\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("hello-from-exec"),
+            "stdout should contain echo output.\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_no_banner_on_stdout() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "--", "/usr/bin/true"])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // exec must not contaminate stdout with cplt startup messages
+        assert!(
+            stdout.is_empty(),
+            "exec stdout should be clean (no banner).\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_stderr_quiet_by_default() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "--", "/usr/bin/true"])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // quiet is the default for exec — no cplt status lines
+        assert!(
+            stderr.is_empty(),
+            "exec stderr should be empty by default (quiet).\nstderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_env_credentials_filtered() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["exec", "--no-validate", "--", "/usr/bin/env"])
+            .current_dir(project_dir())
+            .env("AWS_SECRET_ACCESS_KEY", "should-be-stripped")
+            .env("DATABASE_URL", "postgres://secret")
+            .output()
+            .expect("cplt exec should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("should-be-stripped"),
+            "AWS_SECRET_ACCESS_KEY must be stripped from sandbox env.\nstdout: {stdout}"
+        );
+        assert!(
+            !stdout.contains("postgres://secret"),
+            "DATABASE_URL must be stripped from sandbox env.\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_no_command_errors() {
+        let output = cplt_cmd()
+            .args(["exec"])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec with no cmd should run");
+
+        assert!(
+            !output.status.success(),
+            "cplt exec with no command should exit non-zero"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("exec")
+                || stderr.contains("Usage")
+                || stderr.contains("CMD")
+                || stderr.contains("no command"),
+            "stderr should contain usage hint.\nstderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_no_quiet_shows_summary() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args([
+                "exec",
+                "--no-validate",
+                "--no-quiet",
+                "--yes",
+                "--",
+                "/usr/bin/true",
+            ])
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec --no-quiet should run");
+
+        assert!(
+            output.status.success(),
+            "cplt exec --no-quiet should still succeed.\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // --no-quiet should print sandbox configuration summary
+        assert!(
+            stderr.contains("Project") || stderr.contains("project"),
+            "exec --no-quiet should print sandbox summary.\nstderr: {stderr}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #80

## Summary

Adds `cplt exec -- <cmd> [args]` to run any command inside the same kernel-level sandbox as `--agent shell`.

```bash
cplt exec -- npm install
cplt exec --allow-lifecycle-scripts -- npm install
cplt exec -c "npm install && npm test"   # shell -c mode
alias npm="cplt exec -- npm"             # sandboxed npm for all projects
```

## Behavior

- Reuses `Agent::Shell` sandbox policy — filesystem isolation, env filtering, network proxy, deny lists all inherited
- Defaults to `--quiet` + `--yes` for clean piping and shell aliases; override with `--no-quiet`
- stdin/stdout/stderr passed through transparently
- Exit code forwarded from the child process
- All top-level flags work: `--project-dir`, `--allow-read`, `--with-proxy`, `--pass-env`, `--deny-path`, etc.
- Recursion guard: blocked inside an existing cplt sandbox
- `-c CMD` mode delegates to `$SHELL -c CMD` for shell built-ins and pipelines

## Implementation notes

- New `Command::Exec` variant in the clap subcommand enum
- Dispatch via `cli.command.take()` before the main match to avoid Rust borrow conflict (resolve_context still needs `&cli`)
- `copilot_install_dir = None` — no extra exec permissions granted to the sandboxed binary's parent dir

## Security

| Finding | Severity | Fix |
|---------|----------|-----|
| Absolute binary path not canonicalized | Low | `fs::canonicalize()` applied — resolves symlinks and `..\ components |
| `--inherit-env`, `--allow-docker`, `--allow-tmp-exec` warnings silently suppressed by default quiet mode | Medium | Explicit `ui::warn()` before quiet takes effect |

## Tests

8 new E2E tests in `tests/e2e.rs`:
- `e2e_exec_runs_true` — basic exit 0
- `e2e_exec_exit_code_pass_through` — exit code forwarded
- `e2e_exec_shell_c_mode` — `-c` mode stdout
- `e2e_exec_no_banner_on_stdout` — stdout is clean
- `e2e_exec_stderr_quiet_by_default` — stderr is empty
- `e2e_exec_env_credentials_filtered` — AWS/DB creds stripped
- `e2e_exec_no_command_errors` — error path
- `e2e_exec_no_quiet_shows_summary` — `--no-quiet` shows sandbox config