### PR TITLE
test: harden test harness against vacuous/silent-skip gaps (#126)

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1747,10 +1747,13 @@ mod tests {
     fn proxy_allowlist_bypasses_private_ip_block() {
         require_localhost_tcp!();
 
-        // 255.255.255.255 is the limited broadcast address → is_private_ip() == true
-        // (is_broadcast), non-loopback, and connect() on a stream socket fails
-        // immediately (EACCES/EHOSTUNREACH) rather than hanging for CONNECT_TIMEOUT.
-        let private_addr: std::net::IpAddr = "255.255.255.255".parse().unwrap();
+        // 0.0.0.0 is the unspecified address → is_private_ip() == true
+        // (is_unspecified), non-loopback, and connect() to it on a stream socket
+        // fails immediately (EADDRNOTAVAIL on macOS; on Linux it is treated as
+        // 127.0.0.1 and yields a prompt ECONNREFUSED since nothing is listening
+        // on this privileged port). The former 255.255.255.255 broadcast address
+        // had OS-dependent connect behavior that could hang for CONNECT_TIMEOUT.
+        let private_addr: std::net::IpAddr = "0.0.0.0".parse().unwrap();
         let resolver: ResolverFn = Arc::new(move |host: &str, port: u16| {
             if host == "corp.internal" {
                 Some(std::net::SocketAddr::new(private_addr, port))

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1683,6 +1683,115 @@ mod tests {
         );
     }
 
+    // #126 Tier 2: the old `allow_private_domains_bypasses_private_ip_check`
+    // unit test re-implemented the guard's boolean expression with constants and
+    // never drove `handle_connect`, so deleting the real SSRF/private-IP guard
+    // left it green. These two tests exercise the ACTUAL guard end-to-end through
+    // the proxy with an injected resolver that maps a public-looking hostname onto
+    // a private (RFC1918) IP — DNS rebinding — proving the resolved-IP block fires
+    // and that `allow_private_domains` (and only it) is what lifts the block.
+
+    /// A domain that resolves to a private IP and is NOT allow-listed must be
+    /// blocked with 403 "Resolved to private IP". Deleting the `is_private_ip`
+    /// guard makes the proxy forward the CONNECT instead → this turns red.
+    #[test]
+    fn proxy_blocks_private_ip_resolution_when_not_allowlisted() {
+        require_localhost_tcp!();
+
+        let private_addr: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        // `corp.internal` is not an IP literal and not *.localhost/*.local, so it
+        // passes the pre-DNS `is_private_hostname` fast path and reaches the
+        // resolved-IP guard — the code under test.
+        let resolver: ResolverFn = Arc::new(move |host: &str, port: u16| {
+            if host == "corp.internal" {
+                Some(std::net::SocketAddr::new(private_addr, port))
+            } else {
+                None
+            }
+        });
+
+        let proxy = start(ProxyOptions {
+            port: 0,
+            blocked_file: PathBuf::from("/dev/null"),
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports: vec![],
+            allow_localhost_any: false,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            cli_private_domains: Vec::new(), // NOT allow-listed
+            config_private_domains: Vec::new(),
+            config_file: None,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(60),
+            resolver: Some(resolver),
+        })
+        .expect("proxy start failed");
+
+        let status = proxy_connect(proxy.port, "corp.internal:443");
+        proxy.shutdown();
+
+        assert!(
+            status.contains("403"),
+            "corp.internal resolves to 10.0.0.1 (private) and is not allow-listed — \
+             the resolved-IP guard must block it with 403; got: {status}"
+        );
+    }
+
+    /// The same domain→private-IP mapping, but WITH the domain in
+    /// `allow_private_domains`, must bypass the private-IP block. We resolve to a
+    /// reserved/unroutable private IP so the (now-permitted) upstream connect
+    /// fails fast with 502 rather than the 403 the guard would have produced —
+    /// proving the allow-list, and only the allow-list, changed the decision.
+    #[test]
+    fn proxy_allowlist_bypasses_private_ip_block() {
+        require_localhost_tcp!();
+
+        // 255.255.255.255 is the limited broadcast address → is_private_ip() == true
+        // (is_broadcast), non-loopback, and connect() on a stream socket fails
+        // immediately (EACCES/EHOSTUNREACH) rather than hanging for CONNECT_TIMEOUT.
+        let private_addr: std::net::IpAddr = "255.255.255.255".parse().unwrap();
+        let resolver: ResolverFn = Arc::new(move |host: &str, port: u16| {
+            if host == "corp.internal" {
+                Some(std::net::SocketAddr::new(private_addr, port))
+            } else {
+                None
+            }
+        });
+
+        let proxy = start(ProxyOptions {
+            port: 0,
+            blocked_file: PathBuf::from("/dev/null"),
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports: vec![],
+            allow_localhost_any: false,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            cli_private_domains: vec!["corp.internal".to_string()], // allow-listed
+            config_private_domains: Vec::new(),
+            config_file: None,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(60),
+            resolver: Some(resolver),
+        })
+        .expect("proxy start failed");
+
+        let status = proxy_connect(proxy.port, "corp.internal:443");
+        proxy.shutdown();
+
+        // The guard was bypassed: the proxy proceeded to connect (and failed with
+        // 502) instead of returning the private-IP 403.
+        assert!(
+            !status.contains("403"),
+            "allow_private_domains must lift the private-IP block for corp.internal; got: {status}"
+        );
+        assert!(
+            status.contains("502"),
+            "with the block lifted, the unroutable upstream connect should fail with 502; got: {status}"
+        );
+    }
+
     /// Verify that legitimate localhost still works when --allow-localhost is set.
     /// This is the positive counterpart to proxy_blocks_dns_rebinding_evil_localhost_to_imds:
     /// real localhost resolves to 127.0.0.1, which is_loopback() = true → allowed.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1748,11 +1748,15 @@ mod tests {
         require_localhost_tcp!();
 
         // 0.0.0.0 is the unspecified address → is_private_ip() == true
-        // (is_unspecified), non-loopback, and connect() to it on a stream socket
-        // fails immediately (EADDRNOTAVAIL on macOS; on Linux it is treated as
-        // 127.0.0.1 and yields a prompt ECONNREFUSED since nothing is listening
-        // on this privileged port). The former 255.255.255.255 broadcast address
-        // had OS-dependent connect behavior that could hang for CONNECT_TIMEOUT.
+        // (is_unspecified). We assert only that the block was LIFTED (no 403);
+        // we deliberately do NOT assert the downstream connect outcome, because
+        // it is environment-dependent: connect(0.0.0.0) is refused on macOS but
+        // on Linux is treated as 127.0.0.1, which may connect successfully if a
+        // loopback listener happens to be running (the linux CI job runs a
+        // :443 listener for the proxy-forced enforcement test). The security
+        // property under test — allow_private_domains flips the decision — is
+        // proven by "not 403" here paired with the sibling test that returns 403
+        // for the same IP without the allow-list.
         let private_addr: std::net::IpAddr = "0.0.0.0".parse().unwrap();
         let resolver: ResolverFn = Arc::new(move |host: &str, port: u16| {
             if host == "corp.internal" {
@@ -1783,15 +1787,14 @@ mod tests {
         let status = proxy_connect(proxy.port, "corp.internal:443");
         proxy.shutdown();
 
-        // The guard was bypassed: the proxy proceeded to connect (and failed with
-        // 502) instead of returning the private-IP 403.
+        // The guard was bypassed: the proxy did NOT return the private-IP 403 and
+        // proceeded past the block. (Sibling test proxy_blocks_private_ip_...
+        // returns 403 for the same IP without the allow-list, so "not 403" is the
+        // differential that proves the allow-list, and only the allow-list,
+        // flipped the decision.)
         assert!(
             !status.contains("403"),
             "allow_private_domains must lift the private-IP block for corp.internal; got: {status}"
-        );
-        assert!(
-            status.contains("502"),
-            "with the block lifted, the unroutable upstream connect should fail with 502; got: {status}"
         );
     }
 

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -1432,6 +1432,58 @@ mod tests {
         );
     }
 
+    /// #126 Tier 1b: SBPL uses last-match-wins, so every security `(deny ...)`
+    /// MUST be emitted AFTER the broader `(allow ...)` it overrides. Nothing
+    /// asserted this ordering, so reordering a deny before its allow (silently
+    /// permitting `.git/config` writes or credential reads) left every other test
+    /// green. This pins the byte-offset ordering for the sensitive rules.
+    #[test]
+    fn sensitive_denies_come_after_their_broader_allows() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let p = generate_profile(&test_options(project, home));
+
+        // Helper: assert `allow` appears strictly before `deny` in the profile.
+        let assert_deny_after_allow = |allow: &str, deny: &str| {
+            let a = p
+                .find(allow)
+                .unwrap_or_else(|| panic!("expected allow rule missing from profile: {allow}"));
+            let d = p
+                .find(deny)
+                .unwrap_or_else(|| panic!("expected deny rule missing from profile: {deny}"));
+            assert!(
+                a < d,
+                "SBPL last-match-wins violated: deny must come AFTER its allow.\n  \
+                 allow @ {a}: {allow}\n  deny  @ {d}: {deny}"
+            );
+        };
+
+        // Project-dir write allow must precede the .git write denies it overrides.
+        assert_deny_after_allow(
+            r#"(allow file-write* (subpath "/projects/app"))"#,
+            r#"(deny file-write* (subpath "/projects/app/.git/hooks"))"#,
+        );
+        assert_deny_after_allow(
+            r#"(allow file-write* (subpath "/projects/app"))"#,
+            r#"(deny file-write* (literal "/projects/app/.git/config"))"#,
+        );
+        assert_deny_after_allow(
+            r#"(allow file-write* (subpath "/projects/app"))"#,
+            r#"(deny file-write* (literal "/projects/app/.cplt.toml"))"#,
+        );
+
+        // The broad ~/.m2 tool-dir read allow must precede the credential-file deny
+        // (`.m2/settings.xml` lives inside the allowed dir — DENIED_HOME_SUBPATHS).
+        assert_deny_after_allow(
+            r#"(allow file-read* (subpath "/Users/test/.m2"))"#,
+            r#"(deny file-read* (literal "/Users/test/.m2/settings.xml"))"#,
+        );
+        assert_deny_after_allow(
+            r#"(allow file-read* (subpath "/Users/test/.gradle"))"#,
+            r#"(deny file-read* (literal "/Users/test/.gradle/gradle.properties"))"#,
+        );
+    }
+
     #[test]
     fn proxy_forced_without_port_fails_closed_no_443() {
         // Defensive fail-closed: proxy_forced with no proxy port is a

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -2414,9 +2414,11 @@ else
     echo "RESULT:tcp_ipv6_bind:SKIP:no python3"
 fi
 
-# Test 5: TCP on 0.0.0.0 — known SBPL limitation: "localhost" matches INADDR_ANY.
-# SBPL only accepts `*` or `localhost` as host, and `localhost` includes 0.0.0.0.
-# We document this gap rather than asserting it's denied.
+# Test 5: TCP bind on 0.0.0.0 (wildcard / all interfaces).
+# #126 Tier 2: cplt INTENTIONALLY emits `(allow network-bind (local ip "*:*"))`
+# (see sandbox_profile.rs — it must cover IPv4 127.0.0.1 bind() which SBPL's
+# "localhost" host does not match), so a wildcard bind is EXPECTED TO SUCCEED.
+# Assert that specific documented outcome instead of accepting allowed-or-denied.
 if command -v python3 >/dev/null 2>&1; then
     BIND_ALL_RESULT=$(python3 -c "
 import socket
@@ -2431,12 +2433,11 @@ except Exception as e:
     print(f'DENIED:{{e}}')
 " 2>&1)
     case "$BIND_ALL_RESULT" in
-        DENIED*)
-            echo "RESULT:tcp_wildcard_bind:OK:denied"
-            ;;
         ALLOWED*)
-            # Known SBPL limitation — not a test failure
-            echo "RESULT:tcp_wildcard_bind:OK:allowed_sbpl_limitation"
+            echo "RESULT:tcp_wildcard_bind:OK:allowed"
+            ;;
+        DENIED*)
+            echo "RESULT:tcp_wildcard_bind:FAIL:unexpectedly_denied:$BIND_ALL_RESULT"
             ;;
         *)
             echo "RESULT:tcp_wildcard_bind:FAIL:$BIND_ALL_RESULT"

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -2425,7 +2425,10 @@ import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 try:
-    s.bind(('0.0.0.0', 18999))
+    # Bind an ephemeral port (0) rather than a fixed one: a fixed port can flake
+    # with 'Address already in use' under parallel CI. The kernel assigns a free
+    # port, which is all this wildcard-bind check needs.
+    s.bind(('0.0.0.0', 0))
     s.listen(1)
     s.close()
     print('ALLOWED')

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -818,6 +818,84 @@ mod macos_tests {
         );
     }
 
+    // ── Credential-dir read denial (planted secrets in a temp HOME) ──
+    //
+    // #126 Tier 1a: the older `sandbox_blocks_ssh_read`/`_aws`/... tests build a
+    // HAND-WRITTEN SBPL profile and self-skip whenever ~/.ssh etc. are absent
+    // (always true on a fresh CI runner), so dropping a credential deny from
+    // cplt's REAL profile shipped green. This test closes that gap:
+    //   • it points `home_dir` at a throwaway temp HOME and PLANTS fake secrets,
+    //   • it generates cplt's REAL profile via `generate_profile` (write_real_profile),
+    //   • it asserts each planted secret read is DENIED at the kernel level and the
+    //     sentinel contents never leak, with an allowed project-file read as a
+    //     positive control.
+    //
+    // Crucially it is NOT vacuous: `.m2/settings.xml` and `.gradle/gradle.properties`
+    // sit UNDER the broad `~/.m2` / `~/.gradle` tool-dir read allows (DENIED_HOME_SUBPATHS),
+    // so if the credential deny is removed from `emit_deny_rules` — or reordered
+    // before its allow — those reads succeed and this test turns red.
+    #[test]
+    fn real_profile_blocks_planted_credentials_in_temp_home() {
+        require_sandbox!();
+
+        // Positive control lives in the REAL project dir (allowed for read).
+        let project = fs::canonicalize(".").unwrap();
+
+        // Throwaway HOME with planted secrets — never touches the developer's real ~.
+        let home = std::env::temp_dir().join(format!("cplt-credhome-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&home).unwrap();
+
+        // (relative path under HOME, sentinel contents). The `.ssh`/`.aws` entries
+        // cover the hard-denied dotfiles; `.m2`/`.gradle` cover credential files that
+        // live inside otherwise-allowed tool dirs (the real last-match-wins case).
+        let planted: &[(&str, &str)] = &[
+            (".ssh/id_rsa", "SENTINEL_SSH_PRIVATE_KEY_c0ffee"),
+            (".aws/credentials", "SENTINEL_AWS_SECRET_deadbeef"),
+            (".m2/settings.xml", "SENTINEL_M2_REGISTRY_PASSWORD_1234"),
+            (".gradle/gradle.properties", "SENTINEL_GRADLE_TOKEN_5678"),
+        ];
+        for (rel, contents) in planted {
+            let path = home.join(rel);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, contents).unwrap();
+        }
+
+        let home = fs::canonicalize(&home).unwrap();
+        let opts = default_opts(&project, &home);
+        let profile = write_real_profile(&opts);
+
+        // Every planted secret must be unreadable AND its sentinel must never leak.
+        let mut failures: Vec<String> = Vec::new();
+        for (rel, sentinel) in planted {
+            let secret = home.join(rel);
+            let cmd = format!("cat '{}' 2>&1; echo EXIT:$?", secret.display());
+            let (output, _) = run_sandboxed(&profile, &cmd);
+            let denied = output.contains("Operation not permitted") || output.contains("EXIT:1");
+            let leaked = output.contains(sentinel);
+            if !denied || leaked {
+                failures.push(format!(
+                    "{rel}: denied={denied} leaked={leaked} output={output:?}"
+                ));
+            }
+        }
+
+        // Positive control: an allowed project file must still be readable.
+        let (ctrl_out, ctrl_ok) = run_sandboxed(&profile, "cat Cargo.toml | head -1");
+
+        fs::remove_dir_all(&home).ok();
+        fs::remove_file(&profile).ok();
+
+        assert!(
+            failures.is_empty(),
+            "cplt's real profile must DENY planted credential reads: {failures:?}"
+        );
+        assert!(
+            ctrl_ok && ctrl_out.contains("[package]"),
+            "positive control: allowed project file must be readable, got: {ctrl_out}"
+        );
+    }
+
     // ── GPG signing ─────────────────────────────────────────────
 
     #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -6641,6 +6641,14 @@ level = "blocked"
 format = "text"
 "#;
 
+    // Parse the fixture so coverage is checked per-section, not by a bare
+    // substring. A plain `"{key} ="` grep matches ANYWHERE in the fixture, so
+    // keys that recur across sections (e.g. `enabled`, `mode`, `port`) let a
+    // key missing from ITS OWN section pass because a same-named key exists
+    // under a different section. Parsing forces each registry `section.key` to
+    // actually appear under `[section]`.
+    let parsed: toml::Value = toml::from_str(toml).expect("fixture TOML must parse");
+
     for key_info in all_config_keys() {
         if matches!(key_info.value_type, ConfigValueType::ArrayOfTables) {
             continue;
@@ -6649,14 +6657,19 @@ format = "text"
         if excluded.contains(&dotted.as_str()) {
             continue;
         }
-        // #126 Tier 2: dropped the always-true `|| toml.contains("[{section}]")`
-        // disjunct — with it, adding a new key to an EXISTING section passed
-        // silently because the section header was already present. Each key must
-        // now actually appear as `key =` in the fixture.
+        // #126 Tier 2 / #129: require `key` under its OWN `[section]` table, not
+        // merely somewhere in the fixture. This makes the guard force the
+        // fixture to cover every distinct section.key pair.
+        let covered = parsed
+            .get(key_info.section)
+            .and_then(|section| section.get(key_info.key))
+            .is_some();
         assert!(
-            toml.contains(&format!("{} =", key_info.key)),
-            "registry key '{dotted}' is not covered by the fixture TOML in \
-             `registry_keys_match_validate_all_valid_keys_fixture` — add it"
+            covered,
+            "registry key '{dotted}' is not covered under its own [{}] section in \
+             the fixture TOML in \
+             `registry_keys_match_validate_all_valid_keys_fixture` — add it",
+            key_info.section
         );
     }
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -379,26 +379,15 @@ fn allow_private_domains_rejects_empty_string() {
     assert!(result.is_err(), "empty domain should be rejected");
 }
 
-#[test]
-fn allow_private_domains_bypasses_private_ip_check() {
-    use cplt::proxy::{is_domain_match, is_private_ip};
-    // Simulate the bypass condition in handle_connect:
-    // block if private IP AND not in allow_private_domains
-    let private_ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
-    let allow_private = vec!["intern.nav.no".to_string()];
-
-    // Domain in list → should NOT be blocked
-    assert!(
-        !is_private_ip(&private_ip) || is_domain_match("mcp.intern.nav.no", &allow_private),
-        "domain in allow_private_domains should bypass private IP block"
-    );
-
-    // Domain not in list → should be blocked
-    assert!(
-        is_private_ip(&private_ip) && !is_domain_match("evil.com", &allow_private),
-        "domain not in allow_private_domains should still be blocked"
-    );
-}
+// #126 Tier 2: `allow_private_domains_bypasses_private_ip_check` used to live
+// here, but it only re-implemented the guard's boolean expression with local
+// constants and never drove `handle_connect`, so deleting the real private-IP
+// SSRF guard left it green (vacuous). `handle_connect` and the test-only DNS
+// resolver are private to the `cplt` crate and cannot be reached from this
+// external integration-test crate, so the real end-to-end replacement lives in
+// `src/proxy.rs`: `proxy_blocks_private_ip_resolution_when_not_allowlisted` and
+// `proxy_allowlist_bypasses_private_ip_block`. The `is_domain_match` suffix
+// semantics this test also touched are still covered below.
 
 #[test]
 fn allow_private_domains_suffix_match() {
@@ -2351,11 +2340,12 @@ fn allow_localhost_any_affects_both_backends() {
         allow_cache_exec_any: false,
         allow_browser: false,
     });
-    // macOS SBPL should allow all localhost ports
+    // macOS SBPL should allow all localhost ports.
+    // #126 Tier 2: dropped the always-true `|| p.contains("network-outbound")`
+    // disjunct (every profile contains that substring) so this now actually
+    // asserts the unrestricted localhost outbound rule is present.
     assert!(
-        p.contains(r#"(allow network-outbound (local ip "localhost:*"))"#)
-            || p.contains(r#"(allow network-outbound (remote ip "localhost:*"))"#)
-            || p.contains("network-outbound"),
+        p.contains(r#"(allow network-outbound (remote ip "localhost:*"))"#),
         "macOS profile should have unrestricted localhost outbound when allow_localhost_any=true"
     );
 
@@ -5241,11 +5231,21 @@ fn profile_socket_skipped_when_deny_path_overlaps() {
         p.contains("Socket access skipped: --deny-path overlaps with /Users/test/.codex/codex-lsp/daemon/daemon.sock"),
         "Profile must skip the socket rules when a parent directory is denied"
     );
+    // #126 Tier 2: socket allows are emitted with `(literal ...)`, never
+    // `(subpath ...)`, so the old `!contains(subpath …)` assertion targeted a
+    // rule form that is never generated and could never catch a regression.
+    // Target the actual `(literal ...)` form the socket rules use.
     assert!(
         !p.contains(
-            r#"(allow file-read* (subpath "/Users/test/.codex/codex-lsp/daemon/daemon.sock"))"#
+            r#"(allow file-read* (literal "/Users/test/.codex/codex-lsp/daemon/daemon.sock"))"#
         ),
-        "Profile must not contain allows when parent is denied"
+        "Profile must not contain socket allows when parent dir is denied"
+    );
+    assert!(
+        !p.contains(
+            r#"(allow network-outbound (remote unix-socket (literal "/Users/test/.codex/codex-lsp/daemon/daemon.sock")))"#
+        ),
+        "Profile must not contain socket network allows when parent dir is denied"
     );
 }
 
@@ -6578,6 +6578,7 @@ fn registry_keys_match_validate_all_valid_keys_fixture() {
     let toml = r#"
 [proxy]
 enabled = false
+forced = false
 port = 18080
 blocked_domains = "file.txt"
 allowed_domains = "file.txt"
@@ -6589,15 +6590,15 @@ allow_private_domains = []
 [allow]
 read = []
 write = []
+socket = []
 ports = []
 localhost = []
-net = []
 
 [deny]
 paths = []
-net = []
 
 [sandbox]
+agent = "copilot"
 validate = true
 allow_env_files = false
 allow_localhost_any = false
@@ -6607,26 +6608,36 @@ allow_lifecycle_scripts = false
 allow_gpg_signing = false
 allow_tmp_exec = false
 scratch_dir = false
+use_bubblewrap = false
 quiet = false
+yes = false
+allow_jvm_attach = false
+allow_docker = false
 allow_cache_exec = []
 allow_cache_exec_any = false
-allow_jvm_attach = false
 allow_browser = false
+git_push_prevention = false
 
 [gh_guard]
 enabled = false
-log_level = "blocked"
-format = "text"
+mode = "warn"
+scope_check = true
+block_auth_token = true
+inject_token = false
+unknown_command = "warn"
+allow_api_write = false
 
 [git_guard]
 enabled = false
-log_level = "blocked"
-format = "text"
+mode = "warn"
+prevent_push = true
+prevent_force_push = true
+protect_default_branch_only = false
 
 [audit]
 enabled = false
-log_file = "audit.log"
-log_level = "blocked"
+destination = "stderr"
+level = "blocked"
 format = "text"
 "#;
 
@@ -6638,9 +6649,12 @@ format = "text"
         if excluded.contains(&dotted.as_str()) {
             continue;
         }
+        // #126 Tier 2: dropped the always-true `|| toml.contains("[{section}]")`
+        // disjunct — with it, adding a new key to an EXISTING section passed
+        // silently because the section header was already present. Each key must
+        // now actually appear as `key =` in the fixture.
         assert!(
-            toml.contains(&format!("{} =", key_info.key))
-                || toml.contains(&format!("[{}]", key_info.section)),
+            toml.contains(&format!("{} =", key_info.key)),
             "registry key '{dotted}' is not covered by the fixture TOML in \
              `registry_keys_match_validate_all_valid_keys_fixture` — add it"
         );


### PR DESCRIPTION
## Summary

Hardens the test harness so real security regressions can't ship green. Fixes the Tier 1 and Tier 2 findings from #126, each verified by **mutation testing** (break the guard → the test goes red).

Addresses #126 (Tier 1 + Tier 2).

## Tier 1 — a security regression was shipping green

- **macOS credential-dir read-deny now has a real runtime test.** The existing tests used a *hand-written* SBPL (not cplt's) and self-skipped when `~/.ssh`/`~/.aws` were absent (always, on a fresh runner). New `real_profile_blocks_planted_credentials_in_temp_home`: plants sentinels in a temp HOME (`.ssh/id_rsa`, `.aws/credentials`, `.m2/settings.xml`, `.gradle/gradle.properties`), generates cplt's **real** profile, applies it with `sandbox-exec`, and asserts each secret read is DENIED and never leaks (with an allowed `Cargo.toml` read as positive control). Gated by `require_sandbox!` so it runs under `CPLT_TEST_REQUIRE_SANDBOX`. **Mutation-proven**: commenting out the `DENIED_HOME_SUBPATHS` deny loop turns it red (the `.m2`/`.gradle` secrets sit under broad tool-dir read allows).
- **SBPL last-match-wins ordering now tested.** `sensitive_denies_come_after_their_broader_allows` asserts (by byte offset) that each `(deny …)` for `.git/hooks`/`.git/config`/`.cplt.toml` and the credential files is emitted *after* its broader allow. A reorder/removal now fails.

## Tier 2 — vacuous/tautological tests made real (or removed)

- `allow_private_domains_bypasses_private_ip_check` (constant-true, never called the code) → deleted; replaced with two end-to-end tests driving `handle_connect` through the injectable resolver (private-IP blocked unless allowlisted). Mutation-proven.
- `allow_localhost_any_affects_both_backends` — removed the always-true `|| contains("network-outbound")` disjunct.
- `profile_socket_skipped_when_deny_path_overlaps` — retargeted to the real `(literal …)` rule form (was checking a never-emitted `(subpath …)`).
- `registry_keys_match_validate_all_valid_keys_fixture` — removed the always-true `[section]` disjunct; this immediately surfaced real fixture gaps, now synced with the registry.
- `tcp_wildcard_bind` — was OK-either-way; now asserts the specific documented outcome.

## Verification

`cargo fmt`; clippy `-D warnings`; suites pass individually (integration 51, e2e_projects 40, unit 214, lib 520); the new credential test passes normally and under `CPLT_TEST_REQUIRE_SANDBOX=1`; working tree clean. Tier 3/4 (weak `!ok` gate asserts, flaky `::1` races) remain tracked in #126.
