### PR TITLE
ci: add aggregate ci-ok gate for PR / merge-queue requirement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,3 +326,28 @@ jobs:
           name: cplt-${{ matrix.target }}
           path: cplt-${{ matrix.target }}.tar.gz
           retention-days: 7
+
+  # Single aggregate gate for branch-protection / merge-queue. Set THIS check
+  # (context name: ci-ok) as the SOLE required status check in the ruleset,
+  # instead of listing each job. Then adding/renaming/removing a CI job never
+  # needs a ruleset (admin) edit, and a renamed required check can't silently
+  # stop being enforced. Runs on pull_request and merge_group (inherited from
+  # this workflow's `on:`), so it gates both PRs and queue entries.
+  ci-ok:
+    name: ci-ok
+    if: ${{ always() }}
+    needs: [unit-tests, integration-tests, linux-integration-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require all gating jobs to have succeeded
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "gating job results: $results"
+          for r in $(echo "$results" | tr ',' ' '); do
+            if [ "$r" != "success" ]; then
+              echo "::error::ci-ok: a required job did not succeed (result: $r)"
+              exit 1
+            fi
+          done
+          echo "ci-ok: all required jobs succeeded"


### PR DESCRIPTION
## Summary

Adds a single `ci-ok` aggregate status check so the ruleset can require **one** check for PR and merge-queue gating instead of listing every job. Simpler than navikt/copilot#353 (that repo is a monorepo needing path-filter change-detection); cplt is a single crate where all jobs always run, so `ci-ok` just gates on the three required jobs.

## Why

- **Decoupling:** with `ci-ok` as the sole required context, adding/renaming/removing a CI job never needs an admin ruleset edit — you update the job's `needs` instead. It also removes the fragility where a *renamed* required check silently stops being enforced (the old name never reports).
- Builds on the `merge_group` trigger from #130.

## The job

```yaml
ci-ok:
  if: ${{ always() }}                # runs even if a gating job fails, so it always reports
  needs: [unit-tests, integration-tests, linux-integration-tests]
  # fails unless every needed result is 'success' (failure/cancelled/skipped → red)
```

- `if: always()` is essential — otherwise a failed dependency would *skip* `ci-ok`, the required check would never report, and the queue would hang.
- `build-test-binaries` is deliberately **excluded** (it's PR-only / informational and is skipped on `merge_group`; including it would make `ci-ok` fail in the queue).
- Runs on `pull_request` and `merge_group` (inherited from the workflow `on:`), so it gates both.

## Follow-up (admin, AFTER this merges)

In the `main` ruleset, **replace** the three required status-check contexts (`unit-tests`, `integration-tests`, `linux-integration-tests`) with the single `ci-ok` context. Do it after merge so `ci-ok` exists first. I can apply it via the API on request, or it's a two-click edit in Settings → Rules.

actionlint clean.