### PR TITLE
feat(proxy): support no-proxy list for upstream chaining (#135)

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -228,6 +228,39 @@ cplt config set sandbox.pass_env HTTPS_PROXY
 
 > **Note:** Disabling the proxy removes cplt's built-in domain filtering, connection logging, and port enforcement. The `blocked_domains` and `allowed_domains` settings are features of the built-in proxy — they have no effect when the proxy is disabled. If your corporate proxy has its own domain filtering, rely on that instead. The sandbox still enforces filesystem and process isolation regardless of proxy settings.
 
+### Chaining through an upstream (corporate) proxy
+
+Instead of disabling cplt's proxy, you can keep it **and** forward its approved CONNECT tunnels through your corporate proxy. cplt still enforces **all** of its own filtering (allowlist, blocklist, port policy, resolved-IP SSRF guard) *before* forwarding — the upstream only ever receives targets cplt's policy already permits.
+
+```bash
+cplt config set proxy.upstream "http://corporate-proxy.example.com:8080"
+# or for a single run:
+cplt --proxy-upstream http://corporate-proxy.example.com:8080 -- -p "fix the tests"
+```
+
+Optional basic-auth userinfo is supported (`http://user:pass@host:8080`); only the `http` scheme is supported. The credentials are redacted in `config show` and startup output.
+
+#### Bypassing the upstream for some hosts (`NO_PROXY`)
+
+Corporate setups almost always list internal hosts that must **not** go through the corporate proxy. Add them to `proxy.upstream_no_proxy` — a matching CONNECT target is connected to **directly by cplt** instead of being forwarded upstream, exactly like a `NO_PROXY` entry:
+
+```bash
+cplt config set proxy.upstream_no_proxy "internal.example.com"
+# repeatable CLI flag for a single run:
+cplt --proxy-upstream-no-proxy internal.example.com -- -p "..."
+```
+
+```toml
+[proxy]
+upstream = "http://corporate-proxy.example.com:8080"
+upstream_no_proxy = ["internal.example.com", "corp.example"]
+```
+
+- **Matching** uses the same rules as the other domain lists: `example.com` matches the exact host and all subdomains (`internal.example.com`). Case-insensitive; a leading dot (`.example.com`) is stripped automatically.
+- **`NO_PROXY` env is merged in.** In addition to the explicit config/CLI list, cplt reads the ambient `NO_PROXY`/`no_proxy` environment variable (comma- or whitespace-separated) and merges those hosts in, so your existing corporate setup works out of the box. Empty entries and a bare `*` wildcard are ignored (cplt does not honor "bypass everything").
+- **No-op without an upstream.** The list is only consulted when `proxy.upstream` is set.
+- **Security is preserved.** A no-proxy host is **not** exempt from any filtering. Every gate (allow/block/port/SSRF resolved-IP check) runs *before* the upstream-vs-direct decision, and the direct path re-applies the resolved-IP guard. The host is simply connected directly by cplt — which runs **outside** the sandbox — rather than forwarded to the corporate proxy. Because cplt (not the agent) makes that connection, this also works under `proxy.forced`.
+
 ## Copilot CLI network endpoints
 
 Copilot CLI 1.0.21 connects directly to these endpoints (empirically verified):

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -256,8 +256,17 @@ upstream = "http://corporate-proxy.example.com:8080"
 upstream_no_proxy = ["internal.example.com", "corp.example"]
 ```
 
-- **Matching** uses the same rules as the other domain lists: `example.com` matches the exact host and all subdomains (`internal.example.com`). Case-insensitive; a leading dot (`.example.com`) is stripped automatically.
-- **`NO_PROXY` env is merged in.** In addition to the explicit config/CLI list, cplt reads the ambient `NO_PROXY`/`no_proxy` environment variable (comma- or whitespace-separated) and merges those hosts in, so your existing corporate setup works out of the box. Empty entries and a bare `*` wildcard are ignored (cplt does not honor "bypass everything").
+> [!IMPORTANT]
+> **Internal hosts also need `allow_private_domains`.** A no-proxy host takes cplt's **direct** path, which applies the resolved-IP SSRF guard — so an internal host that resolves to a private IP (the usual `NO_PROXY` target) is **blocked** (`403 Resolved to private IP`) unless you *also* allow it to resolve private:
+> ```toml
+> [proxy]
+> upstream = "http://corporate-proxy.example.com:8080"
+> upstream_no_proxy   = ["internal.example.com"]  # bypass the upstream
+> allow_private_domains = ["internal.example.com"]  # AND permit its private IP
+> ```
+
+- **Matching** uses the same rules as the other domain lists: `example.com` matches the exact host and all subdomains (`internal.example.com`). Case-insensitive; leading/trailing dots (`.example.com.`) are stripped automatically. **CIDR/IP ranges are not honored** — only hostnames (exact + subdomain) and exact IPs match; a `10.0.0.0/8`-style entry is silently ignored (it could only divert to the already-filtered direct path anyway).
+- **`NO_PROXY` env is merged in, additively.** cplt reads the ambient `NO_PROXY`/`no_proxy` environment variable (comma- or whitespace-separated) and merges those hosts on top of the config/CLI list; there is no CLI way to *subtract* an ambient entry. Empty entries and a bare `*` wildcard are ignored (cplt does not honor "bypass everything").
 - **No-op without an upstream.** The list is only consulted when `proxy.upstream` is set.
 - **Security is preserved.** A no-proxy host is **not** exempt from any filtering. Every gate (allow/block/port/SSRF resolved-IP check) runs *before* the upstream-vs-direct decision, and the direct path re-applies the resolved-IP guard. The host is simply connected directly by cplt — which runs **outside** the sandbox — rather than forwarded to the corporate proxy. Because cplt (not the agent) makes that connection, this also works under `proxy.forced`.
 

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -216,6 +216,12 @@ pub fn display_config(loaded: Option<&LoadedConfig>) {
             crate::proxy::redact_upstream_url(up)
         );
     }
+    // No-proxy bypass list — plain hostnames, no secrets to redact.
+    if let Some(ref np) = c.proxy.upstream_no_proxy
+        && !np.is_empty()
+    {
+        println!("{blue}[cplt]{nc}    upstream_no_proxy = {np:?}");
+    }
     println!(
         "{blue}[cplt]{nc}    log_level        = \"{}\"{}",
         c.proxy.log_level.as_deref().unwrap_or("none"),
@@ -505,5 +511,22 @@ mod tests {
         assert!(from_file);
         assert!(val.contains("8080"));
         assert!(val.contains("9090"));
+    }
+
+    #[test]
+    fn get_config_value_renders_upstream_no_proxy_list() {
+        // `config show` / `explain` render proxy.upstream_no_proxy as a plain
+        // list of hostnames (no secrets to redact).
+        let info = crate::config::lookup_key("proxy.upstream_no_proxy").unwrap();
+        let raw = "[proxy]\nupstream_no_proxy = [\"internal.example.com\", \"corp.example\"]\n";
+        let loaded = LoadedConfig {
+            config: Config::parse(raw).unwrap(),
+            raw: raw.to_string(),
+            path: std::path::PathBuf::from("/tmp/fake"),
+        };
+        let (val, from_file) = get_config_value(info, Some(&loaded));
+        assert!(from_file);
+        assert!(val.contains("internal.example.com"), "got: {val}");
+        assert!(val.contains("corp.example"), "got: {val}");
     }
 }

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -125,6 +125,31 @@ impl Config {
             None => None,
         };
 
+        // Upstream no-proxy list: hosts that BYPASS the upstream and connect
+        // DIRECTLY (standard NO_PROXY behavior). CLI over config (mirrors
+        // proxy.upstream's precedence), then MERGE the ambient NO_PROXY/no_proxy
+        // env so an existing corporate setup works out of the box. Every entry is
+        // normalized (lowercase, leading dots stripped; empty and bare `*`
+        // dropped). This is a no-op at runtime when proxy.upstream is unset — the
+        // list is only consulted on the upstream-forward branch of the proxy.
+        let proxy_upstream_no_proxy = {
+            let base: Vec<String> = if cli.proxy_upstream_no_proxy.is_empty() {
+                self.proxy.upstream_no_proxy.clone().unwrap_or_default()
+            } else {
+                cli.proxy_upstream_no_proxy.clone()
+            };
+            let mut merged: Vec<String> = base
+                .iter()
+                .filter_map(|e| crate::proxy::normalize_no_proxy_entry(e))
+                .collect();
+            if let Some(env) = no_proxy_env_value() {
+                merged.extend(crate::proxy::parse_no_proxy_list(&env));
+            }
+            merged.sort_unstable();
+            merged.dedup();
+            merged
+        };
+
         // Allow private domains: merge CLI + config list, sort+dedup.
         // Validates that entries are non-empty (empty string would bypass private IP
         // check for all domains that match is_domain_match("", _), which is none — but
@@ -413,6 +438,7 @@ impl Config {
             proxy_log_level,
             proxy_timeout,
             proxy_upstream,
+            proxy_upstream_no_proxy,
             allow_private_domains,
             allow_read,
             allow_write,
@@ -444,6 +470,18 @@ impl Config {
             deny_env: Vec::new(),
         })
     }
+}
+
+/// Read the ambient `NO_PROXY`/`no_proxy` environment value, if any. Kept as a
+/// tiny standalone fn so there is a single place cplt reaches into the process
+/// environment for upstream-proxy-bypass configuration. cplt runs OUTSIDE the
+/// sandbox, so this reads the user's own shell environment — exactly the
+/// existing corporate `NO_PROXY` setup we want to honor.
+fn no_proxy_env_value() -> Option<String> {
+    std::env::var("NO_PROXY")
+        .or_else(|_| std::env::var("no_proxy"))
+        .ok()
+        .filter(|v| !v.trim().is_empty())
 }
 
 impl Resolved {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -73,6 +73,22 @@ impl Config {
     /// Returns an error if a deny path from config cannot be resolved
     /// (security-critical: silently dropping deny rules is dangerous).
     pub fn merge(&self, cli: CliFlags) -> Result<Resolved, ConfigError> {
+        self.merge_with_no_proxy_env(cli, no_proxy_env_value())
+    }
+
+    /// Same as [`merge`](Self::merge) but with the ambient `NO_PROXY`/`no_proxy`
+    /// value injected explicitly rather than read from the process environment.
+    ///
+    /// `merge` is the normal entry point (it reads the real environment); this
+    /// variant exists so tests can exercise the NO_PROXY-merge path
+    /// deterministically without mutating process-global env — which is UB under
+    /// concurrent test threads (edition 2024) and would clobber a developer's
+    /// real setting. Pass `None` for "no ambient NO_PROXY".
+    pub fn merge_with_no_proxy_env(
+        &self,
+        cli: CliFlags,
+        no_proxy_env: Option<String>,
+    ) -> Result<Resolved, ConfigError> {
         // Proxy: FeatureToggle resolves --with-proxy/--no-proxy against config default (true).
         let with_proxy = cli.proxy.resolve(self.proxy.enabled.unwrap_or(true));
 
@@ -142,7 +158,7 @@ impl Config {
                 .iter()
                 .filter_map(|e| crate::proxy::normalize_no_proxy_entry(e))
                 .collect();
-            if let Some(env) = no_proxy_env_value() {
+            if let Some(env) = no_proxy_env {
                 merged.extend(crate::proxy::parse_no_proxy_list(&env));
             }
             merged.sort_unstable();

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -66,6 +66,12 @@ pub fn default_config_contents() -> String {
 # then forwards approved tunnels to this proxy instead of connecting directly.
 # Optional basic auth: "http://user:pass@host:8080". Only the http scheme is supported.
 # upstream = "http://corporate-proxy.example.com:8080"
+# Hosts that BYPASS the upstream proxy and are connected to directly (like
+# NO_PROXY). Only meaningful together with `upstream`. Suffix matching:
+# "example.com" covers all its subdomains. The ambient NO_PROXY/no_proxy env var
+# is merged in automatically. All of cplt's domain/port/SSRF filtering still
+# applies — a listed host is just connected directly instead of forwarded.
+# upstream_no_proxy = ["internal.example.com"]
 
 # ─── Allowed paths ──────────────────────────────────────────
 # Additional paths the sandboxed process may access.

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -119,7 +119,7 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         value_type: ConfigValueType::StrArray,
         dangerous: false,
         default_display: "[]",
-        description: "Hosts that BYPASS the upstream proxy and are connected to directly (like NO_PROXY). Only meaningful with proxy.upstream. Suffix matching: \"example.com\" covers all subdomains. Merged with the ambient NO_PROXY/no_proxy environment. All of cplt's domain/port/SSRF filtering still applies — the host is just connected directly instead of forwarded.",
+        description: "Hosts that BYPASS the upstream proxy and are connected to directly (like NO_PROXY). Only meaningful with proxy.upstream. Suffix matching: \"example.com\" covers all subdomains; CIDR/IP ranges are NOT honored. Merged additively with the ambient NO_PROXY/no_proxy environment. All of cplt's domain/port/SSRF filtering still applies — so an internal host that resolves to a private IP is BLOCKED (403) unless you ALSO add it to proxy.allow_private_domains.",
     },
     ConfigKeyInfo {
         section: "proxy",

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -115,6 +115,14 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
     },
     ConfigKeyInfo {
         section: "proxy",
+        key: "upstream_no_proxy",
+        value_type: ConfigValueType::StrArray,
+        dangerous: false,
+        default_display: "[]",
+        description: "Hosts that BYPASS the upstream proxy and are connected to directly (like NO_PROXY). Only meaningful with proxy.upstream. Suffix matching: \"example.com\" covers all subdomains. Merged with the ambient NO_PROXY/no_proxy environment. All of cplt's domain/port/SSRF filtering still applies — the host is just connected directly instead of forwarded.",
+    },
+    ConfigKeyInfo {
+        section: "proxy",
         key: "allow_private_domains",
         value_type: ConfigValueType::StrArray,
         dangerous: false,

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -83,6 +83,9 @@ pub fn repo_key_rejection_reason(key_info: &ConfigKeyInfo) -> &'static str {
         ("proxy", "upstream") => {
             "the corporate proxy is machine/network-specific, not project policy"
         }
+        ("proxy", "upstream_no_proxy") => {
+            "the corporate proxy is machine/network-specific, not project policy"
+        }
         _ => "not supported in repo config",
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -265,6 +265,15 @@ pub struct ProxyConfig {
     /// directly. Optional basic-auth userinfo is supported
     /// ("http://user:pass@host:8080"); only the http scheme is supported.
     pub upstream: Option<String>,
+    /// Hosts that BYPASS the upstream proxy and are connected to DIRECTLY by
+    /// cplt (standard NO_PROXY behavior). Only meaningful when `upstream` is set
+    /// — a no-op otherwise. Suffix matching (`example.com` covers all
+    /// subdomains), like the other domain lists. Merged with any explicit CLI
+    /// entries and the ambient `NO_PROXY`/`no_proxy` environment variable.
+    /// A no-proxy host is still subject to ALL of cplt's filtering (domain
+    /// allow/block, port policy, resolved-IP SSRF guard); it is simply connected
+    /// directly instead of being forwarded to the corporate proxy.
+    pub upstream_no_proxy: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -441,6 +450,10 @@ pub struct Resolved {
     /// Parsed upstream (corporate) proxy to forward CONNECT tunnels through.
     /// `None` = direct connections (unchanged behavior).
     pub proxy_upstream: Option<crate::proxy::UpstreamProxy>,
+    /// Normalized hosts that bypass the upstream proxy and connect directly
+    /// (NO_PROXY semantics). Merged from config, CLI, and the `NO_PROXY` env.
+    /// A no-op when `proxy_upstream` is `None`.
+    pub proxy_upstream_no_proxy: Vec<String>,
     pub allow_private_domains: Vec<String>,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,
@@ -490,6 +503,10 @@ pub struct CliFlags {
     pub proxy_timeout: Option<u64>,
     /// Upstream proxy URL from `--proxy-upstream` (unparsed; validated in merge).
     pub proxy_upstream: Option<String>,
+    /// Hosts to bypass the upstream proxy, from `--proxy-upstream-no-proxy`
+    /// (repeatable). When non-empty, overrides the config list; the ambient
+    /// `NO_PROXY` env is merged on top of whichever wins.
+    pub proxy_upstream_no_proxy: Vec<String>,
     pub allow_private_domains: Vec<String>,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,15 @@ struct Cli {
     #[arg(long, value_name = "URL")]
     proxy_upstream: Option<String>,
 
+    /// Host that BYPASSES the upstream proxy and is connected to directly, like
+    /// NO_PROXY. Only meaningful together with --proxy-upstream. Suffix matching:
+    /// "example.com" covers all its subdomains. Can be specified multiple times.
+    /// When set, overrides proxy.upstream_no_proxy in config; the ambient
+    /// NO_PROXY/no_proxy environment is always merged on top. cplt still enforces
+    /// all domain, port, and SSRF filtering — the host is just connected directly.
+    #[arg(long = "proxy-upstream-no-proxy", value_name = "DOMAIN")]
+    proxy_upstream_no_proxy: Vec<String>,
+
     /// Allow connections to this domain even if it resolves to a private/internal IP.
     /// Use for corporate intranet services such as internal MCP servers.
     /// Suffix matching: "intern.nav.no" covers all its subdomains.
@@ -1058,6 +1067,7 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
         },
         proxy_timeout: cli.proxy_timeout,
         proxy_upstream: cli.proxy_upstream.clone(),
+        proxy_upstream_no_proxy: cli.proxy_upstream_no_proxy.clone(),
         allow_private_domains: cli.allow_private_domains.clone(),
         allow_read: cli_allow_read,
         allow_write: cli_allow_write,
@@ -1473,6 +1483,7 @@ fn start_proxy_if_enabled(
         log_level: resolved.proxy_log_level,
         timeout: resolved.proxy_timeout,
         upstream: resolved.proxy_upstream.clone(),
+        upstream_no_proxy: resolved.proxy_upstream_no_proxy.clone(),
     }) {
         Ok(handle) => {
             resolved.proxy_port = handle.port;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -372,9 +372,10 @@ pub struct ProxyState {
     upstream: Option<UpstreamProxy>,
 
     // Hosts that BYPASS `upstream` and are connected to directly (NO_PROXY).
-    // Normalized (lowercase, no leading dots) at config-merge time. Empty when
-    // no upstream is configured makes this a no-op. Consulted with
-    // `is_domain_match` (exact + subdomain), like the other domain lists.
+    // Normalized (lowercase, no leading/trailing dots) at config-merge time.
+    // A no-op when `upstream` is None: the list is only consulted inside the
+    // upstream-forward branch of handle_connect. Consulted with `is_domain_match`
+    // (exact + subdomain), like the other domain lists.
     upstream_no_proxy: Vec<String>,
 
     // Test-only: injectable DNS resolver to simulate fake DNS responses.
@@ -1393,8 +1394,13 @@ fn host_matches_no_proxy(host: &str, no_proxy: &[String]) -> bool {
 }
 
 /// Normalize a single NO_PROXY-style entry so `is_domain_match` handles it
-/// consistently with cplt's other domain lists: trim, lowercase, and strip a
-/// leading dot (`.example.com` → `example.com`).
+/// consistently with cplt's other domain lists: trim, lowercase, and strip
+/// leading AND trailing dots (`.example.com.` → `example.com`).
+///
+/// The trailing dot matters: the CONNECT host is normalized via
+/// `normalize_hostname`, which strips a trailing dot, so an FQDN entry like
+/// `example.com.` would otherwise never match `example.com`. Stripping it here
+/// mirrors `parse_domain_file` / `is_blocked_in_content` (`trim_end_matches('.')`).
 ///
 /// Returns `None` for entries that must be ignored:
 /// - empty (blank field from a trailing comma or stray whitespace), and
@@ -1406,6 +1412,7 @@ pub fn normalize_no_proxy_entry(raw: &str) -> Option<String> {
     let s = raw
         .trim()
         .trim_start_matches('.')
+        .trim_end_matches('.')
         .trim()
         .to_ascii_lowercase();
     if s.is_empty() || s == "*" {
@@ -3449,8 +3456,8 @@ mod tests {
         assert!(!host_matches_no_proxy("example.com", &[]));
     }
 
-    /// Entry normalization: trim, lowercase, strip a leading dot; empty and a
-    /// bare `*` are dropped.
+    /// Entry normalization: trim, lowercase, strip leading AND trailing dots;
+    /// empty and a bare `*` are dropped.
     #[test]
     fn no_proxy_entry_normalization() {
         assert_eq!(
@@ -3461,9 +3468,32 @@ mod tests {
             normalize_no_proxy_entry("  host.example  "),
             Some("host.example".to_string())
         );
+        // FQDN with a trailing dot must normalize the same as without, so it
+        // matches the CONNECT host (which normalize_hostname strips too).
+        assert_eq!(
+            normalize_no_proxy_entry("example.com."),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            normalize_no_proxy_entry(".example.com."),
+            Some("example.com".to_string())
+        );
         assert_eq!(normalize_no_proxy_entry(""), None);
         assert_eq!(normalize_no_proxy_entry("   "), None);
+        assert_eq!(normalize_no_proxy_entry("."), None);
         assert_eq!(normalize_no_proxy_entry("*"), None);
+    }
+
+    /// A trailing-dot FQDN entry (`example.com.`) matches the plain host
+    /// `example.com`: the entry is normalized, then compared against the host
+    /// which `is_domain_match` normalizes via `normalize_hostname`. Without the
+    /// trailing-dot strip the corporate proxy would be used for a NO_PROXY host.
+    #[test]
+    fn no_proxy_trailing_dot_entry_matches_host() {
+        let list = parse_no_proxy_list("example.com.");
+        assert_eq!(list, vec!["example.com".to_string()]);
+        assert!(host_matches_no_proxy("example.com", &list));
+        assert!(host_matches_no_proxy("sub.example.com", &list));
     }
 
     /// A NO_PROXY env value is comma/whitespace-separated, normalized, with
@@ -3672,5 +3702,59 @@ mod tests {
             .shutdown
             .store(true, std::sync::atomic::Ordering::SeqCst);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Companion NEGATIVE test to `proxy_no_proxy_host_takes_direct_path_not_upstream`
+    /// (which sets allow_private_domains): a no-proxy host that resolves to a
+    /// PRIVATE IP but is NOT an allow_private_domains entry is BLOCKED with 403 by
+    /// the direct path's resolved-IP SSRF guard, and the upstream is never used.
+    ///
+    /// This is the feature's central gotcha: NO_PROXY diverts an internal host to
+    /// cplt's DIRECT path, which then applies the private-IP guard — so the same
+    /// internal host must ALSO be in `proxy.allow_private_domains` to connect.
+    #[test]
+    fn proxy_no_proxy_host_private_ip_blocked_without_allow_private() {
+        require_localhost_tcp!();
+
+        let upstream_srv = spawn_fake_upstream();
+        let upstream =
+            UpstreamProxy::parse(&format!("http://127.0.0.1:{}", upstream_srv.port)).unwrap();
+
+        // The no-proxy host resolves to an RFC1918 private IP.
+        let private_ip: std::net::IpAddr = "10.1.2.3".parse().unwrap();
+        let resolver: ResolverFn = Arc::new(move |host: &str, _port: u16| match host {
+            "internal.corp.example" => Some(std::net::SocketAddr::new(private_ip, 443)),
+            _ => None,
+        });
+
+        // NOTE: cli_private_domains is EMPTY — the host is NOT permitted to
+        // resolve to a private IP.
+        let proxy = make_proxy_with_no_proxy(
+            upstream,
+            vec!["internal.corp.example".to_string()],
+            PathBuf::from("/dev/null"),
+            Vec::new(),
+            Some(resolver),
+        );
+
+        let status = proxy_connect(proxy.port, "internal.corp.example:443");
+        assert!(
+            status.contains("403"),
+            "a no-proxy host resolving to a private IP without allow_private_domains \
+             must be 403; got: {status}"
+        );
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !upstream_srv
+                .contacted
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "upstream must NOT be contacted for a no-proxy host"
+        );
+
+        proxy.shutdown();
+        upstream_srv
+            .shutdown
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -371,6 +371,12 @@ pub struct ProxyState {
     // after all policy checks pass. When None, behavior is a direct connect.
     upstream: Option<UpstreamProxy>,
 
+    // Hosts that BYPASS `upstream` and are connected to directly (NO_PROXY).
+    // Normalized (lowercase, no leading dots) at config-merge time. Empty when
+    // no upstream is configured makes this a no-op. Consulted with
+    // `is_domain_match` (exact + subdomain), like the other domain lists.
+    upstream_no_proxy: Vec<String>,
+
     // Test-only: injectable DNS resolver to simulate fake DNS responses.
     #[cfg(test)]
     resolver: Option<ResolverFn>,
@@ -573,6 +579,9 @@ pub struct ProxyOptions {
     /// Optional upstream (corporate) proxy to forward CONNECT tunnels through.
     /// When `None`, cplt connects to targets directly (unchanged behavior).
     pub upstream: Option<UpstreamProxy>,
+    /// Normalized hosts that bypass `upstream` and are connected to directly
+    /// (NO_PROXY semantics). No-op when `upstream` is `None`.
+    pub upstream_no_proxy: Vec<String>,
 
     /// Test-only: injectable DNS resolver. Pass a closure to override DNS
     /// resolution in proxy tests (e.g. to simulate DNS rebinding).
@@ -650,6 +659,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         log_level: opts.log_level,
         timeout: opts.timeout,
         upstream: opts.upstream,
+        upstream_no_proxy: opts.upstream_no_proxy,
         #[cfg(test)]
         resolver: opts.resolver,
     });
@@ -898,7 +908,21 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // host rather than the user's machine. Skipping the branch here keeps every
     // localhost carve-out local, and the direct path's stricter resolved-IP
     // loopback check (below) still applies.
-    if !localhost_connect_allowed && let Some(upstream) = state.upstream.as_ref() {
+    //
+    // No-proxy carve-out (upstream_no_proxy / NO_PROXY): a target whose host
+    // matches the no-proxy list must ALSO skip this branch and fall through to
+    // the direct-connect path below, exactly as NO_PROXY makes a host bypass a
+    // corporate proxy. `host_matches_no_proxy` gates the branch. Security is
+    // preserved for free: every hostname policy gate above already ran, and the
+    // direct path re-applies the resolved-IP SSRF guard (`resolved_ip_is_blocked`
+    // at ~line 1000), so a no-proxy host is still fully policy-checked — it is
+    // just connected DIRECTLY by cplt (which runs OUTSIDE the sandbox) instead
+    // of being forwarded. Because cplt makes that connection, this also works
+    // under `proxy.forced`, where the agent itself cannot reach the network.
+    if !localhost_connect_allowed
+        && let Some(upstream) = state.upstream.as_ref()
+        && !host_matches_no_proxy(&host, &state.upstream_no_proxy)
+    {
         // SSRF / DNS-rebinding guard for the forwarded path. We apply the SAME
         // resolved-IP check the direct path applies below, so upstream and
         // direct mode treat a *resolvable* host identically: a public name
@@ -1352,6 +1376,55 @@ pub fn is_domain_match(hostname: &str, domains: &[String]) -> bool {
     false
 }
 
+/// Whether `host` must BYPASS the upstream (corporate) proxy and be connected
+/// to DIRECTLY by cplt, i.e. it matches the `upstream_no_proxy` list.
+///
+/// SECURITY: matching here does NOT bypass any filtering. Every hostname policy
+/// gate (allowlist, blocklist, port policy, private-hostname) has already run in
+/// `handle_connect` before this is consulted, and the direct-connect path this
+/// host falls through to re-applies the resolved-IP SSRF guard
+/// (`resolved_ip_is_blocked`). A no-proxy host is therefore fully policy-checked;
+/// it is merely connected directly by cplt (which runs outside the sandbox)
+/// rather than forwarded to the corporate proxy — so it also works under
+/// `proxy.forced`. Matching reuses `is_domain_match` for consistency with cplt's
+/// other domain lists (exact host + subdomain suffix).
+fn host_matches_no_proxy(host: &str, no_proxy: &[String]) -> bool {
+    is_domain_match(host, no_proxy)
+}
+
+/// Normalize a single NO_PROXY-style entry so `is_domain_match` handles it
+/// consistently with cplt's other domain lists: trim, lowercase, and strip a
+/// leading dot (`.example.com` → `example.com`).
+///
+/// Returns `None` for entries that must be ignored:
+/// - empty (blank field from a trailing comma or stray whitespace), and
+/// - a bare `*` — in NO_PROXY this means "bypass the proxy for everything". cplt
+///   deliberately does NOT honor a blanket wildcard here: silently sending ALL
+///   traffic direct would disable the corporate proxy wholesale (and any egress
+///   policy tied to it), so the wildcard is dropped. List real hosts instead.
+pub fn normalize_no_proxy_entry(raw: &str) -> Option<String> {
+    let s = raw
+        .trim()
+        .trim_start_matches('.')
+        .trim()
+        .to_ascii_lowercase();
+    if s.is_empty() || s == "*" {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Parse a `NO_PROXY`/`no_proxy` environment value into normalized no-proxy
+/// entries. The value is comma- and/or whitespace-separated (both conventions
+/// appear in the wild). Entries are normalized via [`normalize_no_proxy_entry`];
+/// empty entries and a bare `*` are dropped.
+pub fn parse_no_proxy_list(raw: &str) -> Vec<String> {
+    raw.split([',', ' ', '\t', '\n', '\r'])
+        .filter_map(normalize_no_proxy_entry)
+        .collect()
+}
+
 /// Parse a domain list file into normalized entries.
 /// Returns an error if the file cannot be read (fail-closed for allowlists).
 pub fn parse_domain_file(path: &std::path::Path) -> Result<Vec<String>, String> {
@@ -1795,6 +1868,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         };
 
@@ -1820,6 +1894,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         };
 
@@ -1850,6 +1925,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         };
 
@@ -1883,6 +1959,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         };
 
@@ -1922,6 +1999,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         };
 
@@ -1983,6 +2061,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         });
         assert!(result.is_ok());
@@ -2016,6 +2095,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         });
         assert!(result.is_err(), "should fail when allowlist is unreadable");
@@ -2049,6 +2129,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         };
 
@@ -2124,6 +2205,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(60),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
             resolver,
         })
         .expect("proxy start failed")
@@ -2346,6 +2428,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             resolver: Some(resolver),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
         })
         .expect("proxy start failed");
 
@@ -2403,6 +2486,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             resolver: Some(resolver),
             upstream: None,
+            upstream_no_proxy: Vec::new(),
         })
         .expect("proxy start failed");
 
@@ -2850,6 +2934,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(5),
             upstream: Some(upstream),
+            upstream_no_proxy: Vec::new(),
             resolver: None,
         })
         .expect("proxy start failed")
@@ -3057,6 +3142,7 @@ mod tests {
             log_level: ProxyLogLevel::None,
             timeout: Duration::from_secs(5),
             upstream: Some(upstream),
+            upstream_no_proxy: Vec::new(),
             resolver,
         })
         .expect("proxy start failed")
@@ -3347,5 +3433,244 @@ mod tests {
         upstream_srv
             .shutdown
             .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    // ── upstream_no_proxy (NO_PROXY) carve-out ───────────────────────────
+
+    /// `host_matches_no_proxy` reuses `is_domain_match`: an entry matches the
+    /// exact host and all its subdomains, and an empty list matches nothing.
+    #[test]
+    fn no_proxy_matches_exact_and_subdomain() {
+        let list = vec!["example.com".to_string()];
+        assert!(host_matches_no_proxy("example.com", &list));
+        assert!(host_matches_no_proxy("internal.example.com", &list));
+        assert!(host_matches_no_proxy("a.b.example.com", &list));
+        assert!(!host_matches_no_proxy("notexample.com", &list));
+        assert!(!host_matches_no_proxy("example.com", &[]));
+    }
+
+    /// Entry normalization: trim, lowercase, strip a leading dot; empty and a
+    /// bare `*` are dropped.
+    #[test]
+    fn no_proxy_entry_normalization() {
+        assert_eq!(
+            normalize_no_proxy_entry(".Example.COM"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            normalize_no_proxy_entry("  host.example  "),
+            Some("host.example".to_string())
+        );
+        assert_eq!(normalize_no_proxy_entry(""), None);
+        assert_eq!(normalize_no_proxy_entry("   "), None);
+        assert_eq!(normalize_no_proxy_entry("*"), None);
+    }
+
+    /// A NO_PROXY env value is comma/whitespace-separated, normalized, with
+    /// empties and the bare wildcard dropped.
+    #[test]
+    fn no_proxy_env_value_parsing() {
+        let got = parse_no_proxy_list(".foo.com, bar.example\tBAZ.NET,,*");
+        assert_eq!(
+            got,
+            vec![
+                "foo.com".to_string(),
+                "bar.example".to_string(),
+                "baz.net".to_string(),
+            ]
+        );
+    }
+
+    /// A minimal fake DIRECT origin: a plain TCP listener that flips `contacted`
+    /// on accept, proving cplt connected directly rather than via the upstream.
+    struct FakeDirect {
+        port: u16,
+        contacted: Arc<std::sync::atomic::AtomicBool>,
+        shutdown: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    fn spawn_fake_direct_target() -> FakeDirect {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).ok();
+        let port = listener.local_addr().unwrap().port();
+        let contacted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let c = contacted.clone();
+        let s = shutdown.clone();
+        std::thread::spawn(move || {
+            loop {
+                if s.load(std::sync::atomic::Ordering::SeqCst) {
+                    break;
+                }
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        c.store(true, std::sync::atomic::Ordering::SeqCst);
+                        // Hold the stream briefly so cplt's relay setup succeeds.
+                        std::thread::spawn(move || {
+                            std::thread::sleep(Duration::from_millis(50));
+                            drop(stream);
+                        });
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => {}
+                }
+            }
+        });
+        FakeDirect {
+            port,
+            contacted,
+            shutdown,
+        }
+    }
+
+    /// Build an upstream-forwarding proxy that also honors an `upstream_no_proxy`
+    /// bypass list. Used by the NO_PROXY carve-out tests.
+    fn make_proxy_with_no_proxy(
+        upstream: UpstreamProxy,
+        upstream_no_proxy: Vec<String>,
+        blocked_file: PathBuf,
+        cli_private_domains: Vec<String>,
+        resolver: Option<ResolverFn>,
+    ) -> ProxyHandle {
+        start(ProxyOptions {
+            port: 0,
+            blocked_file,
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            cli_private_domains,
+            config_private_domains: Vec::new(),
+            config_file: None,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(5),
+            upstream: Some(upstream),
+            upstream_no_proxy,
+            resolver,
+        })
+        .expect("proxy start failed")
+    }
+
+    /// Core behavior: a host in `upstream_no_proxy` takes the DIRECT path and the
+    /// upstream is NEVER contacted for it, while a host NOT in the list is still
+    /// forwarded to the upstream. Proves the bypass is scoped to the list.
+    #[test]
+    fn proxy_no_proxy_host_takes_direct_path_not_upstream() {
+        require_localhost_tcp!();
+
+        let upstream_srv = spawn_fake_upstream();
+        let upstream =
+            UpstreamProxy::parse(&format!("http://127.0.0.1:{}", upstream_srv.port)).unwrap();
+        let direct = spawn_fake_direct_target();
+
+        let direct_ip: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let direct_port = direct.port;
+        let resolver: ResolverFn = Arc::new(move |host: &str, _port: u16| match host {
+            // The no-proxy host resolves to our local fake origin (stands in for
+            // an internal/public IP we cannot bind in a unit test).
+            "internal.corp.example" => Some(std::net::SocketAddr::new(direct_ip, direct_port)),
+            // The forwarded host is only resolvable by the (fake) upstream, so
+            // local resolution returns None and cplt forwards it as-is.
+            _ => None,
+        });
+
+        let proxy = make_proxy_with_no_proxy(
+            upstream,
+            vec!["internal.corp.example".to_string()],
+            PathBuf::from("/dev/null"),
+            // Trust the no-proxy host to resolve to loopback so the direct path's
+            // resolved-IP guard permits our local fake origin.
+            vec!["internal.corp.example".to_string()],
+            Some(resolver),
+        );
+
+        // 1. No-proxy host → DIRECT path: 200, direct origin reached, upstream not.
+        let status = proxy_connect(proxy.port, "internal.corp.example:443");
+        assert!(
+            status.contains("200"),
+            "no-proxy host should connect directly; got: {status}"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            direct.contacted.load(std::sync::atomic::Ordering::SeqCst),
+            "no-proxy host must reach the DIRECT origin"
+        );
+        assert!(
+            !upstream_srv
+                .contacted
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "upstream must NOT be contacted for a no-proxy host"
+        );
+
+        // 2. A host NOT in the no-proxy list is still forwarded to the upstream.
+        let status = proxy_connect(proxy.port, "external.example.net:443");
+        assert!(
+            status.contains("200"),
+            "non-no-proxy host should be forwarded via upstream; got: {status}"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            upstream_srv
+                .contacted
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "upstream MUST be contacted for a host outside the no-proxy list"
+        );
+
+        proxy.shutdown();
+        upstream_srv
+            .shutdown
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        direct
+            .shutdown
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Filtering precedence preserved: a no-proxy host that is BLOCKED by the
+    /// blocklist is still rejected with 403, and the upstream is never contacted.
+    /// The NO_PROXY carve-out only chooses direct-vs-upstream; it does NOT skip
+    /// the allow/block/port/SSRF gates that run first.
+    #[test]
+    fn proxy_no_proxy_host_still_blocked_by_policy() {
+        require_localhost_tcp!();
+
+        let dir = test_dir("no-proxy-blocked");
+        let blocked = dir.join("blocked.txt");
+        std::fs::write(&blocked, "blocked.example.com\n").unwrap();
+
+        let upstream_srv = spawn_fake_upstream();
+        let upstream =
+            UpstreamProxy::parse(&format!("http://127.0.0.1:{}", upstream_srv.port)).unwrap();
+        // The blocked host is ALSO in the no-proxy list — policy must still win.
+        let proxy = make_proxy_with_no_proxy(
+            upstream,
+            vec!["blocked.example.com".to_string()],
+            blocked,
+            Vec::new(),
+            None,
+        );
+
+        let status = proxy_connect(proxy.port, "blocked.example.com:443");
+        assert!(
+            status.contains("403"),
+            "a blocklisted no-proxy host must still be 403; got: {status}"
+        );
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !upstream_srv
+                .contacted
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "upstream must NOT be contacted for a blocked host"
+        );
+
+        proxy.shutdown();
+        upstream_srv
+            .shutdown
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -498,21 +498,19 @@ fn proxy_upstream_no_proxy_cli_overrides_config() {
 #[test]
 fn proxy_upstream_no_proxy_merges_env() {
     use cplt::config::{CliFlags, Config};
-    // The ambient NO_PROXY/no_proxy is merged on top of config/CLI. Use a
-    // process-unique value to avoid clobbering a real developer setting.
-    // SAFETY: single-threaded within this test; we set then immediately merge
-    // then remove. No other test asserts on this exact hostname.
-    unsafe {
-        std::env::set_var("NO_PROXY", ".env-host.example.io, other.example");
-    }
+    // The ambient NO_PROXY/no_proxy is merged on top of config/CLI. Inject the
+    // value directly via merge_with_no_proxy_env instead of mutating the
+    // process-global environment: cargo runs tests on parallel threads, and
+    // set_var/remove_var is UB while sibling tests read env (edition 2024),
+    // besides clobbering a developer's real NO_PROXY.
     let toml = "[proxy]\nupstream_no_proxy = [\"config-host.example.com\"]\n";
     let resolved = Config::parse(toml)
         .unwrap()
-        .merge(CliFlags::default())
+        .merge_with_no_proxy_env(
+            CliFlags::default(),
+            Some(".env-host.example.io, other.example".to_string()),
+        )
         .unwrap();
-    unsafe {
-        std::env::remove_var("NO_PROXY");
-    }
     assert!(
         resolved
             .proxy_upstream_no_proxy

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -446,6 +446,90 @@ fn proxy_upstream_invalid_url_rejected() {
 }
 
 #[test]
+fn proxy_upstream_no_proxy_parsed_from_config() {
+    use cplt::config::{CliFlags, Config};
+    // A leading-dot entry must be normalized to a bare host so is_domain_match
+    // handles it. `.contains` (not exact eq) keeps this robust against any
+    // ambient NO_PROXY on the test host.
+    let toml = "[proxy]\nupstream_no_proxy = [\".Internal.Example.COM\", \"corp.example\"]\n";
+    let resolved = Config::parse(toml)
+        .unwrap()
+        .merge(CliFlags::default())
+        .unwrap();
+    assert!(
+        resolved
+            .proxy_upstream_no_proxy
+            .contains(&"internal.example.com".to_string()),
+        "leading dot + case must normalize; got: {:?}",
+        resolved.proxy_upstream_no_proxy
+    );
+    assert!(
+        resolved
+            .proxy_upstream_no_proxy
+            .contains(&"corp.example".to_string())
+    );
+}
+
+#[test]
+fn proxy_upstream_no_proxy_cli_overrides_config() {
+    use cplt::config::{CliFlags, Config};
+    let toml = "[proxy]\nupstream_no_proxy = [\"config-only.example.com\"]\n";
+    let cli = CliFlags {
+        proxy_upstream_no_proxy: vec!["cli-host.example.net".to_string()],
+        ..Default::default()
+    };
+    let resolved = Config::parse(toml).unwrap().merge(cli).unwrap();
+    assert!(
+        resolved
+            .proxy_upstream_no_proxy
+            .contains(&"cli-host.example.net".to_string()),
+        "CLI entry must be present; got: {:?}",
+        resolved.proxy_upstream_no_proxy
+    );
+    assert!(
+        !resolved
+            .proxy_upstream_no_proxy
+            .contains(&"config-only.example.com".to_string()),
+        "CLI must override (replace) the config list; got: {:?}",
+        resolved.proxy_upstream_no_proxy
+    );
+}
+
+#[test]
+fn proxy_upstream_no_proxy_merges_env() {
+    use cplt::config::{CliFlags, Config};
+    // The ambient NO_PROXY/no_proxy is merged on top of config/CLI. Use a
+    // process-unique value to avoid clobbering a real developer setting.
+    // SAFETY: single-threaded within this test; we set then immediately merge
+    // then remove. No other test asserts on this exact hostname.
+    unsafe {
+        std::env::set_var("NO_PROXY", ".env-host.example.io, other.example");
+    }
+    let toml = "[proxy]\nupstream_no_proxy = [\"config-host.example.com\"]\n";
+    let resolved = Config::parse(toml)
+        .unwrap()
+        .merge(CliFlags::default())
+        .unwrap();
+    unsafe {
+        std::env::remove_var("NO_PROXY");
+    }
+    assert!(
+        resolved
+            .proxy_upstream_no_proxy
+            .contains(&"env-host.example.io".to_string()),
+        "NO_PROXY env entry (leading dot stripped) must be merged in; got: {:?}",
+        resolved.proxy_upstream_no_proxy
+    );
+    assert!(
+        resolved
+            .proxy_upstream_no_proxy
+            .contains(&"config-host.example.com".to_string()),
+        "config entries must survive the env merge; got: {:?}",
+        resolved.proxy_upstream_no_proxy
+    );
+}
+
+#[test]
 fn config_show_redacts_upstream_credentials() {
     // `cplt config show`/`explain` print proxy.upstream through
     // redact_upstream_url. A URL carrying `user:pass@` must never leak the
@@ -6687,6 +6771,7 @@ enabled = false
 forced = false
 port = 18080
 upstream = "http://corp-proxy.example.com:8080"
+upstream_no_proxy = []
 blocked_domains = "file.txt"
 allowed_domains = "file.txt"
 log_file = "log.txt"


### PR DESCRIPTION
Closes #135. Lets specific domains BYPASS the upstream (corporate) proxy and connect directly — standard `NO_PROXY` semantics — for teams behind a corporate proxy (from #125).

- `proxy.upstream_no_proxy` config + `--proxy-upstream-no-proxy` flag; the ambient `NO_PROXY`/`no_proxy` env var is merged in so existing corporate setups work out of the box. Entries normalized (leading-dot stripped; bare `*`/empty dropped).
- A no-proxy host skips the `connect_via_upstream` branch and falls through to cplt's existing DIRECT path. **Security preserved for free**: all domain/port filtering + the resolved-IP SSRF guard run *before* the upstream-vs-direct decision, and the direct path re-applies the guard. cplt (outside the sandbox) makes the direct connection, so it also works under `proxy.forced`.
- Matching reuses `is_domain_match` (exact + subdomain).
- Rejected in repo config (machine/network-specific, like `proxy.upstream`).
- Tests: no-proxy host takes direct path (fake upstream NOT contacted; non-listed host IS forwarded); a blocklisted no-proxy host is still 403 (filtering not bypassed); subdomain match; config/CLI/env merge + normalization; `config show`. Also documented `proxy.upstream` itself in docs/proxy.md (it shipped undocumented in #125). clippy clean both targets; lib 564 + unit 243.