### PR TITLE
feat(proxy): --observe-domains — empirically capture an agent's contacted domains (#52)

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -174,6 +174,44 @@ cplt config set proxy.default_allowlist true         # permanently
 - **Escape hatch.** `--allow-all-domains` disables the allowlist for a single run (and ignores any `--allowed-domains` file) — allow-all again, for debugging. It overrides both `--default-allowlist` and `proxy.default_allowlist`.
 - **Composes with the other proxy features.** The domain allowlist is enforced by the proxy regardless of `proxy.forced` (kernel egress restriction) or `proxy.upstream` (corporate-proxy forwarding): a no-proxy/upstream target still passes through the same allowlist check — the allowlist governs **which** domains, orthogonal to **how** they are routed.
 
+### Verifying / generating an agent's domain allowlist
+
+The per-agent default allowlists (see above) should be **empirically observed**, not guessed. `--observe-domains` runs the session with the proxy in **allow-all mode** and records every domain the agent contacts, then prints the set as a ready-to-paste allowlist. This is how you make a default allowlist *verifiable and exhaustive*.
+
+```bash
+# Capture what the agent contacts while doing a representative task.
+cplt --agent copilot --observe-domains -- -p "add tests for the parser and run them"
+```
+
+`--observe-domains`:
+
+- **Forces the proxy on and in allow-all mode for this run.** It overrides `--preset strict`, `--default-allowlist`, `proxy.default_allowlist`, and any configured `allowed_domains` — nothing is blocked, so you observe the *full* set the agent would contact. cplt prints a one-line notice and a warning that **this run does not enforce domain filtering** (do not treat an observe run as a protected session).
+- **Records every CONNECT** regardless of `--proxy-log` / `--proxy-log-level`, then emits the sorted, deduplicated host list to stderr (always, even under `--quiet`):
+
+```
+[cplt] observe-domains: 14 domains contacted by Copilot this session
+# add to allowed_domains (or src/agent.rs default_allowed_domains):
+# bare hosts, exact-or-subdomain match; collapse subdomains to a parent by hand
+# e.g. api.githubcopilot.com + proxy.githubcopilot.com -> githubcopilot.com
+api.github.com
+api.githubcopilot.com
+github.com
+registry.npmjs.org
+...
+```
+
+- **`--observe-domains-out <FILE>`** also writes the bare domain list (one per line) to `FILE` for scripting.
+- **Works for `cplt exec` too:** `cplt --agent claude --observe-domains exec -- npm test`.
+
+To make it representative, exercise the workflows you care about in one session: resume a chat, build, run tests, install a dependency, etc. The emitted hosts are the *raw* observed set; subdomains are **not** auto-collapsed (that needs a public-suffix heuristic that risks over-broadening). Because the allowlist matcher is **exact-or-subdomain**, you can fold related subdomains to a parent by hand — e.g. `api.githubcopilot.com` + `proxy.githubcopilot.com` → `githubcopilot.com`.
+
+**Updating the allowlist.** Paste the observed hosts into either:
+
+- your own `allowed_domains` file / `proxy.allowed_domains` config (per-project), or
+- an agent's built-in defaults in [`src/agent.rs`](../src/agent.rs) (`default_allowed_domains` and the `*_DOMAINS` consts) for a change shipped to everyone.
+
+When editing `src/agent.rs`, record **provenance** in a comment on the const — which agent + version and the date you captured the domains — so reviewers can tell whether the list is current (see the convention note above those consts). Do not fabricate provenance for lists you did not actually observe.
+
 ## Proxy operations
 
 ### Connection log

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,6 +8,23 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+// ── Per-agent default allowlists ─────────────────────────────────────────────
+//
+// These lists are the fail-closed egress allowlist each agent gets under
+// `--default-allowlist` / `proxy.default_allowlist`. They should be captured
+// EMPIRICALLY, not guessed: run the agent under discovery mode and paste the
+// observed set. See the "Verifying / generating an agent's domain allowlist"
+// section in docs/proxy.md for the workflow:
+//
+//     cplt --agent <X> --observe-domains -- <do a representative task>
+//
+// Convention: when you add or refresh an agent's list, record its PROVENANCE in
+// a comment on the const — which agent + version and the date the domains were
+// observed — so a reviewer can tell whether the list is current, e.g.:
+//     // Observed with copilot 0.24.1 on 2026-01-15 via `--observe-domains`.
+// The existing lists below predate this convention and carry NO verified
+// provenance yet; do not fabricate one — capture it the next time each is run.
+
 /// Package registries that virtually every coding agent needs to fetch
 /// dependencies (npm, Yarn, Maven, Gradle, crates.io, PyPI). This is the
 /// shared base for every agent's built-in allowlist so that, when fail-closed

--- a/src/main.rs
+++ b/src/main.rs
@@ -1515,10 +1515,25 @@ fn emit_observed_domains(
     }
 
     if let Some(path) = out_file {
-        let body: String = observed.iter().map(|o| format!("{}\n", o.host)).collect();
+        // The out-file is meant to be a ready-to-use allowlist, so it must
+        // contain ONLY hosts that were actually PERMITTED. In observe mode
+        // domain filtering is off, but port policy / blocklist / private-IP
+        // guards still enforce — a host refused by those is recorded Blocked.
+        // Skip Blocked entries here so a user scripting off --observe-domains-out
+        // never pastes a policy-blocked host into their allowlist. (The stderr
+        // output above still lists Blocked hosts annotated '# BLOCKED this run'.)
+        // If every entry was Blocked the out-file is written empty, which is a
+        // valid allowlist.
+        let allowed: Vec<&str> = observed
+            .iter()
+            .filter(|o| o.verdict == proxy::DomainVerdict::Allowed)
+            .map(|o| o.host.as_str())
+            .collect();
+        let written = allowed.len();
+        let body: String = allowed.iter().map(|h| format!("{h}\n")).collect();
         match std::fs::write(path, body) {
             Ok(()) => eprintln!(
-                "[cplt] observe-domains: wrote {count} domains to {}",
+                "[cplt] observe-domains: wrote {written} domains to {}",
                 path.display()
             ),
             Err(e) => ui::warn(&format!(
@@ -1526,6 +1541,45 @@ fn emit_observed_domains(
                 path.display()
             )),
         }
+    }
+}
+
+/// The domain-allowlist resolution decision for a run.
+///
+/// Extracted as a pure function so the security-critical no-leak invariant can
+/// be unit-tested in isolation: the observe-mode allow-all override is
+/// **flag-gated** — it can only null the allowlist when `--observe-domains` is
+/// set — and it touches **only** the domain allowlist, never port/SSRF policy
+/// (which are resolved elsewhere and not visible here). A run with no override
+/// keeps its configured / default allowlist and enforcement is preserved.
+struct DomainAllowlistDecision {
+    /// Whether the explicit `allowed_domains` file is consulted this run.
+    /// `false` = allow-all (the file is dropped, no domain enforcement from it).
+    use_allowed_file: bool,
+    /// Whether the agent's built-in default allowlist contributes this run.
+    use_default_allowlist: bool,
+    /// Whether the proxy must be forced on (observe mode needs a choke point to
+    /// record CONNECTs even if the user disabled the proxy).
+    force_proxy_on: bool,
+}
+
+/// Compute the domain-allowlist decision from the two allow-all escape hatches
+/// and whether the agent default allowlist is enabled.
+///
+/// `--observe-domains` forces allow-all exactly like `--allow-all-domains`
+/// (drops both the configured file and the agent defaults so the FULL contacted
+/// set is observed) and additionally forces the proxy on. Both overrides are
+/// flag-gated: with neither flag set the configured / default allowlist stands.
+fn resolve_domain_allowlist_decision(
+    observe_domains: bool,
+    allow_all_domains: bool,
+    default_allowlist_enabled: bool,
+) -> DomainAllowlistDecision {
+    let observe_allow_all = observe_domains;
+    DomainAllowlistDecision {
+        use_allowed_file: !(allow_all_domains || observe_allow_all),
+        use_default_allowlist: default_allowlist_enabled && !observe_allow_all,
+        force_proxy_on: observe_domains,
     }
 }
 
@@ -1554,12 +1608,23 @@ fn start_proxy_if_enabled(
         resolved.with_proxy = true;
     }
 
+    // Domain-allowlist resolution (security-critical, see
+    // resolve_domain_allowlist_decision): the observe-mode allow-all override is
+    // flag-gated and touches only the domain allowlist. Computed once here and
+    // consumed both to force the proxy on (discovery choke point) and to null
+    // the effective allowlist below.
+    let allowlist_decision = resolve_domain_allowlist_decision(
+        cli.observe_domains,
+        resolved.allow_all_domains,
+        resolved.default_allowlist,
+    );
+
     // Discovery mode (--observe-domains): force the proxy ON so there is a choke
     // point to record CONNECTs, even if the user disabled it. The allow-all
     // override (empty effective allowlist) is applied below where the allowlist
     // is computed. Print the mandatory warning that this run does NOT enforce
     // domain filtering.
-    if cli.observe_domains {
+    if allowlist_decision.force_proxy_on {
         resolved.with_proxy = true;
         ui::warn("observe-domains: proxy in allow-all mode; all traffic permitted and recorded");
         ui::warn(
@@ -1600,18 +1665,17 @@ fn start_proxy_if_enabled(
     // allowlist file and (below) no agent default allowlist, so nothing is
     // blocked and the FULL contacted set is observed. This must override any
     // configured allowlist, not combine with it (fail-closed would hide domains).
-    let observe_allow_all = cli.observe_domains;
-    let allowed_domains_file = if resolved.allow_all_domains || observe_allow_all {
-        None
-    } else {
+    let allowed_domains_file = if allowlist_decision.use_allowed_file {
         resolved.allowed_domains.clone()
+    } else {
+        None
     };
 
     // Fail-closed networking (#52): when proxy.default_allowlist is on, the
     // effective allowlist is the running agent's built-in defaults, which the
     // proxy MERGES with the user's allowed_domains file. Empty vec = feature
     // off, so the proxy keeps today's allow-all behaviour unchanged.
-    let default_allowlist: Vec<String> = if resolved.default_allowlist && !observe_allow_all {
+    let default_allowlist: Vec<String> = if allowlist_decision.use_default_allowlist {
         active_agent
             .default_allowed_domains()
             .iter()
@@ -4850,7 +4914,9 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let out = dir.join("domains.txt");
         // The list is already sorted+unique (as ProxyHandle::observed_domains
-        // guarantees); the out-file must be the bare hosts, one per line.
+        // guarantees). The out-file is a ready-to-use allowlist, so it must
+        // contain ONLY the Allowed (permitted) hosts, bare, one per line — the
+        // Blocked host must be excluded so it is never pasted into an allowlist.
         let observed = vec![
             ObservedDomain {
                 host: "a.example".into(),
@@ -4862,11 +4928,99 @@ mod tests {
                 verdict: DomainVerdict::Blocked,
                 count: 1,
             },
+            ObservedDomain {
+                host: "c.example".into(),
+                verdict: DomainVerdict::Allowed,
+                count: 1,
+            },
         ];
         emit_observed_domains("Copilot", &observed, Some(&out));
         let body = std::fs::read_to_string(&out).unwrap();
-        assert_eq!(body, "a.example\nb.example\n");
+        // Allowed hosts are present, in order; the Blocked host is absent.
+        assert_eq!(body, "a.example\nc.example\n");
+        assert!(
+            !body.contains("b.example"),
+            "Blocked host must not appear in the out-file allowlist"
+        );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// No-leak invariant: the observe-mode allow-all override is flag-gated and
+    /// cannot weaken a normal run's domain enforcement, while an observe run
+    /// nulls the effective allowlist and forces the proxy on. Exercised at the
+    /// allowlist-resolution seam (`resolve_domain_allowlist_decision`), the
+    /// single source of truth `start_proxy_if_enabled` consumes.
+    #[test]
+    fn observe_domains_override_is_flag_gated_and_scoped_to_the_allowlist() {
+        // Sample enforcement sources. A non-empty effective allowlist means
+        // fail-closed enforcement is active; an empty one means allow-all.
+        let configured = ["configured.example".to_string()];
+        let agent_defaults = ["default.example"];
+        let effective = |d: &DomainAllowlistDecision| -> Vec<String> {
+            let mut v: Vec<String> = Vec::new();
+            if d.use_default_allowlist {
+                v.extend(agent_defaults.iter().map(|s| (*s).to_string()));
+            }
+            if d.use_allowed_file {
+                v.extend(configured.iter().cloned());
+            }
+            v.sort_unstable();
+            v.dedup();
+            v
+        };
+
+        // WITHOUT --observe-domains, default allowlist on (≈ --preset strict):
+        // enforcement preserved — effective allowlist NON-empty, proxy not forced
+        // on by observe logic, both allowlist sources honored.
+        let normal = resolve_domain_allowlist_decision(false, false, true);
+        assert!(
+            normal.use_allowed_file,
+            "normal run must honor the configured allowlist"
+        );
+        assert!(
+            normal.use_default_allowlist,
+            "normal run must keep the default allowlist"
+        );
+        assert!(
+            !normal.force_proxy_on,
+            "observe must not force the proxy on a normal run"
+        );
+        assert!(
+            !effective(&normal).is_empty(),
+            "normal run must have a NON-empty effective allowlist (enforcement preserved)"
+        );
+
+        // WITHOUT --observe-domains, only a configured allowlist file (default
+        // off): still enforced (non-empty).
+        let normal_file_only = resolve_domain_allowlist_decision(false, false, false);
+        assert!(normal_file_only.use_allowed_file);
+        assert!(!normal_file_only.force_proxy_on);
+        assert!(!effective(&normal_file_only).is_empty());
+
+        // WITH --observe-domains: the domain allowlist is nulled (allow-all) AND
+        // the proxy is forced on, regardless of a configured file or default
+        // allowlist being present.
+        let observe = resolve_domain_allowlist_decision(true, false, true);
+        assert!(
+            !observe.use_allowed_file,
+            "observe must drop the configured allowlist file"
+        );
+        assert!(
+            !observe.use_default_allowlist,
+            "observe must drop the agent default allowlist"
+        );
+        assert!(observe.force_proxy_on, "observe must force the proxy on");
+        assert!(
+            effective(&observe).is_empty(),
+            "observe must NULL the effective allowlist (allow-all)"
+        );
+
+        // The override is scoped to the domain allowlist by construction: the
+        // decision exposes only allowlist fields, so it cannot touch port/SSRF
+        // policy. And it is strictly flag-gated — the only difference between the
+        // enforced `normal` case and the allow-all `observe` case above is the
+        // observe flag; the allow_all_domains and default_allowlist inputs are
+        // identical, proving observe alone flips enforcement.
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,20 @@ struct Cli {
     #[arg(long)]
     allow_all_domains: bool,
 
+    /// Discovery mode: run with the proxy in ALLOW-ALL mode (nothing is blocked)
+    /// and record every domain the agent contacts, then print the observed set
+    /// as a ready-to-paste allowlist. Use it to empirically build/verify an
+    /// agent's default allowlist. This run does NOT enforce domain filtering —
+    /// it overrides --preset strict / --default-allowlist / any configured
+    /// allowlist for the session. See docs/proxy.md.
+    #[arg(long)]
+    observe_domains: bool,
+
+    /// With --observe-domains, also write the bare observed domain list (one per
+    /// line) to this file, in addition to printing it to stderr.
+    #[arg(long, value_name = "FILE")]
+    observe_domains_out: Option<PathBuf>,
+
     /// Write proxy connection log to a file (one line per CONNECT).
     /// Useful for post-session audit. File is created if it doesn't exist.
     #[arg(long, value_name = "FILE")]
@@ -1467,6 +1481,54 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
 
 /// Start the CONNECT proxy if enabled, returning the handle for RAII ownership.
 /// Updates `resolved.proxy_port` with the actual bound port.
+/// Print the observed domain set (from `--observe-domains`) to stderr as a
+/// ready-to-paste allowlist, and optionally write the bare list to `out_file`.
+///
+/// Always prints regardless of `--quiet`: observe-domains is an explicit
+/// diagnostic whose result is the entire purpose of the run. Subdomains are NOT
+/// auto-collapsed — folding e.g. `api.githubcopilot.com` +
+/// `proxy.githubcopilot.com` to `githubcopilot.com` needs a registrable-domain
+/// (public-suffix) heuristic that would risk over-broadening the allowlist, so
+/// the raw observed hosts are emitted and the note points out that the matcher
+/// is exact-or-subdomain and a parent can be substituted by hand.
+fn emit_observed_domains(
+    agent_label: &str,
+    observed: &[proxy::ObservedDomain],
+    out_file: Option<&Path>,
+) {
+    let count = observed.len();
+    eprintln!(
+        "[cplt] observe-domains: {count} domain{} contacted by {agent_label} this session",
+        if count == 1 { "" } else { "s" }
+    );
+    eprintln!("# add to allowed_domains (or src/agent.rs default_allowed_domains):");
+    eprintln!("# bare hosts, exact-or-subdomain match; collapse subdomains to a parent by hand");
+    eprintln!("# e.g. api.githubcopilot.com + proxy.githubcopilot.com -> githubcopilot.com");
+    for o in observed {
+        // In pure observe (allow-all) mode every entry is Allowed and prints
+        // bare. A Blocked entry can only appear if an allowlist was somehow
+        // active; flag it so it is not pasted blindly.
+        match o.verdict {
+            proxy::DomainVerdict::Allowed => eprintln!("{}", o.host),
+            proxy::DomainVerdict::Blocked => eprintln!("{}  # BLOCKED this run", o.host),
+        }
+    }
+
+    if let Some(path) = out_file {
+        let body: String = observed.iter().map(|o| format!("{}\n", o.host)).collect();
+        match std::fs::write(path, body) {
+            Ok(()) => eprintln!(
+                "[cplt] observe-domains: wrote {count} domains to {}",
+                path.display()
+            ),
+            Err(e) => ui::warn(&format!(
+                "observe-domains: cannot write {}: {e}",
+                path.display()
+            )),
+        }
+    }
+}
+
 fn start_proxy_if_enabled(
     resolved: &mut config::Resolved,
     cli: &Cli,
@@ -1490,6 +1552,20 @@ fn start_proxy_if_enabled(
             );
         }
         resolved.with_proxy = true;
+    }
+
+    // Discovery mode (--observe-domains): force the proxy ON so there is a choke
+    // point to record CONNECTs, even if the user disabled it. The allow-all
+    // override (empty effective allowlist) is applied below where the allowlist
+    // is computed. Print the mandatory warning that this run does NOT enforce
+    // domain filtering.
+    if cli.observe_domains {
+        resolved.with_proxy = true;
+        ui::warn("observe-domains: proxy in allow-all mode; all traffic permitted and recorded");
+        ui::warn(
+            "observe-domains: this run does NOT enforce domain filtering \
+             (overrides --preset strict / --default-allowlist / configured allowlist)",
+        );
     }
 
     if !resolved.with_proxy || cli.print_profile {
@@ -1520,7 +1596,12 @@ fn start_proxy_if_enabled(
     // disabling BOTH the agent default allowlist and any explicit
     // allowed_domains file. `resolved.default_allowlist` was already forced off
     // in the config merge when --allow-all-domains is set.
-    let allowed_domains_file = if resolved.allow_all_domains {
+    // --observe-domains forces allow-all exactly like --allow-all-domains: no
+    // allowlist file and (below) no agent default allowlist, so nothing is
+    // blocked and the FULL contacted set is observed. This must override any
+    // configured allowlist, not combine with it (fail-closed would hide domains).
+    let observe_allow_all = cli.observe_domains;
+    let allowed_domains_file = if resolved.allow_all_domains || observe_allow_all {
         None
     } else {
         resolved.allowed_domains.clone()
@@ -1530,7 +1611,7 @@ fn start_proxy_if_enabled(
     // effective allowlist is the running agent's built-in defaults, which the
     // proxy MERGES with the user's allowed_domains file. Empty vec = feature
     // off, so the proxy keeps today's allow-all behaviour unchanged.
-    let default_allowlist: Vec<String> = if resolved.default_allowlist {
+    let default_allowlist: Vec<String> = if resolved.default_allowlist && !observe_allow_all {
         active_agent
             .default_allowed_domains()
             .iter()
@@ -2030,6 +2111,15 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
 
     // Cleanup
     if let Some(handle) = proxy_handle {
+        // --observe-domains: read the collected set BEFORE shutdown and emit the
+        // ready-to-paste allowlist (always, even under --quiet).
+        if cli.observe_domains {
+            emit_observed_domains(
+                active_agent.display_name(),
+                &handle.observed_domains(),
+                cli.observe_domains_out.as_deref(),
+            );
+        }
         handle.shutdown();
     }
     if let Some(mut child) = denial_proc {
@@ -2492,6 +2582,15 @@ fn run_exec_command(
     });
 
     if let Some(handle) = proxy_handle {
+        // --observe-domains also works for `cplt exec -- <cmd>`: emit the
+        // observed set before shutdown (always, even under exec's default quiet).
+        if cli.observe_domains {
+            emit_observed_domains(
+                active_agent.display_name(),
+                &handle.observed_domains(),
+                cli.observe_domains_out.as_deref(),
+            );
+        }
         handle.shutdown();
     }
 
@@ -4732,6 +4831,42 @@ mod tests {
 
     fn parse(args: &[&str]) -> Cli {
         Cli::parse_from(std::iter::once("cplt").chain(args.iter().copied()))
+    }
+
+    #[test]
+    fn observe_domains_flags_parse() {
+        let cli = parse(&["--observe-domains", "--observe-domains-out", "/tmp/obs.txt"]);
+        assert!(cli.observe_domains);
+        assert_eq!(
+            cli.observe_domains_out.as_deref(),
+            Some(Path::new("/tmp/obs.txt"))
+        );
+    }
+
+    #[test]
+    fn emit_observed_domains_writes_sorted_unique_out_file() {
+        use crate::proxy::{DomainVerdict, ObservedDomain};
+        let dir = std::env::temp_dir().join(format!("cplt-observe-emit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let out = dir.join("domains.txt");
+        // The list is already sorted+unique (as ProxyHandle::observed_domains
+        // guarantees); the out-file must be the bare hosts, one per line.
+        let observed = vec![
+            ObservedDomain {
+                host: "a.example".into(),
+                verdict: DomainVerdict::Allowed,
+                count: 2,
+            },
+            ObservedDomain {
+                host: "b.example".into(),
+                verdict: DomainVerdict::Blocked,
+                count: 1,
+            },
+        ];
+        emit_observed_domains("Copilot", &observed, Some(&out));
+        let body = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(body, "a.example\nb.example\n");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3,6 +3,7 @@
 //! Intercepts outbound HTTPS connections from the sandboxed agent,
 //! enforcing blocked/allowed domain lists and private IP restrictions.
 
+use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
@@ -335,6 +336,60 @@ pub fn redact_upstream_url(url: &str) -> String {
     }
 }
 
+/// Verdict recorded for an observed CONNECT target: whether cplt's policy
+/// permitted the connection (`Allowed`) or refused it (`Blocked`). A DNS or
+/// transport failure on an otherwise-permitted target still counts as
+/// `Allowed` — the point of observation is what the agent was *allowed to
+/// attempt*, not whether the far end happened to answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DomainVerdict {
+    /// Policy permitted the CONNECT (CONNECTED, or an allowed attempt that then
+    /// failed DNS/transport).
+    Allowed,
+    /// Policy refused the CONNECT (any `BLOCKED*` status).
+    Blocked,
+}
+
+impl DomainVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allowed => "allowed",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
+/// One host the proxy observed a CONNECT for, with its verdict and how many
+/// CONNECTs targeted it. Returned (sorted by host) from
+/// [`ProxyHandle::observed_domains`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObservedDomain {
+    /// Normalized host (lowercase, trailing dot stripped).
+    pub host: String,
+    /// Whether the connection was allowed or blocked by policy.
+    pub verdict: DomainVerdict,
+    /// Number of CONNECTs seen for this host this session.
+    pub count: u64,
+}
+
+/// Internal per-host accumulator behind the collector's `BTreeMap`.
+struct DomainObservation {
+    verdict: DomainVerdict,
+    count: u64,
+}
+
+/// Thread-safe map of normalized host → observation, keyed for stable sorted
+/// output. Held behind an `Arc` so the connection threads and the
+/// [`ProxyHandle`] share one collector and results can be read after the
+/// session ends.
+///
+/// This is the generic capture substrate for BOTH `--observe-domains` and audit
+/// Phase 2 network reporting — it records EVERY CONNECT verdict regardless of
+/// the stderr log level or whether a `--proxy-log` file is configured. A lock
+/// per connection is intentionally acceptable: at cplt's scale (`MAX_CONNECTIONS`
+/// = 64) the CONNECT path is not hot.
+type DomainCollector = Mutex<BTreeMap<String, DomainObservation>>;
+
 /// Shared proxy state holding cached domain lists and config paths.
 /// Wrapped in `Arc` and shared across connection threads.
 pub struct ProxyState {
@@ -385,12 +440,44 @@ pub struct ProxyState {
     // (exact + subdomain), like the other domain lists.
     upstream_no_proxy: Vec<String>,
 
+    // Observed-domains collector: records every CONNECT target host and whether
+    // policy allowed or blocked it. Shared (Arc) with the ProxyHandle so the set
+    // can be read after the session. Always present (cheap at cplt's scale);
+    // `--observe-domains` merely reads it and forces allow-all so the full set
+    // is captured. Foundation for audit Phase 2 network reporting.
+    domain_collector: Arc<DomainCollector>,
+
     // Test-only: injectable DNS resolver to simulate fake DNS responses.
     #[cfg(test)]
     resolver: Option<ResolverFn>,
 }
 
 impl ProxyState {
+    /// Record a CONNECT verdict for `host` in the observation collector.
+    ///
+    /// The host is normalized (lowercase, trailing dot stripped) before keying
+    /// so `API.Example.com`, `api.example.com`, and `api.example.com.` collapse
+    /// to a single entry. `Blocked` is sticky: once a host is seen blocked it
+    /// stays blocked even if a later attempt is allowed, so the observed list
+    /// always surfaces anything policy refused.
+    fn record_observation(&self, host: &str, verdict: DomainVerdict) {
+        let key = normalize_hostname(host);
+        if key.is_empty() {
+            return;
+        }
+        let mut map = self
+            .domain_collector
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = map
+            .entry(key)
+            .or_insert(DomainObservation { verdict, count: 0 });
+        entry.count = entry.count.saturating_add(1);
+        if verdict == DomainVerdict::Blocked {
+            entry.verdict = DomainVerdict::Blocked;
+        }
+    }
+
     /// Get the current blocklist, re-reading from disk if TTL expired.
     /// On read failure, keeps last-good list and resets TTL for retry.
     fn get_blocked_domains(&self) -> Vec<String> {
@@ -568,6 +655,10 @@ pub struct ProxyHandle {
     /// Actual port the proxy is listening on. With a configured port of 0,
     /// the OS assigns an ephemeral port; this field reflects the real value.
     pub port: u16,
+    /// Shared observation collector (see [`ProxyState::domain_collector`]).
+    /// Cloned from the state so the observed set can be read after the session
+    /// via [`ProxyHandle::observed_domains`].
+    domain_collector: Arc<DomainCollector>,
 }
 
 impl ProxyHandle {
@@ -576,6 +667,25 @@ impl ProxyHandle {
             .store(true, std::sync::atomic::Ordering::SeqCst);
         // Accept loop is non-blocking with 50ms sleep, so it will notice
         // the flag within ~50ms without needing a wake-up connection.
+    }
+
+    /// Snapshot every host the proxy saw a CONNECT for this session, sorted by
+    /// host, each with its verdict (`Allowed`/`Blocked`) and CONNECT count.
+    ///
+    /// Backs `--observe-domains` (and, later, audit Phase 2 network reporting).
+    /// The `BTreeMap` yields hosts already sorted and deduplicated.
+    pub fn observed_domains(&self) -> Vec<ObservedDomain> {
+        let map = self
+            .domain_collector
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.iter()
+            .map(|(host, obs)| ObservedDomain {
+                host: host.clone(),
+                verdict: obs.verdict,
+                count: obs.count,
+            })
+            .collect()
     }
 }
 
@@ -678,6 +788,10 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
             .map_err(|e| format!("Cannot open proxy log file {}: {e}", log_path.display()))?;
     }
 
+    // Observation collector, shared between the connection threads (via state)
+    // and the returned handle so observed domains can be read after shutdown.
+    let domain_collector: Arc<DomainCollector> = Arc::new(Mutex::new(BTreeMap::new()));
+
     // Build shared state with initial caches
     let state = Arc::new(ProxyState {
         blocked_file: opts.blocked_file,
@@ -696,6 +810,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         timeout: opts.timeout,
         upstream: opts.upstream,
         upstream_no_proxy: opts.upstream_no_proxy,
+        domain_collector: domain_collector.clone(),
         #[cfg(test)]
         resolver: opts.resolver,
     });
@@ -720,6 +835,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
     Ok(ProxyHandle {
         shutdown_flag,
         port: actual_port,
+        domain_collector,
     })
 }
 
@@ -754,13 +870,7 @@ fn accept_loop(
         // Connection limit
         let count = active_count.load(std::sync::atomic::Ordering::SeqCst);
         if count >= MAX_CONNECTIONS {
-            log_connection(
-                "REJECT",
-                "connection limit",
-                "LIMIT",
-                state.log_file.as_deref(),
-                state.log_level,
-            );
+            log_connection(&state, "REJECT", "connection limit", "LIMIT");
             drop(stream);
             continue;
         }
@@ -777,13 +887,7 @@ fn accept_loop(
             })
         {
             active_count.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
-            log_connection(
-                "INTERNAL",
-                "thread-spawn",
-                &format!("FAIL:{e}"),
-                state.log_file.as_deref(),
-                state.log_level,
-            );
+            log_connection(&state, "INTERNAL", "thread-spawn", &format!("FAIL:{e}"));
         }
     }
 }
@@ -817,13 +921,7 @@ fn handle_connection(mut client: TcpStream, state: &ProxyState) {
     } else {
         // For non-CONNECT, send a simple error — the sandbox should force
         // CONNECT via proxy env vars for HTTPS traffic
-        log_connection(
-            method,
-            target,
-            "UNSUPPORTED",
-            state.log_file.as_deref(),
-            state.log_level,
-        );
+        log_connection(state, method, target, "UNSUPPORTED");
         let _ = client.write_all(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n");
     }
 }
@@ -868,8 +966,6 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // Normalize hostname: lowercase, strip trailing dot (valid DNS but
     // would bypass exact-match rules otherwise).
     let host = normalize_hostname(&host);
-    let log_file = state.log_file.as_deref();
-    let log_level = state.log_level;
 
     // Compute localhost bypass before the port check: --allow-localhost <PORT> must
     // also exempt that port from the general port policy (which only lists remote ports
@@ -898,7 +994,7 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // intent with --allow-localhost <PORT> is to reach that port regardless of
     // whether it appears in the general allowed_ports list.
     if !localhost_connect_allowed && !state.allowed_ports.contains(&port) {
-        log_connection("CONNECT", target, "BLOCKED-PORT", log_file, log_level);
+        log_connection(state, "CONNECT", target, "BLOCKED-PORT");
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPort not allowed\r\n");
         return;
     }
@@ -923,7 +1019,7 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
         && !allowed_domains.is_empty()
         && !is_domain_match(&host, &allowed_domains)
     {
-        log_connection("CONNECT", target, "BLOCKED-ALLOWLIST", log_file, log_level);
+        log_connection(state, "CONNECT", target, "BLOCKED-ALLOWLIST");
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nDomain not in allowlist\r\n");
         return;
     }
@@ -931,14 +1027,14 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // Check blocklist (hostname-level)
     let blocked_domains = state.get_blocked_domains();
     if is_blocked_in_list(&host, &blocked_domains) {
-        log_connection("CONNECT", target, "BLOCKED", log_file, log_level);
+        log_connection(state, "CONNECT", target, "BLOCKED");
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nBlocked by cplt\r\n");
         let _ = client.shutdown(std::net::Shutdown::Both);
         return;
     }
     // Reject hostname patterns that are known private (fast path before DNS)
     if !localhost_connect_allowed && is_private_hostname(&host) {
-        log_connection("CONNECT", target, "BLOCKED-PRIVATE", log_file, log_level);
+        log_connection(state, "CONNECT", target, "BLOCKED-PRIVATE");
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPrivate target blocked\r\n");
         let _ = client.shutdown(std::net::Shutdown::Both);
         return;
@@ -997,13 +1093,7 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
                 localhost_opt_in,
             )
         {
-            log_connection(
-                "CONNECT",
-                target,
-                "BLOCKED-PRIVATE-RESOLVED",
-                log_file,
-                log_level,
-            );
+            log_connection(state, "CONNECT", target, "BLOCKED-PRIVATE-RESOLVED");
             let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nResolved to private IP\r\n");
             let _ = client.shutdown(std::net::Shutdown::Both);
             return;
@@ -1015,7 +1105,7 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // Resolve DNS FIRST, then check the resolved IP. A local resolution failure
     // on the direct path is a hard error — there is no upstream to defer to.
     let Some(socket_addr) = resolve_locally(state, &host, port) else {
-        log_connection("CONNECT", target, "DNS-FAIL", log_file, log_level);
+        log_connection(state, "CONNECT", target, "DNS-FAIL");
         let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
         return;
     };
@@ -1030,13 +1120,7 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
     // The earlier is_private_ip guard below only catches *private* IPs; this also
     // closes the *public* non-loopback case.
     if localhost_connect_allowed && !socket_addr.ip().is_loopback() {
-        log_connection(
-            "CONNECT",
-            target,
-            "BLOCKED-PRIVATE-RESOLVED",
-            log_file,
-            log_level,
-        );
+        log_connection(state, "CONNECT", target, "BLOCKED-PRIVATE-RESOLVED");
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nResolved to non-loopback IP\r\n");
         let _ = client.shutdown(std::net::Shutdown::Both);
         return;
@@ -1066,13 +1150,7 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
         is_domain_match(&host, &private_domains),
         localhost_opt_in,
     ) {
-        log_connection(
-            "CONNECT",
-            target,
-            "BLOCKED-PRIVATE-RESOLVED",
-            log_file,
-            log_level,
-        );
+        log_connection(state, "CONNECT", target, "BLOCKED-PRIVATE-RESOLVED");
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nResolved to private IP\r\n");
         let _ = client.shutdown(std::net::Shutdown::Both);
         return;
@@ -1085,20 +1163,14 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
             s
         }
         Err(e) => {
-            log_connection(
-                "CONNECT",
-                target,
-                &format!("CONNECT-FAIL:{e}"),
-                log_file,
-                log_level,
-            );
+            log_connection(state, "CONNECT", target, &format!("CONNECT-FAIL:{e}"));
             let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
             return;
         }
     };
 
     // Log after TCP connect succeeds — this is the audit-relevant event.
-    log_connection("CONNECT", target, "CONNECTED", log_file, log_level);
+    log_connection(state, "CONNECT", target, "CONNECTED");
 
     // Send 200 to client
     if client
@@ -1127,9 +1199,6 @@ fn connect_via_upstream(
     upstream: &UpstreamProxy,
     state: &ProxyState,
 ) {
-    let log_file = state.log_file.as_deref();
-    let log_level = state.log_level;
-
     // Connect to the upstream proxy itself (not the target).
     let upstream_addr = upstream.socket_addr();
     let Some(socket_addr) = upstream_addr
@@ -1137,13 +1206,7 @@ fn connect_via_upstream(
         .ok()
         .and_then(|mut a| a.next())
     else {
-        log_connection(
-            "CONNECT",
-            target,
-            "CONNECT-FAIL:upstream-dns",
-            log_file,
-            log_level,
-        );
+        log_connection(state, "CONNECT", target, "CONNECT-FAIL:upstream-dns");
         let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
         return;
     };
@@ -1154,11 +1217,10 @@ fn connect_via_upstream(
         }
         Err(e) => {
             log_connection(
+                state,
                 "CONNECT",
                 target,
                 &format!("CONNECT-FAIL:upstream:{e}"),
-                log_file,
-                log_level,
             );
             let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
             return;
@@ -1170,13 +1232,7 @@ fn connect_via_upstream(
     // Ask the upstream to open a tunnel to the real target.
     let request = upstream.connect_request(host, port);
     if remote.write_all(request.as_bytes()).is_err() {
-        log_connection(
-            "CONNECT",
-            target,
-            "CONNECT-FAIL:upstream-write",
-            log_file,
-            log_level,
-        );
+        log_connection(state, "CONNECT", target, "CONNECT-FAIL:upstream-write");
         let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
         return;
     }
@@ -1186,24 +1242,12 @@ fn connect_via_upstream(
     match read_upstream_connect_status(&mut remote) {
         Ok(true) => {}
         Ok(false) => {
-            log_connection(
-                "CONNECT",
-                target,
-                "CONNECT-FAIL:upstream-refused",
-                log_file,
-                log_level,
-            );
+            log_connection(state, "CONNECT", target, "CONNECT-FAIL:upstream-refused");
             let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
             return;
         }
         Err(_) => {
-            log_connection(
-                "CONNECT",
-                target,
-                "CONNECT-FAIL:upstream-read",
-                log_file,
-                log_level,
-            );
+            log_connection(state, "CONNECT", target, "CONNECT-FAIL:upstream-read");
             let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
             return;
         }
@@ -1212,7 +1256,7 @@ fn connect_via_upstream(
     // Log as CONNECTED — identical audit/stats semantics to a direct connect,
     // so the allowed connection is recorded the same way whether or not an
     // upstream is in use.
-    log_connection("CONNECT", target, "CONNECTED", log_file, log_level);
+    log_connection(state, "CONNECT", target, "CONNECTED");
 
     // Tell the client its tunnel is established, then splice bytes as usual.
     if client
@@ -1638,13 +1682,25 @@ fn is_v4_mapped_private(ip: &std::net::Ipv6Addr) -> bool {
     }
 }
 
-fn log_connection(
-    method: &str,
-    target: &str,
-    status: &str,
-    log_file: Option<&Path>,
-    level: ProxyLogLevel,
-) {
+fn log_connection(state: &ProxyState, method: &str, target: &str, status: &str) {
+    let log_file = state.log_file.as_deref();
+    let level = state.log_level;
+
+    // Record the observation for every CONNECT verdict, regardless of the stderr
+    // log level or whether a --proxy-log file is set. This is the single choke
+    // point every verdict flows through, so the collector sees the FULL set of
+    // hosts the agent contacted. Only CONNECT targets are hostnames; REJECT /
+    // INTERNAL / non-CONNECT-method log lines carry no host and are skipped.
+    if method.eq_ignore_ascii_case("CONNECT") {
+        let host = target.rsplit_once(':').map_or(target, |(h, _)| h);
+        let verdict = if status.starts_with("BLOCKED") {
+            DomainVerdict::Blocked
+        } else {
+            DomainVerdict::Allowed
+        };
+        state.record_observation(host, verdict);
+    }
+
     if level.should_log(status) {
         let color = match status {
             "BLOCKED" | "BLOCKED-PRIVATE" | "BLOCKED-PORT" | "BLOCKED-ALLOWLIST" | "LIMIT" => {
@@ -1928,6 +1984,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         };
 
@@ -1955,6 +2012,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         };
 
@@ -1987,6 +2045,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         };
 
@@ -2022,6 +2081,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         };
 
@@ -2063,6 +2123,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         };
 
@@ -2196,6 +2257,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         };
 
@@ -2241,6 +2303,7 @@ mod tests {
             timeout: Duration::from_secs(60),
             upstream: None,
             upstream_no_proxy: Vec::new(),
+            domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
             resolver: None,
         }
     }
@@ -2293,6 +2356,95 @@ mod tests {
             state.get_allowed_domains().is_empty(),
             "default off must remain allow-all"
         );
+    }
+
+    #[test]
+    fn collector_records_verdicts_dedups_and_normalizes() {
+        // The observation collector must record both allowed and blocked hosts
+        // with the right verdict, collapse case/trailing-dot variants of the
+        // same host into one entry, and count repeat CONNECTs.
+        let state = state_for_allowlist(Vec::new(), None);
+        state.record_observation("api.github.com", DomainVerdict::Allowed);
+        // Same host, different spelling: uppercase + trailing dot must normalize
+        // to the same key rather than creating a second entry.
+        state.record_observation("API.GitHub.com.", DomainVerdict::Allowed);
+        state.record_observation("evil.example", DomainVerdict::Blocked);
+
+        let map = state
+            .domain_collector
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            map.len(),
+            2,
+            "case/trailing-dot variants must collapse to one host"
+        );
+        let gh = map.get("api.github.com").expect("host recorded normalized");
+        assert_eq!(gh.verdict, DomainVerdict::Allowed);
+        assert_eq!(gh.count, 2, "repeat CONNECTs must increment the count");
+        assert_eq!(
+            map.get("evil.example")
+                .expect("blocked host recorded")
+                .verdict,
+            DomainVerdict::Blocked
+        );
+    }
+
+    #[test]
+    fn collector_blocked_verdict_is_sticky() {
+        // A host seen blocked once must stay Blocked in the observed set even if
+        // a later attempt is allowed, so the list always flags what policy
+        // refused.
+        let state = state_for_allowlist(Vec::new(), None);
+        state.record_observation("x.example", DomainVerdict::Allowed);
+        state.record_observation("x.example", DomainVerdict::Blocked);
+        state.record_observation("x.example", DomainVerdict::Allowed);
+
+        let map = state
+            .domain_collector
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = map.get("x.example").expect("host recorded");
+        assert_eq!(
+            entry.verdict,
+            DomainVerdict::Blocked,
+            "blocked verdict must be sticky"
+        );
+        assert_eq!(entry.count, 3);
+    }
+
+    #[test]
+    fn observed_domains_sorted_and_unique() {
+        // observed_domains() returns hosts sorted and deduplicated (the BTreeMap
+        // key ordering) with verdict + count, ready for a paste-able allowlist.
+        let collector: Arc<DomainCollector> = Arc::new(Mutex::new(BTreeMap::new()));
+        {
+            let mut map = collector.lock().unwrap();
+            map.insert(
+                "b.example".to_string(),
+                DomainObservation {
+                    verdict: DomainVerdict::Allowed,
+                    count: 3,
+                },
+            );
+            map.insert(
+                "a.example".to_string(),
+                DomainObservation {
+                    verdict: DomainVerdict::Blocked,
+                    count: 1,
+                },
+            );
+        }
+        let handle = ProxyHandle {
+            shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            port: 0,
+            domain_collector: collector,
+        };
+        let observed = handle.observed_domains();
+        let hosts: Vec<&str> = observed.iter().map(|o| o.host.as_str()).collect();
+        assert_eq!(hosts, vec!["a.example", "b.example"], "must be sorted");
+        assert_eq!(observed[0].verdict, DomainVerdict::Blocked);
+        assert_eq!(observed[1].count, 3);
     }
 
     /// Skip guard for tests that make real TCP connections.
@@ -2443,6 +2595,66 @@ mod tests {
         assert_connect_allowed(proxy.port, "evil.com");
         proxy.shutdown();
         up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[test]
+    fn observe_allow_all_records_domain_that_would_be_blocked() {
+        // The `--observe-domains` override forces the proxy into allow-all mode
+        // (main.rs passes an empty allowlist). A host that WOULD be blocked under
+        // a configured allowlist must instead be permitted AND recorded here, so
+        // the observed set is exhaustive rather than pre-filtered.
+        require_localhost_tcp!();
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        // Allow-all: empty default allowlist + no file — exactly what observe forces.
+        let proxy = make_proxy_default_allowlist(Vec::new(), None, upstream);
+
+        let status = proxy_connect(proxy.port, "would-be-blocked.example:443");
+        // Let the connection thread finish recording before snapshotting.
+        std::thread::sleep(Duration::from_millis(50));
+        let observed = proxy.observed_domains();
+        proxy.shutdown();
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(
+            !status.contains("Forbidden"),
+            "allow-all (observe) must NOT block would-be-blocked.example; got {status}"
+        );
+        let rec = observed
+            .iter()
+            .find(|o| o.host == "would-be-blocked.example")
+            .expect("contacted host must be recorded even in allow-all mode");
+        assert_eq!(
+            rec.verdict,
+            DomainVerdict::Allowed,
+            "in allow-all mode the host is recorded as Allowed"
+        );
+    }
+
+    #[test]
+    fn observe_records_blocked_verdict_under_allowlist() {
+        // Complementary to the allow-all case: when a real allowlist IS in force,
+        // a refused host is still recorded — with a Blocked verdict.
+        require_localhost_tcp!();
+        let up = spawn_fake_upstream();
+        let upstream = UpstreamProxy::parse(&format!("http://127.0.0.1:{}", up.port)).unwrap();
+        let proxy = make_proxy_default_allowlist(copilot_defaults(), None, upstream);
+
+        let status = proxy_connect(proxy.port, "evil.com:443");
+        std::thread::sleep(Duration::from_millis(50));
+        let observed = proxy.observed_domains();
+        proxy.shutdown();
+        up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(
+            status.contains("403"),
+            "evil.com must be blocked under the allowlist; got {status}"
+        );
+        let rec = observed
+            .iter()
+            .find(|o| o.host == "evil.com")
+            .expect("blocked host must still be recorded");
+        assert_eq!(rec.verdict, DomainVerdict::Blocked);
     }
 
     #[test]


### PR DESCRIPTION
Answers 'how do we ensure the per-agent allowlists (#52/#140) are correct and exhaustive?' — by empirical observation, since cplt is itself a domain-logging proxy.

- **Always-on domain collector** on `ProxyState` (`observed_domains() -> Vec<ObservedDomain>`, sorted/unique, verdict Allowed|Blocked + count), populated from the single `log_connection` choke point — records every CONNECT regardless of log level. Generic + cheap; also the foundation for audit Phase 2 network reporting.
- **`--observe-domains`** (+ `--observe-domains-out <file>`): forces the proxy on in **allow-all** mode (overriding `--preset strict`/allowlist so the FULL contacted set is seen — with a prominent warning that this run does NOT enforce domain filtering), runs the session, then emits the observed domains as a ready-to-paste `allowed_domains` block. Works in the main run flow and `cplt exec`.
- **Methodology docs** (docs/proxy.md: 'Verifying / generating an agent's domain allowlist') + a provenance convention comment in src/agent.rs.

This makes the shipped per-agent lists verifiable/maintainable (run `cplt --agent <X> --observe-domains -- <task>` → get the real domains → update src/agent.rs), and doubles as a user feature for building an allowlist. **Does not change the shipped lists** — it's the mechanism to verify them. clippy clean both targets; lib 631 + unit 249.