### PR TITLE
fix(proxy): allow --allow-localhost ports to bypass proxy on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,17 @@ cplt config explain   # list all keys with descriptions
 
 Per-repo config (`.cplt.toml`) operates as a separate layer: `[deny]` tightens unconditionally, and approved permissions are **additive only** — they can enable features but cannot disable anything set by CLI or global config.
 
+#### Global-only settings
+
+These keys stay in `~/.config/cplt/config.toml` and are rejected from
+`.cplt.toml` because they are machine-specific or local preferences:
+
+`sandbox.agent`, `sandbox.quiet`, `sandbox.yes`, `sandbox.validate`,
+`sandbox.scratch_dir`, `sandbox.pass_env`, `sandbox.inherit_env`,
+`sandbox.allow_cache_exec`, `sandbox.allow_cache_exec_any`, `proxy.enabled`,
+`proxy.port`, `proxy.log_file`, `proxy.log_level`, `proxy.blocked_domains`,
+`proxy.allowed_domains`, and all `[gh_guard]`, `[git_guard]`, and `[audit]` keys
+
 ### Per-repo configuration (`.cplt.toml`)
 
 Commit a `.cplt.toml` to your repository root to enforce team policy:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,16 @@
 # Configuration
 
+## How cplt config works
+
+cplt reads config in this order:
+
+1. CLI flags for the current run
+2. `~/.config/cplt/config.toml` (or `CPLT_CONFIG`)
+3. built-in defaults
+
+List values are merged, so repeated `cplt config set` commands accumulate for
+`allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, and `deny.paths`.
+
 ## Quick setup
 
 Use `cplt config set` to configure cplt without editing files:
@@ -12,6 +23,68 @@ cplt config set allow.ports 8080
 cplt config set gh_guard.enabled true
 cplt config set git_guard.enabled true
 ```
+
+If your startup command is getting long, move repeated flags into config.
+For your personal machine setup, use global config (no `--repo`):
+
+```bash
+cplt config set sandbox.allow_localhost_any true
+cplt config set sandbox.allow_docker true
+cplt config set sandbox.allow_jvm_attach true
+cplt config set allow.read ~/.gitconfig
+cplt config set allow.read ~/code/work/.gitconfig-nav
+```
+
+That translates a one-off command like:
+
+```bash
+cplt --allow-localhost-any --allow-docker --allow-jvm-attach \
+  --allow-read ~/.gitconfig --allow-read ~/code/work/.gitconfig-nav
+```
+
+into saved config:
+
+- `sandbox.allow_localhost_any` for tools that spin up random localhost ports
+- `sandbox.allow_docker` for Gradle/Testcontainers/Docker access
+- `sandbox.allow_jvm_attach` for Gradle daemon, MockK, and Mockito inline mocking
+- `allow.read` for host files the agent should always be able to inspect
+
+Use `cplt config explain` to see what a key does and how to set it.
+
+Use **repo config + trust** for project-specific sandbox permissions that
+belong to the repository, and **global config** for machine-specific paths:
+
+- `.cplt.toml` + `cplt trust` for `sandbox.allow_jvm_attach`,
+  `sandbox.allow_docker`, `sandbox.allow_localhost_any`, `allow.ports`
+- `~/.config/cplt/config.toml` for `allow.read ~/.gitconfig` and other
+  host-specific file paths
+
+### Global-only settings
+
+These settings are **not supported in `.cplt.toml`** because they are machine-
+specific or local CLI preferences. `cplt config set --repo <key>` rejects them
+with an explanation — set them in `~/.config/cplt/config.toml` instead:
+
+| Key | Why |
+|---|---|
+| `sandbox.agent` | preferred agent depends on what's installed locally |
+| `sandbox.quiet` | local output preference |
+| `sandbox.yes` | local prompt-skip preference |
+| `sandbox.validate` | local launch behavior |
+| `sandbox.scratch_dir` | local temp handling |
+| `sandbox.pass_env` | machine-specific env passthrough |
+| `sandbox.inherit_env` | local debug-only behavior |
+| `sandbox.allow_cache_exec` | cache paths differ per machine |
+| `sandbox.allow_cache_exec_any` | too broad for repo policy |
+| `proxy.enabled` | local proxy preference |
+| `proxy.port` | port conflicts are machine-specific |
+| `proxy.log_file` | local log path |
+| `proxy.log_level` | local verbosity preference |
+| `proxy.blocked_domains` | local path to a blocklist file |
+| `proxy.allowed_domains` | local path to an allowlist file |
+| all `[gh_guard]` keys | guard policy is configured globally, not per-repo |
+| all `[git_guard]` keys | guard policy is configured globally, not per-repo |
+| all `[audit]` keys | audit destination/level is a local concern |
 
 For project-specific settings (committed to `.cplt.toml`):
 
@@ -44,7 +117,7 @@ cplt config validate                      # check for syntax errors and unknown 
 The config file lives at `~/.config/cplt/config.toml`. You can create a starter template with:
 
 ```bash
-cplt --init-config
+cplt config init
 ```
 
 This creates a commented template at `~/.config/cplt/config.toml`:

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1303,6 +1303,16 @@ fn parse_repo_from_url(url: &str) -> Option<String> {
     // Look for github.com in the path
     let path = url
         .strip_prefix("https://github.com/")
+        .or_else(|| {
+            // HTTPS with embedded credentials: https://x-access-token:TOKEN@github.com/owner/repo.git
+            // Used by GitHub Actions and other CI systems.
+            if url.starts_with("https://") {
+                url.find("@github.com/")
+                    .map(|pos| &url[pos + "@github.com/".len()..])
+            } else {
+                None
+            }
+        })
         .or_else(|| url.strip_prefix("ssh://git@github.com/"))
         .or_else(|| url.strip_prefix("http://github.com/"))?;
 
@@ -2520,6 +2530,15 @@ mod tests {
     fn parse_ssh_url() {
         assert_eq!(
             parse_repo_from_url("ssh://git@github.com/navikt/cplt.git"),
+            Some("navikt/cplt".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_https_url_with_embedded_token() {
+        // GitHub Actions clones with https://x-access-token:TOKEN@github.com/owner/repo.git
+        assert_eq!(
+            parse_repo_from_url("https://x-access-token:ghs_abc123@github.com/navikt/cplt.git"),
             Some("navikt/cplt".to_string())
         );
     }

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1304,14 +1304,26 @@ fn parse_repo_from_url(url: &str) -> Option<String> {
     let path = url
         .strip_prefix("https://github.com/")
         .or_else(|| {
-            // HTTPS with embedded credentials: https://x-access-token:TOKEN@github.com/owner/repo.git
-            // Used by GitHub Actions and other CI systems.
-            if url.starts_with("https://") {
-                url.find("@github.com/")
-                    .map(|pos| &url[pos + "@github.com/".len()..])
-            } else {
-                None
-            }
+            // HTTPS with embedded credentials:
+            //   https://x-access-token:TOKEN@github.com/owner/repo.git
+            // Anchor the host check to the URL *authority* (the segment before the
+            // first '/'), so a crafted path such as
+            //   https://evil.example/@github.com/owner/repo.git
+            // is NOT mis-parsed as a GitHub URL.
+            let after_scheme = url.strip_prefix("https://")?;
+            let (authority, rest) = match after_scheme.split_once('/') {
+                Some((a, r)) => (a, r),
+                None => (after_scheme, ""),
+            };
+            // Strip any userinfo (user:token@) and an optional :port.
+            let host = authority
+                .rsplit('@')
+                .next()
+                .unwrap_or(authority)
+                .split(':')
+                .next()
+                .unwrap_or(authority);
+            (host == "github.com").then_some(rest)
         })
         .or_else(|| url.strip_prefix("ssh://git@github.com/"))
         .or_else(|| url.strip_prefix("http://github.com/"))?;
@@ -2547,6 +2559,22 @@ mod tests {
     fn parse_non_github_url() {
         assert_eq!(
             parse_repo_from_url("https://gitlab.com/owner/repo.git"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_https_url_spoofed_github_in_path_rejected() {
+        // The host is evil.example, not github.com — the `@github.com/` substring
+        // sits in the path and must NOT be treated as a GitHub URL.
+        assert_eq!(
+            parse_repo_from_url("https://evil.example/@github.com/navikt/cplt.git"),
+            None
+        );
+        assert_eq!(
+            parse_repo_from_url(
+                "https://x-access-token:TOKEN@evil.example/@github.com/navikt/cplt.git"
+            ),
             None
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,8 +462,31 @@ the attack surface. Prefer --allow-cache-exec with specific subdirs (e.g.,
 enum Command {
     /// Manage cplt configuration.
     ///
-    /// Validate, inspect, or initialize your config file.
-    /// Config is stored at ~/.config/cplt/config.toml (override with CPLT_CONFIG).
+    /// cplt reads config from `~/.config/cplt/config.toml` by default
+    /// (override with `CPLT_CONFIG`).
+    ///
+    /// Use `cplt config explain` to learn what each key does, `show` to see the
+    /// merged result, `set` to save values, and `validate` to catch typos early.
+    ///
+    /// Use `--repo` with `config set` for project-specific permissions that
+    /// should live in `.cplt.toml`, then approve them with `cplt trust`.
+    #[command(after_help = "\
+QUICK START:
+  cplt config explain
+    List all keys with their descriptions, current values, and set commands.
+
+  cplt config explain sandbox.allow_docker
+    Learn what a specific key does before enabling it.
+
+  cplt config show
+    Show the merged config file + defaults.
+
+  cplt config set sandbox.quiet true
+    Save a value without editing TOML.
+
+  cplt config validate
+    Catch typos and type errors before launch.
+")]
     Config {
         #[command(subcommand)]
         action: ConfigAction,
@@ -717,9 +740,23 @@ enum ConfigAction {
 
     /// Explain what config keys do.
     ///
-    /// Without arguments, lists all keys with descriptions.
-    /// With a key, shows detailed info for that key.
-    /// Example: cplt config explain sandbox.quiet
+    /// Without a key, lists all keys grouped by section.
+    /// With a key, shows the description, current value, default, and the
+    /// matching `cplt config set ...` command.
+    #[command(after_help = "\
+EXAMPLES:
+  cplt config explain
+    Browse all config keys by section.
+
+  cplt config explain sandbox.allow_jvm_attach
+    See why Gradle/MockK/Mockito inline mocking may need JVM attach.
+
+  cplt config explain sandbox.allow_docker
+    See why Docker access is treated as dangerous.
+
+  cplt config explain allow.read
+    Learn how repeated values are merged.
+")]
     Explain {
         /// Config key to explain (omit to list all)
         key: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1250,6 +1250,8 @@ fn start_proxy_if_enabled(
         port: resolved.proxy_port,
         blocked_file,
         allowed_ports: resolved.allow_ports.clone(),
+        allow_localhost_ports: resolved.allow_localhost.clone(),
+        allow_localhost_any: resolved.allow_localhost_any,
         allowed_domains_file,
         allowed_domains_initial: Vec::new(),
         cli_private_domains: cli.allow_private_domains.clone(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -570,9 +570,14 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // the private-IP block below would deny all loopback connections regardless
     // of the user's intent — particularly important on Linux where the proxy is
     // the primary localhost enforcement layer.
-    let localhost_connect_allowed = is_private_hostname(&host)
-        && (state.allow_localhost_any || state.allow_localhost_ports.contains(&port));
-
+    let localhost_connect_allowed = {
+        let h = host.trim_start_matches('[').trim_end_matches(']');
+        let is_loopback = h == "localhost"
+            || h.ends_with(".localhost")
+            || h.parse::<std::net::IpAddr>()
+                .is_ok_and(|ip| ip.is_loopback());
+        is_loopback && (state.allow_localhost_any || state.allow_localhost_ports.contains(&port))
+    };
     // Reject hostname patterns that are known private (fast path before DNS)
     if !localhost_connect_allowed && is_private_hostname(&host) {
         log_connection("CONNECT", target, "BLOCKED-PRIVATE", log_file, log_level);
@@ -1337,5 +1342,127 @@ mod tests {
         assert!(domains.contains(&"npm.pkg.github.com".to_string()));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Skip guard for tests that make real TCP connections.
+    /// These tests require localhost TCP access, which is blocked inside the cplt sandbox.
+    macro_rules! require_localhost_tcp {
+        () => {
+            if std::env::var("__CPLT_WRAPPED").is_ok() {
+                eprintln!("SKIPPED: proxy CONNECT tests require localhost TCP (blocked inside cplt sandbox)");
+                return;
+            }
+        };
+    }
+
+    /// Helper: make a raw CONNECT request through the proxy and return the status line.
+    fn proxy_connect(proxy_port: u16, target: &str) -> String {
+        use std::io::{BufRead as _, BufReader, Write as _};
+        let mut conn = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+        write!(conn, "CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n").unwrap();
+        let mut reader = BufReader::new(conn);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        line.trim().to_string()
+    }
+
+    fn make_proxy(allow_localhost_ports: Vec<u16>, allow_localhost_any: bool) -> ProxyHandle {
+        let blocked = PathBuf::from("/dev/null");
+        start(ProxyOptions {
+            port: 0,
+            blocked_file: blocked,
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports,
+            allow_localhost_any,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            cli_private_domains: Vec::new(),
+            config_private_domains: Vec::new(),
+            config_file: None,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+        })
+        .expect("proxy start failed")
+    }
+
+    #[test]
+    fn proxy_connect_localhost_blocked_without_allow() {
+        require_localhost_tcp!();
+        // Start a real listener so the proxy can actually resolve the target.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let proxy = make_proxy(vec![], false);
+        let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
+        proxy.shutdown();
+        drop(listener);
+
+        assert!(
+            status.contains("403"),
+            "CONNECT to localhost should be blocked without --allow-localhost; got: {status}"
+        );
+    }
+
+    #[test]
+    fn proxy_connect_localhost_allowed_with_specific_port() {
+        require_localhost_tcp!();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Accept the one connection so CONNECT doesn't hang waiting for TCP handshake.
+        let handle = std::thread::spawn(move || {
+            listener.accept().ok();
+        });
+
+        let proxy = make_proxy(vec![port], false);
+        let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
+        proxy.shutdown();
+        handle.join().ok();
+
+        assert!(
+            status.contains("200"),
+            "CONNECT to localhost:{port} should succeed with --allow-localhost {port}; got: {status}"
+        );
+    }
+
+    #[test]
+    fn proxy_connect_localhost_other_port_still_blocked() {
+        require_localhost_tcp!();
+        let listener1 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let allowed_port = listener1.local_addr().unwrap().port();
+        let listener2 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let blocked_port = listener2.local_addr().unwrap().port();
+
+        let proxy = make_proxy(vec![allowed_port], false);
+        let status = proxy_connect(proxy.port, &format!("localhost:{blocked_port}"));
+        proxy.shutdown();
+        drop(listener1);
+        drop(listener2);
+
+        assert!(
+            status.contains("403"),
+            "CONNECT to localhost:{blocked_port} should be blocked when only {allowed_port} is allowed; got: {status}"
+        );
+    }
+
+    #[test]
+    fn proxy_connect_localhost_any_opens_all_ports() {
+        require_localhost_tcp!();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = std::thread::spawn(move || {
+            listener.accept().ok();
+        });
+
+        let proxy = make_proxy(vec![], true);
+        let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
+        proxy.shutdown();
+        handle.join().ok();
+
+        assert!(
+            status.contains("200"),
+            "CONNECT to localhost:{port} should succeed with --allow-localhost-any; got: {status}"
+        );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -539,10 +539,26 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     let log_file = state.log_file.as_deref();
     let log_level = state.log_level;
 
+    // Compute localhost bypass before the port check: --allow-localhost <PORT> must
+    // also exempt that port from the general port policy (which only lists remote ports
+    // like 443/80). Without this, allow_localhost_ports would be silently ignored —
+    // the port check would fire first and return 403 before the localhost logic ran.
+    let localhost_connect_allowed = {
+        let h = host.trim_start_matches('[').trim_end_matches(']');
+        let is_loopback = h == "localhost"
+            || h.ends_with(".localhost")
+            || h.parse::<std::net::IpAddr>()
+                .is_ok_and(|ip| ip.is_loopback());
+        is_loopback && (state.allow_localhost_any || state.allow_localhost_ports.contains(&port))
+    };
+
     // Enforce port policy — only allow ports matching the sandbox network rules.
     // Without this, the proxy would let sandboxed processes tunnel to arbitrary
     // remote ports, bypassing the sandbox's port restrictions.
-    if !state.allowed_ports.contains(&port) {
+    // Exception: explicitly-opened localhost ports bypass this check; the user's
+    // intent with --allow-localhost <PORT> is to reach that port regardless of
+    // whether it appears in the general allowed_ports list.
+    if !localhost_connect_allowed && !state.allowed_ports.contains(&port) {
         log_connection("CONNECT", target, "BLOCKED-PORT", log_file, log_level);
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPort not allowed\r\n");
         return;
@@ -564,20 +580,6 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nBlocked by cplt\r\n");
         return;
     }
-
-    // Allow CONNECT to localhost when the user has explicitly opened the port
-    // via `--allow-localhost <PORT>` or `--allow-localhost-any`. Without this,
-    // the private-IP block below would deny all loopback connections regardless
-    // of the user's intent — particularly important on Linux where the proxy is
-    // the primary localhost enforcement layer.
-    let localhost_connect_allowed = {
-        let h = host.trim_start_matches('[').trim_end_matches(']');
-        let is_loopback = h == "localhost"
-            || h.ends_with(".localhost")
-            || h.parse::<std::net::IpAddr>()
-                .is_ok_and(|ip| ip.is_loopback());
-        is_loopback && (state.allow_localhost_any || state.allow_localhost_ports.contains(&port))
-    };
     // Reject hostname patterns that are known private (fast path before DNS)
     if !localhost_connect_allowed && is_private_hostname(&host) {
         log_connection("CONNECT", target, "BLOCKED-PRIVATE", log_file, log_level);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1474,9 +1474,17 @@ mod tests {
             listener.accept().ok();
         });
 
-        let proxy = make_proxy(vec![port], false);
+        // Force IPv4 resolution: on macOS, `localhost` may resolve to ::1 first,
+        // which fails to connect to our IPv4-only listener. The injected resolver
+        // pins localhost → 127.0.0.1 so we test proxy allow-logic, not DNS order.
+        let loopback_v4: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let resolver: ResolverFn =
+            Arc::new(move |_host: &str, p: u16| Some(std::net::SocketAddr::new(loopback_v4, p)));
+        let proxy = make_proxy_with_resolver(vec![port], false, Some(resolver));
         let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
         proxy.shutdown();
+        // Fallback connect so the accept thread unblocks if proxy didn't reach it.
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
         handle.join().ok();
 
         assert!(
@@ -1515,9 +1523,14 @@ mod tests {
             listener.accept().ok();
         });
 
-        let proxy = make_proxy(vec![], true);
+        // Force IPv4 resolution (same macOS ::1-first issue as the test above).
+        let loopback_v4: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let resolver: ResolverFn =
+            Arc::new(move |_host: &str, p: u16| Some(std::net::SocketAddr::new(loopback_v4, p)));
+        let proxy = make_proxy_with_resolver(vec![], true, Some(resolver));
         let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
         proxy.shutdown();
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
         handle.join().ok();
 
         assert!(
@@ -1609,6 +1622,9 @@ mod tests {
     /// Verify that legitimate localhost still works when --allow-localhost is set.
     /// This is the positive counterpart to proxy_blocks_dns_rebinding_evil_localhost_to_imds:
     /// real localhost resolves to 127.0.0.1, which is_loopback() = true → allowed.
+    ///
+    /// Uses an injected resolver to pin localhost → 127.0.0.1 so the test is stable
+    /// on macOS where getaddrinfo("localhost") returns ::1 first.
     #[test]
     fn proxy_allows_real_localhost_with_allow_localhost() {
         require_localhost_tcp!();
@@ -1620,10 +1636,13 @@ mod tests {
             listener.accept().ok();
         });
 
-        // No injected resolver — real DNS resolution: localhost → 127.0.0.1 (loopback)
-        let proxy = make_proxy(vec![port], false);
+        let loopback_v4: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let resolver: ResolverFn =
+            Arc::new(move |_host: &str, p: u16| Some(std::net::SocketAddr::new(loopback_v4, p)));
+        let proxy = make_proxy_with_resolver(vec![port], false, Some(resolver));
         let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
         proxy.shutdown();
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
         handle.join().ok();
 
         assert!(

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -637,6 +637,27 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
         }
     };
 
+    // Hard requirement for the localhost carve-out: a target that was only
+    // permitted because of --allow-localhost(-any) MUST resolve to a loopback
+    // address. `*.localhost` is supposed to map to 127.0.0.1/::1, but a hostile
+    // resolver or /etc/hosts entry could point `evil.localhost` at a public or
+    // private non-loopback IP. Without this check the carve-out (which already
+    // bypassed the port policy and private-hostname block) would tunnel to an
+    // arbitrary port on an arbitrary host — an SSRF / egress-widening vector.
+    // The earlier is_private_ip guard below only catches *private* IPs; this also
+    // closes the *public* non-loopback case.
+    if localhost_connect_allowed && !socket_addr.ip().is_loopback() {
+        log_connection(
+            "CONNECT",
+            target,
+            "BLOCKED-PRIVATE-RESOLVED",
+            log_file,
+            log_level,
+        );
+        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nResolved to non-loopback IP\r\n");
+        return;
+    }
+
     // Check the RESOLVED IP address (prevents DNS rebinding attacks).
     // Domains in allow_private_domains are explicitly trusted to resolve to private IPs
     // (e.g. corporate internal services). All other checks still apply.
@@ -1648,6 +1669,37 @@ mod tests {
         assert!(
             status.contains("200"),
             "localhost:{port} with allow_localhost must succeed (resolves to 127.0.0.1); got: {status}"
+        );
+    }
+
+    /// Regression test for the *public-IP* DNS-rebinding variant of the localhost
+    /// carve-out. The private-IP path is covered by the IMDS test above; this one
+    /// pins `evil.localhost` to a public address (which `is_private_ip` does NOT
+    /// catch) and asserts the loopback requirement still blocks it.
+    #[test]
+    fn proxy_blocks_localhost_carveout_to_public_ip() {
+        require_localhost_tcp!();
+
+        // 93.184.216.34 (example.com) — a routable public IP, not private/loopback.
+        let public_addr: std::net::IpAddr = "93.184.216.34".parse().unwrap();
+        let resolver: ResolverFn = Arc::new(move |host: &str, port: u16| {
+            if host == "evil.localhost" {
+                Some(std::net::SocketAddr::new(public_addr, port))
+            } else {
+                format!("{host}:{port}")
+                    .to_socket_addrs()
+                    .ok()
+                    .and_then(|mut a| a.next())
+            }
+        });
+
+        let proxy = make_proxy_with_resolver(vec![8080], false, Some(resolver));
+        let status = proxy_connect(proxy.port, "evil.localhost:8080");
+        proxy.shutdown();
+
+        assert!(
+            status.contains("403"),
+            "carve-out: evil.localhost:8080 resolving to a public IP must be blocked (resolved IP is not loopback); got: {status}"
         );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -123,6 +123,11 @@ pub struct ProxyState {
     // Ports: frozen at startup (kernel Seatbelt profile is immutable)
     allowed_ports: Vec<u16>,
 
+    // Localhost: ports (or all) explicitly opened via --allow-localhost[/-any].
+    // The proxy bypasses its private-IP block for CONNECT to these.
+    allow_localhost_ports: Vec<u16>,
+    allow_localhost_any: bool,
+
     // Audit log
     log_file: Option<PathBuf>,
     // Verbosity level for stderr output
@@ -300,6 +305,11 @@ pub struct ProxyOptions {
     pub port: u16,
     pub blocked_file: PathBuf,
     pub allowed_ports: Vec<u16>,
+    /// Specific localhost ports explicitly opened by `--allow-localhost`.
+    /// The proxy bypasses its private-IP block for CONNECT to these ports.
+    pub allow_localhost_ports: Vec<u16>,
+    /// Whether all localhost ports are open (`--allow-localhost-any`).
+    pub allow_localhost_any: bool,
     /// Path to an allowlist file (one domain per line). When set, only
     /// matching domains pass. The file is re-read every RELOAD_TTL seconds.
     pub allowed_domains_file: Option<PathBuf>,
@@ -382,6 +392,8 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         config_file: opts.config_file,
         private_domains_cache: Mutex::new(DomainCache::new(opts.config_private_domains)),
         allowed_ports: ports,
+        allow_localhost_ports: opts.allow_localhost_ports,
+        allow_localhost_any: opts.allow_localhost_any,
         log_file: opts.log_file,
         log_level: opts.log_level,
     });
@@ -553,8 +565,16 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
         return;
     }
 
+    // Allow CONNECT to localhost when the user has explicitly opened the port
+    // via `--allow-localhost <PORT>` or `--allow-localhost-any`. Without this,
+    // the private-IP block below would deny all loopback connections regardless
+    // of the user's intent — particularly important on Linux where the proxy is
+    // the primary localhost enforcement layer.
+    let localhost_connect_allowed = is_private_hostname(&host)
+        && (state.allow_localhost_any || state.allow_localhost_ports.contains(&port));
+
     // Reject hostname patterns that are known private (fast path before DNS)
-    if is_private_hostname(&host) {
+    if !localhost_connect_allowed && is_private_hostname(&host) {
         log_connection("CONNECT", target, "BLOCKED-PRIVATE", log_file, log_level);
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPrivate target blocked\r\n");
         return;
@@ -579,8 +599,13 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // Check the RESOLVED IP address (prevents DNS rebinding attacks).
     // Domains in allow_private_domains are explicitly trusted to resolve to private IPs
     // (e.g. corporate internal services). All other checks still apply.
+    // Exception: localhost connections explicitly opened via --allow-localhost are
+    // permitted to resolve to loopback without being in allow_private_domains.
     let private_domains = state.get_private_domains();
-    if is_private_ip(&socket_addr.ip()) && !is_domain_match(&host, &private_domains) {
+    if is_private_ip(&socket_addr.ip())
+        && !is_domain_match(&host, &private_domains)
+        && !localhost_connect_allowed
+    {
         log_connection(
             "CONNECT",
             target,
@@ -1059,6 +1084,8 @@ mod tests {
                 "config.example.com".to_string(),
             ])),
             allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
         };
@@ -1079,6 +1106,8 @@ mod tests {
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec!["shared.com".to_string()])),
             allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
         };
@@ -1104,6 +1133,8 @@ mod tests {
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
         };
@@ -1132,6 +1163,8 @@ mod tests {
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
         };
@@ -1166,6 +1199,8 @@ mod tests {
                     .unwrap(),
             }),
             allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
         };
@@ -1217,6 +1252,8 @@ mod tests {
             port: 0,
             blocked_file: blocked,
             allowed_ports: vec![],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -1245,6 +1282,8 @@ mod tests {
             port: 0,
             blocked_file: blocked,
             allowed_ports: vec![],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             allowed_domains_file: Some(allowlist_path),
             allowed_domains_initial: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -1278,6 +1317,8 @@ mod tests {
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
         };

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -104,6 +104,12 @@ impl DomainCache {
     }
 }
 
+/// DNS resolver override used in tests to inject fake DNS responses.
+/// Receives (hostname, port) and returns a resolved `SocketAddr`, or `None`
+/// to simulate a DNS failure. Never used in production builds.
+#[cfg(test)]
+pub type ResolverFn = Arc<dyn Fn(&str, u16) -> Option<std::net::SocketAddr> + Send + Sync>;
+
 /// Shared proxy state holding cached domain lists and config paths.
 /// Wrapped in `Arc` and shared across connection threads.
 pub struct ProxyState {
@@ -132,6 +138,10 @@ pub struct ProxyState {
     log_file: Option<PathBuf>,
     // Verbosity level for stderr output
     log_level: ProxyLogLevel,
+
+    // Test-only: injectable DNS resolver to simulate fake DNS responses.
+    #[cfg(test)]
+    resolver: Option<ResolverFn>,
 }
 
 impl ProxyState {
@@ -326,6 +336,11 @@ pub struct ProxyOptions {
     pub log_file: Option<PathBuf>,
     /// Verbosity level for proxy stderr output.
     pub log_level: ProxyLogLevel,
+
+    /// Test-only: injectable DNS resolver. Pass a closure to override DNS
+    /// resolution in proxy tests (e.g. to simulate DNS rebinding).
+    #[cfg(test)]
+    pub resolver: Option<ResolverFn>,
 }
 
 /// Start the proxy on a background thread. Returns a handle for shutdown.
@@ -396,6 +411,8 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         allow_localhost_any: opts.allow_localhost_any,
         log_file: opts.log_file,
         log_level: opts.log_level,
+        #[cfg(test)]
+        resolver: opts.resolver,
     });
 
     listener
@@ -588,19 +605,36 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     }
 
     // Resolve DNS FIRST, then check the resolved IP
-    let addr = format!("{host}:{port}");
-    let socket_addr = if let Ok(mut addrs) = addr.to_socket_addrs() {
-        if let Some(a) = addrs.next() {
+    let addr_str = format!("{host}:{port}");
+    #[cfg(test)]
+    let socket_addr = {
+        // In tests, an injected resolver can fake DNS responses (e.g. to simulate
+        // DNS rebinding where evil.localhost → 169.254.169.254).
+        if let Some(ref resolver) = state.resolver {
+            if let Some(a) = resolver(&host, port) {
+                a
+            } else {
+                log_connection("CONNECT", target, "DNS-FAIL", log_file, log_level);
+                let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
+                return;
+            }
+        } else if let Some(a) = addr_str.to_socket_addrs().ok().and_then(|mut a| a.next()) {
             a
         } else {
             log_connection("CONNECT", target, "DNS-FAIL", log_file, log_level);
             let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
             return;
         }
-    } else {
-        log_connection("CONNECT", target, "DNS-FAIL", log_file, log_level);
-        let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
-        return;
+    };
+    #[cfg(not(test))]
+    let socket_addr = {
+        if let Some(a) = addr_str.to_socket_addrs().ok().and_then(|mut a| a.next()) {
+            a
+        } else {
+            log_connection("CONNECT", target, "DNS-FAIL", log_file, log_level);
+            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
+            return;
+        }
     };
 
     // Check the RESOLVED IP address (prevents DNS rebinding attacks).
@@ -1099,6 +1133,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         };
 
         let domains = state.get_private_domains();
@@ -1121,6 +1156,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         };
 
         let domains = state.get_private_domains();
@@ -1148,6 +1184,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         };
 
         let domains = state.get_allowed_domains();
@@ -1178,6 +1215,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         };
 
         let blocked = state.get_blocked_domains();
@@ -1214,6 +1252,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         };
 
         // First read: picks up "old.nav.no" from cache reload + "cli.nav.no"
@@ -1272,6 +1311,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         });
         assert!(result.is_ok());
         result.unwrap().shutdown();
@@ -1302,6 +1342,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         });
         assert!(result.is_err(), "should fail when allowlist is unreadable");
 
@@ -1332,6 +1373,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver: None,
         };
 
         // Initial read picks up github.com from stale cache (triggers reload)
@@ -1373,6 +1415,17 @@ mod tests {
     }
 
     fn make_proxy(allow_localhost_ports: Vec<u16>, allow_localhost_any: bool) -> ProxyHandle {
+        make_proxy_with_resolver(allow_localhost_ports, allow_localhost_any, None)
+    }
+
+    /// Start a proxy with an optional injected DNS resolver.
+    /// Pass `Some(f)` to override DNS resolution in tests (e.g. to simulate
+    /// DNS rebinding where `evil.localhost` resolves to `169.254.169.254`).
+    fn make_proxy_with_resolver(
+        allow_localhost_ports: Vec<u16>,
+        allow_localhost_any: bool,
+        resolver: Option<ResolverFn>,
+    ) -> ProxyHandle {
         let blocked = PathBuf::from("/dev/null");
         start(ProxyOptions {
             port: 0,
@@ -1387,6 +1440,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
+            resolver,
         })
         .expect("proxy start failed")
     }
@@ -1486,6 +1540,10 @@ mod tests {
     ///
     /// We can't fake DNS in a unit test, but we can assert the IP-level invariants
     /// that the fix relies on.
+    ///
+    /// With the injectable resolver (`make_proxy_with_resolver`), we CAN now simulate
+    /// the full DNS rebinding path: the proxy receives `CONNECT evil.localhost:8080`,
+    /// the injected resolver returns `169.254.169.254`, and we verify the proxy blocks it.
     #[test]
     fn post_dns_check_uses_is_loopback_not_hostname_pattern() {
         // cloud IMDS and internal IPs are private but NOT loopback
@@ -1505,10 +1563,72 @@ mod tests {
         assert!(!internal.is_loopback(), "RFC1918 must not be loopback");
         assert!(loopback.is_loopback(), "127.0.0.1 must be loopback");
         assert!(loopback6.is_loopback(), "::1 must be loopback");
+    }
 
-        // Consequence: if evil.localhost resolves to IMDS, is_loopback() = false
-        // → the private-IP block fires → SSRF prevented.
-        // With the old !localhost_connect_allowed condition, this block would be
-        // skipped for any *.localhost hostname, enabling the SSRF.
+    /// Full proxy-level DNS rebinding test using the injectable resolver.
+    ///
+    /// This test WOULD HAVE FAILED with the old `&& !localhost_connect_allowed`
+    /// condition and PASSES with the fixed `&& !socket_addr.ip().is_loopback()`.
+    ///
+    /// Scenario: agent sends `CONNECT evil.localhost:8080` to the proxy.
+    /// The hostname matches `*.localhost`, so `localhost_connect_allowed = true`.
+    /// The injected resolver returns `169.254.169.254` (cloud IMDS).
+    /// The proxy must block this despite `localhost_connect_allowed` being set,
+    /// because the resolved IP is not loopback.
+    #[test]
+    fn proxy_blocks_dns_rebinding_evil_localhost_to_imds() {
+        require_localhost_tcp!();
+
+        let imds_addr: std::net::IpAddr = "169.254.169.254".parse().unwrap();
+
+        // Inject a resolver that maps evil.localhost → 169.254.169.254 (cloud IMDS)
+        let resolver: ResolverFn = Arc::new(move |host: &str, port: u16| {
+            if host == "evil.localhost" {
+                Some(std::net::SocketAddr::new(imds_addr, port))
+            } else {
+                // Fall back to real resolution for other hosts
+                format!("{host}:{port}")
+                    .to_socket_addrs()
+                    .ok()
+                    .and_then(|mut a| a.next())
+            }
+        });
+
+        // Port 8080 is explicitly "opened" via allow_localhost_ports.
+        // With the old code, this would cause the proxy to forward CONNECT to IMDS.
+        let proxy = make_proxy_with_resolver(vec![8080], false, Some(resolver));
+        let status = proxy_connect(proxy.port, "evil.localhost:8080");
+        proxy.shutdown();
+
+        assert!(
+            status.contains("403"),
+            "DNS rebinding: evil.localhost:8080 resolves to 169.254.169.254 — must block even though port 8080 is in allow_localhost_ports; got: {status}"
+        );
+    }
+
+    /// Verify that legitimate localhost still works when --allow-localhost is set.
+    /// This is the positive counterpart to proxy_blocks_dns_rebinding_evil_localhost_to_imds:
+    /// real localhost resolves to 127.0.0.1, which is_loopback() = true → allowed.
+    #[test]
+    fn proxy_allows_real_localhost_with_allow_localhost() {
+        require_localhost_tcp!();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = std::thread::spawn(move || {
+            listener.accept().ok();
+        });
+
+        // No injected resolver — real DNS resolution: localhost → 127.0.0.1 (loopback)
+        let proxy = make_proxy(vec![port], false);
+        let status = proxy_connect(proxy.port, &format!("localhost:{port}"));
+        proxy.shutdown();
+        handle.join().ok();
+
+        assert!(
+            status.contains("200"),
+            "localhost:{port} with allow_localhost must succeed (resolves to 127.0.0.1); got: {status}"
+        );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -606,12 +606,16 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // Check the RESOLVED IP address (prevents DNS rebinding attacks).
     // Domains in allow_private_domains are explicitly trusted to resolve to private IPs
     // (e.g. corporate internal services). All other checks still apply.
-    // Exception: localhost connections explicitly opened via --allow-localhost are
-    // permitted to resolve to loopback without being in allow_private_domains.
+    //
+    // For --allow-localhost: we use the *resolved* IP to confirm loopback, not the
+    // hostname. `*.localhost` in DNS is supposed to resolve to 127.0.0.1, but a
+    // compromised DNS or /etc/hosts entry could make `evil.localhost` resolve to
+    // 169.254.169.254 (cloud IMDS) or an internal host. Using the hostname pattern
+    // alone would bypass this check entirely, enabling SSRF to cloud metadata.
     let private_domains = state.get_private_domains();
     if is_private_ip(&socket_addr.ip())
         && !is_domain_match(&host, &private_domains)
-        && !localhost_connect_allowed
+        && !socket_addr.ip().is_loopback()
     {
         log_connection(
             "CONNECT",
@@ -1466,5 +1470,45 @@ mod tests {
             status.contains("200"),
             "CONNECT to localhost:{port} should succeed with --allow-localhost-any; got: {status}"
         );
+    }
+
+    /// Regression guard for the DNS rebinding fix:
+    /// The post-DNS private-IP check must use `socket_addr.ip().is_loopback()`, NOT
+    /// `localhost_connect_allowed` (which is derived from the hostname pre-DNS).
+    ///
+    /// Attack: `CONNECT evil.localhost:PORT` where `evil.localhost` resolves to
+    /// `169.254.169.254` (cloud IMDS) or `10.x.x.x` (internal).  The hostname
+    /// `*.localhost` would set `localhost_connect_allowed = true`, bypassing the
+    /// guard entirely with the old condition `&& !localhost_connect_allowed`.
+    ///
+    /// With the fix (`&& !socket_addr.ip().is_loopback()`), the resolved IP is
+    /// always verified — a private non-loopback IP is blocked regardless of hostname.
+    ///
+    /// We can't fake DNS in a unit test, but we can assert the IP-level invariants
+    /// that the fix relies on.
+    #[test]
+    fn post_dns_check_uses_is_loopback_not_hostname_pattern() {
+        // cloud IMDS and internal IPs are private but NOT loopback
+        let imds: std::net::IpAddr = "169.254.169.254".parse().unwrap();
+        let internal: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        let loopback: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let loopback6: std::net::IpAddr = "::1".parse().unwrap();
+
+        // All four are caught by is_private_ip (the outer condition)
+        assert!(is_private_ip(&imds), "IMDS must be private");
+        assert!(is_private_ip(&internal), "RFC1918 must be private");
+        assert!(is_private_ip(&loopback), "loopback must be private");
+        assert!(is_private_ip(&loopback6), "IPv6 loopback must be private");
+
+        // Only true loopback passes is_loopback() — the guard the fix uses
+        assert!(!imds.is_loopback(), "IMDS must not be loopback");
+        assert!(!internal.is_loopback(), "RFC1918 must not be loopback");
+        assert!(loopback.is_loopback(), "127.0.0.1 must be loopback");
+        assert!(loopback6.is_loopback(), "::1 must be loopback");
+
+        // Consequence: if evil.localhost resolves to IMDS, is_loopback() = false
+        // → the private-IP block fires → SSRF prevented.
+        // With the old !localhost_connect_allowed condition, this block would be
+        // skipped for any *.localhost hostname, enabling the SSRF.
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -140,6 +140,10 @@ pub struct PreparedSandbox {
     scratch_dir: Option<PathBuf>,
     proxy_port: Option<u16>,
     agent: Agent,
+    /// Specific localhost ports the user has explicitly opened.
+    allow_localhost: Vec<u16>,
+    /// Whether all localhost ports are open (`--allow-localhost-any`).
+    allow_localhost_any: bool,
     /// Landlock + seccomp pre-computed sandbox data (Linux only).
     /// Built in the parent process; applied in pre_exec.
     #[cfg(target_os = "linux")]
@@ -266,6 +270,8 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
         scratch_dir: config.scratch_dir.map(Path::to_path_buf),
         proxy_port: config.proxy_port,
         agent: config.agent,
+        allow_localhost: config.localhost_ports.to_vec(),
+        allow_localhost_any: config.allow_localhost_any,
     })
 }
 
@@ -325,6 +331,8 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
         scratch_dir: config.scratch_dir.map(Path::to_path_buf),
         proxy_port: config.proxy_port,
         agent: config.agent,
+        allow_localhost: config.localhost_ports.to_vec(),
+        allow_localhost_any: config.allow_localhost_any,
         precomputed,
     })
 }

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -127,11 +127,13 @@ fn configure_command(
         //     --allow-localhost-any. Without explicit localhost access, the proxy is
         //     the sole mechanism blocking loopback connections (Landlock is port-based
         //     only and cannot distinguish localhost from remote hosts).
-        let localhost_allowed = allow_localhost_any || !allow_localhost.is_empty();
         #[cfg(target_os = "macos")]
-        let set_no_proxy = true;
+        let set_no_proxy = {
+            let _ = (allow_localhost, allow_localhost_any); // used on Linux only
+            true
+        };
         #[cfg(not(target_os = "macos"))]
-        let set_no_proxy = localhost_allowed;
+        let set_no_proxy = allow_localhost_any || !allow_localhost.is_empty();
         if set_no_proxy {
             cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
             cmd.env("no_proxy", "localhost,127.0.0.1,::1");

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -60,6 +60,8 @@ fn configure_command(
     disabled_categories: &[HardeningCategory],
     scratch_dir: Option<&Path>,
     proxy_port: Option<u16>,
+    allow_localhost: &[u16],
+    allow_localhost_any: bool,
     agent: Agent,
     gh_guard: &crate::config::GhGuardPolicy,
     git_guard: &crate::config::GitGuardPolicy,
@@ -119,12 +121,18 @@ fn configure_command(
         cmd.env("HTTPS_PROXY", &proxy_url);
         cmd.env("http_proxy", &proxy_url);
         cmd.env("https_proxy", &proxy_url);
-        // On macOS, exclude loopback from proxying — Seatbelt enforces localhost
-        // isolation at the kernel level, and MCP servers/dev servers need direct access.
-        // On Linux, do NOT exclude localhost — the proxy is the only mechanism to
-        // mediate/deny loopback connections (Landlock cannot filter by IP).
+        // Exclude loopback from proxying when localhost access is explicitly enabled:
+        //   - macOS: always excluded — Seatbelt enforces localhost at the kernel level.
+        //   - Linux: excluded only when the user opened specific localhost ports or
+        //     --allow-localhost-any. Without explicit localhost access, the proxy is
+        //     the sole mechanism blocking loopback connections (Landlock is port-based
+        //     only and cannot distinguish localhost from remote hosts).
+        let localhost_allowed = allow_localhost_any || !allow_localhost.is_empty();
         #[cfg(target_os = "macos")]
-        {
+        let set_no_proxy = true;
+        #[cfg(not(target_os = "macos"))]
+        let set_no_proxy = localhost_allowed;
+        if set_no_proxy {
             cmd.env("NO_PROXY", "localhost,127.0.0.1,::1");
             cmd.env("no_proxy", "localhost,127.0.0.1,::1");
         }
@@ -467,6 +475,8 @@ pub fn exec(
         disabled_categories,
         sandbox.scratch_dir.as_deref(),
         sandbox.proxy_port,
+        &sandbox.allow_localhost,
+        sandbox.allow_localhost_any,
         sandbox.agent,
         gh_guard,
         git_guard,
@@ -558,6 +568,8 @@ pub fn exec(
         disabled_categories,
         sandbox.scratch_dir.as_deref(),
         sandbox.proxy_port,
+        &sandbox.allow_localhost,
+        sandbox.allow_localhost_any,
         sandbox.agent,
         gh_guard,
         git_guard,

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -739,4 +739,204 @@ else:
         );
         assert_eq!(code, 0, "~/.cache should be writable");
     }
+
+    // ── Proxy-layer tests ─────────────────────────────────────────
+    //
+    // These tests exercise the cplt CONNECT proxy (not just Landlock).
+    // Existing network tests use /dev/tcp (raw TCP) which bypasses HTTP_PROXY.
+    // curl respects HTTP_PROXY and exercises the full proxy enforcement layer.
+    //
+    // Prerequisite: curl must be in PATH on the test machine.
+
+    /// Skip guard for tests that require curl.
+    macro_rules! require_curl {
+        () => {
+            if !std::process::Command::new("curl")
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+            {
+                eprintln!("SKIPPED: curl not available");
+                return;
+            }
+        };
+    }
+
+    /// Start a minimal HTTP/1.0 server that accepts one connection and returns 200.
+    /// Returns (port, join_handle). The handle must be joined after the test.
+    fn start_http_echo_server() -> (u16, std::thread::JoinHandle<()>) {
+        use std::io::{Read as _, Write as _};
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind echo server");
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 2048];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(
+                    b"HTTP/1.0 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK",
+                );
+            }
+        });
+        (port, handle)
+    }
+
+    /// Full-stack proxy wiring test: --allow-localhost PORT sets NO_PROXY and opens
+    /// the Landlock TCP path so curl can reach the listener directly.
+    ///
+    /// Data flow: curl → (NO_PROXY set) → direct TCP → Landlock allows PORT → listener
+    ///
+    /// This test would fail if:
+    /// - allow_localhost_ports is not wired from CLI into sandbox_exec (NO_PROXY not set)
+    /// - Landlock does not open the port when --allow-localhost is given
+    #[test]
+    fn proxy_allows_curl_to_localhost_with_allow_flag() {
+        require_landlock!(4);
+        require_curl!();
+        let project = create_test_project();
+        let (port, server_handle) = start_http_echo_server();
+
+        let script = format!(
+            "curl --max-time 5 -s http://127.0.0.1:{port}/ && echo CURL_OK || echo CURL_FAIL"
+        );
+        let (_, stdout, stderr) = run_sandboxed_with_flags(
+            project.path(),
+            &["--allow-localhost", &port.to_string()],
+            &script,
+        );
+
+        // Unblock the server if curl didn't connect
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
+        server_handle.join().ok();
+
+        assert!(
+            stdout.contains("CURL_OK"),
+            "--allow-localhost {port}: curl to 127.0.0.1:{port} must succeed; stdout: {stdout} stderr: {stderr}"
+        );
+    }
+
+    /// Negative case: without --allow-localhost, curl to localhost must be blocked.
+    /// Without the flag, NO_PROXY is not set → curl routes through the cplt proxy →
+    /// proxy returns 405 (plain HTTP) or the Landlock TCP deny fires first.
+    #[test]
+    fn proxy_blocks_curl_to_localhost_without_allow_flag() {
+        require_landlock!(4);
+        require_curl!();
+        let project = create_test_project();
+
+        // Use a high ephemeral port. There's nothing listening, but the test
+        // only needs to verify the connection attempt is blocked, not that a
+        // real server responds.
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind test listener");
+        let port = listener.local_addr().unwrap().port();
+        drop(listener); // Close it — we don't want connections to succeed
+
+        let script = format!(
+            "curl --max-time 3 -sf http://127.0.0.1:{port}/ 2>&1 && echo CURL_OK || echo CURL_FAIL"
+        );
+        let (_, stdout, _) = run_sandboxed(project.path(), &script);
+
+        assert!(
+            stdout.contains("CURL_FAIL"),
+            "without --allow-localhost, curl to 127.0.0.1:{port} must fail; got: {stdout}"
+        );
+    }
+
+    /// Verify that the NO_PROXY env var is set inside the sandbox when
+    /// --allow-localhost is configured, so tools bypass the proxy for loopback.
+    #[test]
+    fn no_proxy_set_when_allow_localhost_configured() {
+        require_landlock!();
+        let project = create_test_project();
+
+        let (_, stdout, _) = run_sandboxed_with_flags(
+            project.path(),
+            &["--allow-localhost", "5173"],
+            "echo \"NO_PROXY=${NO_PROXY:-UNSET}\"",
+        );
+
+        assert!(
+            stdout.contains("localhost") || stdout.contains("127.0.0.1"),
+            "--allow-localhost must set NO_PROXY to include loopback addresses; got: {stdout}"
+        );
+    }
+
+    /// Verify that NO_PROXY is NOT set (or does not include loopback) when
+    /// --allow-localhost is not configured — the proxy must intercept loopback.
+    #[test]
+    fn no_proxy_not_set_without_allow_localhost() {
+        require_landlock!();
+        let project = create_test_project();
+
+        let (_, stdout, _) = run_sandboxed(project.path(), "echo \"NO_PROXY=${NO_PROXY:-UNSET}\"");
+
+        assert!(
+            stdout.contains("UNSET")
+                || (!stdout.contains("localhost") && !stdout.contains("127.0.0.1")),
+            "without --allow-localhost, NO_PROXY must not bypass proxy for loopback; got: {stdout}"
+        );
+    }
+
+    // ── Environment isolation tests ───────────────────────────────
+
+    /// Verify that credential-style env vars do not leak into the sandbox.
+    /// The ENV_ALLOWLIST is supposed to filter these out.
+    #[test]
+    fn sandboxed_env_does_not_leak_credentials() {
+        require_landlock!();
+        let project = create_test_project();
+
+        // Inject credential-like vars into the cplt parent process env
+        let output = Command::new(binary_path())
+            .args([
+                "--yes",
+                "--no-validate",
+                "--quiet",
+                "--agent",
+                "shell",
+                "-C",
+                &project.path().to_string_lossy(),
+                "--",
+                "-c",
+                "env | grep -cE '^(AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|AZURE_CLIENT_SECRET|NPM_TOKEN|GITHUB_TOKEN)=' ; true",
+            ])
+            .env("HOME", home_dir())
+            .env("AWS_SECRET_ACCESS_KEY", "test-secret-must-not-leak")
+            .env("AWS_SESSION_TOKEN", "test-token-must-not-leak")
+            .env("AZURE_CLIENT_SECRET", "test-azure-secret")
+            .env("NPM_TOKEN", "test-npm-token")
+            .env("GITHUB_TOKEN", "test-github-token")
+            .output()
+            .expect("Failed to run cplt");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let count: u32 = stdout.trim().parse().unwrap_or(999);
+        assert_eq!(
+            count, 0,
+            "Credential env vars must be filtered by ENV_ALLOWLIST; found {count} leaking into sandbox. stdout: {stdout}"
+        );
+    }
+
+    /// Verify that HOME and other required tool vars pass through to the sandbox.
+    #[test]
+    fn sandboxed_env_passes_home_and_path() {
+        require_landlock!();
+        let project = create_test_project();
+
+        let (_, stdout, _) = run_sandboxed(
+            project.path(),
+            "echo HOME=$HOME && echo PATH_SET=${PATH:+yes}",
+        );
+
+        assert!(
+            stdout.contains("HOME="),
+            "HOME must be present in sandbox env; got: {stdout}"
+        );
+        assert!(
+            stdout.contains("PATH_SET=yes"),
+            "PATH must be present in sandbox env; got: {stdout}"
+        );
+    }
 }

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -526,8 +526,10 @@ else:
             &["--allow-localhost", &port.to_string()],
             &script,
         );
-        handle.join().ok();
 
+        // Ensure the accept thread unblocks even if the sandboxed connect failed.
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
+        handle.join().ok();
         assert!(
             stdout.contains("CONNECT_OK"),
             "--allow-localhost {port} should permit TCP connect to localhost:{port} — stdout: {stdout}"

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -561,6 +561,9 @@ else:
             &script,
         );
         drop(listener2);
+        // Unblock the port1 accept thread (the sandboxed script only touches
+        // port2, so nothing else ever connects to port1) to avoid a hang on join.
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port1));
         handle.join().ok();
 
         assert!(

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -503,6 +503,70 @@ else:
         );
     }
 
+    #[test]
+    fn allow_localhost_port_permits_tcp_connect() {
+        require_landlock!(4);
+        let project = create_test_project();
+
+        // Start a listener that will accept a connection
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind test listener");
+        let port = listener.local_addr().unwrap().port();
+
+        // Spawn a thread to accept the one connection so the sandbox connect() doesn't hang
+        let handle = std::thread::spawn(move || {
+            listener.accept().ok();
+        });
+
+        let script = format!(
+            "bash -c 'echo > /dev/tcp/127.0.0.1/{port}' 2>&1 && echo CONNECT_OK || echo CONNECT_FAILED"
+        );
+        let (_, stdout, _) = run_sandboxed_with_flags(
+            project.path(),
+            &["--allow-localhost", &port.to_string()],
+            &script,
+        );
+        handle.join().ok();
+
+        assert!(
+            stdout.contains("CONNECT_OK"),
+            "--allow-localhost {port} should permit TCP connect to localhost:{port} — stdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn allow_localhost_port_does_not_open_other_ports() {
+        require_landlock!(4);
+        let project = create_test_project();
+
+        let listener1 =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind listener 1");
+        let port1 = listener1.local_addr().unwrap().port();
+        let listener2 =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind listener 2");
+        let port2 = listener2.local_addr().unwrap().port();
+
+        // Accept on port1 so it doesn't hang
+        let handle = std::thread::spawn(move || {
+            listener1.accept().ok();
+        });
+
+        // Allow only port1; port2 should still be blocked
+        let script = format!("bash -c 'echo > /dev/tcp/127.0.0.1/{port2}' 2>&1 || echo BLOCKED");
+        let (_, stdout, _) = run_sandboxed_with_flags(
+            project.path(),
+            &["--allow-localhost", &port1.to_string()],
+            &script,
+        );
+        drop(listener2);
+        handle.join().ok();
+
+        assert!(
+            stdout.contains("BLOCKED"),
+            "--allow-localhost {port1} should not open port {port2} — stdout: {stdout}"
+        );
+    }
+
     // ── E2E binary tests ──────────────────────────────────────────
 
     #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -413,56 +413,6 @@ fn allow_private_domains_suffix_match() {
     assert!(!is_domain_match("notintern.nav.no", &list));
 }
 
-#[test]
-fn proxy_allow_localhost_port_bypasses_private_block() {
-    use cplt::proxy::is_private_hostname;
-    // Simulate the bypass condition in handle_connect when --allow-localhost is set:
-    //   localhost_connect_allowed = is_private_hostname(host)
-    //     && (allow_localhost_any || allow_localhost_ports.contains(&port))
-    let host = "localhost";
-    let port: u16 = 5173;
-
-    // Without allow_localhost: private hostname → should be blocked
-    let allow_localhost_ports: Vec<u16> = vec![];
-    let allow_localhost_any = false;
-    let localhost_connect_allowed =
-        is_private_hostname(host) && (allow_localhost_any || allow_localhost_ports.contains(&port));
-    assert!(
-        !localhost_connect_allowed,
-        "localhost:5173 should be blocked when --allow-localhost is not set"
-    );
-
-    // With --allow-localhost 5173: should be allowed
-    let allow_localhost_ports: Vec<u16> = vec![5173];
-    let localhost_connect_allowed =
-        is_private_hostname(host) && (allow_localhost_any || allow_localhost_ports.contains(&port));
-    assert!(
-        localhost_connect_allowed,
-        "localhost:5173 should be allowed when --allow-localhost 5173 is set"
-    );
-
-    // With --allow-localhost-any: all ports allowed
-    let allow_localhost_ports: Vec<u16> = vec![];
-    let allow_localhost_any = true;
-    let localhost_connect_allowed =
-        is_private_hostname(host) && (allow_localhost_any || allow_localhost_ports.contains(&port));
-    assert!(
-        localhost_connect_allowed,
-        "localhost:5173 should be allowed when --allow-localhost-any is set"
-    );
-
-    // Different port not in allow list → still blocked
-    let other_port: u16 = 9000;
-    let allow_localhost_ports: Vec<u16> = vec![5173];
-    let allow_localhost_any = false;
-    let localhost_connect_allowed = is_private_hostname(host)
-        && (allow_localhost_any || allow_localhost_ports.contains(&other_port));
-    assert!(
-        !localhost_connect_allowed,
-        "localhost:9000 should remain blocked when only port 5173 is allowed"
-    );
-}
-
 // ============================================================
 // SBPL path validation
 // ============================================================

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -413,6 +413,56 @@ fn allow_private_domains_suffix_match() {
     assert!(!is_domain_match("notintern.nav.no", &list));
 }
 
+#[test]
+fn proxy_allow_localhost_port_bypasses_private_block() {
+    use cplt::proxy::is_private_hostname;
+    // Simulate the bypass condition in handle_connect when --allow-localhost is set:
+    //   localhost_connect_allowed = is_private_hostname(host)
+    //     && (allow_localhost_any || allow_localhost_ports.contains(&port))
+    let host = "localhost";
+    let port: u16 = 5173;
+
+    // Without allow_localhost: private hostname → should be blocked
+    let allow_localhost_ports: Vec<u16> = vec![];
+    let allow_localhost_any = false;
+    let localhost_connect_allowed =
+        is_private_hostname(host) && (allow_localhost_any || allow_localhost_ports.contains(&port));
+    assert!(
+        !localhost_connect_allowed,
+        "localhost:5173 should be blocked when --allow-localhost is not set"
+    );
+
+    // With --allow-localhost 5173: should be allowed
+    let allow_localhost_ports: Vec<u16> = vec![5173];
+    let localhost_connect_allowed =
+        is_private_hostname(host) && (allow_localhost_any || allow_localhost_ports.contains(&port));
+    assert!(
+        localhost_connect_allowed,
+        "localhost:5173 should be allowed when --allow-localhost 5173 is set"
+    );
+
+    // With --allow-localhost-any: all ports allowed
+    let allow_localhost_ports: Vec<u16> = vec![];
+    let allow_localhost_any = true;
+    let localhost_connect_allowed =
+        is_private_hostname(host) && (allow_localhost_any || allow_localhost_ports.contains(&port));
+    assert!(
+        localhost_connect_allowed,
+        "localhost:5173 should be allowed when --allow-localhost-any is set"
+    );
+
+    // Different port not in allow list → still blocked
+    let other_port: u16 = 9000;
+    let allow_localhost_ports: Vec<u16> = vec![5173];
+    let allow_localhost_any = false;
+    let localhost_connect_allowed = is_private_hostname(host)
+        && (allow_localhost_any || allow_localhost_ports.contains(&other_port));
+    assert!(
+        !localhost_connect_allowed,
+        "localhost:9000 should remain blocked when only port 5173 is allowed"
+    );
+}
+
 // ============================================================
 // SBPL path validation
 // ============================================================


### PR DESCRIPTION
## Problem

On Linux, `curl http://localhost:5173/` inside a cplt session launched with `--allow-localhost 5173` returned `405 Method Not Allowed`. Outside cplt it worked fine.

**Root cause:** Two separate layers both blocked the connection:

1. **Plain HTTP 405**: `curl` routes plain HTTP through the cplt CONNECT proxy (via `HTTP_PROXY`). The proxy only handles HTTPS tunneling (CONNECT method) and returns 405 for plain GET.
2. **`NO_PROXY` not set on Linux**: On macOS, `NO_PROXY=localhost,...` is always set because Seatbelt enforces localhost isolation at the kernel level. On Linux, it was intentionally omitted — the proxy was supposed to be the sole localhost enforcer. But when the user explicitly opens a port with `--allow-localhost`, the proxy should step aside.

## Fix

**`sandbox_exec.rs`**: Set `NO_PROXY=localhost,127.0.0.1,::1` on Linux when the user has configured `--allow-localhost` or `--allow-localhost-any`. This lets tools like `curl` connect directly, bypassing the proxy entirely. Without explicit localhost access configured, the proxy continues to block all loopback connections on Linux.

**`proxy.rs` + `main.rs`**: Defense-in-depth carve-out in `handle_connect`: when the target is localhost and the port is in `allow_localhost_ports` (or `allow_localhost_any` is set), skip the private-IP block. This ensures HTTPS CONNECT tunnels to localhost also work for tools that ignore `NO_PROXY`.

## Tests

- Unit test: verifies the carve-out logic for allowed vs. blocked localhost ports
- Integration (Linux): `allow_localhost_port_permits_tcp_connect` — confirms TCP connect succeeds on the allowed port
- Integration (Linux): `allow_localhost_port_does_not_open_other_ports` — confirms non-allowed ports remain blocked

## Verified

```
curl -v http://localhost:5173/
# HTTP/1.0 200 OK  ✓
```