### PR TITLE
feat: support global npm/maven registries and symlink protections

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -360,6 +360,9 @@ Files always denied:
 - `~/.gem/credentials` — RubyGems credentials
 - `~/.vault-token` — HashiCorp Vault
 
+#### Symlink attack protection
+SBPL (macOS Seatbelt) resolves symlink targets at the kernel VFS layer before matching paths against deny rules. To verify this, cplt includes integration tests that attempt to read sensitive files (such as `.env`) through symlinks with non-matching names. The kernel correctly resolves the symlink target and blocks the operation.
+
 #### Tool directory permissions
 
 Home tool directories (`~/.cargo`, `~/.nvm`, etc.) use a per-directory permission model (`HomeToolDir`) with granular `process_exec`, `map_exec`, and `write` flags:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -352,16 +352,19 @@ Directories explicitly allowed (read-only):
 
 - `~/.config/gh` — GitHub CLI credentials (Copilot spawns `gh auth token`; see [Honest gaps](#honest-gaps))
 
-Files always denied:
+Files always denied (hard blocks):
 
 - `~/.netrc` — HTTP credentials
-- `~/.npmrc` — npm registry tokens
 - `~/.pypirc` — PyPI credentials
 - `~/.gem/credentials` — RubyGems credentials
 - `~/.vault-token` — HashiCorp Vault
 
+Files denied by default (overridable via `--allow-read` for private registries):
+
+- `~/.npmrc` — npm registry configuration
+
 #### Symlink attack protection
-SBPL (macOS Seatbelt) resolves symlink targets at the kernel VFS layer before matching paths against deny rules. To verify this, cplt includes integration tests that attempt to read sensitive files (such as `.env`) through symlinks with non-matching names. The kernel correctly resolves the symlink target and blocks the operation.
+SBPL (macOS Seatbelt) resolves symlink targets at the kernel VFS layer during path evaluation. To verify this behavior, cplt includes integration tests demonstrating that attempts to read a denied file (such as `.env`) via a symlink with an innocuous name are successfully blocked by the kernel.
 
 #### Tool directory permissions
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -422,10 +422,15 @@ fn detect_jvm(ctx: &DetectContext) -> DetectorOutput {
 
     let mut suggestions = vec![Suggestion::Propose(SandboxFlag::AllowJvmAttach)];
 
-    // Check for ~/.gradle/gradle.properties (common for credentials/proxy config)
-    suggestions.push(Suggestion::AllowRead(
-        "~/.gradle/gradle.properties".to_string(),
-    ));
+    // Check for credentials/proxy config files
+    if is_gradle {
+        suggestions.push(Suggestion::AllowRead(
+            "~/.gradle/gradle.properties".to_string(),
+        ));
+    }
+    if is_maven {
+        suggestions.push(Suggestion::AllowRead("~/.m2/settings.xml".to_string()));
+    }
 
     // Content scan: check for mocking frameworks that need JVM attach
     if is_gradle {
@@ -500,6 +505,14 @@ fn detect_node(ctx: &DetectContext) -> DetectorOutput {
             || content.contains("\"turbo\"")
         {
             suggestions.push(Suggestion::Propose(SandboxFlag::AllowLocalhostAny));
+        }
+
+        // If local .npmrc exists or package.json specifies a registry, suggest ~/.npmrc
+        if ctx.exists(".npmrc")
+            || content.contains("\"registry\"")
+            || content.contains("publishConfig")
+        {
+            suggestions.push(Suggestion::AllowRead("~/.npmrc".to_string()));
         }
     }
 
@@ -1882,6 +1895,16 @@ pub fn detect_global(home: &Path) -> GlobalDetectionReport {
         detections.push(d);
     }
 
+    // npm credentials (private registry access)
+    if let Some(d) = detect_global_npmrc(home) {
+        detections.push(d);
+    }
+
+    // Maven credentials (private registry access)
+    if let Some(d) = detect_global_m2_settings(home) {
+        detections.push(d);
+    }
+
     // Preferred agent from PATH
     if let Some(d) = detect_global_agent() {
         detections.push(d);
@@ -1963,6 +1986,52 @@ fn detect_global_gradle_credentials(home: &Path) -> Option<GlobalDetection> {
         reason: "~/.gradle/gradle.properties contains repository configuration".to_string(),
         suggestions: vec![GlobalSuggestion::AllowRead(
             "~/.gradle/gradle.properties".to_string(),
+        )],
+    })
+}
+
+fn detect_global_npmrc(home: &Path) -> Option<GlobalDetection> {
+    // ~/.npmrc is denied by default (may contain authentication tokens).
+    // If it exists and contains registry configurations/tokens, suggest allowing read access.
+    let npmrc_path = home.join(".npmrc");
+    if !npmrc_path.is_file() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&npmrc_path).ok()?;
+    let has_registry = content.lines().any(|line| {
+        let trimmed = line.trim();
+        !trimmed.starts_with('#')
+            && (trimmed.contains("registry") || trimmed.contains("_authToken"))
+    });
+    if !has_registry {
+        return None;
+    }
+    Some(GlobalDetection {
+        name: "npm registry credentials",
+        reason: "~/.npmrc contains registry or token configuration".to_string(),
+        suggestions: vec![GlobalSuggestion::AllowRead("~/.npmrc".to_string())],
+    })
+}
+
+fn detect_global_m2_settings(home: &Path) -> Option<GlobalDetection> {
+    // ~/.m2/settings.xml is denied by default (may contain repository server credentials).
+    // If it exists and contains custom servers/profiles, suggest allowing read access.
+    let settings_path = home.join(".m2/settings.xml");
+    if !settings_path.is_file() {
+        return None;
+    }
+    let content = std::fs::read_to_string(&settings_path).ok()?;
+    let has_registry = content.contains("<server>")
+        || content.contains("<mirror>")
+        || content.contains("<repository>");
+    if !has_registry {
+        return None;
+    }
+    Some(GlobalDetection {
+        name: "Maven repository settings",
+        reason: "~/.m2/settings.xml contains repository server configurations".to_string(),
+        suggestions: vec![GlobalSuggestion::AllowRead(
+            "~/.m2/settings.xml".to_string(),
         )],
     })
 }
@@ -2907,6 +2976,74 @@ services:
                 .detections
                 .iter()
                 .any(|d| d.name == "Gradle registry credentials")
+        );
+    }
+
+    #[test]
+    fn global_detect_npmrc_credentials() {
+        let home = tempfile::tempdir().unwrap();
+        let npmrc = home.path().join(".npmrc");
+        std::fs::write(
+            &npmrc,
+            "registry=https://npm.pkg.github.com\n_authToken=secret",
+        )
+        .unwrap();
+
+        let report = detect_global(home.path());
+        assert!(
+            report
+                .detections
+                .iter()
+                .any(|d| d.name == "npm registry credentials")
+        );
+        assert!(
+            report
+                .detections
+                .iter()
+                .flat_map(|d| &d.suggestions)
+                .any(|s| matches!(s, GlobalSuggestion::AllowRead(p) if p.contains(".npmrc")))
+        );
+    }
+
+    #[test]
+    fn global_detect_npmrc_no_match() {
+        let home = tempfile::tempdir().unwrap();
+        let npmrc = home.path().join(".npmrc");
+        std::fs::write(&npmrc, "# just a comment").unwrap();
+
+        let report = detect_global(home.path());
+        assert!(
+            !report
+                .detections
+                .iter()
+                .any(|d| d.name == "npm registry credentials")
+        );
+    }
+
+    #[test]
+    fn global_detect_m2_settings_credentials() {
+        let home = tempfile::tempdir().unwrap();
+        let settings = home.path().join(".m2/settings.xml");
+        std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        std::fs::write(
+            &settings,
+            "<settings><servers><server><id>nexus</id></server></servers></settings>",
+        )
+        .unwrap();
+
+        let report = detect_global(home.path());
+        assert!(
+            report
+                .detections
+                .iter()
+                .any(|d| d.name == "Maven repository settings")
+        );
+        assert!(
+            report
+                .detections
+                .iter()
+                .flat_map(|d| &d.suggestions)
+                .any(|s| matches!(s, GlobalSuggestion::AllowRead(p) if p.contains("settings.xml")))
         );
     }
 

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -44,6 +44,8 @@ pub const DENIED_HOME_SUBPATHS: &[&str] = &[
     // NuGet.Config can contain <packageSourceCredentials> with plaintext registry passwords.
     // Same threat model as .m2/settings.xml — override with allow.read if private registry needed.
     ".nuget/NuGet.Config",
+    // .npmrc is a top-level file, but belongs here so it can be overridden via --allow-read
+    // if the user needs to access a private npm registry (unlike hard-denied dotfiles).
     ".npmrc",
 ];
 

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -25,13 +25,7 @@ pub const DENIED_DOTFILES: &[&str] = &[
 ];
 
 /// Sensitive files under $HOME that are always denied.
-pub const DENIED_FILES: &[&str] = &[
-    ".netrc",
-    ".npmrc",
-    ".pypirc",
-    ".gem/credentials",
-    ".vault-token",
-];
+pub const DENIED_FILES: &[&str] = &[".netrc", ".pypirc", ".gem/credentials", ".vault-token"];
 
 /// Credential files inside otherwise-allowed HOME_TOOL_DIRS.
 /// These are denied by default because they typically contain registry
@@ -50,6 +44,7 @@ pub const DENIED_HOME_SUBPATHS: &[&str] = &[
     // NuGet.Config can contain <packageSourceCredentials> with plaintext registry passwords.
     // Same threat model as .m2/settings.xml — override with allow.read if private registry needed.
     ".nuget/NuGet.Config",
+    ".npmrc",
 ];
 
 /// Sensitive file patterns in the project directory that are denied by default.
@@ -913,6 +908,13 @@ pub const HOME_TOOL_DIRS: &[HomeToolDir] = &[
     // Yarn Berry global cache: packages only, no executables
     HomeToolDir {
         path: ".yarn",
+        process_exec: false,
+        map_exec: false,
+        write: true,
+    },
+    // npm global cache: packages only, no executables
+    HomeToolDir {
+        path: ".npm",
         process_exec: false,
         map_exec: false,
         write: true,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -663,6 +663,35 @@ mod macos_tests {
     }
 
     #[test]
+    fn real_profile_blocks_env_file_symlink_read() {
+        require_sandbox!();
+        let project = fs::canonicalize(".").unwrap();
+        let tmp = project.join(format!(".cplt-envsymtest-{}", std::process::id()));
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join(".env"), "SECRET=hunter2\n").unwrap();
+        let tmp = fs::canonicalize(&tmp).unwrap();
+        let home = home_dir();
+
+        // Create symlink innocuous-name -> .env
+        let env_path = tmp.join(".env");
+        let link_path = tmp.join("innocuous-name");
+        std::os::unix::fs::symlink(&env_path, &link_path).unwrap();
+
+        let opts = default_opts(&tmp, &home);
+        let profile = write_real_profile(&opts);
+
+        let cmd = format!("cat '{}' 2>&1; echo EXIT:$?", link_path.display());
+        let (output, _) = run_sandboxed(&profile, &cmd);
+
+        fs::remove_dir_all(&tmp).ok();
+        fs::remove_file(&profile).ok();
+        assert!(
+            output.contains("Operation not permitted") || output.contains("EXIT:1"),
+            "symlink to .env should be blocked by default, got: {output}"
+        );
+    }
+
+    #[test]
     fn real_profile_blocks_env_file_delete() {
         require_sandbox!();
         let project = fs::canonicalize(".").unwrap();

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -817,13 +817,7 @@ fn profile_denies_sensitive_files() {
         allow_cache_exec_any: false,
         allow_browser: false,
     });
-    for file in &[
-        ".netrc",
-        ".npmrc",
-        ".pypirc",
-        ".gem/credentials",
-        ".vault-token",
-    ] {
+    for file in &[".netrc", ".pypirc", ".gem/credentials", ".vault-token"] {
         assert!(
             p.contains(&format!(
                 "(deny file-read* (literal \"/Users/test/{file}\"))"
@@ -874,6 +868,7 @@ fn profile_denies_credential_files_in_tool_dirs() {
         ".gradle/gradle.properties",
         ".cargo/credentials",
         ".cargo/credentials.toml",
+        ".npmrc",
     ] {
         assert!(
             p.contains(&format!(

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -905,6 +905,7 @@ fn profile_allows_credential_files_when_user_opts_in() {
         extra_read: &[
             PathBuf::from("/Users/test/.m2/settings.xml"),
             PathBuf::from("/Users/test/.gradle/gradle.properties"),
+            PathBuf::from("/Users/test/.npmrc"),
         ],
         extra_write: &[],
         allow_socket: &[],
@@ -962,6 +963,18 @@ fn profile_allows_credential_files_when_user_opts_in() {
     assert!(
         allow_pos > deny_pos,
         "re-allow must come AFTER deny for gradle.properties"
+    );
+
+    // Same for npmrc
+    let deny_pos = p
+        .find("(deny file-read* (literal \"/Users/test/.npmrc\"))")
+        .unwrap();
+    let allow_pos = p
+        .find("(allow file-read* (literal \"/Users/test/.npmrc\"))")
+        .expect("should have a post-deny re-allow for .npmrc");
+    assert!(
+        allow_pos > deny_pos,
+        "re-allow must come AFTER deny for .npmrc"
     );
 
     // Files NOT in extra_read should remain denied without override


### PR DESCRIPTION
## Overview
This pull request addresses two open issues regarding registry configurations and sandbox bypass protections. 

Fixes #65 (npm/Maven private registry build blocks)
Fixes #60 (symlink attack protection for sensitive file denies)

## Changes

### 1. Support for npm/Maven Private Registries (#65)
To support developers pulling internal packages from private registries (like Nexus, GitHub Packages, or Artifactory) without compromising the deny-by-default posture of the sandbox:
- **Relocated `.npmrc`:** Moved from `DENIED_FILES` (hard-block) to `DENIED_HOME_SUBPATHS` in `src/sandbox_policy.rs`. This allows users to opt-in via `--allow-read ~/.npmrc` or `allow.read = ["~/.npmrc"]`.
- **Cache Writes:** Added `.npm` to `HOME_TOOL_DIRS` with write permissions enabled, ensuring global cache operations succeed without granting `process-exec` or `map-exec` privileges.
- **Global Detectors:** Implemented `detect_global_npmrc` and `detect_global_m2_settings` in `src/detect.rs`. These functions safely scan the home directory files for custom registry endpoints and authentication tokens, dynamically suggesting the `allow.read` configurations to the user.
- **Unit Tests:** Updated and added tests verifying that `.npmrc` properly triggers suggestions and that default Seatbelt subpath/literal block rules still apply if not explicitly overridden.

### 2. Symlink Attack Protection Verification (#60)
To eliminate concerns regarding symbolic link resolution bypassing sandbox restrictions:
- **Integration Test:** Added `real_profile_blocks_env_file_symlink_read` in `tests/integration.rs`. The test creates a `.env` file, symlinks it to `innocuous-name`, and verifies that a `cat innocuous-name` inside the sandbox is correctly blocked.
- **Security Posture:** The test confirms that macOS Seatbelt (SBPL) naturally evaluates targets at the kernel VFS layer before applying rules. No further application-side path canonicalization is required to thwart this attack vector.
- **Documentation:** Updated `SECURITY.md` with a "Symlink attack protection" section to explicitly document this kernel-level enforcement.

## Security Considerations
An adversarial review was conducted over these changes:
- `--allow-read ~/.npmrc` combined with symlink manipulation cannot be exploited due to strict configuration path canonicalization interacting with last-match-wins SBPL rule ordering.
- Write access to `~/.npm` limits attackers to dropping files without execution permissions. Cache poisoning vectors are natively mitigated by standard package-manager integrity checks (e.g. SHA-512 in `package-lock.json`).

## Testing
- [x] All formatting checks passed (`mise run fmt`)
- [x] Clippy linter warnings resolved (`mise run clippy`)
- [x] Unit/lib tests passing (`mise run test:unit`)
- [x] macOS kernel-enforcement integration tests passing (`mise run test:integration`)
