### PR TITLE
feat: honor tool-path env vars for non-default sandbox paths (#35)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -954,6 +954,38 @@ fn canonicalize_deny_paths(paths: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
         .collect()
 }
 
+/// Grant sandbox access to tool paths relocated via env vars (e.g. `GOPATH`,
+/// `CARGO_HOME`, `NODE_PATH`).
+///
+/// cplt allowlists each tool's *default* directory (e.g. `~/go`, `~/.cargo`),
+/// but when a user overrides one of these env vars to a custom path and that
+/// value is passed into the sandbox, the custom path is not in the allow set,
+/// so builds fail (e.g. `GOPATH=/custom` → `go build` cannot write there).
+///
+/// We read the *parent* process env (the well-known tool vars all reach the
+/// sandbox via the env allowlist), compute the implied read/write paths, then
+/// canonicalize and drop any that don't exist — Landlock requires an existing
+/// path to open, and macOS SBPL rules for missing paths are inert. Paths are
+/// merged into `allow_read`/`allow_write`, which the backends already handle;
+/// this only ever *adds* access.
+fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) {
+    let env: Vec<(String, String)> = std::env::vars().collect();
+    for ovr in cplt::sandbox::tool_path_env_overrides(&env, home) {
+        // canonicalize() also serves as the existence check: a missing path errors.
+        let Ok(path) = std::fs::canonicalize(&ovr.path) else {
+            continue;
+        };
+        let target = if ovr.write {
+            &mut resolved.allow_write
+        } else {
+            &mut resolved.allow_read
+        };
+        if !target.contains(&path) {
+            target.push(path);
+        }
+    }
+}
+
 /// Resolved configuration, paths, and agent info needed by the sandbox.
 #[allow(dead_code)] // unapproved_proposals is consumed by the warning block in resolve_context
 struct ResolvedContext {
@@ -1644,6 +1676,9 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     // Start proxy (handle returned for RAII ownership)
     let proxy_handle = start_proxy_if_enabled(&mut resolved, &cli, config_path.as_ref())?;
 
+    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
+    merge_tool_path_env_overrides(&mut resolved, &home_dir);
+
     // Prepare the sandbox — validates paths, generates platform-specific profile.
     // Path validation (SBPL injection checks on macOS) is handled internally
     // by prepare(), so callers don't need to know about backend-specific risks.
@@ -2161,6 +2196,9 @@ fn run_exec_command(
 
     let proxy_handle = start_proxy_if_enabled(&mut resolved, cli, config_path.as_ref())?;
     let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
+
+    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
+    merge_tool_path_env_overrides(&mut resolved, &home_dir);
 
     let prepared = match sandbox::prepare(&sandbox::SandboxConfig {
         project_dir: &project_dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -969,7 +969,17 @@ fn canonicalize_deny_paths(paths: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
 /// merged into `allow_read`/`allow_write`, which the backends already handle;
 /// this only ever *adds* access.
 fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) {
-    let env: Vec<(String, String)> = std::env::vars().collect();
+    // Read only the handful of recognized tool-path vars rather than snapshotting
+    // the entire parent environment — no need to copy unrelated secrets (tokens,
+    // credentials) into a Vec just to inspect a fixed, small set of names.
+    let env: Vec<(String, String)> = cplt::sandbox::TOOL_PATH_ENV_VARS
+        .iter()
+        .filter_map(|tv| {
+            std::env::var(tv.name)
+                .ok()
+                .map(|v| (tv.name.to_string(), v))
+        })
+        .collect();
     for ovr in cplt::sandbox::tool_path_env_overrides(&env, home) {
         // canonicalize() also serves as the existence check: a missing path errors.
         let Ok(path) = std::fs::canonicalize(&ovr.path) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -975,6 +975,21 @@ fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) {
         let Ok(path) = std::fs::canonicalize(&ovr.path) else {
             continue;
         };
+        // Security guard: an ambient tool-path env var (exported long ago for
+        // unrelated reasons, or injected via a repo config / --pass-env) must
+        // never widen the sandbox to an unsafe root or to HOME/its ancestors —
+        // e.g. GOPATH=$HOME would make the whole home dir writable, GOPATH=/ the
+        // whole filesystem. canonicalize() above has already resolved any `..`,
+        // so this is the single choke point where the effective grant is vetted.
+        // Applies to read grants too (read access to `/` or `$HOME` over-grants).
+        if !cplt::sandbox::tool_override_path_is_safe(&path, home) {
+            ui::warn(&format!(
+                "Ignoring {} = {}: resolves to an unsafe root or HOME and would defeat the sandbox",
+                ovr.name,
+                path.display()
+            ));
+            continue;
+        }
         let target = if ovr.write {
             &mut resolved.allow_write
         } else {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -52,7 +52,8 @@ mod profile;
 pub use policy::{
     AppDir, AppDirKind, DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS, ENV_ALLOWLIST,
     ENV_PREFIX_ALLOWLIST, HARDENING_ENV_VARS, HOME_TOOL_DIRS, HardeningCategory, HardeningEnvVar,
-    HomeToolDir, app_dirs, home_tool_dirs, validate_sbpl_path,
+    HomeToolDir, TOOL_PATH_ENV_VARS, ToolPathEnvVar, ToolPathOverride, app_dirs, home_tool_dirs,
+    tool_path_env_overrides, validate_sbpl_path,
 };
 
 // SBPL profile generation — kept public for unit tests.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -53,7 +53,7 @@ pub use policy::{
     AppDir, AppDirKind, DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS, ENV_ALLOWLIST,
     ENV_PREFIX_ALLOWLIST, HARDENING_ENV_VARS, HOME_TOOL_DIRS, HardeningCategory, HardeningEnvVar,
     HomeToolDir, TOOL_PATH_ENV_VARS, ToolPathEnvVar, ToolPathOverride, app_dirs, home_tool_dirs,
-    tool_path_env_overrides, validate_sbpl_path,
+    tool_override_path_is_safe, tool_path_env_overrides, validate_sbpl_path,
 };
 
 // SBPL profile generation — kept public for unit tests.

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -1104,6 +1104,9 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
 /// A single resolved tool-path override to add to the sandbox allow set.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolPathOverride {
+    /// Name of the env var this override came from (e.g. `GOPATH`). Used for
+    /// diagnostics when the override is dropped by the safety guard.
+    pub name: &'static str,
     /// Resolved path (leading `~/` expanded, relative paths joined onto `$HOME`).
     /// Not yet canonicalized or existence-checked — the caller does that so the
     /// backend only receives paths that actually exist (Landlock requires it).
@@ -1117,8 +1120,11 @@ pub struct ToolPathOverride {
 /// - Leading `~/` (or a bare `~`) expands to `home`.
 /// - Absolute paths are kept as-is.
 /// - Relative paths are joined onto `home` (env-var paths are almost always
-///   absolute; this keeps a stray relative value inside HOME rather than
-///   resolving it against an unknown cwd and widening access outside HOME).
+///   absolute) rather than resolved against an unknown cwd. This is *not* a
+///   containment guarantee: a value like `../../etc` still escapes HOME once the
+///   caller's `canonicalize()` collapses the `..` components. Final safety is
+///   enforced downstream by [`tool_override_path_is_safe`] at the merge site,
+///   which drops any override that resolves to an unsafe root or to HOME/above.
 ///
 /// Does not canonicalize or check existence — kept pure for cross-platform tests.
 fn resolve_tool_path(raw: &str, home: &Path) -> PathBuf {
@@ -1168,12 +1174,46 @@ pub fn tool_path_env_overrides(env: &[(String, String)], home: &Path) -> Vec<Too
             existing.write = existing.write || tv.write;
         } else {
             out.push(ToolPathOverride {
+                name: tv.name,
                 path: resolved,
                 write: tv.write,
             });
         }
     }
     out
+}
+
+/// Whether a canonicalized tool-path override is safe to add to the sandbox
+/// allow set.
+///
+/// A tool-path env var (`GOPATH`, `CARGO_HOME`, …) is attacker-influenceable: it
+/// may have been exported long ago for unrelated reasons, or injected via a repo
+/// config or `--pass-env`. Legitimate tool directories are always
+/// *subdirectories* of `$HOME` (e.g. `~/go`, `~/.cargo`) or of a custom project
+/// root, so an override that resolves to an unsafe root ([`crate::is_unsafe_root`]:
+/// `/`, `$HOME`, `/tmp`, platform system dirs) or to `$HOME` itself or any
+/// ancestor of it can only *widen* the sandbox and defeat its purpose. Such
+/// overrides must be dropped.
+///
+/// This is the single choke point where a canonicalized override becomes an
+/// allow rule; `canonicalize()` has already collapsed any `..`, so the path
+/// passed here is the effective grant. Applies to read grants too — read access
+/// to `/` or `$HOME` is also an over-grant.
+///
+/// `path` must already be canonicalized; `home` is the (canonical) home dir.
+pub fn tool_override_path_is_safe(path: &Path, home: &Path) -> bool {
+    // `/`, `$HOME`, `/tmp`, and platform system roots — mirrors every other
+    // path-widening guard in the codebase (project_dir, tool-dir discovery).
+    if crate::is_unsafe_root(path, home) {
+        return false;
+    }
+    // Any ancestor of HOME (e.g. `/Users` on macOS, `/home` on Linux, or a
+    // deeper parent). `starts_with` also matches HOME itself, which
+    // `is_unsafe_root` already covers — kept as defense in depth.
+    if home.starts_with(path) {
+        return false;
+    }
+    true
 }
 
 /// Validate that a path is safe for interpolation into SBPL profile strings.

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -196,6 +196,8 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     "NODE_ENV",
     "NODE_EXTRA_CA_CERTS",
     "NPM_CONFIG_CACHE",
+    "npm_config_cache",  // npm's canonical lowercase spelling of the cache path
+    "YARN_CACHE_FOLDER", // Yarn global cache location (also matches YARN_ prefix)
     "NPM_CONFIG_PREFIX",
     // Go
     "GOPATH",
@@ -227,6 +229,7 @@ pub const ENV_ALLOWLIST: &[&str] = &[
     "ASDF_DIR",                // asdf install directory
     "ASDF_DATA_DIR",           // asdf data directory (installs, shims)
     "PYTHONDONTWRITEBYTECODE", // Prevent .pyc writes (common in CI/sandboxed envs)
+    "PIP_CACHE_DIR",           // pip download/wheel cache location
     // pnpm
     "PNPM_HOME",             // pnpm binary location
     "NPM_CONFIG_USERCONFIG", // path to a custom .npmrc file (not the file itself — no auth tokens)
@@ -993,6 +996,184 @@ pub const HOME_TOOL_DIRS: &[HomeToolDir] = &[
 /// the profile generator.
 pub fn home_tool_dirs() -> &'static [HomeToolDir] {
     HOME_TOOL_DIRS
+}
+
+// ── Tool-path environment variable overrides ───────────────────────────────
+
+/// A development tool environment variable that relocates where the tool reads
+/// or writes files (e.g. `GOPATH`, `CARGO_HOME`, `NODE_PATH`).
+///
+/// [`HOME_TOOL_DIRS`] allowlists each tool's *default* location under `$HOME`.
+/// When a user points one of these env vars at a **non-default** path and that
+/// value is passed into the sandbox, builds fail because the custom path is not
+/// in the allow set (e.g. `GOPATH=/custom` → `go build` cannot write there).
+/// [`tool_path_env_overrides`] closes that gap by granting the resolved path.
+///
+/// Security note: an env var value is user-controlled configuration, so honoring
+/// it is consistent with how cplt already trusts `pass-env` — the same user who
+/// launches cplt set the variable. We only ever *add* access (never remove), and
+/// grant write only for the tools that genuinely write to the path.
+pub struct ToolPathEnvVar {
+    /// Environment variable name (looked up in the parent process env).
+    pub name: &'static str,
+    /// `true` → grant read+write (build caches / dependency stores the tool
+    /// writes to). `false` → grant read-only (lookup paths the tool only reads).
+    pub write: bool,
+    /// Home-relative default locations already covered by [`HOME_TOOL_DIRS`] (or
+    /// redirected elsewhere, e.g. `GOCACHE` → scratch dir). If the env var
+    /// resolves to one of these, no extra rule is added — the base policy already
+    /// grants it, so adding it again would only widen or duplicate the grant.
+    /// Multiple entries cover per-platform defaults (macOS `Library/...` vs XDG).
+    pub default_subpaths: &'static [&'static str],
+}
+
+/// Recognized tool-path env vars and how their target path is granted.
+///
+/// Covers the common Go, Node/npm/yarn/pnpm, Rust/cargo and Python/pip knobs.
+/// Write is granted for caches and dependency stores the tool populates; read
+/// for pure lookup paths (`NODE_PATH`). All of these vars reach the sandbox via
+/// [`ENV_ALLOWLIST`] (or a prefix in [`ENV_PREFIX_ALLOWLIST`]), so the granted
+/// path is actually nameable by the sandboxed process.
+pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
+    // ── Go ──────────────────────────────────────────────────────────────────
+    // GOPATH holds go/bin, go/pkg (module cache) and go/src; builds write here.
+    ToolPathEnvVar {
+        name: "GOPATH",
+        write: true,
+        default_subpaths: &["go"],
+    },
+    // Module cache — `go build`/`go test`/`go get` download & extract modules.
+    ToolPathEnvVar {
+        name: "GOMODCACHE",
+        write: true,
+        default_subpaths: &["go/pkg/mod"],
+    },
+    // Build cache. Default is redirected to the scratch dir (SCRATCH_DIR_ENV_VARS),
+    // so honor only an explicit non-default override.
+    ToolPathEnvVar {
+        name: "GOCACHE",
+        write: true,
+        default_subpaths: &["Library/Caches/go-build", ".cache/go-build"],
+    },
+    // ── Rust / cargo ─────────────────────────────────────────────────────────
+    // CARGO_HOME holds bin/, registry/ and git/ — cargo writes to registry & git.
+    ToolPathEnvVar {
+        name: "CARGO_HOME",
+        write: true,
+        default_subpaths: &[".cargo"],
+    },
+    // ── Node / npm / yarn / pnpm ─────────────────────────────────────────────
+    // npm cache (uppercase and npm's canonical lowercase spelling).
+    ToolPathEnvVar {
+        name: "NPM_CONFIG_CACHE",
+        write: true,
+        default_subpaths: &[".npm"],
+    },
+    ToolPathEnvVar {
+        name: "npm_config_cache",
+        write: true,
+        default_subpaths: &[".npm"],
+    },
+    // Yarn (Classic & Berry) global cache folder.
+    ToolPathEnvVar {
+        name: "YARN_CACHE_FOLDER",
+        write: true,
+        default_subpaths: &[".cache/yarn", "Library/Caches/Yarn"],
+    },
+    // pnpm home (global store + shims).
+    ToolPathEnvVar {
+        name: "PNPM_HOME",
+        write: true,
+        default_subpaths: &["Library/pnpm", ".local/share/pnpm"],
+    },
+    // NODE_PATH is a module *lookup* path — read-only is sufficient.
+    ToolPathEnvVar {
+        name: "NODE_PATH",
+        write: false,
+        default_subpaths: &[],
+    },
+    // ── Python / pip ─────────────────────────────────────────────────────────
+    // pip download/wheel cache.
+    ToolPathEnvVar {
+        name: "PIP_CACHE_DIR",
+        write: true,
+        default_subpaths: &[".cache/pip", "Library/Caches/pip"],
+    },
+];
+
+/// A single resolved tool-path override to add to the sandbox allow set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolPathOverride {
+    /// Resolved path (leading `~/` expanded, relative paths joined onto `$HOME`).
+    /// Not yet canonicalized or existence-checked — the caller does that so the
+    /// backend only receives paths that actually exist (Landlock requires it).
+    pub path: PathBuf,
+    /// `true` → read+write, `false` → read-only.
+    pub write: bool,
+}
+
+/// Expand a raw env var path value into an absolute path.
+///
+/// - Leading `~/` (or a bare `~`) expands to `home`.
+/// - Absolute paths are kept as-is.
+/// - Relative paths are joined onto `home` (env-var paths are almost always
+///   absolute; this keeps a stray relative value inside HOME rather than
+///   resolving it against an unknown cwd and widening access outside HOME).
+///
+/// Does not canonicalize or check existence — kept pure for cross-platform tests.
+fn resolve_tool_path(raw: &str, home: &Path) -> PathBuf {
+    if let Some(rest) = raw.strip_prefix("~/") {
+        home.join(rest)
+    } else if raw == "~" {
+        home.to_path_buf()
+    } else {
+        let p = Path::new(raw);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            home.join(p)
+        }
+    }
+}
+
+/// Compute the extra read/write paths implied by tool-path env vars.
+///
+/// For each variable in [`TOOL_PATH_ENV_VARS`] present in `env`, resolve its
+/// value (see [`resolve_tool_path`]) and, if it points at a **non-default**
+/// location, emit a [`ToolPathOverride`]. Default locations are skipped because
+/// [`HOME_TOOL_DIRS`] already grants them. Unset/empty vars contribute nothing.
+///
+/// `env` is the *parent* process environment as `(name, value)` pairs. Duplicate
+/// resolved paths are collapsed; if the same path is requested read-only and
+/// read+write, the write grant wins.
+///
+/// Pure function (env passed in, no `std::env` / filesystem access) so rule
+/// generation is testable on any platform.
+pub fn tool_path_env_overrides(env: &[(String, String)], home: &Path) -> Vec<ToolPathOverride> {
+    let mut out: Vec<ToolPathOverride> = Vec::new();
+    for tv in TOOL_PATH_ENV_VARS {
+        let Some((_, raw)) = env.iter().find(|(k, _)| k == tv.name) else {
+            continue;
+        };
+        if raw.is_empty() {
+            continue;
+        }
+        let resolved = resolve_tool_path(raw, home);
+        // Skip values that resolve to a default location already in the base policy.
+        if tv.default_subpaths.iter().any(|d| resolved == home.join(d)) {
+            continue;
+        }
+        // Deduplicate; upgrade an existing read-only grant to write if needed.
+        if let Some(existing) = out.iter_mut().find(|o| o.path == resolved) {
+            existing.write = existing.write || tv.write;
+        } else {
+            out.push(ToolPathOverride {
+                path: resolved,
+                write: tv.write,
+            });
+        }
+    }
+    out
 }
 
 /// Validate that a path is safe for interpolation into SBPL profile strings.

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -1025,6 +1025,12 @@ pub struct ToolPathEnvVar {
     /// grants it, so adding it again would only widen or duplicate the grant.
     /// Multiple entries cover per-platform defaults (macOS `Library/...` vs XDG).
     pub default_subpaths: &'static [&'static str],
+    /// `true` → the value is an OS path list (colon-separated on Unix, e.g.
+    /// `GOPATH=/a:/b` or `NODE_PATH=/x:/y`), so each segment is a separate path
+    /// and must be resolved and granted independently. `false` → the whole value
+    /// is a single path, even if it happens to contain a `:`, so it is never
+    /// split.
+    pub list: bool,
 }
 
 /// Recognized tool-path env vars and how their target path is granted.
@@ -1034,6 +1040,11 @@ pub struct ToolPathEnvVar {
 /// for pure lookup paths (`NODE_PATH`). All of these vars reach the sandbox via
 /// [`ENV_ALLOWLIST`] (or a prefix in [`ENV_PREFIX_ALLOWLIST`]), so the granted
 /// path is actually nameable by the sandboxed process.
+/// Separator between entries in a list-valued tool-path env var. cplt targets
+/// Unix (macOS/Linux) where the OS path-list separator is `:` (as used by
+/// `PATH`, `GOPATH`, `NODE_PATH`, …).
+const TOOL_PATH_LIST_SEPARATOR: char = ':';
+
 pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
     // ── Go ──────────────────────────────────────────────────────────────────
     // GOPATH holds go/bin, go/pkg (module cache) and go/src; builds write here.
@@ -1041,12 +1052,15 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
         name: "GOPATH",
         write: true,
         default_subpaths: &["go"],
+        // GOPATH is a colon-separated list on Unix; each entry is its own root.
+        list: true,
     },
     // Module cache — `go build`/`go test`/`go get` download & extract modules.
     ToolPathEnvVar {
         name: "GOMODCACHE",
         write: true,
         default_subpaths: &["go/pkg/mod"],
+        list: false,
     },
     // Build cache. Default is redirected to the scratch dir (SCRATCH_DIR_ENV_VARS),
     // so honor only an explicit non-default override.
@@ -1054,6 +1068,7 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
         name: "GOCACHE",
         write: true,
         default_subpaths: &["Library/Caches/go-build", ".cache/go-build"],
+        list: false,
     },
     // ── Rust / cargo ─────────────────────────────────────────────────────────
     // CARGO_HOME holds bin/, registry/ and git/ — cargo writes to registry & git.
@@ -1061,6 +1076,7 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
         name: "CARGO_HOME",
         write: true,
         default_subpaths: &[".cargo"],
+        list: false,
     },
     // ── Node / npm / yarn / pnpm ─────────────────────────────────────────────
     // npm cache (uppercase and npm's canonical lowercase spelling).
@@ -1068,29 +1084,35 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
         name: "NPM_CONFIG_CACHE",
         write: true,
         default_subpaths: &[".npm"],
+        list: false,
     },
     ToolPathEnvVar {
         name: "npm_config_cache",
         write: true,
         default_subpaths: &[".npm"],
+        list: false,
     },
     // Yarn (Classic & Berry) global cache folder.
     ToolPathEnvVar {
         name: "YARN_CACHE_FOLDER",
         write: true,
         default_subpaths: &[".cache/yarn", "Library/Caches/Yarn"],
+        list: false,
     },
     // pnpm home (global store + shims).
     ToolPathEnvVar {
         name: "PNPM_HOME",
         write: true,
         default_subpaths: &["Library/pnpm", ".local/share/pnpm"],
+        list: false,
     },
-    // NODE_PATH is a module *lookup* path — read-only is sufficient.
+    // NODE_PATH is a module *lookup* path — read-only is sufficient. Like the
+    // shell PATH, it is a colon-separated list of directories on Unix.
     ToolPathEnvVar {
         name: "NODE_PATH",
         write: false,
         default_subpaths: &[],
+        list: true,
     },
     // ── Python / pip ─────────────────────────────────────────────────────────
     // pip download/wheel cache.
@@ -1098,6 +1120,7 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
         name: "PIP_CACHE_DIR",
         write: true,
         default_subpaths: &[".cache/pip", "Library/Caches/pip"],
+        list: false,
     },
 ];
 
@@ -1149,9 +1172,18 @@ fn resolve_tool_path(raw: &str, home: &Path) -> PathBuf {
 /// location, emit a [`ToolPathOverride`]. Default locations are skipped because
 /// [`HOME_TOOL_DIRS`] already grants them. Unset/empty vars contribute nothing.
 ///
+/// List-valued vars ([`ToolPathEnvVar::list`], e.g. `GOPATH`, `NODE_PATH`) hold a
+/// colon-separated list of directories on Unix (`GOPATH=/a:/b`); each segment is
+/// resolved and granted independently, and empty segments (from `/a::/b` or a
+/// trailing `:`) are skipped. Single-path vars are never split, so a `:` inside a
+/// genuine directory name is preserved verbatim.
+///
 /// `env` is the *parent* process environment as `(name, value)` pairs. Duplicate
 /// resolved paths are collapsed; if the same path is requested read-only and
 /// read+write, the write grant wins.
+///
+/// The downstream safety guard ([`tool_override_path_is_safe`]) runs per emitted
+/// override at the merge site, so it is applied per segment for list vars.
 ///
 /// Pure function (env passed in, no `std::env` / filesystem access) so rule
 /// generation is testable on any platform.
@@ -1164,20 +1196,31 @@ pub fn tool_path_env_overrides(env: &[(String, String)], home: &Path) -> Vec<Too
         if raw.is_empty() {
             continue;
         }
-        let resolved = resolve_tool_path(raw, home);
-        // Skip values that resolve to a default location already in the base policy.
-        if tv.default_subpaths.iter().any(|d| resolved == home.join(d)) {
-            continue;
-        }
-        // Deduplicate; upgrade an existing read-only grant to write if needed.
-        if let Some(existing) = out.iter_mut().find(|o| o.path == resolved) {
-            existing.write = existing.write || tv.write;
+        // List vars are colon-separated path lists on Unix; single-path vars are
+        // treated as one value even if they contain a `:`.
+        let segments: Vec<&str> = if tv.list {
+            raw.split(TOOL_PATH_LIST_SEPARATOR)
+                .filter(|s| !s.is_empty())
+                .collect()
         } else {
-            out.push(ToolPathOverride {
-                name: tv.name,
-                path: resolved,
-                write: tv.write,
-            });
+            vec![raw.as_str()]
+        };
+        for seg in segments {
+            let resolved = resolve_tool_path(seg, home);
+            // Skip values that resolve to a default location already in the base policy.
+            if tv.default_subpaths.iter().any(|d| resolved == home.join(d)) {
+                continue;
+            }
+            // Deduplicate; upgrade an existing read-only grant to write if needed.
+            if let Some(existing) = out.iter_mut().find(|o| o.path == resolved) {
+                existing.write = existing.write || tv.write;
+            } else {
+                out.push(ToolPathOverride {
+                    name: tv.name,
+                    path: resolved,
+                    write: tv.write,
+                });
+            }
         }
     }
     out

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8,7 +8,7 @@ use cplt::is_unsafe_root;
 use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, is_private_ip};
 use cplt::sandbox::{
     HardeningCategory, ProfileOptions, SandboxConfig, build_sandbox_env, generate_policy,
-    generate_profile, validate_sbpl_path,
+    generate_profile, tool_path_env_overrides, validate_sbpl_path,
 };
 
 // ============================================================
@@ -6645,4 +6645,139 @@ format = "text"
              `registry_keys_match_validate_all_valid_keys_fixture` — add it"
         );
     }
+}
+
+// ============================================================
+// Tool-path env var overrides (GOPATH, CARGO_HOME, NODE_PATH, ...)
+// ============================================================
+
+fn env_pairs(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+#[test]
+fn tool_path_gopath_custom_yields_writable_rule() {
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("GOPATH", "/custom/gopath")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert_eq!(overrides.len(), 1, "GOPATH override should be emitted");
+    assert_eq!(
+        overrides[0].path,
+        std::path::PathBuf::from("/custom/gopath")
+    );
+    assert!(overrides[0].write, "GOPATH is a build cache → read+write");
+}
+
+#[test]
+fn tool_path_node_path_yields_read_only_rule() {
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("NODE_PATH", "/custom/node_modules")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert_eq!(overrides.len(), 1);
+    assert_eq!(
+        overrides[0].path,
+        std::path::PathBuf::from("/custom/node_modules")
+    );
+    assert!(
+        !overrides[0].write,
+        "NODE_PATH is a lookup path → read-only"
+    );
+}
+
+#[test]
+fn tool_path_unset_env_vars_add_nothing() {
+    let home = std::path::Path::new("/home/tester");
+    let env: Vec<(String, String)> = Vec::new();
+    let overrides = tool_path_env_overrides(&env, home);
+    assert!(
+        overrides.is_empty(),
+        "no tool-path env vars set → no overrides"
+    );
+}
+
+#[test]
+fn tool_path_empty_value_adds_nothing() {
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("GOPATH", "")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert!(overrides.is_empty(), "empty value → treated as unset");
+}
+
+#[test]
+fn tool_path_default_value_not_double_added() {
+    // GOPATH pointing at the default ~/go is already covered by HOME_TOOL_DIRS
+    // (go/bin, go/pkg), so it must not produce an extra override.
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("GOPATH", "/home/tester/go")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert!(
+        overrides.is_empty(),
+        "default GOPATH must not be double-added, got: {overrides:?}"
+    );
+}
+
+#[test]
+fn tool_path_default_value_via_tilde_not_double_added() {
+    // The tilde form of the default must also resolve to ~/go and be skipped.
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("CARGO_HOME", "~/.cargo")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert!(
+        overrides.is_empty(),
+        "default CARGO_HOME (~/.cargo) must not be double-added, got: {overrides:?}"
+    );
+}
+
+#[test]
+fn tool_path_tilde_is_expanded_to_home() {
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("CARGO_HOME", "~/alt-cargo")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert_eq!(overrides.len(), 1);
+    assert_eq!(
+        overrides[0].path,
+        std::path::PathBuf::from("/home/tester/alt-cargo")
+    );
+    assert!(overrides[0].write);
+}
+
+#[test]
+fn tool_path_multiple_vars_mapped_by_access() {
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[
+        ("GOPATH", "/custom/gopath"),
+        ("CARGO_HOME", "/custom/cargo"),
+        ("NODE_PATH", "/custom/lookup"),
+        ("PIP_CACHE_DIR", "/custom/pip"),
+    ]);
+    let overrides = tool_path_env_overrides(&env, home);
+    let write: Vec<&std::path::Path> = overrides
+        .iter()
+        .filter(|o| o.write)
+        .map(|o| o.path.as_path())
+        .collect();
+    let read: Vec<&std::path::Path> = overrides
+        .iter()
+        .filter(|o| !o.write)
+        .map(|o| o.path.as_path())
+        .collect();
+    assert!(write.contains(&std::path::Path::new("/custom/gopath")));
+    assert!(write.contains(&std::path::Path::new("/custom/cargo")));
+    assert!(write.contains(&std::path::Path::new("/custom/pip")));
+    assert_eq!(read, vec![std::path::Path::new("/custom/lookup")]);
+}
+
+#[test]
+fn tool_path_same_path_write_wins_over_read() {
+    // If a read-only var and a write var resolve to the same custom path,
+    // the write grant must win (deduped to a single writable override).
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("NODE_PATH", "/shared/dir"), ("GOPATH", "/shared/dir")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert_eq!(overrides.len(), 1, "same path must be deduplicated");
+    assert_eq!(overrides[0].path, std::path::PathBuf::from("/shared/dir"));
+    assert!(overrides[0].write, "write grant wins over read");
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8,7 +8,7 @@ use cplt::is_unsafe_root;
 use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, is_private_ip};
 use cplt::sandbox::{
     HardeningCategory, ProfileOptions, SandboxConfig, build_sandbox_env, generate_policy,
-    generate_profile, tool_path_env_overrides, validate_sbpl_path,
+    generate_profile, tool_override_path_is_safe, tool_path_env_overrides, validate_sbpl_path,
 };
 
 // ============================================================
@@ -6780,4 +6780,77 @@ fn tool_path_same_path_write_wins_over_read() {
     assert_eq!(overrides.len(), 1, "same path must be deduplicated");
     assert_eq!(overrides[0].path, std::path::PathBuf::from("/shared/dir"));
     assert!(overrides[0].write, "write grant wins over read");
+}
+
+// --- Safety guard: reject over-broad tool-path overrides -------------------
+// tool_override_path_is_safe() is the choke point that stops an ambient env var
+// (e.g. GOPATH=$HOME or GOPATH=/) from silently widening the sandbox. It runs on
+// the already-canonicalized path, so `..` has been collapsed by then.
+
+#[test]
+fn tool_override_home_dir_is_dropped() {
+    // GOPATH=$HOME → granting write to the entire home dir defeats the sandbox.
+    let home = std::path::Path::new("/home/tester");
+    assert!(
+        !tool_override_path_is_safe(home, home),
+        "an override resolving to HOME itself must be dropped"
+    );
+}
+
+#[test]
+fn tool_override_filesystem_root_is_dropped() {
+    // GOPATH=/ → granting the whole filesystem must be dropped.
+    let home = std::path::Path::new("/home/tester");
+    assert!(
+        !tool_override_path_is_safe(std::path::Path::new("/"), home),
+        "an override resolving to / must be dropped"
+    );
+}
+
+#[test]
+fn tool_override_home_ancestor_is_dropped() {
+    // A relative value like GOPATH=../../.. canonicalizes to an ancestor of HOME
+    // (e.g. /home or /). Any ancestor of HOME is an over-grant and must be
+    // dropped — this holds cross-platform (is_unsafe_root does not list /home on
+    // macOS, so the HOME-ancestor check is what catches it there).
+    let home = std::path::Path::new("/home/tester");
+    for ancestor in ["/home", "/"] {
+        assert!(
+            !tool_override_path_is_safe(std::path::Path::new(ancestor), home),
+            "ancestor of HOME ({ancestor}) must be dropped"
+        );
+    }
+}
+
+#[test]
+fn tool_override_escaped_path_to_unsafe_root_is_dropped() {
+    // GOPATH=../../../../etc canonicalizes to /etc — resolve_tool_path's
+    // join-to-HOME does NOT contain it once `..` collapses. The guard catches the
+    // effective (canonicalized) grant. /tmp is an unsafe root everywhere; /etc is
+    // one on Linux.
+    let home = std::path::Path::new("/home/tester");
+    assert!(
+        !tool_override_path_is_safe(std::path::Path::new("/tmp"), home),
+        "an override resolving to /tmp must be dropped"
+    );
+    #[cfg(target_os = "linux")]
+    assert!(
+        !tool_override_path_is_safe(std::path::Path::new("/etc"), home),
+        "an override escaping HOME to a system root must be dropped"
+    );
+}
+
+#[test]
+fn tool_override_normal_custom_dir_is_kept() {
+    // The feature must still work: a real custom tool dir that is neither a root
+    // nor HOME/an ancestor stays granted — both outside and inside HOME.
+    let home = std::path::Path::new("/home/tester");
+    assert!(
+        tool_override_path_is_safe(std::path::Path::new("/opt/custom-gopath"), home),
+        "a normal custom dir outside HOME must be granted"
+    );
+    assert!(
+        tool_override_path_is_safe(std::path::Path::new("/home/tester/go-alt"), home),
+        "a normal custom SUBdir of HOME must be granted"
+    );
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -6782,6 +6782,105 @@ fn tool_path_same_path_write_wins_over_read() {
     assert!(overrides[0].write, "write grant wins over read");
 }
 
+// --- List-valued tool-path env vars (colon-separated on Unix) ---------------
+// GOPATH and NODE_PATH are OS path lists (`GOPATH=/a:/b`); each segment must
+// become its own override. Single-path vars are never split.
+
+#[test]
+fn tool_path_gopath_list_yields_one_override_per_segment() {
+    // GOPATH=/a:/b → two writable overrides, one per directory in the list.
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("GOPATH", "/a:/b")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    let paths: Vec<&std::path::Path> = overrides.iter().map(|o| o.path.as_path()).collect();
+    assert_eq!(overrides.len(), 2, "each GOPATH segment → its own override");
+    assert!(paths.contains(&std::path::Path::new("/a")));
+    assert!(paths.contains(&std::path::Path::new("/b")));
+    assert!(
+        overrides.iter().all(|o| o.write),
+        "GOPATH segments are build roots → read+write"
+    );
+}
+
+#[test]
+fn tool_path_node_path_list_yields_read_only_per_segment() {
+    // NODE_PATH=/x:/y → two read-only overrides, one per lookup directory.
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("NODE_PATH", "/x:/y")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    let paths: Vec<&std::path::Path> = overrides.iter().map(|o| o.path.as_path()).collect();
+    assert_eq!(
+        overrides.len(),
+        2,
+        "each NODE_PATH segment → its own override"
+    );
+    assert!(paths.contains(&std::path::Path::new("/x")));
+    assert!(paths.contains(&std::path::Path::new("/y")));
+    assert!(
+        overrides.iter().all(|o| !o.write),
+        "NODE_PATH segments are lookup paths → read-only"
+    );
+}
+
+#[test]
+fn tool_path_list_empty_segments_are_ignored() {
+    // Doubled (`/a::/b`) and trailing (`/b:`) separators produce empty segments
+    // that must be skipped rather than resolving to HOME (join of an empty path).
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("GOPATH", "/a::/b:")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    let paths: Vec<&std::path::Path> = overrides.iter().map(|o| o.path.as_path()).collect();
+    assert_eq!(
+        overrides.len(),
+        2,
+        "empty segments must be skipped, got: {overrides:?}"
+    );
+    assert!(paths.contains(&std::path::Path::new("/a")));
+    assert!(paths.contains(&std::path::Path::new("/b")));
+    assert!(
+        !paths.contains(&home),
+        "an empty segment must NOT resolve to HOME"
+    );
+}
+
+#[test]
+fn tool_path_single_path_var_with_colon_is_not_split() {
+    // A single-path var (CARGO_HOME) is never split, so a `:` in a weird-but-real
+    // directory name is preserved verbatim as one path.
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("CARGO_HOME", "/weird:dir/cargo")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert_eq!(overrides.len(), 1, "single-path var must not be split");
+    assert_eq!(
+        overrides[0].path,
+        std::path::PathBuf::from("/weird:dir/cargo")
+    );
+    assert!(overrides[0].write);
+}
+
+#[test]
+fn tool_path_list_per_segment_safety_guard_drops_unsafe_segment() {
+    // GOPATH=/custom:/ → the list splits into /custom and /. tool_path_env_overrides
+    // emits both; the per-segment safety guard keeps /custom and drops the root.
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("GOPATH", "/custom:/")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    let kept: Vec<&std::path::Path> = overrides
+        .iter()
+        .map(|o| o.path.as_path())
+        .filter(|p| tool_override_path_is_safe(p, home))
+        .collect();
+    assert_eq!(
+        kept,
+        vec![std::path::Path::new("/custom")],
+        "only the safe segment survives the per-segment guard"
+    );
+    assert!(
+        !tool_override_path_is_safe(std::path::Path::new("/"), home),
+        "the `/` segment must be dropped by the guard"
+    );
+}
+
 // --- Safety guard: reject over-broad tool-path overrides -------------------
 // tool_override_path_is_safe() is the choke point that stops an ambient env var
 // (e.g. GOPATH=$HOME or GOPATH=/) from silently widening the sandbox. It runs on


### PR DESCRIPTION
## Summary

Honors tool-path env vars when a user has overridden them to a non-default location, so builds don't fail inside the sandbox.

Fixes #35.

## Problem

cplt allowlists the *default* tool locations (`~/go`, `~/.cargo`, …) for read/write. If a user sets e.g. `GOPATH=/custom` and that env var is passed into the sandbox, `/custom` is not in the allowlist and `go build` fails writing there.

## Change

When a recognized tool-path env var is set to a non-default, existing path, its resolved/canonicalized path is added to the appropriate allow set (works on both SBPL and Landlock). Grants are strictly additive and minimal per tool:

| Env var | Access |
|---|---|
| `GOPATH`, `GOMODCACHE`, `GOCACHE`, `CARGO_HOME`, `npm_config_cache`, `YARN_CACHE_FOLDER`, `PNPM_HOME`, `PIP_CACHE_DIR` | read+write |
| `NODE_PATH` | read-only |

- `~`/relative paths are expanded and canonicalized; non-existent paths are dropped (Landlock needs an openable path); default-valued vars are not double-added.
- `npm_config_cache`/`YARN_CACHE_FOLDER`/`PIP_CACHE_DIR` were added to the env allowlist so the honored paths are nameable inside the sandbox.
- Trust assumption documented: an env-var value is user-controlled config, consistent with how cplt already trusts `pass-env`.

## Verification

9 new unit tests (custom GOPATH → writable, NODE_PATH → read-only, unset/empty/default add nothing, tilde expansion, write-wins-over-read). `cargo fmt`; clippy `-D warnings` host + `x86_64-unknown-linux-gnu`; lib 517 + unit 224 green.
