### PR TITLE
fix(security): close audit findings — loopback SSRF, trust pinning, secret leak

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1086,10 +1086,12 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
                 // Check trust store — validate content hash
                 if let Some(t) = trust::load_trust(&project_dir) {
                     let current_hash = trust::proposal_content_hash(&loaded.config.propose);
-                    if !t.accepted.content_hash.is_empty()
-                        && t.accepted.content_hash != current_hash
-                    {
-                        // Proposals changed since approval — invalidate
+                    // Treat a legacy empty stored hash as STALE (see approval_is_stale):
+                    // it pins nothing, so applying its keys against arbitrary proposal
+                    // *values* with no re-prompt would be unsafe.
+                    if trust::approval_is_stale(&t.accepted.content_hash, &current_hash) {
+                        // Proposals changed since approval (or a legacy unpinned
+                        // entry) — invalidate and require re-approval.
                         if !resolved.quiet {
                             ui::warn(
                                 ".cplt.toml permissions changed since last approval — re-approve with `cplt trust accept`",

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -674,11 +674,15 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // compromised DNS or /etc/hosts entry could make `evil.localhost` resolve to
     // 169.254.169.254 (cloud IMDS) or an internal host. Using the hostname pattern
     // alone would bypass this check entirely, enabling SSRF to cloud metadata.
+    //
+    // Crucially, a loopback-resolving target is only exempted when localhost
+    // access was explicitly allowed. See `resolved_ip_is_blocked` for the why.
     let private_domains = state.get_private_domains();
-    if is_private_ip(&socket_addr.ip())
-        && !is_domain_match(&host, &private_domains)
-        && !socket_addr.ip().is_loopback()
-    {
+    if resolved_ip_is_blocked(
+        &socket_addr.ip(),
+        is_domain_match(&host, &private_domains),
+        localhost_connect_allowed,
+    ) {
         log_connection(
             "CONNECT",
             target,
@@ -896,6 +900,37 @@ pub fn is_private_ip(ip: &std::net::IpAddr) -> bool {
     }
 }
 
+/// Decide whether a target's *resolved* IP must be blocked as a private-network
+/// SSRF risk, given whether the host is an approved private domain and whether
+/// localhost access was explicitly allowed.
+///
+/// Security: a hostname that resolves to loopback (`lvh.me`, `127.0.0.1.nip.io`,
+/// or alternate encodings such as `2130706433`, `0x7f000001`, `127.1`) must NOT
+/// be silently exempted just because the final IP is loopback. Reaching loopback
+/// services is only permitted when localhost access was explicitly requested
+/// (`localhost_allowed` — the same flag that gated the port and private-hostname
+/// carve-outs above) or the host is an approved private domain. Otherwise a
+/// crafted DNS name defeats the no-localhost default — and under `--proxy-forced`,
+/// where this proxy is the sole egress gate, it would tunnel to arbitrary
+/// loopback services. `is_private_hostname` only catches the literal `localhost`
+/// pre-DNS, so this resolved-IP check is the real gate for the rest.
+pub fn resolved_ip_is_blocked(
+    ip: &std::net::IpAddr,
+    host_is_private_domain: bool,
+    localhost_allowed: bool,
+) -> bool {
+    if !is_private_ip(ip) {
+        return false;
+    }
+    // Explicitly-approved corporate/internal domains may resolve to private IPs.
+    if host_is_private_domain {
+        return false;
+    }
+    // Loopback is reachable only when localhost access was explicitly allowed;
+    // every other private/reserved IP is always blocked here.
+    !(ip.is_loopback() && localhost_allowed)
+}
+
 /// Check hostname patterns that are known to be private (pre-DNS fast path).
 pub fn is_private_hostname(host: &str) -> bool {
     let h = host.trim_start_matches('[').trim_end_matches(']');
@@ -1042,6 +1077,62 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn resolved_loopback_blocked_unless_localhost_allowed() {
+        // A target that resolves to loopback (e.g. lvh.me, 127.0.0.1.nip.io,
+        // 2130706433, 0x7f000001, 127.1) must be BLOCKED when localhost access
+        // was not explicitly allowed, and ALLOWED when it was. No real DNS is
+        // needed — the decision is a pure function of the resolved IP.
+        let loopback: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+
+        // Not allowed, not a private domain → blocked.
+        assert!(
+            resolved_ip_is_blocked(&loopback, false, false),
+            "loopback-resolving target must be blocked when localhost not allowed"
+        );
+
+        // Localhost explicitly allowed → permitted.
+        assert!(
+            !resolved_ip_is_blocked(&loopback, false, true),
+            "loopback must be reachable when localhost access is allowed"
+        );
+
+        // Approved private domain → permitted even without localhost flag.
+        assert!(
+            !resolved_ip_is_blocked(&loopback, true, false),
+            "approved private domain resolving to loopback is permitted"
+        );
+
+        // IPv6 loopback behaves the same.
+        let loopback_v6: std::net::IpAddr = "::1".parse().unwrap();
+        assert!(resolved_ip_is_blocked(&loopback_v6, false, false));
+        assert!(!resolved_ip_is_blocked(&loopback_v6, false, true));
+    }
+
+    #[test]
+    fn resolved_non_loopback_private_always_blocked() {
+        // Non-loopback private/reserved IPs are blocked regardless of the
+        // localhost flag — the carve-out is loopback-only.
+        let imds: std::net::IpAddr = "169.254.169.254".parse().unwrap(); // cloud IMDS
+        let rfc1918: std::net::IpAddr = "10.0.0.5".parse().unwrap();
+        for allowed in [false, true] {
+            assert!(
+                resolved_ip_is_blocked(&imds, false, allowed),
+                "link-local IMDS must be blocked even with localhost allowed"
+            );
+            assert!(
+                resolved_ip_is_blocked(&rfc1918, false, allowed),
+                "RFC1918 private IP must be blocked even with localhost allowed"
+            );
+        }
+        // But an approved private domain may reach a private (non-loopback) IP.
+        assert!(!resolved_ip_is_blocked(&rfc1918, true, false));
+
+        // Public IPs are never blocked by this gate.
+        let public: std::net::IpAddr = "93.184.216.34".parse().unwrap();
+        assert!(!resolved_ip_is_blocked(&public, false, false));
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -564,13 +564,20 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // also exempt that port from the general port policy (which only lists remote ports
     // like 443/80). Without this, allow_localhost_ports would be silently ignored —
     // the port check would fire first and return 403 before the localhost logic ran.
+    // Config-level localhost opt-in for this connection, independent of how the
+    // hostname is spelled: the user either allowed all localhost ports
+    // (`--allow-localhost-any`) or explicitly allow-listed this port
+    // (`--allow-localhost <PORT>`). This is the sole gate for a target that
+    // *resolves* to loopback — see the `resolved_ip_is_blocked` call below.
+    let localhost_opt_in = state.allow_localhost_any || state.allow_localhost_ports.contains(&port);
+
     let localhost_connect_allowed = {
         let h = host.trim_start_matches('[').trim_end_matches(']');
         let is_loopback = h == "localhost"
             || h.ends_with(".localhost")
             || h.parse::<std::net::IpAddr>()
                 .is_ok_and(|ip| ip.is_loopback());
-        is_loopback && (state.allow_localhost_any || state.allow_localhost_ports.contains(&port))
+        is_loopback && localhost_opt_in
     };
 
     // Enforce port policy — only allow ports matching the sandbox network rules.
@@ -675,13 +682,19 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // 169.254.169.254 (cloud IMDS) or an internal host. Using the hostname pattern
     // alone would bypass this check entirely, enabling SSRF to cloud metadata.
     //
-    // Crucially, a loopback-resolving target is only exempted when localhost
-    // access was explicitly allowed. See `resolved_ip_is_blocked` for the why.
+    // Crucially, a loopback-resolving target is exempted only when the user opted
+    // into localhost access for this connection (`localhost_opt_in`) — NOT based on
+    // whether the hostname literally spells "localhost". Once the target has
+    // resolved to a loopback IP, the spelling of the name is irrelevant: a user who
+    // opted in with `--allow-localhost-any` (or `--allow-localhost <PORT>`) may
+    // legitimately reach loopback via a loopback-aliasing name (`lvh.me`,
+    // `127.0.0.1.nip.io`). With no opt-in, loopback stays blocked regardless of the
+    // name, preserving the no-localhost default. See `resolved_ip_is_blocked`.
     let private_domains = state.get_private_domains();
     if resolved_ip_is_blocked(
         &socket_addr.ip(),
         is_domain_match(&host, &private_domains),
-        localhost_connect_allowed,
+        localhost_opt_in,
     ) {
         log_connection(
             "CONNECT",
@@ -902,18 +915,29 @@ pub fn is_private_ip(ip: &std::net::IpAddr) -> bool {
 
 /// Decide whether a target's *resolved* IP must be blocked as a private-network
 /// SSRF risk, given whether the host is an approved private domain and whether
-/// localhost access was explicitly allowed.
+/// the user opted into localhost access for this connection.
+///
+/// Semantics:
+/// - A non-loopback private/reserved IP (RFC1918, CGNAT, link-local, cloud IMDS,
+///   ULA, ...) is ALWAYS blocked here unless the host is an approved private
+///   domain (`allow_private_domains`). The localhost opt-in never opens these.
+/// - A loopback IP is blocked UNLESS the user opted into localhost access for this
+///   connection (`localhost_allowed`, i.e. `--allow-localhost-any` OR the target
+///   port is in the allow-listed localhost ports). This is the *config-level*
+///   opt-in — it does not depend on whether the hostname literally spells
+///   "localhost".
 ///
 /// Security: a hostname that resolves to loopback (`lvh.me`, `127.0.0.1.nip.io`,
 /// or alternate encodings such as `2130706433`, `0x7f000001`, `127.1`) must NOT
 /// be silently exempted just because the final IP is loopback. Reaching loopback
-/// services is only permitted when localhost access was explicitly requested
-/// (`localhost_allowed` — the same flag that gated the port and private-hostname
-/// carve-outs above) or the host is an approved private domain. Otherwise a
-/// crafted DNS name defeats the no-localhost default — and under `--proxy-forced`,
-/// where this proxy is the sole egress gate, it would tunnel to arbitrary
-/// loopback services. `is_private_hostname` only catches the literal `localhost`
-/// pre-DNS, so this resolved-IP check is the real gate for the rest.
+/// services is only permitted when localhost access was explicitly requested;
+/// otherwise a crafted DNS name defeats the no-localhost default — and under
+/// `--proxy-forced`, where this proxy is the sole egress gate, it would tunnel to
+/// arbitrary loopback services. Conversely, keying the loopback waiver on the
+/// config opt-in (rather than the literal hostname) honors an explicit opt-in
+/// consistently for loopback-aliasing names, without ever loosening the block on
+/// non-loopback private IPs. `is_private_hostname` only catches the literal
+/// `localhost` pre-DNS, so this resolved-IP check is the real gate for the rest.
 pub fn resolved_ip_is_blocked(
     ip: &std::net::IpAddr,
     host_is_private_domain: bool,
@@ -1834,6 +1858,133 @@ mod tests {
         assert!(
             status.contains("403"),
             "carve-out: evil.localhost:8080 resolving to a public IP must be blocked (resolved IP is not loopback); got: {status}"
+        );
+    }
+
+    /// Direct unit test of the `resolved_ip_is_blocked` contract after the
+    /// localhost-opt-in change: the `localhost_allowed` argument is the
+    /// config-level opt-in, and it waives ONLY loopback — never non-loopback
+    /// private IPs like RFC1918.
+    #[test]
+    fn resolved_ip_is_blocked_waives_only_loopback_on_optin() {
+        let loopback: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let loopback6: std::net::IpAddr = "::1".parse().unwrap();
+        let rfc1918: std::net::IpAddr = "10.0.0.5".parse().unwrap();
+        let public: std::net::IpAddr = "93.184.216.34".parse().unwrap();
+
+        // No opt-in: loopback stays blocked (the SSRF-fix default).
+        assert!(resolved_ip_is_blocked(&loopback, false, false));
+        assert!(resolved_ip_is_blocked(&loopback6, false, false));
+
+        // Opt-in: loopback is waived (v4 and v6).
+        assert!(!resolved_ip_is_blocked(&loopback, false, true));
+        assert!(!resolved_ip_is_blocked(&loopback6, false, true));
+
+        // Opt-in must NOT open non-loopback private IPs (RFC1918).
+        assert!(resolved_ip_is_blocked(&rfc1918, false, true));
+        assert!(resolved_ip_is_blocked(&rfc1918, false, false));
+
+        // Approved private domain lifts the block for the non-loopback private IP.
+        assert!(!resolved_ip_is_blocked(&rfc1918, true, false));
+
+        // Public IPs are never private → never blocked here regardless of flags.
+        assert!(!resolved_ip_is_blocked(&public, false, false));
+    }
+
+    /// The localhost opt-in must be honored for a loopback-ALIASING DNS name
+    /// (e.g. `lvh.me`) that does NOT literally spell "localhost". Before the fix,
+    /// `resolved_ip_is_blocked` was gated on the hostname-literal flag, so such a
+    /// name resolving to 127.0.0.1 was over-blocked even with `--allow-localhost-any`.
+    ///
+    /// CONNECT `lvh.me:443` (443 is in the general allowed_ports, so it clears the
+    /// port policy), resolver pins `lvh.me` → the loopback listener. With the fix
+    /// (`localhost_opt_in` passed to `resolved_ip_is_blocked`) this is ALLOWED.
+    #[test]
+    fn proxy_allows_loopback_aliasing_name_with_localhost_optin() {
+        require_localhost_tcp!();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let listen_port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            listener.accept().ok();
+        });
+
+        let loopback_addr = std::net::SocketAddr::new("127.0.0.1".parse().unwrap(), listen_port);
+        let resolver: ResolverFn = Arc::new(move |host: &str, _port: u16| {
+            if host == "lvh.me" {
+                Some(loopback_addr)
+            } else {
+                None
+            }
+        });
+
+        // allow_localhost_any = true (config-level opt-in), no hostname literal.
+        let proxy = make_proxy_with_resolver(vec![], true, Some(resolver));
+        let status = proxy_connect(proxy.port, "lvh.me:443");
+        proxy.shutdown();
+        let _ = std::net::TcpStream::connect(("127.0.0.1", listen_port));
+        handle.join().ok();
+
+        assert!(
+            status.contains("200"),
+            "lvh.me:443 resolving to loopback must be ALLOWED with --allow-localhost-any \
+             even though the name isn't literally 'localhost'; got: {status}"
+        );
+    }
+
+    /// The no-opt-in default stays fail-closed regardless of the hostname: a
+    /// loopback-aliasing name resolving to 127.0.0.1 is BLOCKED when the user did
+    /// not opt into localhost. Preserves the loopback SSRF fix.
+    #[test]
+    fn proxy_blocks_loopback_aliasing_name_without_optin() {
+        require_localhost_tcp!();
+
+        let loopback_addr = std::net::SocketAddr::new("127.0.0.1".parse().unwrap(), 443);
+        let resolver: ResolverFn = Arc::new(move |host: &str, _port: u16| {
+            if host == "lvh.me" {
+                Some(loopback_addr)
+            } else {
+                None
+            }
+        });
+
+        // No localhost opt-in at all.
+        let proxy = make_proxy_with_resolver(vec![], false, Some(resolver));
+        let status = proxy_connect(proxy.port, "lvh.me:443");
+        proxy.shutdown();
+
+        assert!(
+            status.contains("403"),
+            "lvh.me:443 resolving to loopback must be BLOCKED without any localhost opt-in; got: {status}"
+        );
+    }
+
+    /// The localhost opt-in must NOT open non-loopback private IPs (RFC1918):
+    /// `--allow-localhost-any` waives loopback only, never 10.0.0.0/8 etc.
+    /// `corp.internal` (not allow-listed) resolving to 10.0.0.5 must stay BLOCKED
+    /// even with `allow_localhost_any = true`.
+    #[test]
+    fn proxy_localhost_optin_does_not_open_rfc1918() {
+        require_localhost_tcp!();
+
+        let private_addr = std::net::SocketAddr::new("10.0.0.5".parse().unwrap(), 443);
+        let resolver: ResolverFn = Arc::new(move |host: &str, _port: u16| {
+            if host == "corp.internal" {
+                Some(private_addr)
+            } else {
+                None
+            }
+        });
+
+        // Opt into localhost broadly — must not affect the RFC1918 block.
+        let proxy = make_proxy_with_resolver(vec![], true, Some(resolver));
+        let status = proxy_connect(proxy.port, "corp.internal:443");
+        proxy.shutdown();
+
+        assert!(
+            status.contains("403"),
+            "corp.internal → 10.0.0.5 (RFC1918, not allow-listed) must stay BLOCKED even with \
+             --allow-localhost-any; localhost opt-in must not open private networks; got: {status}"
         );
     }
 }

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -122,6 +122,11 @@ pub(super) const TOOL_READ_DIRS: &[&str] = &[
 /// Vars matching a prefix allowlist entry BUT also matching one of these
 /// suffixes are stripped — deny wins. Prevents `YARN_NPM_AUTH_TOKEN`,
 /// `COPILOT_SECRET_KEY`, etc. from leaking through broad prefix rules.
+///
+/// `_IDENT` is included because Yarn Berry's `YARN_NPM_AUTH_IDENT` holds a
+/// base64-encoded `user:password` registry credential; without this suffix it
+/// would pass through the `YARN_` prefix allowlist and leak to the sandboxed
+/// agent in default sanitized mode.
 const ENV_PREFIX_DENY_SUFFIXES: &[&str] = &[
     "_TOKEN",
     "_AUTH",
@@ -130,6 +135,7 @@ const ENV_PREFIX_DENY_SUFFIXES: &[&str] = &[
     "_KEY",
     "_PASSWORD",
     "_CREDENTIALS",
+    "_IDENT",
 ];
 
 /// Check if a var name looks like a secret based on its suffix.

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -314,6 +314,21 @@ pub fn proposal_content_hash(propose: &crate::repo_config::ProposeSection) -> St
         hasher.update(format!("allow.write={p}\n").as_bytes());
     }
 
+    // Unix-socket proposals are proposable AND applied (apply_repo_config), and a
+    // socket like /var/run/docker.sock is a host-escape vector. They MUST be part
+    // of the pinned content so a trusted repo cannot later add or change
+    // `[propose.allow] socket=[…]` without re-approval.
+    let mut socket: Vec<&str> = propose
+        .allow
+        .socket
+        .iter()
+        .map(std::string::String::as_str)
+        .collect();
+    socket.sort_unstable();
+    for p in &socket {
+        hasher.update(format!("allow.socket={p}\n").as_bytes());
+    }
+
     let mut ports: Vec<u16> = propose.allow.ports.clone();
     ports.sort_unstable();
     for port in &ports {
@@ -340,6 +355,19 @@ pub fn proposal_content_hash(propose: &crate::repo_config::ProposeSection) -> St
     let hash = hasher.finalize();
     // Full SHA-256 hex (64 chars) — collision-resistant content pinning
     hash.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Decide whether a stored approval is stale relative to the current proposal
+/// content hash and must be re-approved before its keys can be applied.
+///
+/// Security: an EMPTY `stored_hash` is a legacy trust file written before content
+/// pinning existed. It pins nothing, so it MUST be treated as stale — never as a
+/// match. If it were treated as "matches", the previously-approved keys would be
+/// applied against arbitrary (possibly malicious) proposal *values* with no
+/// re-prompt. Any mismatch — including empty-vs-current — invalidates, forcing a
+/// one-time re-approval that writes a real hash.
+pub fn approval_is_stale(stored_hash: &str, current_hash: &str) -> bool {
+    stored_hash != current_hash
 }
 
 #[cfg(test)]
@@ -537,6 +565,26 @@ approved_at = "2026-05-01T12:00:00Z"
     }
 
     #[test]
+    fn empty_stored_hash_is_stale() {
+        // Legacy trust files have an empty content_hash. It must NOT be treated
+        // as "matches" — it should invalidate and force re-approval. A non-empty
+        // matching hash stays fresh; a non-empty differing hash is stale.
+        let current = "a".repeat(64);
+        assert!(
+            approval_is_stale("", &current),
+            "empty (legacy) stored hash must be treated as stale"
+        );
+        assert!(
+            approval_is_stale("deadbeef", &current),
+            "differing stored hash must be stale"
+        );
+        assert!(
+            !approval_is_stale(&current, &current),
+            "matching non-empty stored hash must stay fresh (no false re-prompt)"
+        );
+    }
+
+    #[test]
     fn proposal_content_hash_is_stable() {
         use crate::repo_config::{ProposeAllowSection, ProposeSection};
 
@@ -578,6 +626,52 @@ approved_at = "2026-05-01T12:00:00Z"
         assert_ne!(
             proposal_content_hash(&propose1),
             proposal_content_hash(&propose2)
+        );
+    }
+
+    #[test]
+    fn proposal_content_hash_changes_on_socket_change() {
+        // Security: `propose.allow.socket` is applied by apply_repo_config and a
+        // socket like /var/run/docker.sock is a host-escape vector. Changing it
+        // must invalidate an existing approval, so it must alter the content hash.
+        use crate::repo_config::{ProposeAllowSection, ProposeSection};
+
+        let base = ProposeSection {
+            allow: ProposeAllowSection {
+                read: vec!["~/.gradle/gradle.properties".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let with_socket = ProposeSection {
+            allow: ProposeAllowSection {
+                read: vec!["~/.gradle/gradle.properties".to_string()],
+                socket: vec!["/var/run/docker.sock".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_ne!(
+            proposal_content_hash(&base),
+            proposal_content_hash(&with_socket),
+            "adding a proposed socket must change the content hash"
+        );
+
+        // Changing the socket path must also change the hash.
+        let with_other_socket = ProposeSection {
+            allow: ProposeAllowSection {
+                read: vec!["~/.gradle/gradle.properties".to_string()],
+                socket: vec!["/tmp/other.sock".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_ne!(
+            proposal_content_hash(&with_socket),
+            proposal_content_hash(&with_other_socket),
+            "changing a proposed socket path must change the content hash"
         );
     }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3345,6 +3345,29 @@ fn env_prefix_denies_secret_suffixes() {
 }
 
 #[test]
+fn env_yarn_npm_auth_ident_is_stripped() {
+    // Yarn Berry's YARN_NPM_AUTH_IDENT is a base64 `user:password` registry
+    // credential. It must be stripped by the _IDENT deny-suffix even though the
+    // YARN_ prefix is allowlisted, while benign YARN_ config vars still pass.
+    let parent = make_env(&[
+        ("HOME", "/Users/test"),
+        ("PATH", "/usr/bin"),
+        ("YARN_NPM_AUTH_IDENT", "dXNlcjpwYXNzd29yZA=="),
+        ("YARN_CACHE_FOLDER", "/some/cache"),
+    ]);
+    let env = build_sandbox_env(&parent, &[], false, &[], None, cplt::agent::Agent::Copilot);
+
+    assert!(
+        !env.vars.iter().any(|(k, _)| k == "YARN_NPM_AUTH_IDENT"),
+        "YARN_NPM_AUTH_IDENT (base64 user:pass) must not leak through YARN_ prefix"
+    );
+    assert!(
+        env.vars.iter().any(|(k, _)| k == "YARN_CACHE_FOLDER"),
+        "benign YARN_ config var should still pass through"
+    );
+}
+
+#[test]
 fn env_explicit_allowlist_bypasses_suffix_deny() {
     // GH_TOKEN and GITHUB_TOKEN are in the explicit ENV_ALLOWLIST and must pass
     // through even though they end in _TOKEN.


### PR DESCRIPTION
## Summary

Fixes four confirmed findings from an adversarial security audit of the sandbox/proxy/trust/env layers. Each is small, targeted, and covered by a test.

## Fixes

1. **HIGH — SSRF to loopback via the proxy** (`proxy.rs`). The resolved-IP guard unconditionally exempted loopback (`&& !is_loopback()`), and `is_private_hostname` only catches the literal `localhost`. So `CONNECT lvh.me:443`, `127.0.0.1.nip.io`, or alternate encodings (`2130706433`, `0x7f000001`, `127.1`) resolved to 127.0.0.1 and reached loopback services — defeating the no-localhost default (and under `--proxy-forced` this is *the* egress gate). Now the loopback exemption is gated on `localhost_allowed`: a loopback-resolving target is blocked unless localhost is explicitly permitted (or the host is an approved private domain). Decision factored into a pure `resolved_ip_is_blocked` with unit tests.
2. **HIGH/MED — trust store didn't pin `allow.socket`** (`trust.rs`). `proposal_content_hash` omitted `allow.socket` while socket *is* proposable and applied, so a trusted repo could later switch to `socket=["/var/run/docker.sock"]` (host escape) with no re-approval. Socket paths are now hashed.
3. **MED — legacy empty `content_hash` short-circuited re-approval** (`trust.rs` + `main.rs`). An empty stored hash made the invalidation check always pass, so a legacy-trusted repo could change *any* approved proposal without a re-prompt. Now an empty stored hash is treated as stale → re-prompts once; the normal matching path is unchanged.
4. **MED — `YARN_*_IDENT` secret leak** (`sandbox_policy.rs`). The `YARN_` prefix is allowed and the secret-suffix deny-list lacked `_IDENT`, so Yarn Berry's `YARN_NPM_AUTH_IDENT` (base64 `user:pass`) passed through to the agent. Added `_IDENT` to the deny-list.

## Not in this PR

Remaining confirmed findings (Linux write+exec / `.git/hooks` asymmetry, `--allow-localhost-any` disabling Linux net restriction, the opt-in gh-token-to-file exposure, trust origin-URL spoofing) are tracked in #127 — they're inherent-limitation tradeoffs or need design.

## Verification

New unit tests for each fix (loopback blocked-unless-allowed, socket-hash-changes, empty-hash-stale, YARN `_IDENT` stripped). `cargo fmt`; clippy `-D warnings` host + `x86_64-unknown-linux-gnu`; lib 521 + unit 216 green.
