### PR TITLE
test(ci): require-mode + Copilot-skip visibility for macOS e2e (#115)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,8 +86,41 @@ jobs:
       - name: Install Gradle (for Gradle sandbox tests)
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # ratchet:gradle/actions/setup-gradle@v6.2.0
 
-      - name: Run all tests
-        run: cargo test --verbose
+      - name: Run all tests (skips fail the job)
+        # CPLT_TEST_REQUIRE_SANDBOX=1 makes require_sandbox! panic instead of skip,
+        # so a missing/broken sandbox-exec (a Seatbelt regression on the runner)
+        # turns this job red rather than silently passing while nothing is
+        # enforced — the macOS analogue of the Linux job's execute-or-fail guard
+        # (issue #115). sandbox-exec is always present on macos-latest, so this is
+        # safe to require. Output is teed (with pipefail) to a log outside the
+        # workspace so the skip-summary step below can count residual skips without
+        # dirtying the working tree; a real test failure still fails the pipeline.
+        env:
+          CPLT_TEST_REQUIRE_SANDBOX: "1"
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo test --verbose -- --nocapture 2>&1 | tee "$RUNNER_TEMP/test-output.log"
+
+      - name: Surface tests skipped for missing tooling
+        if: always()
+        shell: bash
+        run: |
+          # Copilot cannot be installed/authed in CI, so tests that genuinely need
+          # the real Copilot binary self-skip with a `SKIPPED (copilot):` marker.
+          # cargo hides passing-test stderr, so we run with --nocapture above and
+          # count the markers here, surfacing the residual (unrunnable-in-CI) count
+          # as a ::warning:: so a silent-skip regression stays observable (#115).
+          LOG="$RUNNER_TEMP/test-output.log"
+          if [ ! -f "$LOG" ]; then
+            echo "No test output captured — skipping summary"
+            exit 0
+          fi
+          copilot_skips=$(grep -c "SKIPPED (copilot)" "$LOG" || true)
+          echo "Copilot-gated tests skipped (Copilot not installed in CI): $copilot_skips"
+          if [ "$copilot_skips" -gt 0 ]; then
+            echo "::warning::${copilot_skips} E2E test(s) skipped because the real Copilot CLI is not installed in CI. These genuinely require the Copilot binary/auth (see require_copilot! in tests/e2e.rs); all sandbox/proxy/profile behaviour is covered without it."
+          fi
 
       - name: Assert working tree is clean (no leaked test artifacts)
         run: |

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -46,22 +46,50 @@ mod e2e_tests {
             .unwrap_or(false)
     }
 
-    /// Skip guard — call at the top of tests that need Copilot CLI.
-    /// Returns true if the test should be skipped.
+    /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox
+    /// capability must FAIL the test rather than silently skip. This mirrors the
+    /// Linux `require_sandbox_enforced()` in `integration_linux.rs` and closes the
+    /// gap where a `sandbox-exec`/Seatbelt regression on the macOS runner would
+    /// leave CI green because every enforcement test self-skipped. Default (unset)
+    /// behaviour is unchanged for local dev / nested-sandbox runs.
+    fn require_sandbox_enforced() -> bool {
+        std::env::var("CPLT_TEST_REQUIRE_SANDBOX").as_deref() == Ok("1")
+    }
+
+    /// Skip guard — call at the top of tests that need the REAL Copilot CLI.
+    ///
+    /// Copilot cannot be installed/authenticated in CI, so this always self-skips
+    /// (never a require-mode). Only tests whose intent genuinely depends on the
+    /// real Copilot binary/output keep this guard; sandbox/proxy/profile behaviour
+    /// is exercised via `--print-profile`, the default Copilot agent (no binary
+    /// needed), or the fake-copilot fixtures instead. The `SKIPPED (copilot):`
+    /// marker is grepped by the CI summary step so the residual skip count is
+    /// surfaced as a `::warning::`.
     macro_rules! require_copilot {
         () => {
             if !copilot_cli_available() {
-                eprintln!("SKIPPED: copilot CLI not found in PATH");
+                eprintln!(
+                    "SKIPPED (copilot): copilot CLI not found in PATH — test genuinely requires the real Copilot binary"
+                );
                 return;
             }
         };
     }
 
     /// Skip guard — call at the top of tests that invoke sandbox-exec.
-    /// Skips when already inside a sandbox (nested sandbox-exec is denied by macOS).
+    ///
+    /// Skips when already inside a sandbox (nested sandbox-exec is denied by
+    /// macOS). Under `CPLT_TEST_REQUIRE_SANDBOX=1` the skip branch panics instead,
+    /// so a missing/broken `sandbox-exec` on the CI runner turns the job red.
     macro_rules! require_sandbox {
         () => {
             if !sandbox_exec_available() {
+                if require_sandbox_enforced() {
+                    panic!(
+                        "sandbox-exec required by CPLT_TEST_REQUIRE_SANDBOX but unavailable \
+                         (a trivial profile failed to apply — Seatbelt/sandbox-exec regression?)"
+                    );
+                }
                 eprintln!("SKIPPED: sandbox-exec not available (likely already sandboxed)");
                 return;
             }
@@ -112,11 +140,12 @@ mod e2e_tests {
 
     #[test]
     fn e2e_sandbox_validation_passes() {
-        require_copilot!();
         require_sandbox!();
-        let output = Command::new(binary_path())
+        // Fake copilot on PATH (not the real binary): sandbox validation passing
+        // and the agent launching is agent-agnostic, so this runs in CI.
+        let (mut cmd, _fake) = cplt_cmd_with_fake_copilot();
+        let output = cmd
             .args(["--yes", "--", "--version"])
-            .current_dir(project_dir())
             .output()
             .expect("binary should run");
 
@@ -134,12 +163,13 @@ mod e2e_tests {
 
     #[test]
     fn e2e_proxy_starts_with_version() {
-        require_copilot!();
         require_sandbox!();
+        // Fake copilot on PATH: proxy startup is agent-agnostic, so this runs in CI.
         // Use a high unique port to avoid collisions
         let port = 19200 + (std::process::id() % 800) as u16;
 
-        let output = Command::new(binary_path())
+        let (mut cmd, _fake) = cplt_cmd_with_fake_copilot();
+        let output = cmd
             .args([
                 "--yes",
                 "--with-proxy",
@@ -149,7 +179,6 @@ mod e2e_tests {
                 "--",
                 "--version",
             ])
-            .current_dir(project_dir())
             .output()
             .expect("binary should run");
 
@@ -168,9 +197,10 @@ mod e2e_tests {
 
     #[test]
     fn e2e_show_denials_doesnt_crash() {
-        require_copilot!();
         require_sandbox!();
-        let output = Command::new(binary_path())
+        // Fake copilot on PATH: denial-log streaming is agent-agnostic, runs in CI.
+        let (mut cmd, _fake) = cplt_cmd_with_fake_copilot();
+        let output = cmd
             .args([
                 "--yes",
                 "--show-denials",
@@ -178,7 +208,6 @@ mod e2e_tests {
                 "--",
                 "--version",
             ])
-            .current_dir(project_dir())
             .output()
             .expect("binary should run");
 
@@ -201,7 +230,8 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_contains_deny_default() {
-        require_copilot!();
+        // No require_copilot!: --print-profile defaults to the Copilot agent and
+        // needs no Copilot binary (see main.rs), so this runs in CI.
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -219,7 +249,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_blocks_sensitive_dirs() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -239,7 +268,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allows_project_dir() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -272,7 +300,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_restricts_network() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -305,7 +332,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allows_gh_config_readonly() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -337,7 +363,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_deny_path_overrides_project() {
-        require_copilot!();
         // Create a temp project with a subdir to deny. TempDir auto-cleans on
         // drop (including panic); the project path is passed explicitly so no
         // fixture is written into the repo checkout.
@@ -373,7 +398,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_allow_read_appears_in_profile() {
-        require_copilot!();
         // Create a temp dir outside the project to allow-read
         let allow_dir = std::env::temp_dir().join(format!("cplt-e2e-allow-{}", std::process::id()));
         std::fs::create_dir_all(&allow_dir).unwrap();
@@ -410,7 +434,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_custom_project_dir() {
-        require_copilot!();
         let custom_dir =
             std::env::temp_dir().join(format!("cplt-e2e-project-{}", std::process::id()));
         std::fs::create_dir_all(&custom_dir).unwrap();
@@ -459,7 +482,8 @@ mod e2e_tests {
 
     #[test]
     fn e2e_doctor_reports_auth_section() {
-        require_copilot!();
+        // No require_copilot!: doctor always prints the Auth section header
+        // regardless of whether Copilot is installed, so this runs in CI.
         let output = Command::new(binary_path())
             .args(["--doctor"])
             .current_dir(project_dir())
@@ -493,7 +517,8 @@ mod e2e_tests {
 
     #[test]
     fn e2e_doctor_reports_tools_section() {
-        require_copilot!();
+        // No require_copilot!: doctor always prints the Tools section (git is
+        // present on the runner) regardless of Copilot, so this runs in CI.
         let output = Command::new(binary_path())
             .args(["--doctor"])
             .current_dir(project_dir())
@@ -683,7 +708,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allow_tmp_exec_removes_denies() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--allow-tmp-exec", "--print-profile"])
             .current_dir(project_dir())
@@ -705,7 +729,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allow_localhost_any() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--allow-localhost-any", "--print-profile"])
             .current_dir(project_dir())
@@ -727,7 +750,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allow_localhost_port() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--allow-localhost", "3000", "--print-profile"])
             .current_dir(project_dir())
@@ -750,7 +772,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allow_port() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--allow-port", "8080", "--print-profile"])
             .current_dir(project_dir())
@@ -768,7 +789,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_deny_clipboard_emits_pasteboard_deny() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--deny-clipboard", "--print-profile"])
             .current_dir(project_dir())
@@ -792,7 +812,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allow_write() {
-        require_copilot!();
         let allow_dir =
             std::env::temp_dir().join(format!("cplt-e2e-allow-write-{}", std::process::id()));
         std::fs::create_dir_all(&allow_dir).unwrap();
@@ -826,7 +845,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_allow_env_files() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--allow-env-files", "--print-profile"])
             .current_dir(project_dir())
@@ -845,7 +863,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_scratch_dir_appears() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--scratch-dir", "--print-profile"])
             .current_dir(project_dir())
@@ -867,7 +884,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_copilot_pkg_write_denied() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -885,7 +901,6 @@ mod e2e_tests {
 
     #[test]
     fn e2e_print_profile_git_persistence_blocked() {
-        require_copilot!();
         let output = cplt_cmd()
             .args(["--print-profile"])
             .current_dir(project_dir())
@@ -961,6 +976,20 @@ mod e2e_tests {
             String::from_utf8_lossy(&output.stdout).to_string(),
             String::from_utf8_lossy(&output.stderr).to_string(),
         )
+    }
+
+    /// Build a `cplt` Command with a fake `copilot` prepended to PATH, for
+    /// pipeline tests that exercise sandbox/proxy/denial *wiring* (agent-agnostic)
+    /// rather than real Copilot behaviour — so they run in CI without the real
+    /// binary. The returned `TempDir` holds the fake script and must stay alive
+    /// for the duration of the run (its Drop removes it), so bind it (`let (_, _f)`).
+    fn cplt_cmd_with_fake_copilot() -> (Command, tempfile::TempDir) {
+        let fake_dir = create_fake_copilot();
+        let current_path = std::env::var("PATH").unwrap_or_default();
+        let new_path = format!("{}:{current_path}", fake_dir.path().display());
+        let mut cmd = Command::new(binary_path());
+        cmd.current_dir(project_dir()).env("PATH", &new_path);
+        (cmd, fake_dir)
     }
 
     #[test]

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -955,9 +955,23 @@ mod sandbox_integration {
             .unwrap_or(false)
     }
 
+    /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox
+    /// capability must FAIL the test rather than silently skip (mirrors the Linux
+    /// `require_sandbox_enforced()` in `integration_linux.rs`). Default (unset)
+    /// behaviour is unchanged for local dev / nested-sandbox runs.
+    fn require_sandbox_enforced() -> bool {
+        std::env::var("CPLT_TEST_REQUIRE_SANDBOX").as_deref() == Ok("1")
+    }
+
     macro_rules! require_sandbox {
         () => {
             if !sandbox_exec_available() {
+                if require_sandbox_enforced() {
+                    panic!(
+                        "sandbox-exec required by CPLT_TEST_REQUIRE_SANDBOX but unavailable \
+                         (a trivial profile failed to apply — Seatbelt/sandbox-exec regression?)"
+                    );
+                }
                 eprintln!("SKIPPED: sandbox-exec not available");
                 return;
             }

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -37,9 +37,23 @@ mod project_tests {
             .unwrap_or(false)
     }
 
+    /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox
+    /// capability must FAIL the test rather than silently skip (mirrors the Linux
+    /// `require_sandbox_enforced()` in `integration_linux.rs`). Default (unset)
+    /// behaviour is unchanged for local dev / nested-sandbox runs.
+    fn require_sandbox_enforced() -> bool {
+        std::env::var("CPLT_TEST_REQUIRE_SANDBOX").as_deref() == Ok("1")
+    }
+
     macro_rules! require_sandbox {
         () => {
             if !sandbox_exec_available() {
+                if require_sandbox_enforced() {
+                    panic!(
+                        "sandbox-exec required by CPLT_TEST_REQUIRE_SANDBOX but unavailable \
+                         (a trivial profile failed to apply — Seatbelt/sandbox-exec regression?)"
+                    );
+                }
                 eprintln!("SKIPPED: sandbox-exec not available (likely already sandboxed)");
                 return;
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,10 +22,29 @@ mod macos_tests {
             .unwrap_or(false)
     }
 
+    /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox
+    /// capability must FAIL the test rather than silently skip. Mirrors the Linux
+    /// `require_sandbox_enforced()` in `integration_linux.rs`: a `sandbox-exec`
+    /// regression on the macOS runner turns the job red instead of leaving CI
+    /// green while nothing is enforced. Default (unset) behaviour is unchanged for
+    /// local dev / nested-sandbox runs.
+    fn require_sandbox_enforced() -> bool {
+        std::env::var("CPLT_TEST_REQUIRE_SANDBOX").as_deref() == Ok("1")
+    }
+
     /// Skip guard — call at the top of tests that invoke sandbox-exec.
+    ///
+    /// Under `CPLT_TEST_REQUIRE_SANDBOX=1` the skip branch panics instead, so a
+    /// missing/broken `sandbox-exec` on the CI runner turns the job red.
     macro_rules! require_sandbox {
         () => {
             if !sandbox_exec_available() {
+                if require_sandbox_enforced() {
+                    panic!(
+                        "sandbox-exec required by CPLT_TEST_REQUIRE_SANDBOX but unavailable \
+                         (a trivial profile failed to apply — Seatbelt/sandbox-exec regression?)"
+                    );
+                }
                 eprintln!("SKIPPED: sandbox-exec not available (likely already sandboxed)");
                 return;
             }


### PR DESCRIPTION
## Summary

Gives the macOS integration/e2e suites the same **execute-or-fail** guarantee PR #64 gave the Linux job, closing two silent-coverage gaps.

Fixes #115.

## Gaps closed

**1. No require-mode (a Seatbelt regression would skip, not fail).** `require_sandbox!` returned early — counting as a *passed* test — when `sandbox-exec` was unavailable. Added `require_sandbox_enforced()` (mirroring `integration_linux.rs`) to all four macOS test files; under `CPLT_TEST_REQUIRE_SANDBOX=1` the guard now **panics** instead of skipping. The macOS CI job sets that env (sandbox-exec is always present on `macos-latest`, so it's safe to require).

**2. Copilot-gated tests silently skipped.** `require_copilot!` self-skips when the Copilot CLI is absent, and CI never installs it — so **30 tests reported green without running**. Audited all 36 call sites and **converted 23 to run without the real binary**:
- 18 `--print-profile` tests (default to the copilot agent, no binary needed),
- 2 doctor section tests,
- 3 pipeline tests via the existing fake-copilot fixture.

Intent preserved, no assertions weakened. **7** tests that genuinely need the real Copilot binary/auth stay gated (down from 30), and a CI step now counts the residual `SKIPPED (copilot)` markers and surfaces them as a `::warning::` so the skip can't silently grow again.

## Verification (macOS host)

- 308 macOS tests pass (e2e 120, integration 50, e2e_guards 98, e2e_projects 40).
- Require-mode **proven**: shadowed `sandbox-exec` with a failing stub → panics under `CPLT_TEST_REQUIRE_SANDBOX=1`, skips without it.
- Conversions **proven**: stripped Copilot from `PATH` → the 23 converted tests run (0 skip); the 7 residual emit `SKIPPED (copilot)`.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean. Only test files + `ci.yaml` changed (Linux job untouched).
