### PR TITLE
ci: run required checks on the merge queue (merge_group trigger)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run the required checks on the merge queue's temporary ref. The ruleset
+  # requires unit-tests / integration-tests / linux-integration-tests before
+  # merge; without this trigger those checks never report in the merge_group
+  # context, so queued entries wait until the 60-min timeout and fail to merge.
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

The `main` ruleset requires `unit-tests`, `integration-tests`, `linux-integration-tests` (strict) and has the **merge queue enabled** (grouping `ALLGREEN`). But no workflow triggers on `merge_group`, so in the queue those required checks never report against the temporary merge ref — entries wait until the 60-minute timeout and **fail to merge**.

## Fix

Add `merge_group:` to the CI `on:` triggers so the three required jobs run on the queue's temp ref and satisfy the ruleset.

- PR-only `build-test-binaries` stays gated on `github.event_name == 'pull_request'` (skipped in-queue — not a required check).
- `release.yaml` is filtered to `branches: [main]`; a merge-queue run's branch is `gh-readonly-queue/*`, so it won't mis-fire.

## Bootstrapping note

This fix must land to unblock the queue, but the queue is currently broken for the same reason — so **this PR likely needs to be merged directly / via admin bypass** (or merged first) rather than through the queue. Once it's on `main`, the other queued PRs will get their required checks in-queue and merge normally.

actionlint clean.