### PR TITLE
fix: grant execution for copilot cache directory on Linux (fixes #102)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1524,12 +1524,6 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             .and_then(|p| {
                 // Try package.json discovery first (npm/Homebrew installs)
                 discover::copilot_pkg_dir(p, &home_dir).or_else(|| {
-                    // SEA binary on Linux: the extracted runtime lives in
-                    // ~/.cache/copilot/pkg/linux-{arch}/ and needs exec access.
-                    #[cfg(target_os = "linux")]
-                    if let Some(cache_dir) = discover::copilot_sea_cache_dir(&home_dir) {
-                        return Some(cache_dir);
-                    }
                     // Fallback: use the binary's parent directory (VS Code extension installs
                     // at ~/Library/Application Support/Code/.../copilotCli/copilot)
                     p.parent().map(std::path::Path::to_path_buf)

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -603,6 +603,19 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 ioctl: false,
             },
         });
+
+        // Copilot SEA cache — auto-updaters download newer versions here.
+        // Execute is required for Node to spawn the newer ripgrep / helpers.
+        // (Write access is already inherited from the broader ~/.cache allow).
+        fs_rules.push(FsRule {
+            path: home.join(".cache/copilot/pkg"),
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: true,
+                ioctl: false,
+            },
+        });
     }
     for dir in config.agent_dirs {
         fs_rules.push(FsRule {


### PR DESCRIPTION
- Remove short-circuiting fallback logic in main.rs so copilot_install_dir consistently points to the base installation path
- Add an explicit execution carve-out for ~/.cache/copilot/pkg in sandbox_landlock.rs
- Ensures Node can spawn newer helper binaries from the auto-updated cache location on Linux
