### PR TITLE
feat(config): strict preset enables fail-closed domain allowlist — full network lockdown (#52/#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Pick a named preset to set a baseline for the five main sandbox toggles with one
 
 | Flag                       | What it does                                                                                                                       |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `--preset strict`          | Locked down: all five toggles off **and** enables `gh_guard`, `git_guard`, and `proxy.forced` (forced-proxy egress).              |
+| `--preset strict`          | Full network lockdown: all five toggles off **and** enables `gh_guard`, `git_guard`, `proxy.forced` (forced-proxy egress), and `proxy.default_allowlist` (fail-closed domain allowlist). Escape hatch: `--allow-all-domains` disables just the allowlist. |
 | `--preset standard`        | Current defaults (all five off, scratch dir stays on). Equivalent to passing no preset.                                          |
 | `--preset permissive`      | Turns on `allow_localhost_any`, `allow_tmp_exec`, and `allow_lifecycle_scripts`.                                                 |
 | `--preset full-trust`      | ⚠️ **Dangerous.** Turns on all five (adds `allow_env_files` and `allow_docker`).                                                 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,10 +55,11 @@ Use `cplt config explain` to see what a key does and how to set it.
 
 Instead of toggling individual flags, pick a named **preset** — a security
 *posture* that sets a baseline for the five sandbox toggles **and** the safety
-features (`gh_guard`, `git_guard`, forced-proxy egress) with one flag or key:
+features (`gh_guard`, `git_guard`, forced-proxy egress, fail-closed domain
+allowlist) with one flag or key:
 
 ```bash
-cplt --preset strict       # locked down: toggles off + guards + forced proxy on
+cplt --preset strict       # full lockdown: toggles off + guards + forced proxy + domain allowlist on
 cplt --preset standard     # the current defaults (no-op baseline)
 cplt --preset permissive   # localhost + tmp exec + lifecycle scripts on
 cplt --preset full-trust   # everything on (docker, env files, tmp exec, localhost, lifecycle)
@@ -71,25 +72,31 @@ Or in config:
 preset = "standard"
 ```
 
-| Preset | localhost (`allow_localhost_any`) | env files (`allow_env_files`) | tmp exec (`allow_tmp_exec`) | docker (`allow_docker`) | lifecycle (`allow_lifecycle_scripts`) | `gh_guard` | `git_guard` | `proxy.forced` |
-|--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| `strict` | off | off | off | off | off | **on** | **on** | **on** |
-| `standard` | off | off | off¹ | off | off | off | off | off |
-| `permissive` | **on** | off | **on** | off | **on** | off | off | off |
-| `full-trust` | **on** | **on** | **on** | **on** | **on** | off | off | off |
+| Preset | localhost (`allow_localhost_any`) | env files (`allow_env_files`) | tmp exec (`allow_tmp_exec`) | docker (`allow_docker`) | lifecycle (`allow_lifecycle_scripts`) | `gh_guard` | `git_guard` | `proxy.forced` | `proxy.default_allowlist` |
+|--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| `strict` | off | off | off | off | off | **on** | **on** | **on** | **on** |
+| `standard` | off | off | off¹ | off | off | off | off | off | off |
+| `permissive` | **on** | off | **on** | off | **on** | off | off | off | off |
+| `full-trust` | **on** | **on** | **on** | **on** | **on** | off | off | off | off |
 
 ¹ `standard` leaves the per-session scratch directory on (the default), which is
 what most tools need — `allow_tmp_exec` (raw `/tmp` exec) stays off. `standard`
 is identical to cplt's hardcoded defaults, so omitting `--preset` behaves exactly
 like `--preset standard`.
 
-**Only `strict` enables the safety features.** It hardens the two dimensions that
-matter most — `gh_guard` (gate GitHub traffic), `git_guard` (block push/force-push),
-and `proxy.forced` (mandatory proxy, kernel egress locked to it). `standard`,
-`permissive`, and `full-trust` all leave those three at their default (off), so
-selecting them changes nothing about guards or forced egress. `strict` enables
+**Only `strict` enables the safety features — a full network lockdown.** It hardens
+the dimensions that matter most: `gh_guard` (gate GitHub traffic), `git_guard`
+(block push/force-push), `proxy.forced` (mandatory proxy, kernel egress locked to
+it), and `proxy.default_allowlist` (fail-closed domain filtering — only the agent's
+built-in allowlist plus any `allowed_domains` resolve, everything else is blocked).
+Forced egress and the domain allowlist are orthogonal and compose: the kernel pins
+egress to the proxy, and the proxy then filters domains. `standard`, `permissive`,
+and `full-trust` all leave those four at their default (off), so selecting them
+changes nothing about guards, forced egress, or the allowlist. `strict` enables
 only *safety* features, so `config set sandbox.preset strict` needs no `--force`
-(unlike `permissive`/`full-trust`, which weaken the sandbox).
+(unlike `permissive`/`full-trust`, which weaken the sandbox). Opt into strict but
+keep the network open with `--allow-all-domains` (or `proxy.default_allowlist =
+false`), which overrides just the allowlist — explicit off wins over the baseline.
 
 **Precedence — the preset is only a baseline.** An explicit individual flag or
 config value always overrides the preset, whichever source the preset came from:

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -135,13 +135,22 @@ impl Config {
         // Fail-closed networking opt-in (#52). `cli.default_allowlist` is a
         // FeatureToggle where `--default-allowlist` is the ON side and
         // `--allow-all-domains` is the OFF side (off wins), resolved against the
-        // `proxy.default_allowlist` config default (false). `--allow-all-domains`
-        // additionally forces allow-all: main.rs uses `allow_all_domains` to
-        // clear any explicit `allowed_domains` file for the run. This is opt-in
-        // and does not change the default (allow-all) behaviour.
-        let default_allowlist = cli
-            .default_allowlist
-            .resolve(self.proxy.default_allowlist.unwrap_or(false));
+        // explicit `proxy.default_allowlist` config, then the preset baseline
+        // (true only for `strict`, false otherwise). Precedence: CLI flag /
+        // `--allow-all-domains` escape hatch > config > preset > default(off) —
+        // mirrors `proxy_forced`, with the preset threaded in as the lowest
+        // layer. So `--preset strict` fails closed to the domain allowlist,
+        // while an explicit `--allow-all-domains` (OFF wins) or
+        // `proxy.default_allowlist = false` still overrides strict's baseline.
+        // `--allow-all-domains` additionally forces allow-all: main.rs uses
+        // `allow_all_domains` to clear any explicit `allowed_domains` file for
+        // the run. With no preset the baseline is Standard (false), so this
+        // resolves exactly as before — no regression.
+        let default_allowlist = cli.default_allowlist.resolve(
+            self.proxy
+                .default_allowlist
+                .unwrap_or(baseline.default_allowlist),
+        );
         let allow_all_domains = cli.allow_all_domains;
 
         // Proxy log file: CLI > config
@@ -1919,15 +1928,23 @@ validate = false
         assert!(err.to_string().contains("invalid preset"), "got: {err}");
     }
 
-    /// Snapshot of the three safety-feature values a preset can set as a
-    /// baseline: (gh_guard.enabled, git_guard.enabled, proxy_forced).
-    fn posture_snapshot(r: &Resolved) -> (bool, bool, bool) {
-        (r.gh_guard.enabled, r.git_guard.enabled, r.proxy_forced)
+    /// Snapshot of the four safety-feature values a preset can set as a
+    /// baseline: (gh_guard.enabled, git_guard.enabled, proxy_forced,
+    /// default_allowlist).
+    fn posture_snapshot(r: &Resolved) -> (bool, bool, bool, bool) {
+        (
+            r.gh_guard.enabled,
+            r.git_guard.enabled,
+            r.proxy_forced,
+            r.default_allowlist,
+        )
     }
 
     #[test]
     fn preset_strict_enables_guards_and_forced_proxy() {
         // strict is a real posture: five toggles off, but the safety features on.
+        // Full network lockdown: gh_guard + git_guard + proxy_forced +
+        // fail-closed default_allowlist all on together.
         let resolved = Config::default()
             .merge(CliFlags {
                 preset: Some(Preset::Strict),
@@ -1938,7 +1955,62 @@ validate = false
             toggle_snapshot(&resolved),
             (false, false, false, false, false)
         );
-        assert_eq!(posture_snapshot(&resolved), (true, true, true));
+        assert_eq!(posture_snapshot(&resolved), (true, true, true, true));
+        // proxy.forced (kernel egress) and default_allowlist (domain filtering)
+        // are orthogonal and compose — both apply under strict.
+        assert!(resolved.proxy_forced && resolved.default_allowlist);
+    }
+
+    #[test]
+    fn preset_strict_enables_default_allowlist() {
+        // strict's baseline flips the fail-closed domain allowlist ON — the glue
+        // that turns strict into a FULL network lockdown.
+        let resolved = Config::default()
+            .merge(CliFlags {
+                preset: Some(Preset::Strict),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(resolved.default_allowlist);
+    }
+
+    #[test]
+    fn explicit_config_default_allowlist_false_overrides_strict() {
+        // Explicit `proxy.default_allowlist = false` must win over strict's
+        // baseline (explicit config > preset) — opt into strict but disable the
+        // allowlist.
+        let config: Config =
+            toml::from_str("[sandbox]\npreset = \"strict\"\n[proxy]\ndefault_allowlist = false\n")
+                .unwrap();
+        let resolved = config.merge(CliFlags::default()).unwrap();
+        assert!(
+            !resolved.default_allowlist,
+            "explicit config false must override strict baseline"
+        );
+        // The rest of strict's posture is untouched.
+        assert!(resolved.proxy_forced && resolved.gh_guard.enabled && resolved.git_guard.enabled);
+    }
+
+    #[test]
+    fn allow_all_domains_escape_hatch_overrides_strict() {
+        // `--preset strict --allow-all-domains`: the OFF side of the toggle wins
+        // over strict's baseline (explicit off > preset), so the allowlist is
+        // disabled while the rest of strict's lockdown stays on.
+        let resolved = Config::default()
+            .merge(CliFlags {
+                preset: Some(Preset::Strict),
+                default_allowlist: FeatureToggle::from_pair(false, true),
+                allow_all_domains: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(
+            !resolved.default_allowlist,
+            "--allow-all-domains must override strict's baseline allowlist"
+        );
+        assert!(resolved.allow_all_domains);
+        // strict's other safety features are unaffected by the escape hatch.
+        assert!(resolved.proxy_forced && resolved.gh_guard.enabled && resolved.git_guard.enabled);
     }
 
     #[test]
@@ -1949,7 +2021,7 @@ validate = false
                 ..Default::default()
             })
             .unwrap();
-        assert_eq!(posture_snapshot(&resolved), (false, false, false));
+        assert_eq!(posture_snapshot(&resolved), (false, false, false, false));
     }
 
     #[test]
@@ -1960,7 +2032,7 @@ validate = false
                 ..Default::default()
             })
             .unwrap();
-        assert_eq!(posture_snapshot(&resolved), (false, false, false));
+        assert_eq!(posture_snapshot(&resolved), (false, false, false, false));
     }
 
     #[test]
@@ -1972,14 +2044,15 @@ validate = false
                 ..Default::default()
             })
             .unwrap();
-        assert_eq!(posture_snapshot(&resolved), (false, false, false));
+        assert_eq!(posture_snapshot(&resolved), (false, false, false, false));
     }
 
     #[test]
     fn no_preset_equals_standard_posture_defaults() {
         // The critical no-regression test: no preset must resolve EXACTLY like
         // `standard` (and today's hardcoded defaults) across every posture
-        // field — guards off, forced proxy off — not just the five toggles.
+        // field — guards off, forced proxy off, default allowlist off — not
+        // just the five toggles.
         let none = Config::default().merge(CliFlags::default()).unwrap();
         let standard = Config::default()
             .merge(CliFlags {
@@ -1987,9 +2060,11 @@ validate = false
                 ..Default::default()
             })
             .unwrap();
-        assert_eq!(posture_snapshot(&none), (false, false, false));
+        assert_eq!(posture_snapshot(&none), (false, false, false, false));
         assert_eq!(posture_snapshot(&none), posture_snapshot(&standard));
         assert_eq!(toggle_snapshot(&none), toggle_snapshot(&standard));
+        // No preset must NOT enable the fail-closed allowlist — today's behavior.
+        assert!(!none.default_allowlist);
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -181,7 +181,8 @@ pub enum Preset {
 }
 
 /// The baseline a [`Preset`] establishes: the five sandbox toggles plus the
-/// three safety features (gh_guard, git_guard, forced proxy). The toggles
+/// four safety features (gh_guard, git_guard, forced proxy, default allowlist).
+/// The toggles
 /// *weaken* the sandbox (dangerous when on); the safety features *harden* it
 /// (never dangerous). Only [`enabled_dangerous_names`](Self::enabled_dangerous_names)
 /// — keyed on the five toggles — gates the `--force`/validate safeguards.
@@ -198,6 +199,11 @@ pub struct PresetBaseline {
     pub git_guard_enabled: bool,
     /// Safety feature: mandatory proxy, kernel egress locked to the proxy port.
     pub proxy_forced: bool,
+    /// Safety feature: fail-closed domain allowlist (#52). Restricts egress to
+    /// the agent's built-in default allowlist merged with any `allowed_domains`;
+    /// every other domain is blocked. Combined with `proxy_forced` this makes
+    /// `strict` a full network lockdown (forced egress + domain filtering).
+    pub default_allowlist: bool,
 }
 
 impl PresetBaseline {
@@ -255,12 +261,13 @@ impl Preset {
         self.baseline().enabled_dangerous_names()
     }
 
-    /// Map the preset to its baseline values (five sandbox toggles + three
+    /// Map the preset to its baseline values (five sandbox toggles + four
     /// safety features).
     ///
     /// `Strict` and `Standard` share the same five *toggle* values (all off),
     /// but differ on the safety features: only `Strict` turns on gh_guard,
-    /// git_guard, and forced-proxy egress — a genuine locked-down posture.
+    /// git_guard, forced-proxy egress, and the fail-closed default allowlist —
+    /// a genuine locked-down posture (full network lockdown).
     /// `Standard` is the no-op baseline (everything off), identical to cplt's
     /// hardcoded defaults. The scratch dir is not a preset-controlled toggle
     /// and stays at its default (on) for every preset.
@@ -275,6 +282,7 @@ impl Preset {
                 gh_guard_enabled: true,
                 git_guard_enabled: true,
                 proxy_forced: true,
+                default_allowlist: true,
             },
             Self::Standard => PresetBaseline {
                 allow_localhost_any: false,
@@ -285,6 +293,7 @@ impl Preset {
                 gh_guard_enabled: false,
                 git_guard_enabled: false,
                 proxy_forced: false,
+                default_allowlist: false,
             },
             Self::Permissive => PresetBaseline {
                 allow_localhost_any: true,
@@ -295,6 +304,7 @@ impl Preset {
                 gh_guard_enabled: false,
                 git_guard_enabled: false,
                 proxy_forced: false,
+                default_allowlist: false,
             },
             Self::FullTrust => PresetBaseline {
                 allow_localhost_any: true,
@@ -305,6 +315,7 @@ impl Preset {
                 gh_guard_enabled: false,
                 git_guard_enabled: false,
                 proxy_forced: false,
+                default_allowlist: false,
             },
         }
     }


### PR DESCRIPTION
The glue step of the secure-by-default epic: wires the #52/#139 fail-closed domain allowlist into the `strict` preset (#134). Now **`--preset strict` = full network lockdown**: dangerous toggles off + gh/git guards on + `proxy.forced` (kernel-forced egress) + `proxy.default_allowlist` (per-agent fail-closed domain filtering).

- `PresetBaseline` gains `default_allowlist`; strict=true, standard/permissive/full-trust=false.
- Threaded into `merge()` with the same precedence as `proxy_forced`: CLI/`--allow-all-domains` (off-wins) > explicit config > preset baseline > default false.
- **No regression:** no preset → baseline false → resolves exactly as today (`no_preset_equals_standard_posture_defaults`).
- `strict` stays out of the `--force` gate (safety feature, not dangerous).
- Escape hatch: `--preset strict --allow-all-domains` disables the allowlist (explicit off wins) — test `allow_all_domains_escape_hatch_overrides_strict`.
- forced egress (kernel) + allowlist (proxy) are orthogonal and compose.

This makes presets the spine of the epic: the eventual #71/#122 rollout reduces to "default preset → strict." clippy clean both targets; lib 626 + unit 249.