### PR TITLE
feat(proxy): per-agent default domain allowlist — fail-closed networking, opt-in (#52)

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -45,6 +45,8 @@ cplt config set proxy.log_file "~/.config/cplt/proxy.log"
 | `--proxy-port <PORT>`       | Which port the proxy listens on (default: 0, OS-assigned ephemeral).                             |
 | `--blocked-domains <FILE>`  | Domains to block, one per line. Re-read every ~5s (edit live, changes take effect within seconds). |
 | `--allowed-domains <FILE>`  | Domains to allow — only listed domains can connect. Validated at startup (fail-closed); re-read every 5s.  |
+| `--default-allowlist`       | Enable the agent's built-in default allowlist for this run (opt-in, default off): restrict egress to the agent's fail-closed domain set merged with `--allowed-domains`. See [Default allowlist](#default-allowlist-fail-closed-networking). |
+| `--allow-all-domains`       | Escape hatch: disable the default allowlist for this run and allow all domains (blocklist still applies). Also ignores any `--allowed-domains` file. |
 | `--proxy-log <FILE>`        | Append a line per connection to this file for post-session audit.                                |
 | `--proxy-log-level <LEVEL>` | Stderr verbosity: `none` (default/silent), `error`, `blocked`, or `all`. The audit log file always records everything. |
 | `--allow-private-domain <DOMAIN>` | Allow connections to this domain even if it resolves to a private/internal IP. Use for corporate intranet services (e.g. internal MCP servers). Suffix matching: `intern.nav.no` covers all subdomains. Can be repeated. |
@@ -139,6 +141,38 @@ cplt config set proxy.allowed_domains "~/.config/cplt/allowed-domains.txt"
 > **Note:** Both the allowlist and blocklist are re-read from disk every ~5 seconds (TTL-cached), so you can edit them live mid-session. Changes take effect within seconds without restarting cplt. If a file becomes unreadable at runtime, the last-known-good list is kept (fail-safe). At startup, an unreadable allowlist causes cplt to exit with an error (fail-closed).
 >
 > The `allow_private_domains` list in `config.toml` is also re-read every ~5 seconds. Domains added via `--allow-private-domain` CLI flags are always preserved regardless of config changes.
+
+### Default allowlist (fail-closed networking)
+
+By default the proxy is **allow-all**: it logs and blocks known-bad domains, but any HTTPS endpoint on the internet is reachable. Because port 443 is open at the kernel level, a compromised agent or a malicious dependency could exfiltrate source code to an arbitrary host. Network control is the only defense-in-depth layer that stops exfiltration *after* an agent is compromised (issue #52).
+
+Each agent ships with a built-in **default allowlist** — the set of domains it legitimately needs. For **Copilot** this is the GitHub Copilot infrastructure plus common package registries:
+
+```
+# GitHub Copilot infrastructure
+githubcopilot.com          # covers *.githubcopilot.com
+api.github.com
+github.com
+copilot-proxy.githubusercontent.com
+actions.githubusercontent.com   # covers *.actions.githubusercontent.com
+default.exp2.cds.s9ch.io
+# Package registries (shared by all agents)
+registry.npmjs.org  registry.yarnpkg.com  repo.maven.apache.org
+plugins.gradle.org  crates.io  static.crates.io  pypi.org  files.pythonhosted.org
+```
+
+Turn it on to make the proxy **fail-closed** — only these domains (and your own additions) are allowed, everything else is blocked:
+
+```bash
+cplt --default-allowlist -- -p "fix the tests"      # for one run
+cplt config set proxy.default_allowlist true         # permanently
+```
+
+- **Opt-in and off by default.** Enabling it does **not** change any other behaviour, and the global default remains allow-all (see issue #71 for making it the default).
+- **Effective allowlist = agent defaults ⊕ your `allowed_domains`.** When on, the agent's built-in list is **merged** with any file/config `allowed_domains`, so you add project registries or internal hosts without re-listing the base set. On startup cplt prints e.g. `Domain policy: 15 domains allowed (agent defaults + 1 configured)`.
+- **Blocked attempts are visible.** Denied connections are logged as `BLOCKED-ALLOWLIST` (see `--proxy-log` / `--proxy-log-level blocked`) so you can quickly see what to add.
+- **Escape hatch.** `--allow-all-domains` disables the allowlist for a single run (and ignores any `--allowed-domains` file) — allow-all again, for debugging. It overrides both `--default-allowlist` and `proxy.default_allowlist`.
+- **Composes with the other proxy features.** The domain allowlist is enforced by the proxy regardless of `proxy.forced` (kernel egress restriction) or `proxy.upstream` (corporate-proxy forwarding): a no-proxy/upstream target still passes through the same allowlist check — the allowlist governs **which** domains, orthogonal to **how** they are routed.
 
 ## Proxy operations
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,6 +8,44 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+/// Package registries that virtually every coding agent needs to fetch
+/// dependencies (npm, Yarn, Maven, Gradle, crates.io, PyPI). This is the
+/// shared base for every agent's built-in allowlist so that, when fail-closed
+/// networking is opted into, a normal `npm/pip/cargo install` still works.
+///
+/// Entries are bare registrable domains: the proxy's `is_domain_match` does
+/// exact-or-subdomain matching, so `crates.io` also covers `static.crates.io`
+/// (both are listed explicitly for clarity, matching issue #52).
+const PACKAGE_REGISTRY_DOMAINS: &[&str] = &[
+    "registry.npmjs.org",
+    "registry.yarnpkg.com",
+    "repo.maven.apache.org",
+    "plugins.gradle.org",
+    "crates.io",
+    "static.crates.io",
+    "pypi.org",
+    "files.pythonhosted.org",
+];
+
+/// GitHub Copilot infrastructure domains (issue #52). These are the endpoints
+/// the Copilot CLI itself talks to for auth, model access, and telemetry.
+///
+/// The list uses BARE domains, not `*.wildcard` syntax: the proxy allowlist
+/// matcher (`crate::proxy::is_domain_match`) treats each entry as an
+/// exact-or-subdomain match, so `githubcopilot.com` already covers
+/// `api.githubcopilot.com`, `proxy.githubcopilot.com`, etc. — the same effect
+/// the issue's `*.githubcopilot.com` intends — and `actions.githubusercontent.com`
+/// covers `*.actions.githubusercontent.com`. Do not add a leading `*.`; the
+/// matcher does not interpret glob syntax.
+const COPILOT_INFRA_DOMAINS: &[&str] = &[
+    "githubcopilot.com",
+    "api.github.com",
+    "github.com",
+    "copilot-proxy.githubusercontent.com",
+    "actions.githubusercontent.com",
+    "default.exp2.cds.s9ch.io",
+];
+
 /// Supported AI coding agents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -187,6 +225,32 @@ impl Agent {
     /// Whether this agent needs access to ~/.copilot directory.
     pub fn needs_copilot_dir(&self) -> bool {
         matches!(self, Agent::Copilot)
+    }
+
+    /// The agent's built-in default domain allowlist — the set of domains the
+    /// agent legitimately needs to reach.
+    ///
+    /// This is the fail-closed base for `proxy.default_allowlist` (issue #52):
+    /// when that opt-in is enabled, the proxy permits ONLY these domains (merged
+    /// with any user-configured `allowed_domains`) and blocks everything else,
+    /// so a compromised agent cannot exfiltrate to an arbitrary HTTPS endpoint.
+    ///
+    /// Every agent gets the shared package-registry base; Copilot additionally
+    /// gets its GitHub Copilot infrastructure endpoints. Entries are bare
+    /// domains matched by `crate::proxy::is_domain_match` (exact or subdomain).
+    ///
+    /// NOTE: this is opt-in and does NOT change the default behaviour. For
+    /// non-Copilot agents the base list intentionally omits that agent's own
+    /// LLM endpoint — enabling `default_allowlist` for them today requires the
+    /// user to add it via `allowed_domains`. Per-agent infra lists can be added
+    /// here as those agents are hardened.
+    pub fn default_allowed_domains(&self) -> Vec<&'static str> {
+        let mut domains: Vec<&'static str> = Vec::new();
+        if matches!(self, Agent::Copilot) {
+            domains.extend_from_slice(COPILOT_INFRA_DOMAINS);
+        }
+        domains.extend_from_slice(PACKAGE_REGISTRY_DOMAINS);
+        domains
     }
 
     /// Config directories under $HOME that need read/write access.
@@ -1280,6 +1344,78 @@ mod tests {
         // (We can't easily fake PATH here, but the detection loop has no
         // claude branch — this guards against a regression in intent.)
         assert_ne!(Agent::auto_detect(), Some(Agent::Claude));
+    }
+
+    #[test]
+    fn copilot_default_allowed_domains_matches_issue_52() {
+        let domains = Agent::Copilot.default_allowed_domains();
+        // 6 GitHub Copilot infra domains + 8 package registries = 14.
+        assert_eq!(domains.len(), 14, "copilot list: infra + registries");
+        // GitHub Copilot infrastructure (bare forms of the issue's wildcards).
+        for d in [
+            "githubcopilot.com",
+            "api.github.com",
+            "github.com",
+            "copilot-proxy.githubusercontent.com",
+            "actions.githubusercontent.com",
+            "default.exp2.cds.s9ch.io",
+        ] {
+            assert!(domains.contains(&d), "copilot infra must include {d}");
+        }
+        // Package registries.
+        for d in [
+            "registry.npmjs.org",
+            "registry.yarnpkg.com",
+            "repo.maven.apache.org",
+            "plugins.gradle.org",
+            "crates.io",
+            "static.crates.io",
+            "pypi.org",
+            "files.pythonhosted.org",
+        ] {
+            assert!(domains.contains(&d), "copilot list must include {d}");
+        }
+        // No glob syntax — the proxy matcher does exact/subdomain matching only.
+        assert!(
+            domains.iter().all(|d| !d.contains('*')),
+            "default domains must be bare (no wildcard syntax)"
+        );
+    }
+
+    #[test]
+    fn copilot_default_domains_cover_subdomains_via_matcher() {
+        // The bare `githubcopilot.com` entry must cover `*.githubcopilot.com`
+        // through the proxy's subdomain matcher — this is the contract that lets
+        // us drop the issue's `*.` prefix.
+        let domains: Vec<String> = Agent::Copilot
+            .default_allowed_domains()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        assert!(crate::proxy::is_domain_match(
+            "api.githubcopilot.com",
+            &domains
+        ));
+        assert!(crate::proxy::is_domain_match(
+            "run.actions.githubusercontent.com",
+            &domains
+        ));
+        assert!(crate::proxy::is_domain_match("github.com", &domains));
+        assert!(!crate::proxy::is_domain_match("evil.com", &domains));
+    }
+
+    #[test]
+    fn non_copilot_agents_get_registry_base_only() {
+        // Other agents share the package-registry base but not Copilot infra.
+        for agent in [Agent::OpenCode, Agent::Claude, Agent::Gemini] {
+            let domains = agent.default_allowed_domains();
+            assert_eq!(domains.len(), 8, "{agent:?} gets registry base only");
+            assert!(domains.contains(&"registry.npmjs.org"));
+            assert!(
+                !domains.contains(&"githubcopilot.com"),
+                "{agent:?} must not get Copilot infra"
+            );
+        }
     }
 
     #[test]

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -204,6 +204,13 @@ pub fn display_config(loaded: Option<&LoadedConfig>) {
     if let Some(ref ad) = c.proxy.allowed_domains {
         println!("{blue}[cplt]{nc}    allowed_domains  = \"{ad}\"");
     }
+    let default_allowlist = c.proxy.default_allowlist.unwrap_or(false);
+    println!(
+        "{blue}[cplt]{nc}    default_allowlist = {}{}{nc}{}",
+        if default_allowlist { green } else { yellow },
+        default_allowlist,
+        src(c.proxy.default_allowlist.is_some())
+    );
     if let Some(ref lf) = c.proxy.log_file {
         println!("{blue}[cplt]{nc}    log_file         = \"{lf}\"");
     }

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -112,6 +112,18 @@ impl Config {
             .allowed_domains
             .or_else(|| self.proxy.allowed_domains.as_ref().map(|s| expand_tilde(s)));
 
+        // Fail-closed networking opt-in (#52). `cli.default_allowlist` is a
+        // FeatureToggle where `--default-allowlist` is the ON side and
+        // `--allow-all-domains` is the OFF side (off wins), resolved against the
+        // `proxy.default_allowlist` config default (false). `--allow-all-domains`
+        // additionally forces allow-all: main.rs uses `allow_all_domains` to
+        // clear any explicit `allowed_domains` file for the run. This is opt-in
+        // and does not change the default (allow-all) behaviour.
+        let default_allowlist = cli
+            .default_allowlist
+            .resolve(self.proxy.default_allowlist.unwrap_or(false));
+        let allow_all_domains = cli.allow_all_domains;
+
         // Proxy log file: CLI > config
         let proxy_log_file = cli
             .proxy_log_file
@@ -454,6 +466,8 @@ impl Config {
             proxy_port,
             blocked_domains,
             allowed_domains,
+            default_allowlist,
+            allow_all_domains,
             proxy_log_file,
             proxy_log_level,
             proxy_timeout,
@@ -1121,6 +1135,58 @@ validate = false
         let config: Config = toml::from_str("[proxy]\nforced = true\n").unwrap();
         let resolved = config.merge(CliFlags::default()).unwrap();
         assert!(resolved.proxy_forced);
+    }
+
+    // ── proxy.default_allowlist (#52) precedence ────────────────────────
+
+    #[test]
+    fn default_allowlist_off_by_default() {
+        // Critical: no config, no flags => feature stays OFF (allow-all).
+        let config: Config = toml::from_str("").unwrap();
+        let resolved = config.merge(CliFlags::default()).unwrap();
+        assert!(
+            !resolved.default_allowlist,
+            "default must be OFF (no behaviour change)"
+        );
+        assert!(!resolved.allow_all_domains);
+    }
+
+    #[test]
+    fn config_default_allowlist_used_when_no_cli_flag() {
+        let config: Config = toml::from_str("[proxy]\ndefault_allowlist = true\n").unwrap();
+        let resolved = config.merge(CliFlags::default()).unwrap();
+        assert!(resolved.default_allowlist);
+    }
+
+    #[test]
+    fn cli_default_allowlist_overrides_config_disabled() {
+        let config: Config = toml::from_str("[proxy]\ndefault_allowlist = false\n").unwrap();
+        let resolved = config
+            .merge(CliFlags {
+                default_allowlist: FeatureToggle::ForceOn,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(resolved.default_allowlist);
+    }
+
+    #[test]
+    fn allow_all_domains_overrides_config_enabled() {
+        // --allow-all-domains is the OFF side of the toggle: it wins over the
+        // config default AND records the escape-hatch flag.
+        let config: Config = toml::from_str("[proxy]\ndefault_allowlist = true\n").unwrap();
+        let resolved = config
+            .merge(CliFlags {
+                default_allowlist: FeatureToggle::from_pair(false, true),
+                allow_all_domains: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(
+            !resolved.default_allowlist,
+            "--allow-all-domains must disable the default allowlist"
+        );
+        assert!(resolved.allow_all_domains);
     }
 
     #[test]

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -53,6 +53,11 @@ pub fn default_config_contents() -> String {
 # port = 0  # 0 = OS-assigned ephemeral port (avoids conflicts, default)
 # blocked_domains = "~/.config/cplt/blocked-domains.txt"
 # allowed_domains = "~/.config/cplt/allowed-domains.txt"
+# Fail-closed networking (opt-in, default: false). When true, egress is
+# restricted to the agent's built-in default allowlist (GitHub Copilot infra +
+# package registries for Copilot) merged with allowed_domains above; every other
+# domain is blocked. Override for a single run with --allow-all-domains.
+# default_allowlist = false
 # log_file = "~/.config/cplt/proxy.log"
 # Stderr verbosity: "none" (default/silent), "error", "blocked", or "all".
 # The log_file always records everything regardless of this setting.

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -83,6 +83,14 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
     },
     ConfigKeyInfo {
         section: "proxy",
+        key: "default_allowlist",
+        value_type: ConfigValueType::Bool,
+        dangerous: false,
+        default_display: "false",
+        description: "Fail-closed networking (opt-in): restrict egress to the agent's built-in default allowlist (e.g. GitHub Copilot infrastructure + package registries) merged with allowed_domains; block all other domains. Override for one run with --allow-all-domains.",
+    },
+    ConfigKeyInfo {
+        section: "proxy",
         key: "log_file",
         value_type: ConfigValueType::Str,
         dangerous: false,

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -81,6 +81,7 @@ pub fn repo_key_rejection_reason(key_info: &ConfigKeyInfo) -> &'static str {
         ("proxy", "allowed_domains") => {
             "domain lists are machine-specific paths, not project policy"
         }
+        ("proxy", "default_allowlist") => "proxy settings are machine-specific, not project policy",
         ("proxy", "upstream") => {
             "the corporate proxy is machine/network-specific, not project policy"
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -248,6 +248,13 @@ pub struct ProxyConfig {
     pub blocked_domains: Option<String>,
     /// Path to allowed domains file. When set, only listed domains are permitted.
     pub allowed_domains: Option<String>,
+    /// Opt-in fail-closed networking (issue #52, default: false). When true, the
+    /// proxy restricts egress to the running agent's built-in default allowlist
+    /// (e.g. GitHub Copilot infra + package registries for Copilot) MERGED with
+    /// any `allowed_domains` — every other domain is blocked. Overridden for a
+    /// single run by `--allow-all-domains`. Enabling this does NOT change any
+    /// other default; flipping the global default is tracked separately (#71).
+    pub default_allowlist: Option<bool>,
     /// Path to write proxy audit log (one line per CONNECT).
     pub log_file: Option<String>,
     /// Stderr verbosity level: "none", "error", "blocked", "all" (default: "none").
@@ -449,6 +456,13 @@ pub struct Resolved {
     pub proxy_port: u16,
     pub blocked_domains: Option<PathBuf>,
     pub allowed_domains: Option<PathBuf>,
+    /// Fail-closed networking opt-in (#52): restrict egress to the agent's
+    /// built-in default allowlist merged with `allowed_domains`. Already
+    /// reconciled with `--allow-all-domains` (which forces this off).
+    pub default_allowlist: bool,
+    /// Escape hatch (#52): force allow-all for this run, disabling BOTH the
+    /// default allowlist and any explicit `allowed_domains` file.
+    pub allow_all_domains: bool,
     pub proxy_log_file: Option<PathBuf>,
     pub proxy_log_level: crate::proxy::ProxyLogLevel,
     pub proxy_timeout: std::time::Duration,
@@ -505,6 +519,11 @@ pub struct CliFlags {
     pub proxy_port: Option<u16>,
     pub blocked_domains: Option<PathBuf>,
     pub allowed_domains: Option<PathBuf>,
+    /// `--default-allowlist` (on) vs `--allow-all-domains` (off); off wins.
+    /// Resolved against `proxy.default_allowlist` config.
+    pub default_allowlist: FeatureToggle,
+    /// `--allow-all-domains`: force allow-all for this run (escape hatch).
+    pub allow_all_domains: bool,
     pub proxy_log_file: Option<PathBuf>,
     pub proxy_log_level: Option<crate::proxy::ProxyLogLevel>,
     pub proxy_timeout: Option<u64>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,19 @@ struct Cli {
     #[arg(long, value_name = "FILE")]
     allowed_domains: Option<PathBuf>,
 
+    /// Enable fail-closed networking for this run (#52): restrict egress to the
+    /// agent's built-in default allowlist (GitHub Copilot infrastructure +
+    /// package registries for Copilot) merged with any --allowed-domains.
+    /// Everything else is blocked. Opt-in; overrides proxy.default_allowlist = false.
+    #[arg(long)]
+    default_allowlist: bool,
+
+    /// Escape hatch: disable the default allowlist for this run and allow all
+    /// domains (subject to the blocklist). Overrides --default-allowlist and
+    /// proxy.default_allowlist, and also ignores any --allowed-domains file.
+    #[arg(long)]
+    allow_all_domains: bool,
+
     /// Write proxy connection log to a file (one line per CONNECT).
     /// Useful for post-session audit. File is created if it doesn't exist.
     #[arg(long, value_name = "FILE")]
@@ -1066,6 +1079,12 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
         proxy_port: cli.proxy_port,
         blocked_domains: cli.blocked_domains.clone(),
         allowed_domains: cli.allowed_domains.clone(),
+        // --default-allowlist enables, --allow-all-domains disables (off wins).
+        default_allowlist: config::FeatureToggle::from_pair(
+            cli.default_allowlist,
+            cli.allow_all_domains,
+        ),
+        allow_all_domains: cli.allow_all_domains,
         proxy_log_file: cli.proxy_log.clone(),
         proxy_log_level: match cli.proxy_log_level.as_deref() {
             Some(s) => match s.parse::<crate::proxy::ProxyLogLevel>() {
@@ -1397,6 +1416,7 @@ fn start_proxy_if_enabled(
     resolved: &mut config::Resolved,
     cli: &Cli,
     config_path: Option<&PathBuf>,
+    active_agent: agent::Agent,
 ) -> anyhow::Result<Option<proxy::ProxyHandle>> {
     // Proxy-forced (#53): the proxy is mandatory. `with_proxy` defaults to true,
     // so the only way it is false here is an explicit disable (--no-proxy or
@@ -1441,16 +1461,45 @@ fn start_proxy_if_enabled(
         PathBuf::from("/dev/null/no-blocklist")
     });
 
-    // Validate domain allowlist at startup (fail-closed: abort if unreadable)
-    let allowed_domains_file = resolved.allowed_domains.clone();
+    // Escape hatch (#52): --allow-all-domains forces allow-all for this run,
+    // disabling BOTH the agent default allowlist and any explicit
+    // allowed_domains file. `resolved.default_allowlist` was already forced off
+    // in the config merge when --allow-all-domains is set.
+    let allowed_domains_file = if resolved.allow_all_domains {
+        None
+    } else {
+        resolved.allowed_domains.clone()
+    };
+
+    // Fail-closed networking (#52): when proxy.default_allowlist is on, the
+    // effective allowlist is the running agent's built-in defaults, which the
+    // proxy MERGES with the user's allowed_domains file. Empty vec = feature
+    // off, so the proxy keeps today's allow-all behaviour unchanged.
+    let default_allowlist: Vec<String> = if resolved.default_allowlist {
+        active_agent
+            .default_allowed_domains()
+            .iter()
+            .map(|d| (*d).to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // Validate domain allowlist file at startup (fail-closed: abort if
+    // unreadable) and capture the user-configured domains for the policy report.
+    let mut configured_domains: Vec<String> = Vec::new();
     if let Some(ref path) = allowed_domains_file {
         if path.exists() {
             match proxy::parse_domain_file(path) {
                 Ok(domains) => {
-                    if !resolved.quiet {
+                    configured_domains = domains;
+                    // Only print the legacy "N from FILE" line when the default
+                    // allowlist is off; otherwise the "Domain policy" line below
+                    // gives the complete, merged picture.
+                    if !resolved.quiet && default_allowlist.is_empty() {
                         ui::info(&format!(
                             "Domain allowlist: {} domains from {}",
-                            domains.len(),
+                            configured_domains.len(),
                             path.display()
                         ));
                     }
@@ -1463,6 +1512,26 @@ fn start_proxy_if_enabled(
                 path.display()
             ));
         }
+    }
+
+    // Report the active fail-closed policy: total permitted domains, and how
+    // many the user added on top of the agent's built-in base. The merge here
+    // mirrors the proxy's own dedup so the count matches what is enforced.
+    if !default_allowlist.is_empty() && !resolved.quiet {
+        let mut merged = default_allowlist.clone();
+        merged.extend(configured_domains.iter().cloned());
+        merged.sort_unstable();
+        merged.dedup();
+        let extra = merged.len().saturating_sub(default_allowlist.len());
+        ui::info(&format!(
+            "Domain policy: {} domains allowed (agent defaults + {} configured)",
+            merged.len(),
+            extra
+        ));
+        ui::info(
+            "Fail-closed: unknown domains are blocked (BLOCKED-ALLOWLIST in the \
+             proxy log). Add to allowed-domains or use --allow-all-domains.",
+        );
     }
 
     let port_hint = if resolved.proxy_port == 0 {
@@ -1482,6 +1551,7 @@ fn start_proxy_if_enabled(
         allow_localhost_any: resolved.allow_localhost_any,
         allowed_domains_file,
         allowed_domains_initial: Vec::new(),
+        default_allowlist,
         cli_private_domains: cli.allow_private_domains.clone(),
         config_private_domains: resolved
             .allow_private_domains
@@ -1752,7 +1822,8 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     }
 
     // Start proxy (handle returned for RAII ownership)
-    let proxy_handle = start_proxy_if_enabled(&mut resolved, &cli, config_path.as_ref())?;
+    let proxy_handle =
+        start_proxy_if_enabled(&mut resolved, &cli, config_path.as_ref(), active_agent)?;
 
     // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
     merge_tool_path_env_overrides(&mut resolved, &home_dir);
@@ -2278,7 +2349,8 @@ fn run_exec_command(
         }
     }
 
-    let proxy_handle = start_proxy_if_enabled(&mut resolved, cli, config_path.as_ref())?;
+    let proxy_handle =
+        start_proxy_if_enabled(&mut resolved, cli, config_path.as_ref(), active_agent)?;
     let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
 
     // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -905,8 +905,24 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
 
     // Enforce domain allowlist — when configured, only listed domains pass.
     // Fail-closed: if the allowlist is non-empty and the domain isn't in it, deny.
+    //
+    // Localhost carve-out: skip the allowlist gate for an opted-in localhost
+    // target, consistent with the port-policy and private-hostname gates above
+    // (both also skip when `localhost_connect_allowed`). The agent-default
+    // allowlist never contains "localhost", so without this exemption a user
+    // combining fail-closed networking with a local dev-server carve-out
+    // (`--default-allowlist --allow-localhost 3000`) would get
+    // `CONNECT localhost:3000` blocked — a surprising break of a legitimate
+    // combo. Still safe: `localhost_connect_allowed` requires both an explicit
+    // opt-in AND a loopback-spelled host, and the resolved-IP loopback check
+    // below still enforces that the target actually resolves to a loopback IP,
+    // so this exemption cannot let a non-loopback host masquerade as localhost
+    // to bypass the allowlist.
     let allowed_domains = state.get_allowed_domains();
-    if !allowed_domains.is_empty() && !is_domain_match(&host, &allowed_domains) {
+    if !localhost_connect_allowed
+        && !allowed_domains.is_empty()
+        && !is_domain_match(&host, &allowed_domains)
+    {
         log_connection("CONNECT", target, "BLOCKED-ALLOWLIST", log_file, log_level);
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nDomain not in allowlist\r\n");
         return;
@@ -2427,6 +2443,73 @@ mod tests {
         assert_connect_allowed(proxy.port, "evil.com");
         proxy.shutdown();
         up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[test]
+    fn proxy_default_allowlist_allows_localhost_carveout_but_blocks_unknown() {
+        // Combining fail-closed networking with a local dev-server carve-out
+        // (`--default-allowlist --allow-localhost <PORT>`) must let the opted-in
+        // localhost port through even though "localhost" is not in the agent
+        // default allowlist, while a non-allowlisted public domain stays blocked.
+        require_localhost_tcp!();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Accept the one localhost connection so the tunnel completes (200).
+        let handle = std::thread::spawn(move || {
+            listener.accept().ok();
+        });
+
+        // Pin resolution to IPv4 loopback so the tunnel reaches our listener and
+        // the resolved-IP loopback check passes (localhost connects directly,
+        // never via the upstream). evil.com never reaches resolution — it is
+        // blocked at the allowlist gate first.
+        let loopback_v4: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let resolver: ResolverFn =
+            Arc::new(move |_host: &str, p: u16| Some(std::net::SocketAddr::new(loopback_v4, p)));
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        let proxy = start(ProxyOptions {
+            port: 0,
+            blocked_file: PathBuf::from("/dev/null"),
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports: vec![port],
+            allow_localhost_any: false,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            default_allowlist: copilot_defaults(),
+            cli_private_domains: Vec::new(),
+            config_private_domains: Vec::new(),
+            config_file: None,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(5),
+            upstream: Some(upstream),
+            upstream_no_proxy: Vec::new(),
+            resolver: Some(resolver),
+        })
+        .expect("proxy start failed");
+
+        let localhost_status = proxy_connect(proxy.port, &format!("localhost:{port}"));
+        let evil_status = proxy_connect(proxy.port, "evil.com:443");
+
+        proxy.shutdown();
+        // Fallback connect so the accept thread unblocks if the proxy didn't reach it.
+        let _ = std::net::TcpStream::connect(("127.0.0.1", port));
+        handle.join().ok();
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(
+            localhost_status.contains("200"),
+            "CONNECT localhost:{port} must be ALLOWED under --default-allowlist \
+             with --allow-localhost {port} (allowlist gate must not block the \
+             localhost carve-out); got: {localhost_status}"
+        );
+        assert!(
+            evil_status.contains("403"),
+            "evil.com must stay BLOCKED (BLOCKED-ALLOWLIST) under the default \
+             allowlist even when a localhost carve-out is active; got: {evil_status}"
+        );
     }
 
     /// Helper: make a raw CONNECT request through the proxy and return the status line.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -346,6 +346,13 @@ pub struct ProxyState {
     allowed_domains_file: Option<PathBuf>,
     allowlist_cache: Mutex<DomainCache>,
 
+    // Agent default allowlist (issue #52): the agent's built-in fail-closed
+    // domain set, frozen at startup. Empty = the feature is off (unchanged
+    // allow-all behaviour). When non-empty it is MERGED with the reloadable
+    // `allowed_domains_file` to form the effective allowlist — so the built-in
+    // base and the user's additions both apply without re-listing either.
+    default_allowlist: Vec<String>,
+
     // Private domains: merged from immutable CLI args + dynamic TOML config
     cli_private_domains: Vec<String>,
     config_file: Option<PathBuf>,
@@ -394,13 +401,36 @@ impl ProxyState {
         )
     }
 
-    /// Get the allowlist, re-reading from disk if TTL expired.
-    /// Returns empty Vec when no allowlist file is configured (allow-all mode).
+    /// Get the effective allowlist, re-reading the user file from disk if the
+    /// TTL expired and merging in the agent's built-in default allowlist.
+    ///
+    /// Resolution (issue #52):
+    /// - `default_allowlist` empty (feature off / `--allow-all-domains`):
+    ///   behaviour is UNCHANGED — the reloadable file is the sole source, and an
+    ///   empty result means allow-all.
+    /// - `default_allowlist` non-empty (`proxy.default_allowlist` on): the
+    ///   effective allowlist is the agent defaults MERGED with any
+    ///   user-configured file domains, deduplicated. The result is always
+    ///   non-empty, so `handle_connect` fail-closes on unknown domains.
+    ///
+    /// Either way the returned list is fed to the same `is_domain_match` /
+    /// BLOCKED-ALLOWLIST enforcement — no matching logic is duplicated.
     fn get_allowed_domains(&self) -> Vec<String> {
-        match self.allowed_domains_file.as_deref() {
+        let file_domains = match self.allowed_domains_file.as_deref() {
             Some(path) => get_cached_domains(&self.allowlist_cache, Some(path), parse_lines_file),
             None => Vec::new(),
+        };
+
+        if self.default_allowlist.is_empty() {
+            // Feature off — preserve today's exact behaviour.
+            return file_domains;
         }
+
+        let mut merged = self.default_allowlist.clone();
+        merged.extend(file_domains);
+        merged.sort_unstable();
+        merged.dedup();
+        merged
     }
 
     /// Get private domains: union of immutable CLI entries + dynamic config entries.
@@ -565,6 +595,10 @@ pub struct ProxyOptions {
     /// Initial allowed domains from CLI/config (used for startup validation).
     /// After startup, the file is the source of truth for dynamic reload.
     pub allowed_domains_initial: Vec<String>,
+    /// Agent built-in default allowlist (issue #52). Empty = feature off
+    /// (unchanged allow-all). When set, it is merged with `allowed_domains_file`
+    /// to form the effective, fail-closed allowlist. Frozen at startup.
+    pub default_allowlist: Vec<String>,
     /// Domains allowed to resolve to private IPs — CLI portion (immutable).
     pub cli_private_domains: Vec<String>,
     /// Domains allowed to resolve to private IPs — config portion (initial).
@@ -650,6 +684,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         blocked_cache: Mutex::new(DomainCache::new(blocked_initial)),
         allowed_domains_file: opts.allowed_domains_file,
         allowlist_cache: Mutex::new(DomainCache::new(allowlist_initial)),
+        default_allowlist: opts.default_allowlist,
         cli_private_domains: opts.cli_private_domains,
         config_file: opts.config_file,
         private_domains_cache: Mutex::new(DomainCache::new(opts.config_private_domains)),
@@ -1863,6 +1898,7 @@ mod tests {
             blocked_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
+            default_allowlist: Vec::new(),
             cli_private_domains: vec!["cli.example.com".to_string()],
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec![
@@ -1891,6 +1927,7 @@ mod tests {
             blocked_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
+            default_allowlist: Vec::new(),
             cli_private_domains: vec!["shared.com".to_string()],
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec!["shared.com".to_string()])),
@@ -1922,6 +1959,7 @@ mod tests {
             allowlist_cache: Mutex::new(DomainCache::new(vec![
                 "should-not-appear.com".to_string(),
             ])),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
@@ -1956,6 +1994,7 @@ mod tests {
             }),
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
@@ -1991,6 +2030,7 @@ mod tests {
             blocked_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
+            default_allowlist: Vec::new(),
             cli_private_domains: vec!["cli.nav.no".to_string()],
             config_file: Some(config_path.clone()),
             private_domains_cache: Mutex::new(DomainCache {
@@ -2061,6 +2101,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2095,6 +2136,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: Some(allowlist_path),
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2126,6 +2168,7 @@ mod tests {
                     .checked_sub(RELOAD_TTL + Duration::from_millis(100))
                     .unwrap(),
             }),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
@@ -2156,6 +2199,86 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // ── Default allowlist (issue #52): effective-allowlist merge logic ──────
+
+    /// Build a ProxyState wired for default-allowlist merge tests: a frozen
+    /// agent `default_allowlist` plus an optional user `allowed_domains` file.
+    fn state_for_allowlist(default_allowlist: Vec<String>, file: Option<PathBuf>) -> ProxyState {
+        let initial = file
+            .as_deref()
+            .and_then(parse_lines_file)
+            .unwrap_or_default();
+        ProxyState {
+            blocked_file: PathBuf::from("/dev/null"),
+            blocked_cache: Mutex::new(DomainCache::new(Vec::new())),
+            allowed_domains_file: file,
+            allowlist_cache: Mutex::new(DomainCache::new(initial)),
+            default_allowlist,
+            cli_private_domains: Vec::new(),
+            config_file: None,
+            private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
+            allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(60),
+            upstream: None,
+            upstream_no_proxy: Vec::new(),
+            resolver: None,
+        }
+    }
+
+    #[test]
+    fn default_allowlist_merges_and_fails_closed() {
+        let defaults: Vec<String> = crate::agent::Agent::Copilot
+            .default_allowed_domains()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let state = state_for_allowlist(defaults, None);
+        let eff = state.get_allowed_domains();
+        // Non-empty => the BLOCKED-ALLOWLIST gate fail-closes on unknown domains.
+        assert!(!eff.is_empty(), "default allowlist must be enforced");
+        for d in ["github.com", "api.github.com", "registry.npmjs.org"] {
+            assert!(is_domain_match(d, &eff), "{d} must be allowed");
+        }
+        // Bare `githubcopilot.com` covers the `*.githubcopilot.com` subdomain.
+        assert!(is_domain_match("api.githubcopilot.com", &eff));
+        // Everything else is blocked.
+        assert!(!is_domain_match("evil.com", &eff));
+    }
+
+    #[test]
+    fn default_allowlist_merges_user_configured_domain() {
+        let dir = test_dir("default-allowlist-merge");
+        let path = dir.join("allowed.txt");
+        std::fs::write(&path, "internal.example.com\n").unwrap();
+
+        let state = state_for_allowlist(vec!["github.com".to_string()], Some(path));
+        let eff = state.get_allowed_domains();
+        assert!(is_domain_match("github.com", &eff), "agent default kept");
+        assert!(
+            is_domain_match("internal.example.com", &eff),
+            "user-configured domain must be merged in"
+        );
+        assert!(!is_domain_match("evil.com", &eff));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn empty_default_allowlist_is_allow_all_no_regression() {
+        // CRITICAL no-regression check: feature off (empty default_allowlist)
+        // and no file => empty effective allowlist => allow-all, exactly as
+        // before this change. `handle_connect` treats empty as "no allowlist".
+        let state = state_for_allowlist(Vec::new(), None);
+        assert!(
+            state.get_allowed_domains().is_empty(),
+            "default off must remain allow-all"
+        );
+    }
+
     /// Skip guard for tests that make real TCP connections.
     /// These tests require localhost TCP access, which is blocked inside the cplt sandbox.
     macro_rules! require_localhost_tcp {
@@ -2165,6 +2288,145 @@ mod tests {
                 return;
             }
         };
+    }
+
+    /// Start a proxy with a default allowlist for end-to-end CONNECT tests.
+    /// Traffic is forwarded to the (fake) `upstream`; a public-IP resolver is
+    /// injected so the SSRF/resolved-IP guard passes deterministically for
+    /// allowed domains without real DNS. Blocked domains never reach either.
+    fn make_proxy_default_allowlist(
+        default_allowlist: Vec<String>,
+        allowed_domains_file: Option<PathBuf>,
+        upstream: UpstreamProxy,
+    ) -> ProxyHandle {
+        let public_ip: std::net::IpAddr = "93.184.216.34".parse().unwrap();
+        let resolver: ResolverFn =
+            Arc::new(move |_h: &str, p: u16| Some(std::net::SocketAddr::new(public_ip, p)));
+        start(ProxyOptions {
+            port: 0,
+            blocked_file: PathBuf::from("/dev/null"),
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+            allowed_domains_file,
+            allowed_domains_initial: Vec::new(),
+            default_allowlist,
+            cli_private_domains: Vec::new(),
+            config_private_domains: Vec::new(),
+            config_file: None,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(5),
+            upstream: Some(upstream),
+            upstream_no_proxy: Vec::new(),
+            resolver: Some(resolver),
+        })
+        .expect("proxy start failed")
+    }
+
+    fn copilot_defaults() -> Vec<String> {
+        crate::agent::Agent::Copilot
+            .default_allowed_domains()
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    /// Assert a CONNECT to an ALLOWED host completes with a 200 tunnel through
+    /// the (already running) fake origin/upstream. A real policy block (`403
+    /// Forbidden`) fails immediately; only transient transport closes (`403 EOF`
+    /// / `403 ECONNRESET` from `proxy_connect`, which contain no "Forbidden")
+    /// are retried, since the fake-server handshake can flake under heavy
+    /// parallel test load. `host` is the CONNECT host (":443" is appended).
+    fn assert_connect_allowed(proxy_port: u16, host: &str) {
+        for _ in 0..8 {
+            let status = proxy_connect(proxy_port, &format!("{host}:443"));
+            assert!(
+                !status.contains("Forbidden"),
+                "{host} must NOT be blocked by policy; got {status}"
+            );
+            if status.contains("200") {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("{host} must complete a 200 tunnel once allowed");
+    }
+
+    #[test]
+    fn proxy_default_allowlist_blocks_unknown_domain() {
+        require_localhost_tcp!();
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        let proxy = make_proxy_default_allowlist(copilot_defaults(), None, upstream);
+
+        let status = proxy_connect(proxy.port, "evil.com:443");
+        proxy.shutdown();
+        std::thread::sleep(Duration::from_millis(50));
+        let contacted = up.contacted.load(std::sync::atomic::Ordering::SeqCst);
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(
+            status.contains("403"),
+            "evil.com must be blocked (BLOCKED-ALLOWLIST) under the default allowlist; got {status}"
+        );
+        assert!(
+            !contacted,
+            "upstream must NOT be contacted for a blocked domain"
+        );
+    }
+
+    #[test]
+    fn proxy_default_allowlist_allows_agent_and_registry_domains() {
+        require_localhost_tcp!();
+        // Copilot infra, its subdomain form, and a package registry all pass
+        // the allowlist gate and get forwarded to the fake upstream (200). One
+        // proxy + one upstream serves every host to keep resource use low.
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        let proxy = make_proxy_default_allowlist(copilot_defaults(), None, upstream);
+        for host in [
+            "github.com",
+            "api.github.com",
+            "api.githubcopilot.com",
+            "registry.npmjs.org",
+        ] {
+            assert_connect_allowed(proxy.port, host);
+        }
+        proxy.shutdown();
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[test]
+    fn proxy_default_allowlist_merges_user_domain_e2e() {
+        require_localhost_tcp!();
+        let dir = test_dir("default-allowlist-e2e-merge");
+        let allowlist = dir.join("allowed.txt");
+        std::fs::write(&allowlist, "extra.example.com\n").unwrap();
+
+        // Small agent base + a user file: the user domain is merged and allowed.
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        let proxy =
+            make_proxy_default_allowlist(vec!["github.com".to_string()], Some(allowlist), upstream);
+        assert_connect_allowed(proxy.port, "extra.example.com");
+        proxy.shutdown();
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn proxy_allow_all_domains_disables_allowlist_e2e() {
+        // `--allow-all-domains` => main.rs passes an empty default_allowlist and
+        // no file. At the proxy that is allow-all: evil.com is permitted again.
+        require_localhost_tcp!();
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        let proxy = make_proxy_default_allowlist(Vec::new(), None, upstream);
+        assert_connect_allowed(proxy.port, "evil.com");
+        proxy.shutdown();
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     /// Helper: make a raw CONNECT request through the proxy and return the status line.
@@ -2205,6 +2467,7 @@ mod tests {
             allow_localhost_any,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2427,6 +2690,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(), // NOT allow-listed
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2485,6 +2749,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains: vec!["corp.internal".to_string()], // allow-listed
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2934,6 +3199,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -3142,6 +3408,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains,
             config_private_domains: Vec::new(),
             config_file: None,
@@ -3572,6 +3839,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
             cli_private_domains,
             config_private_domains: Vec::new(),
             config_file: None,

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -5100,6 +5100,7 @@ enabled = false
 port = 18080
 blocked_domains = "file.txt"
 allowed_domains = "file.txt"
+default_allowlist = false
 log_file = "log.txt"
 
 [allow]
@@ -6772,6 +6773,7 @@ upstream = "http://corp-proxy.example.com:8080"
 upstream_no_proxy = []
 blocked_domains = "file.txt"
 allowed_domains = "file.txt"
+default_allowlist = false
 log_file = "log.txt"
 log_level = "none"
 timeout = 60


### PR DESCRIPTION
Implements #52, the foundational capability of the secure-by-default epic (#71): a built-in **per-agent domain allowlist** so the proxy can be **fail-closed** (deny unknown domains) — the only layer that stops data exfiltration after an agent is compromised (governance MCP-R05).

**Opt-in in this PR — no default behavior change.** Today the proxy is allow-all when no allowlist is set; this adds the machinery + an opt-in switch. Flipping the global default is the separate #71 decision.

- **Per-agent defaults** (`src/agent.rs`): Copilot gets the GitHub Copilot infra + common package registries from #52; other agents get the registry base. Bare domains (existing `is_domain_match` does exact+subdomain).
- **Opt-in switch:** `proxy.default_allowlist` (default **false**) + `--default-allowlist`; `--allow-all-domains` is the escape hatch (off wins).
- **Effective allowlist = agent defaults ∪ user `allowed_domains`** (merged in `ProxyState::get_allowed_domains`, feeding the existing `is_domain_match`/BLOCKED-ALLOWLIST gate — no matching logic duplicated). Off → empty → allow-all, exactly as before.
- Composes with `proxy.forced` (#117) and `proxy.upstream`/`upstream_no_proxy` (#125/#137): the allowlist gates WHICH domains, orthogonal to HOW they route.
- Startup: `Domain policy: N domains allowed (agent defaults + K configured)`; blocked attempts visible via the proxy log.

**No-regression test:** `empty_default_allowlist_is_allow_all_no_regression` + `default_allowlist_off_by_default`. Deferred follow-ups: `cplt init` registry auto-detect; wiring `default_allowlist` into the `strict` preset (tiny, once this + #134 land); `cplt doctor` policy display. clippy clean both targets; lib 597 + unit 249.