### PR TITLE
feat: `cplt check` — verify & explain sandbox enforcement (#142)

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -821,6 +821,7 @@ mod tests {
             blocked_domains: blocked.iter().map(|s| (*s).to_string()).collect(),
             allow_localhost_ports: Vec::new(),
             allow_localhost_any: false,
+            ..Default::default()
         }
     }
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,1002 @@
+//! `cplt check` — verify & explain sandbox enforcement.
+//!
+//! Two layers, matching the PRD (#142):
+//!
+//! 1. **Enforcement probes** (Layer 1) execute inside the *real* resolved
+//!    sandbox / against the resolved proxy policy and report ground truth:
+//!    a path is genuinely readable or the kernel denies it, a domain is
+//!    genuinely permitted by the proxy or refused. Those probes live in the
+//!    binary (`main.rs`), which owns the sandbox plumbing; they feed their
+//!    results into the [`CheckItem`] / [`Report`] types defined here.
+//!
+//! 2. **Explain + fix** (Layer 2) is the pure policy-query API in this module:
+//!    [`explain_path`], [`explain_domain`], and [`explain_exec`]. Each maps a
+//!    result to *why* (which rule / status governs it) and *how to change it*
+//!    (the exact config key / flag / preset). These reuse the existing matchers
+//!    — the Landlock `fs_rules` model, [`crate::proxy::classify_connect`], and
+//!    the gh/git guard classifiers — rather than duplicating them.
+//!
+//! # Honest scope
+//!
+//! Probes reflect cplt's *resolved policy*: what cplt itself grants or blocks.
+//! A passing network probe means "cplt is not blocking this" — not that the
+//! target is up or that an arbitrary agent action with a different cwd/env would
+//! behave identically. The static `fs_rules` model is a faithful approximation
+//! of the enforced filesystem policy; where the live probe disagrees (e.g. a
+//! macOS SBPL deny-subpath the Landlock model can't express) the *probe* is
+//! authoritative and the explanation notes the difference.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::proxy::{self, NetPolicy, NetVerdict};
+use crate::sandbox::{
+    DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS, FsAccess, LandlockPolicy,
+};
+
+/// Ground-truth (or, for static-only queries, policy) decision for one probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Decision {
+    /// cplt permits the operation.
+    Allowed,
+    /// cplt blocks the operation.
+    Blocked,
+    /// The probe could not be run to a conclusive result (e.g. the target does
+    /// not exist, or a probe prerequisite failed). Never counts as a verified
+    /// protection and never fails the enforcement verdict.
+    Inconclusive,
+}
+
+impl Decision {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Decision::Allowed => "ALLOWED",
+            Decision::Blocked => "BLOCKED",
+            Decision::Inconclusive => "INCONCLUSIVE",
+        }
+    }
+}
+
+// ── Layer 2: filesystem explain ────────────────────────────────
+
+/// Static explanation of a path against the resolved filesystem policy.
+#[derive(Debug, Clone, Serialize)]
+pub struct FsExplain {
+    pub read: bool,
+    pub write: bool,
+    pub execute: bool,
+    /// The longest matching allow rule (most specific ancestor), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_rule: Option<String>,
+    /// Whether the path is a known protected credential location.
+    pub credential: bool,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+}
+
+impl FsExplain {
+    /// The decision the static model predicts for a *read* of this path.
+    #[must_use]
+    pub fn read_decision(&self) -> Decision {
+        if self.read {
+            Decision::Allowed
+        } else {
+            Decision::Blocked
+        }
+    }
+
+    /// The decision the static model predicts for a *write* to this path.
+    #[must_use]
+    pub fn write_decision(&self) -> Decision {
+        if self.write {
+            Decision::Allowed
+        } else {
+            Decision::Blocked
+        }
+    }
+}
+
+/// Render `{read,write,execute}` as a compact `read+write+execute` string.
+fn access_str(a: &FsAccess) -> String {
+    let mut parts = Vec::new();
+    if a.read {
+        parts.push("read");
+    }
+    if a.write {
+        parts.push("write");
+    }
+    if a.execute {
+        parts.push("execute");
+    }
+    if parts.is_empty() {
+        "no access".to_string()
+    } else {
+        parts.join("+")
+    }
+}
+
+/// Is `path` equal to, or nested under, `base` (component-wise)?
+fn within(path: &Path, base: &Path) -> bool {
+    path == base || path.starts_with(base)
+}
+
+/// Whether `path` is a known protected credential location under `home`.
+///
+/// Reuses the sandbox's own deny lists (`DENIED_DOTFILES`, `DENIED_FILES`,
+/// `DENIED_HOME_SUBPATHS`) so the classification never drifts from what the
+/// profile actually withholds.
+#[must_use]
+pub fn is_credential_path(home: &Path, path: &Path) -> bool {
+    for d in DENIED_DOTFILES {
+        if within(path, &home.join(d)) {
+            return true;
+        }
+    }
+    for f in DENIED_FILES {
+        if within(path, &home.join(f)) {
+            return true;
+        }
+    }
+    for f in DENIED_HOME_SUBPATHS {
+        if within(path, &home.join(f)) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Explain a path against the resolved filesystem policy (longest-prefix match).
+///
+/// Landlock grants are additive over a path's ancestors, so the effective access
+/// is the union of every rule whose path is an ancestor-or-equal of `path`; the
+/// most specific such rule is reported as the matched rule. The reason→fix text
+/// is drawn from a small catalog focused on the high-frequency cases
+/// (credentials, the project dir) with a sensible generic fallback.
+#[must_use]
+pub fn explain_path(
+    policy: &LandlockPolicy,
+    home: &Path,
+    project_dir: &Path,
+    path: &Path,
+) -> FsExplain {
+    let mut acc = FsAccess::default();
+    let mut matched: Option<&PathBuf> = None;
+    for rule in &policy.fs_rules {
+        if within(path, &rule.path) {
+            acc.read |= rule.access.read;
+            acc.write |= rule.access.write;
+            acc.execute |= rule.access.execute;
+            let longer = matched.is_none_or(|m| rule.path.as_os_str().len() > m.as_os_str().len());
+            if longer {
+                matched = Some(&rule.path);
+            }
+        }
+    }
+
+    let credential = is_credential_path(home, path);
+    let matched_str = matched.map(|p| p.display().to_string());
+
+    let (reason, fix) = if credential && !acc.read {
+        (
+            "protected credential path — never exposed to the agent (deny-by-default). \
+             This is intentional."
+                .to_string(),
+            None,
+        )
+    } else if credential && acc.read {
+        (
+            "credential path, but read was explicitly granted for this run \
+             (allow.read / --allow-read)."
+                .to_string(),
+            Some(
+                "remove the matching allow.read entry / --allow-read flag to re-protect it."
+                    .to_string(),
+            ),
+        )
+    } else if within(path, project_dir) {
+        (
+            format!("covered by the project-dir rule ({}).", access_str(&acc)),
+            None,
+        )
+    } else if acc.read || acc.write || acc.execute {
+        (
+            format!(
+                "granted {} by rule {}.",
+                access_str(&acc),
+                matched_str.as_deref().unwrap_or("(project dir)")
+            ),
+            None,
+        )
+    } else {
+        (
+            "not covered by any allow rule — denied by default.".to_string(),
+            Some(
+                "grant access with --allow-read <PATH> (read) or --allow-write <PATH> (read+write), \
+                 or add it under [allow] read/write in config."
+                    .to_string(),
+            ),
+        )
+    };
+
+    FsExplain {
+        read: acc.read,
+        write: acc.write,
+        execute: acc.execute,
+        matched_rule: matched_str,
+        credential,
+        reason,
+        fix,
+    }
+}
+
+// ── Layer 2: network explain ───────────────────────────────────
+
+/// Static explanation of a CONNECT target against the resolved proxy policy.
+#[derive(Debug, Clone, Serialize)]
+pub struct NetExplain {
+    pub decision: Decision,
+    /// The proxy audit-log status (`ALLOWED`, `BLOCKED-PRIVATE`, `NO-PROXY`, …).
+    pub status: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+}
+
+/// Explain a domain/port against the resolved proxy policy.
+///
+/// When the proxy is disabled cplt does no domain filtering at all, so this is
+/// reported honestly (`NO-PROXY`) rather than implying a block. Otherwise the
+/// verdict comes straight from [`crate::proxy::classify_connect`] — the same
+/// gate logic the live proxy enforces — and each `BLOCKED-*` status is mapped to
+/// the governing config plus the exact fix.
+#[must_use]
+pub fn explain_domain(
+    policy: &NetPolicy,
+    host: &str,
+    port: u16,
+    proxy_enabled: bool,
+) -> NetExplain {
+    if !proxy_enabled {
+        return NetExplain {
+            decision: Decision::Allowed,
+            status: "NO-PROXY".to_string(),
+            reason: "the CONNECT proxy is disabled, so cplt does not filter domains; \
+                     egress is constrained only by the kernel port policy (443 + --allow-port)."
+                .to_string(),
+            fix: Some(
+                "enable domain filtering with --with-proxy, or lock egress down with --preset strict."
+                    .to_string(),
+            ),
+        };
+    }
+
+    let verdict = proxy::classify_connect(policy, host, port);
+    let (decision, reason, fix) = match verdict {
+        NetVerdict::Allowed => (
+            Decision::Allowed,
+            "permitted by the proxy policy — cplt is not blocking this.".to_string(),
+            None,
+        ),
+        NetVerdict::BlockedPort => (
+            Decision::Blocked,
+            format!("port {port} is not in the allowed-ports set (443 + --allow-port)."),
+            Some(format!(
+                "allow it with --allow-port {port} (or [allow] ports in config)."
+            )),
+        ),
+        NetVerdict::BlockedAllowlist => (
+            Decision::Blocked,
+            "a fail-closed domain allowlist is active and this host is not in it \
+             (agent defaults + your allowed_domains)."
+                .to_string(),
+            Some(
+                "add it to allowed_domains (--allowed-domains FILE / [proxy] allowed_domains), \
+                 or run with --allow-all-domains."
+                    .to_string(),
+            ),
+        ),
+        NetVerdict::Blocked => (
+            Decision::Blocked,
+            "the host matches the proxy blocklist (blocked-domains).".to_string(),
+            Some(
+                "if you trust it, remove it from the blocklist file (--blocked-domains)."
+                    .to_string(),
+            ),
+        ),
+        NetVerdict::BlockedPrivate => (
+            Decision::Blocked,
+            "private / loopback / link-local target — blocked as an SSRF safeguard \
+             (e.g. cloud metadata 169.254.169.254, internal services)."
+                .to_string(),
+            Some(
+                "for a trusted internal host use --allow-private-domains <DOMAIN>; \
+                 for a local dev server use --allow-localhost <PORT>."
+                    .to_string(),
+            ),
+        ),
+    };
+
+    NetExplain {
+        decision,
+        status: verdict.status().to_string(),
+        reason,
+        fix,
+    }
+}
+
+// ── Layer 2: exec explain ──────────────────────────────────────
+
+/// The exec-relevant slice of the resolved policy, for [`explain_exec`].
+pub struct ExecContext<'a> {
+    pub allow_docker: bool,
+    pub allow_tmp_exec: bool,
+    pub gh_guard: &'a crate::config::GhGuardPolicy,
+    pub git_guard: &'a crate::config::GitGuardPolicy,
+    pub project_dir: &'a Path,
+}
+
+/// Static explanation of whether a command would run under the resolved policy.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecExplain {
+    pub decision: Decision,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+}
+
+/// The file-name (last component) of a command word, lowercased.
+fn command_basename(cmd: &str) -> String {
+    Path::new(cmd)
+        .file_name()
+        .map(|s| s.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default()
+}
+
+/// Explain whether `argv` would run, is guard-blocked, or needs an `allow_*`.
+///
+/// Reuses the gh/git guard classifiers ([`crate::gh_proxy::gate`],
+/// [`crate::gh_proxy::gate_git`]) so the verdict matches what the in-sandbox
+/// wrappers enforce, and the `allow_docker` / `allow_tmp_exec` gates for the
+/// other high-frequency cases. Unrecognized commands get an honest generic
+/// answer (they run, subject to the fs/net policy).
+#[must_use]
+pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
+    let Some(first) = argv.first() else {
+        return ExecExplain {
+            decision: Decision::Inconclusive,
+            reason: "no command given.".to_string(),
+            fix: None,
+        };
+    };
+    let base = command_basename(first);
+    let rest: Vec<&str> = argv[1..].iter().map(String::as_str).collect();
+
+    // ── Docker family: gated by allow_docker (socket = host RCE) ──
+    if matches!(
+        base.as_str(),
+        "docker" | "docker-compose" | "colima" | "nerdctl"
+    ) {
+        return if ctx.allow_docker {
+            ExecExplain {
+                decision: Decision::Allowed,
+                reason: "Docker access is enabled (allow_docker=on).".to_string(),
+                fix: None,
+            }
+        } else {
+            ExecExplain {
+                decision: Decision::Blocked,
+                reason: "Docker access is gated off — the daemon socket and ~/.docker are denied \
+                         (allow_docker=off). It is dangerous: socket access is effectively host RCE \
+                         and volume mounts bypass the sandbox filesystem."
+                    .to_string(),
+                fix: Some(
+                    "--allow-docker, or [sandbox] allow_docker = true (or --preset full-trust)."
+                        .to_string(),
+                ),
+            }
+        };
+    }
+
+    // ── git: push-prevention guard ──
+    if base == "git" {
+        if !ctx.git_guard.enabled {
+            return ExecExplain {
+                decision: Decision::Allowed,
+                reason: "git runs; push prevention is not enabled for this run.".to_string(),
+                fix: None,
+            };
+        }
+        return match crate::gh_proxy::gate_git(
+            &rest,
+            ctx.git_guard.prevent_push,
+            ctx.git_guard.prevent_force_push,
+            ctx.git_guard.protect_default_branch_only,
+            &ctx.git_guard.allow_push,
+            None,
+        ) {
+            Ok(()) => ExecExplain {
+                decision: Decision::Allowed,
+                reason: "allowed by the git guard.".to_string(),
+                fix: None,
+            },
+            Err(msg) => ExecExplain {
+                decision: Decision::Blocked,
+                reason: first_line(&msg),
+                fix: Some(
+                    "push to an allowed branch/remote, configure [git] allow_push, \
+                     or disable with git_push_prevention = false."
+                        .to_string(),
+                ),
+            },
+        };
+    }
+
+    // ── gh: destructive-operation guard ──
+    if base == "gh" {
+        if !ctx.gh_guard.enabled {
+            return ExecExplain {
+                decision: Decision::Allowed,
+                reason: "gh runs; the gh guard is not enabled for this run.".to_string(),
+                fix: None,
+            };
+        }
+        let policy = crate::gh_proxy::GatePolicy {
+            mode: ctx.gh_guard.mode,
+            scope_check: ctx.gh_guard.scope_check,
+            block_auth_token: ctx.gh_guard.block_auth_token,
+            unknown_command: match ctx.gh_guard.unknown_command {
+                crate::config::UnknownCommandPolicy::Allow => {
+                    crate::gh_proxy::UnknownCommandDecision::Allow
+                }
+                crate::config::UnknownCommandPolicy::Block => {
+                    crate::gh_proxy::UnknownCommandDecision::Block
+                }
+            },
+            allow_api_write: ctx.gh_guard.allow_api_write,
+        };
+        return match crate::gh_proxy::gate(&rest, ctx.project_dir, &policy) {
+            Ok(()) => ExecExplain {
+                decision: Decision::Allowed,
+                reason: "allowed by the gh guard.".to_string(),
+                fix: None,
+            },
+            Err(msg) => ExecExplain {
+                decision: Decision::Blocked,
+                reason: first_line(&msg),
+                fix: Some(
+                    "use a read-only / in-scope gh command, or relax the gh guard \
+                     (e.g. [sandbox] gh_proxy settings)."
+                        .to_string(),
+                ),
+            },
+        };
+    }
+
+    // ── tmp/scratch exec: binary-drop prevention ──
+    if !ctx.allow_tmp_exec && looks_like_tmp_path(first) {
+        return ExecExplain {
+            decision: Decision::Blocked,
+            reason: "executing a binary from /tmp or the scratch dir is blocked \
+                     (binary-drop prevention: writable-but-non-executable)."
+                .to_string(),
+            fix: Some(
+                "--allow-tmp-exec, or [sandbox] allow_tmp_exec = true (dangerous).".to_string(),
+            ),
+        };
+    }
+
+    ExecExplain {
+        decision: Decision::Allowed,
+        reason: "not specifically gated — runs inside the sandbox, subject to the \
+                 filesystem, network, and env policy."
+            .to_string(),
+        fix: None,
+    }
+}
+
+fn looks_like_tmp_path(cmd: &str) -> bool {
+    cmd.starts_with("/tmp/") || cmd.starts_with("/private/tmp/") || cmd.starts_with("/var/tmp/")
+}
+
+fn first_line(s: &str) -> String {
+    s.lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or(s)
+        .trim()
+        .to_string()
+}
+
+// ── Report assembly & rendering ────────────────────────────────
+
+/// One line item in a check report — a single probe or explained query.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckItem {
+    /// Short human label, e.g. "read project dir".
+    pub name: String,
+    /// "filesystem" | "network" | "exec".
+    pub category: String,
+    /// The concrete target (path, `host:port`, or command).
+    pub target: String,
+    /// Ground-truth (probe) or policy (static) decision.
+    pub decision: Decision,
+    /// For the enforcement battery: what a working sandbox is expected to do.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<Decision>,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+    /// Extra context (reachability, model-vs-probe mismatch, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl CheckItem {
+    /// Did this item meet its expectation? `None` expectation ⇒ not graded.
+    #[must_use]
+    pub fn passed(&self) -> Option<bool> {
+        self.expected.map(|e| e == self.decision)
+    }
+}
+
+/// A full `cplt check` report.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    pub agent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preset: Option<String>,
+    pub platform: String,
+    /// Whether every graded expectation held (⇒ the sandbox is enforcing).
+    pub enforcing: bool,
+    /// Number of expected-BLOCKED protections that were actually blocked.
+    pub verified: usize,
+    /// True for the bare enforcement battery (drives the verdict rendering).
+    pub battery: bool,
+    pub items: Vec<CheckItem>,
+}
+
+impl Report {
+    /// Build a report from graded items, computing the enforcement verdict.
+    #[must_use]
+    pub fn new(
+        agent: String,
+        preset: Option<String>,
+        battery: bool,
+        items: Vec<CheckItem>,
+    ) -> Self {
+        let verified = items
+            .iter()
+            .filter(|i| i.expected == Some(Decision::Blocked) && i.decision == Decision::Blocked)
+            .count();
+        // Enforcing iff every graded expectation held AND at least one protection
+        // (an expected block) was verified. Inconclusive items are never graded,
+        // so they neither verify nor break the verdict.
+        let all_graded_passed = items.iter().all(|i| i.passed() != Some(false));
+        let enforcing = battery && all_graded_passed && verified >= 1;
+        Report {
+            agent,
+            preset,
+            platform: platform_name().to_string(),
+            enforcing,
+            verified,
+            battery,
+            items,
+        }
+    }
+
+    /// Serialize the report as pretty JSON.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// The process exit code: 0 when enforcing (or a targeted, non-battery
+    /// query), non-zero when the battery could not confirm enforcement.
+    #[must_use]
+    pub fn exit_nonzero(&self) -> bool {
+        self.battery && !self.enforcing
+    }
+
+    /// Render a clean human-readable report.
+    #[must_use]
+    pub fn render(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+
+        if self.battery {
+            self.render_battery(&mut out);
+        } else {
+            for item in &self.items {
+                render_targeted_item(&mut out, item);
+            }
+        }
+
+        // Verdict line (battery only).
+        if self.battery {
+            let _ = writeln!(out);
+            let mut suffix = format!("agent={}", self.agent);
+            if let Some(p) = &self.preset {
+                let _ = write!(suffix, " · preset={p}");
+            }
+            if self.enforcing {
+                let _ = writeln!(
+                    out,
+                    "→ Sandbox is ENFORCING ({} protection{} verified) · {}",
+                    self.verified,
+                    if self.verified == 1 { "" } else { "s" },
+                    suffix
+                );
+            } else {
+                let _ = writeln!(
+                    out,
+                    "→ Sandbox is NOT ENFORCING — {} · {}",
+                    self.failure_summary(),
+                    suffix
+                );
+            }
+        }
+        out
+    }
+
+    fn render_battery(&self, out: &mut String) {
+        use std::fmt::Write as _;
+        for cat in ["filesystem", "network", "exec"] {
+            let items: Vec<&CheckItem> = self.items.iter().filter(|i| i.category == cat).collect();
+            if items.is_empty() {
+                continue;
+            }
+            let _ = writeln!(out, "{}", cat_title(cat));
+            for item in items {
+                let sym = match item.passed() {
+                    Some(true) => "✓",
+                    Some(false) => "✗",
+                    None => "·",
+                };
+                let mut line = format!("  {sym} {:<26} → {}", item.name, item.decision.as_str());
+                if item.passed() == Some(false)
+                    && let Some(exp) = item.expected
+                {
+                    let _ = write!(line, "  [expected {}]", exp.as_str());
+                }
+                if item.decision == Decision::Inconclusive
+                    && let Some(note) = &item.note
+                {
+                    let _ = write!(line, "  ({note})");
+                }
+                let _ = writeln!(out, "{line}");
+            }
+        }
+    }
+
+    fn failure_summary(&self) -> String {
+        let mut reasons = Vec::new();
+        let under = self
+            .items
+            .iter()
+            .filter(|i| i.expected == Some(Decision::Blocked) && i.decision == Decision::Allowed)
+            .count();
+        let over = self
+            .items
+            .iter()
+            .filter(|i| i.expected == Some(Decision::Allowed) && i.decision == Decision::Blocked)
+            .count();
+        if under > 0 {
+            reasons.push(format!("{under} protection(s) did NOT block"));
+        }
+        if over > 0 {
+            reasons.push(format!("{over} expected-allowed check(s) were blocked"));
+        }
+        if self.verified == 0 && reasons.is_empty() {
+            reasons.push("no protection could be verified".to_string());
+        }
+        reasons.join("; ")
+    }
+}
+
+fn render_targeted_item(out: &mut String, item: &CheckItem) {
+    use std::fmt::Write as _;
+    let _ = writeln!(out, "{}: {}", item.target, item.decision.as_str());
+    let _ = writeln!(out, "  Reason: {}", item.reason);
+    if let Some(note) = &item.note {
+        let _ = writeln!(out, "  Note: {note}");
+    }
+    match &item.fix {
+        Some(fix) => {
+            let _ = writeln!(out, "  Fix: {fix}");
+        }
+        None => {
+            let _ = writeln!(out, "  Fix: none needed (intentional).");
+        }
+    }
+}
+
+fn cat_title(cat: &str) -> &'static str {
+    match cat {
+        "filesystem" => "Filesystem",
+        "network" => "Network",
+        "exec" => "Exec",
+        _ => "Other",
+    }
+}
+
+#[must_use]
+fn platform_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos (Seatbelt)"
+    } else if cfg!(target_os = "linux") {
+        "linux (Landlock+seccomp)"
+    } else {
+        "unsupported"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{GhGuardPolicy, GitGuardPolicy};
+    use crate::sandbox::{FsAccess, FsRule, LandlockPolicy};
+
+    fn rule(path: &str, read: bool, write: bool, execute: bool) -> FsRule {
+        FsRule {
+            path: PathBuf::from(path),
+            access: FsAccess {
+                read,
+                write,
+                execute,
+                ioctl: false,
+            },
+        }
+    }
+
+    fn policy(rules: Vec<FsRule>) -> LandlockPolicy {
+        LandlockPolicy {
+            fs_rules: rules,
+            net_rules: Vec::new(),
+            restrict_net_connect: true,
+            proxy_forced: false,
+            home_dir: PathBuf::from("/home/u"),
+        }
+    }
+
+    // ── explain_path ──
+
+    #[test]
+    fn project_dir_is_read_write() {
+        let home = Path::new("/home/u");
+        let proj = Path::new("/home/u/proj");
+        let p = policy(vec![rule("/home/u/proj", true, true, true)]);
+        let e = explain_path(&p, home, proj, Path::new("/home/u/proj/build/out"));
+        assert_eq!(e.read_decision(), Decision::Allowed);
+        assert_eq!(e.write_decision(), Decision::Allowed);
+        assert!(e.reason.contains("project-dir"));
+        assert!(e.fix.is_none());
+    }
+
+    #[test]
+    fn ssh_key_is_blocked_credential() {
+        let home = Path::new("/home/u");
+        let proj = Path::new("/home/u/proj");
+        // No rule grants ~/.ssh — deny by default.
+        let p = policy(vec![rule("/home/u/proj", true, true, true)]);
+        let e = explain_path(&p, home, proj, Path::new("/home/u/.ssh/id_rsa"));
+        assert_eq!(e.read_decision(), Decision::Blocked);
+        assert!(e.credential);
+        assert!(e.reason.contains("credential"));
+        // Intentional — no fix recommended.
+        assert!(e.fix.is_none());
+    }
+
+    #[test]
+    fn aws_dir_is_credential() {
+        let home = Path::new("/home/u");
+        assert!(is_credential_path(
+            home,
+            Path::new("/home/u/.aws/credentials")
+        ));
+        assert!(is_credential_path(home, Path::new("/home/u/.ssh")));
+        assert!(is_credential_path(home, Path::new("/home/u/.netrc")));
+        assert!(!is_credential_path(home, Path::new("/home/u/proj/src")));
+    }
+
+    #[test]
+    fn unlisted_path_is_blocked_with_fix() {
+        let home = Path::new("/home/u");
+        let proj = Path::new("/home/u/proj");
+        let p = policy(vec![rule("/home/u/proj", true, true, true)]);
+        let e = explain_path(&p, home, proj, Path::new("/opt/other"));
+        assert_eq!(e.read_decision(), Decision::Blocked);
+        assert!(!e.credential);
+        assert!(e.fix.as_deref().unwrap().contains("--allow-read"));
+    }
+
+    // ── explain_domain ──
+
+    fn net_policy(allowed: &[&str], blocked: &[&str], ports: &[u16]) -> NetPolicy {
+        NetPolicy {
+            allowed_ports: ports.to_vec(),
+            allowed_domains: allowed.iter().map(|s| (*s).to_string()).collect(),
+            blocked_domains: blocked.iter().map(|s| (*s).to_string()).collect(),
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+        }
+    }
+
+    #[test]
+    fn allowed_domain_is_allowed() {
+        let np = net_policy(&["github.com"], &[], &[443]);
+        let e = explain_domain(&np, "github.com", 443, true);
+        assert_eq!(e.decision, Decision::Allowed);
+        assert_eq!(e.status, "ALLOWED");
+    }
+
+    #[test]
+    fn unknown_domain_blocked_by_allowlist() {
+        let np = net_policy(&["github.com"], &[], &[443]);
+        let e = explain_domain(&np, "evil.example", 443, true);
+        assert_eq!(e.decision, Decision::Blocked);
+        assert_eq!(e.status, "BLOCKED-ALLOWLIST");
+        assert!(e.fix.as_deref().unwrap().contains("allowed_domains"));
+    }
+
+    #[test]
+    fn metadata_ip_blocked_private() {
+        // Empty allowlist ⇒ allow-all, so the SSRF guard is what blocks it.
+        let np = net_policy(&[], &[], &[443]);
+        let e = explain_domain(&np, "169.254.169.254", 443, true);
+        assert_eq!(e.decision, Decision::Blocked);
+        assert_eq!(e.status, "BLOCKED-PRIVATE");
+    }
+
+    #[test]
+    fn bad_port_blocked() {
+        let np = net_policy(&[], &[], &[443]);
+        let e = explain_domain(&np, "github.com", 22, true);
+        assert_eq!(e.decision, Decision::Blocked);
+        assert_eq!(e.status, "BLOCKED-PORT");
+    }
+
+    #[test]
+    fn proxy_disabled_is_not_filtered() {
+        let np = net_policy(&[], &[], &[443]);
+        let e = explain_domain(&np, "anything.example", 443, false);
+        assert_eq!(e.decision, Decision::Allowed);
+        assert_eq!(e.status, "NO-PROXY");
+    }
+
+    // ── explain_exec ──
+
+    fn exec_ctx<'a>(
+        gh: &'a GhGuardPolicy,
+        git: &'a GitGuardPolicy,
+        allow_docker: bool,
+    ) -> ExecContext<'a> {
+        ExecContext {
+            allow_docker,
+            allow_tmp_exec: false,
+            gh_guard: gh,
+            git_guard: git,
+            project_dir: Path::new("/home/u/proj"),
+        }
+    }
+
+    #[test]
+    fn docker_blocked_without_allow() {
+        let gh = GhGuardPolicy::default();
+        let git = GitGuardPolicy::default();
+        let ctx = exec_ctx(&gh, &git, false);
+        let e = explain_exec(&["docker".into(), "ps".into()], &ctx);
+        assert_eq!(e.decision, Decision::Blocked);
+        assert!(e.fix.as_deref().unwrap().contains("--allow-docker"));
+    }
+
+    #[test]
+    fn docker_allowed_with_flag() {
+        let gh = GhGuardPolicy::default();
+        let git = GitGuardPolicy::default();
+        let ctx = exec_ctx(&gh, &git, true);
+        let e = explain_exec(&["/usr/bin/docker".into(), "ps".into()], &ctx);
+        assert_eq!(e.decision, Decision::Allowed);
+    }
+
+    #[test]
+    fn git_push_blocked_when_guard_enabled() {
+        let gh = GhGuardPolicy::default();
+        let git = GitGuardPolicy {
+            enabled: true,
+            ..GitGuardPolicy::default()
+        };
+        let ctx = exec_ctx(&gh, &git, false);
+        let e = explain_exec(
+            &["git".into(), "push".into(), "origin".into(), "main".into()],
+            &ctx,
+        );
+        assert_eq!(e.decision, Decision::Blocked);
+    }
+
+    #[test]
+    fn git_status_allowed() {
+        let gh = GhGuardPolicy::default();
+        let git = GitGuardPolicy {
+            enabled: true,
+            ..GitGuardPolicy::default()
+        };
+        let ctx = exec_ctx(&gh, &git, false);
+        let e = explain_exec(&["git".into(), "status".into()], &ctx);
+        assert_eq!(e.decision, Decision::Allowed);
+    }
+
+    #[test]
+    fn generic_command_runs() {
+        let gh = GhGuardPolicy::default();
+        let git = GitGuardPolicy::default();
+        let ctx = exec_ctx(&gh, &git, false);
+        let e = explain_exec(&["node".into(), "app.js".into()], &ctx);
+        assert_eq!(e.decision, Decision::Allowed);
+    }
+
+    // ── Report verdict & JSON ──
+
+    fn blocked_item(name: &str) -> CheckItem {
+        CheckItem {
+            name: name.to_string(),
+            category: "filesystem".to_string(),
+            target: name.to_string(),
+            decision: Decision::Blocked,
+            expected: Some(Decision::Blocked),
+            reason: "r".to_string(),
+            fix: None,
+            note: None,
+        }
+    }
+
+    fn allowed_item(name: &str) -> CheckItem {
+        CheckItem {
+            name: name.to_string(),
+            category: "filesystem".to_string(),
+            target: name.to_string(),
+            decision: Decision::Allowed,
+            expected: Some(Decision::Allowed),
+            reason: "r".to_string(),
+            fix: None,
+            note: None,
+        }
+    }
+
+    #[test]
+    fn enforcing_when_all_expectations_met() {
+        let items = vec![allowed_item("proj"), blocked_item("ssh")];
+        let r = Report::new("copilot".into(), Some("strict".into()), true, items);
+        assert!(r.enforcing);
+        assert_eq!(r.verified, 1);
+        assert!(!r.exit_nonzero());
+        assert!(r.render().contains("ENFORCING"));
+    }
+
+    #[test]
+    fn not_enforcing_when_protection_leaks() {
+        let mut leak = blocked_item("ssh");
+        leak.decision = Decision::Allowed; // protection failed to block
+        let r = Report::new(
+            "copilot".into(),
+            None,
+            true,
+            vec![allowed_item("proj"), leak],
+        );
+        assert!(!r.enforcing);
+        assert!(r.exit_nonzero());
+        assert!(r.render().contains("NOT ENFORCING"));
+    }
+
+    #[test]
+    fn json_shape_has_fields() {
+        let r = Report::new("copilot".into(), None, true, vec![blocked_item("ssh")]);
+        let j = r.to_json();
+        assert!(j.contains("\"enforcing\""));
+        assert!(j.contains("\"verified\""));
+        assert!(j.contains("\"items\""));
+        assert!(j.contains("\"decision\": \"blocked\""));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod agent;
 pub mod audit;
+pub mod check;
 pub mod config;
 pub mod detect;
 pub mod discover;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1181,7 +1181,7 @@ struct ResolvedContext {
 }
 
 /// Load config, merge CLI flags, resolve paths, detect agent, print info messages.
-fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
+fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContext> {
     // Canonicalize CLI paths for consistency with config path handling
     let cli_allow_read = canonicalize_paths(&cli.allow_read, "--allow-read");
     let cli_allow_write = canonicalize_paths(&cli.allow_write, "--allow-write");
@@ -1448,6 +1448,21 @@ fn resolve_context(cli: &Cli) -> anyhow::Result<ResolvedContext> {
                     // Default to Copilot so they work without anything installed.
                     if cli.print_profile || cli.doctor {
                         agent::Agent::Copilot
+                    } else if check_mode {
+                        // `cplt check` is a diagnostic: users run it precisely when
+                        // unsure what's installed, so it must not hard-require an
+                        // agent binary. With no --agent and nothing auto-detected,
+                        // fall back to the always-available Shell profile (uses
+                        // $SHELL / /bin/sh, no external binary) rather than erroring.
+                        // Printed even under check's default --quiet: it explains
+                        // which profile is being reported. Goes to stderr, so it
+                        // never contaminates --json output on stdout.
+                        ui::info(
+                            "check: no agent specified/detected — checking the 'shell' \
+                             sandbox profile (pass --agent <name> to check a specific \
+                             agent's policy)",
+                        );
+                        agent::Agent::Shell
                     } else {
                         bail!(
                             "No supported AI coding agent found in PATH. \
@@ -1884,7 +1899,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         project_dir,
         active_agent,
         unapproved_proposals: _,
-    } = resolve_context(&cli)?;
+    } = resolve_context(&cli, false)?;
 
     // Run auto-discovery to tighten the sandbox profile
     let tool_discovery = discover::discover_tools(&home_dir);
@@ -2549,7 +2564,7 @@ fn run_exec_command(
         unapproved_proposals: _,
         // active_agent from resolve_context is ignored — exec always uses Shell
         active_agent: _,
-    } = resolve_context(cli)?;
+    } = resolve_context(cli, false)?;
 
     // exec defaults to quiet+yes (scripting UX). User can override with --no-quiet / --no-yes.
     if !cli.no_quiet {
@@ -2937,7 +2952,7 @@ fn run_check_command(
         project_dir,
         active_agent,
         unapproved_proposals: _,
-    } = resolve_context(cli)?;
+    } = resolve_context(cli, true)?;
 
     // check prints its own report; never prompt.
     resolved.yes = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2835,7 +2835,14 @@ fn build_net_policy(resolved: &config::Resolved, agent: agent::Agent) -> proxy::
     let file_domains: Vec<String> = if resolved.allow_all_domains {
         Vec::new()
     } else if let Some(ref path) = resolved.allowed_domains {
-        proxy::parse_domain_file(path).unwrap_or_default()
+        // Parse the allowed_domains file through the EXACT parser the live
+        // allowlist cache uses (`parse_lines_file` via `get_cached_domains`), NOT
+        // `parse_domain_file`. The latter extra-normalizes (strips scheme/path/
+        // port), so a non-canonical entry like `github.com:443` would be stored
+        // as `github.com` for check but kept verbatim for live enforcement —
+        // making check report ALLOWED while `handle_connect` returns
+        // BLOCKED-ALLOWLIST. Sharing one parser keeps the two byte-identical.
+        proxy::parse_lines_file(path).unwrap_or_default()
     } else {
         Vec::new()
     };
@@ -2849,8 +2856,10 @@ fn build_net_policy(resolved: &config::Resolved, agent: agent::Agent) -> proxy::
         merged
     };
 
+    // Same parser-parity requirement for the blocklist: the live cache reads it
+    // via `parse_lines_file`, so check must too (see the allowlist note above).
     let blocked_domains = default_blocklist_path(resolved)
-        .and_then(|p| proxy::parse_domain_file(&p).ok())
+        .and_then(|p| proxy::parse_lines_file(&p))
         .unwrap_or_default();
 
     proxy::NetPolicy {
@@ -2859,6 +2868,10 @@ fn build_net_policy(resolved: &config::Resolved, agent: agent::Agent) -> proxy::
         blocked_domains,
         allow_localhost_ports: resolved.allow_localhost.clone(),
         allow_localhost_any: resolved.allow_localhost_any,
+        // Mirror the live proxy's private-domain union (config + CLI, deduped),
+        // which `resolved.allow_private_domains` already holds, so check's
+        // post-DNS resolved-IP guard waives exactly the hosts the live proxy does.
+        private_domains: resolved.allow_private_domains.clone(),
     }
 }
 
@@ -3269,6 +3282,55 @@ fn mismatch_note(probe: check::Decision, model: check::Decision) -> Option<Strin
     }
 }
 
+/// Replicate the live proxy's post-DNS resolved-IP SSRF guard for `cplt check
+/// net`. `classify_connect`/`explain_domain` classify PRE-DNS only, but
+/// `handle_connect` ALSO runs `resolved_ip_is_blocked` AFTER DNS — blocking a
+/// public host whose A record points at a private/link-local IP
+/// (10.x/172.16.x/192.168.x/169.254.169.254) with BLOCKED-PRIVATE-RESOLVED.
+///
+/// Returns `Some(blocked item)` when the resolved IP is blocked (so check
+/// reports BLOCKED, matching live enforcement, and never runs the reachability
+/// probe for such a target); returns `None` when the resolved IP passes the
+/// guard OR the host does not resolve here (in which case the pre-DNS ALLOWED
+/// verdict stands and `probe_reachable` reports the resolution failure honestly,
+/// exactly as the live proxy would then hit DNS-FAIL rather than a policy block).
+///
+/// Uses the same resolver ([`proxy::resolve_socket_addr`]) and guard
+/// ([`proxy::resolved_ip_is_blocked`]) as the live path, with the same
+/// localhost-opt-in and `allow_private_domains` semantics.
+fn resolved_ip_block_item(
+    net_policy: &proxy::NetPolicy,
+    host: &str,
+    port: u16,
+) -> Option<check::CheckItem> {
+    let addr = proxy::resolve_socket_addr(host, port)?;
+    let localhost_opt_in =
+        net_policy.allow_localhost_any || net_policy.allow_localhost_ports.contains(&port);
+    let host_is_private_domain = proxy::is_domain_match(host, &net_policy.private_domains);
+    if !proxy::resolved_ip_is_blocked(&addr.ip(), host_is_private_domain, localhost_opt_in) {
+        return None;
+    }
+    Some(check::CheckItem {
+        name: "BLOCKED-PRIVATE-RESOLVED".to_string(),
+        category: "network".to_string(),
+        target: format!("{host}:{port}"),
+        decision: check::Decision::Blocked,
+        expected: None,
+        reason: format!(
+            "{host} resolves to {} — a private / loopback / link-local IP the proxy blocks \
+             AFTER DNS (BLOCKED-PRIVATE-RESOLVED) as an SSRF / DNS-rebinding safeguard \
+             (e.g. cloud metadata 169.254.169.254, internal services).",
+            addr.ip()
+        ),
+        fix: Some(
+            "for a trusted internal host use --allow-private-domains <DOMAIN>; \
+             for a local dev server use --allow-localhost <PORT>."
+                .to_string(),
+        ),
+        note: None,
+    })
+}
+
 fn build_net_check(
     net_policy: &proxy::NetPolicy,
     proxy_enabled: bool,
@@ -3279,6 +3341,18 @@ fn build_net_check(
 ) -> check::Report {
     let (host, port) = split_host_port(target);
     let expl = check::explain_domain(net_policy, &host, port, proxy_enabled);
+
+    // The live proxy applies a SECOND, post-DNS guard once the pre-DNS gates in
+    // `classify_connect` pass. Mirror it before trusting an ALLOWED verdict so
+    // check never reports ALLOWED — nor probes reachability (which cplt runs
+    // OUTSIDE the sandbox, where private IPs ARE reachable) — for a target the
+    // live proxy would block on its resolved IP.
+    if proxy_enabled
+        && expl.decision == check::Decision::Allowed
+        && let Some(item) = resolved_ip_block_item(net_policy, &host, port)
+    {
+        return check::Report::new(agent_name, preset_name, false, vec![item]);
+    }
 
     let note = if !no_connect && expl.decision == check::Decision::Allowed && proxy_enabled {
         Some(probe_reachable(&host, port))
@@ -5769,5 +5843,84 @@ mod tests {
         // A shorter prefix must not spuriously match (1.0.3 != 1.0.32).
         assert_eq!(find_complete_dir_for_version(&tmp, "1.0.3"), None);
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ── `cplt check net` must MATCH the live proxy's verdict ──────────────
+
+    #[test]
+    fn check_net_non_canonical_allowlist_matches_live_blocked() {
+        // FIX 1: with a non-canonical allowlist entry (`github.com:443`), the live
+        // proxy stores it verbatim and returns BLOCKED-ALLOWLIST for `github.com`
+        // (it does not verbatim-match). `build_net_policy` now parses the file with
+        // the SAME `parse_lines_file` the live cache uses, so `check net github.com`
+        // reports BLOCKED — matching live — instead of the old false ALLOWED that
+        // `parse_domain_file`'s port-stripping produced.
+        let policy = proxy::NetPolicy {
+            allowed_ports: vec![443],
+            allowed_domains: vec!["github.com:443".to_string()],
+            ..Default::default()
+        };
+        let report = build_net_check(
+            &policy,
+            true,
+            "github.com",
+            true, // no_connect
+            "copilot".to_string(),
+            None,
+        );
+        let json = report.to_json();
+        assert!(
+            json.contains("BLOCKED-ALLOWLIST"),
+            "check must match the live BLOCKED-ALLOWLIST verdict, not report ALLOWED:\n{json}"
+        );
+    }
+
+    #[test]
+    fn check_net_applies_post_dns_resolved_ip_guard() {
+        // FIX 2: `cplt check net` must apply the live proxy's post-DNS
+        // `resolved_ip_is_blocked` guard, not just the pre-DNS classify_connect
+        // gates. A host that resolves to a private / link-local IP must be reported
+        // BLOCKED-PRIVATE-RESOLVED (matching live enforcement) — never the false
+        // ALLOWED + "reachable" the old check produced by probing from cplt (which
+        // runs OUTSIDE the sandbox, where private IPs are reachable).
+        let policy = proxy::NetPolicy::default();
+
+        let item = resolved_ip_block_item(&policy, "10.0.0.1", 443)
+            .expect("a private resolved IP must be reported BLOCKED");
+        assert_eq!(item.decision, check::Decision::Blocked);
+        assert_eq!(item.name, "BLOCKED-PRIVATE-RESOLVED");
+
+        // Cloud metadata endpoint (link-local) is likewise blocked post-DNS.
+        assert!(resolved_ip_block_item(&policy, "169.254.169.254", 443).is_some());
+
+        // A public resolved IP passes the guard, so the pre-DNS ALLOWED verdict
+        // stands and reachability may then be probed.
+        assert!(resolved_ip_block_item(&policy, "1.1.1.1", 443).is_none());
+    }
+
+    #[test]
+    fn check_net_resolved_ip_guard_matches_live_optin_semantics() {
+        // Same waiver semantics as the live proxy: a host trusted via
+        // allow_private_domains that resolves private is waived, and loopback is
+        // waived ONLY when localhost access was opted into for this connection.
+        let trusted = proxy::NetPolicy {
+            private_domains: vec!["10.0.0.1".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            resolved_ip_block_item(&trusted, "10.0.0.1", 443).is_none(),
+            "allow_private_domains must waive the resolved-IP block, matching live"
+        );
+
+        // Loopback without opt-in → blocked (default no-localhost posture).
+        let no_optin = proxy::NetPolicy::default();
+        assert!(resolved_ip_block_item(&no_optin, "127.0.0.1", 443).is_some());
+
+        // Loopback with opt-in → waived (matches resolved_ip_is_blocked semantics).
+        let optin = proxy::NetPolicy {
+            allow_localhost_any: true,
+            ..Default::default()
+        };
+        assert!(resolved_ip_block_item(&optin, "127.0.0.1", 443).is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use cplt::{
-    agent, audit, config, discover, gh_proxy, proxy, repo_config, sandbox, scratch, trust, update,
+    agent, audit, check, config, discover, gh_proxy, proxy, repo_config, sandbox, scratch, trust,
+    update,
 };
 use std::collections::BTreeSet;
 use std::io::IsTerminal;
@@ -676,6 +677,41 @@ QUICK START:
     /// and sandbox-critical paths. Exits 0 if all critical checks pass.
     Doctor,
 
+    /// Verify & explain sandbox enforcement.
+    ///
+    /// Runs probes inside the REAL resolved sandbox/proxy (the same policy the
+    /// agent would get) and reports, for each, whether cplt allows or blocks it
+    /// AND why + the exact fix. Honours the policy-affecting flags — put them
+    /// before `check`, e.g. `cplt --preset strict check`.
+    ///
+    /// With no subcommand it runs a battery demonstrating enforcement and exits
+    /// non-zero if the sandbox is NOT enforcing (useful in CI).
+    ///
+    /// EXAMPLES:
+    ///   cplt check
+    ///     Enforcement battery + one-line verdict.
+    ///   cplt --preset strict check --json
+    ///     Machine-readable battery for CI.
+    ///   cplt check path ~/.ssh/id_rsa
+    ///     Probe a filesystem path (read, and --write).
+    ///   cplt check net evil.example
+    ///     Probe a domain against the proxy policy.
+    ///   cplt check exec docker
+    ///     Report whether a command would run or is gated.
+    #[command(after_help = "\
+NOTE:
+  Probes reflect cplt's resolved policy. A passing network probe means
+  \"cplt is not blocking this\" — not that the host is up or that an
+  arbitrary agent action would behave identically.")]
+    Check {
+        #[command(subcommand)]
+        target: Option<CheckTarget>,
+
+        /// Emit machine-readable JSON instead of the human report.
+        #[arg(long, global = true)]
+        json: bool,
+    },
+
     /// Run an arbitrary command inside the sandbox.
     ///
     /// Uses the same sandbox as `--agent shell`: filesystem isolation,
@@ -786,6 +822,45 @@ QUICK START:
         /// git arguments to evaluate and potentially pass through.
         #[arg(last = true)]
         args: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum CheckTarget {
+    /// Probe filesystem access to PATH inside the sandbox.
+    ///
+    /// Runs a hermetic read (and, with --write, a write) probe inside the real
+    /// sandbox and reports allowed/blocked + why + the fix. Reads nothing from
+    /// the file and never mutates user state.
+    Path {
+        /// The path to probe (file or directory).
+        path: PathBuf,
+
+        /// Also probe write access (creates and removes a probe file for
+        /// directories; append-opens an existing file without writing bytes).
+        #[arg(long)]
+        write: bool,
+    },
+
+    /// Probe a CONNECT to DOMAIN[:PORT] under the resolved proxy policy.
+    ///
+    /// Blocked targets never leave cplt. An allowed target additionally gets a
+    /// real outbound connection attempt to confirm reachability (skip with
+    /// --no-connect for a static, policy-only answer).
+    Net {
+        /// Target as `domain` or `domain:port` (default port 443).
+        target: String,
+
+        /// Explain from policy only — do not make any outbound connection.
+        #[arg(long)]
+        no_connect: bool,
+    },
+
+    /// Report whether CMD would run, is guard-blocked, or needs an allow_*.
+    Exec {
+        /// The command and its arguments.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+        cmd: Vec<String>,
     },
 }
 
@@ -1689,6 +1764,21 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         }
     }
 
+    // Handle `cplt check` before consuming cli.command, for the same reason as
+    // exec above: run_check_command needs to borrow &cli (via resolve_context)
+    // after taking the check-specific fields out.
+    #[allow(clippy::collapsible_if)]
+    if matches!(&cli.command, Some(Command::Check { .. })) {
+        if let Some(Command::Check { target, json }) = cli.command.take() {
+            // check defaults to quiet: it prints its own report, so suppress the
+            // config-loading diagnostics that would otherwise contaminate --json.
+            if !cli.no_quiet {
+                cli.quiet = true;
+            }
+            return run_check_command(&cli, target, json);
+        }
+    }
+
     // Handle subcommands (these don't need macOS or sandbox)
     if let Some(command) = cli.command {
         return Ok(match command {
@@ -1768,6 +1858,8 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             }
             // Exec is handled before this match (see above) — unreachable
             Command::Exec { .. } => unreachable!("Command::Exec handled before this match"),
+            // Check is handled before this match (see above) — unreachable
+            Command::Check { .. } => unreachable!("Command::Check handled before this match"),
         });
     }
 
@@ -2291,6 +2383,120 @@ fn resolve_exec_binary(name: &str) -> anyhow::Result<PathBuf> {
     bail!("exec: '{name}' not found in PATH")
 }
 
+/// A fully-built Shell sandbox plus the live resources it depends on.
+///
+/// `scratch_guard` and `proxy_handle` are RAII/handle values that must outlive
+/// any use of `prepared` (the scratch dir is cleaned up on drop; the proxy
+/// thread is shut down via the handle). `policy` is the structured Landlock
+/// model of the filesystem policy — the same rules the profile enforces —
+/// used by `cplt check` for the explain layer (`describe_policy`'s model).
+struct ShellSandbox {
+    prepared: sandbox::PreparedSandbox,
+    policy: sandbox::LandlockPolicy,
+    proxy_handle: Option<proxy::ProxyHandle>,
+    scratch_guard: Option<scratch::ScratchDir>,
+}
+
+/// Build the resolved Shell sandbox: tool discovery, scratch dir, optional
+/// proxy, and the compiled sandbox profile.
+///
+/// This is the shared setup used by both `cplt exec` and `cplt check` so their
+/// probes run under byte-for-byte the same policy. Mutates `resolved`
+/// (proxy port, tool-path env overrides) exactly as the agent launch does.
+fn prepare_shell_sandbox(
+    cli: &Cli,
+    resolved: &mut config::Resolved,
+    config_path: Option<&PathBuf>,
+    home_dir: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<ShellSandbox> {
+    let active_agent = agent::Agent::Shell;
+
+    let tool_discovery = discover::discover_tools(home_dir);
+    let existing_home_tool_dirs = tool_discovery.existing_home_tool_dirs;
+    let existing_app_dirs = tool_discovery.existing_app_dirs;
+
+    let scratch_guard = if resolved.scratch_dir {
+        scratch::ScratchDir::gc_stale(home_dir);
+        match scratch::ScratchDir::create(home_dir) {
+            Ok(s) => Some(s),
+            Err(e) => bail!("Cannot create scratch dir: {e}"),
+        }
+    } else {
+        None
+    };
+    let scratch_path = scratch_guard.as_ref().map(cplt::scratch::ScratchDir::path);
+
+    let git_hooks_path = discover::git_hooks_path(home_dir);
+    let git_common_dir = discover::git_common_dir(home_dir, project_dir);
+    let java_home_dir = std::env::var("JAVA_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .filter(|p| !crate::is_unsafe_root(p, home_dir));
+
+    let agent_dirs = active_agent.config_dirs(home_dir);
+    for dir in &agent_dirs {
+        if !dir.path.exists() {
+            let _ = std::fs::create_dir_all(&dir.path);
+        }
+    }
+
+    let proxy_handle = start_proxy_if_enabled(resolved, cli, config_path, active_agent)?;
+    let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
+
+    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
+    merge_tool_path_env_overrides(resolved, home_dir);
+
+    let sandbox_config = sandbox::SandboxConfig {
+        project_dir,
+        home_dir,
+        extra_read: &resolved.allow_read,
+        extra_write: &resolved.allow_write,
+        extra_socket: &resolved.allow_socket,
+        extra_deny: &resolved.deny_paths,
+        existing_home_tool_dirs: Some(&existing_home_tool_dirs),
+        existing_app_dirs: Some(&existing_app_dirs),
+        extra_ports: &resolved.allow_ports,
+        localhost_ports: &resolved.allow_localhost,
+        proxy_port: proxy_port_for_profile,
+        proxy_forced: resolved.proxy_forced,
+        allow_env_files: resolved.allow_env_files,
+        allow_localhost_any: resolved.allow_localhost_any,
+        scratch_dir: scratch_path,
+        allow_tmp_exec: resolved.allow_tmp_exec,
+        // shell/check have no agent install dir to grant special access to
+        copilot_install_dir: None,
+        java_home: java_home_dir.as_deref(),
+        git_hooks_path: git_hooks_path.as_deref(),
+        git_common_dir: git_common_dir.as_deref(),
+        allow_gpg_signing: resolved.allow_gpg_signing,
+        deny_clipboard: resolved.deny_clipboard,
+        allow_jvm_attach: resolved.allow_jvm_attach,
+        allow_docker: resolved.allow_docker,
+        electron_app_dir: None,
+        agent: active_agent,
+        agent_dirs: &agent_dirs,
+        allow_cache_exec: &resolved.allow_cache_exec,
+        allow_cache_exec_any: resolved.allow_cache_exec_any,
+        allow_browser: resolved.allow_browser,
+        use_bubblewrap: resolved.use_bubblewrap,
+    };
+
+    // The structured Landlock model of the fs policy — used by the check
+    // explain layer. It faithfully mirrors the enforced allow-list on both
+    // platforms (the live probe remains authoritative where they differ).
+    let policy = sandbox::generate_policy(&sandbox_config);
+    let prepared = sandbox::prepare(&sandbox_config).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    Ok(ShellSandbox {
+        prepared,
+        policy,
+        proxy_handle,
+        scratch_guard,
+    })
+}
+
 /// Run an arbitrary command inside the sandbox (`cplt exec -- <cmd> [args]`).
 ///
 /// Reuses the Agent::Shell sandbox policy. Defaults to quiet+yes so it is
@@ -2374,80 +2580,20 @@ fn run_exec_command(
     // Always use the Shell sandbox policy
     let active_agent = agent::Agent::Shell;
 
-    let tool_discovery = discover::discover_tools(&home_dir);
-    let existing_home_tool_dirs = tool_discovery.existing_home_tool_dirs;
-    let existing_app_dirs = tool_discovery.existing_app_dirs;
-
-    let scratch_guard = if resolved.scratch_dir {
-        scratch::ScratchDir::gc_stale(&home_dir);
-        match scratch::ScratchDir::create(&home_dir) {
-            Ok(s) => Some(s),
-            Err(e) => bail!("Cannot create scratch dir: {e}"),
-        }
-    } else {
-        None
-    };
-    let scratch_path = scratch_guard.as_ref().map(cplt::scratch::ScratchDir::path);
-
-    let git_hooks_path = discover::git_hooks_path(&home_dir);
-    let git_common_dir = discover::git_common_dir(&home_dir, &project_dir);
-    let java_home_dir = std::env::var("JAVA_HOME")
-        .ok()
-        .map(PathBuf::from)
-        .filter(|p| p.is_dir())
-        .filter(|p| !crate::is_unsafe_root(p, &home_dir));
-
-    let agent_dirs = active_agent.config_dirs(&home_dir);
-    for dir in &agent_dirs {
-        if !dir.path.exists() {
-            let _ = std::fs::create_dir_all(&dir.path);
-        }
-    }
-
-    let proxy_handle =
-        start_proxy_if_enabled(&mut resolved, cli, config_path.as_ref(), active_agent)?;
-    let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
-
-    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
-    merge_tool_path_env_overrides(&mut resolved, &home_dir);
-
-    let prepared = match sandbox::prepare(&sandbox::SandboxConfig {
-        project_dir: &project_dir,
-        home_dir: &home_dir,
-        extra_read: &resolved.allow_read,
-        extra_write: &resolved.allow_write,
-        extra_socket: &resolved.allow_socket,
-        extra_deny: &resolved.deny_paths,
-        existing_home_tool_dirs: Some(&existing_home_tool_dirs),
-        existing_app_dirs: Some(&existing_app_dirs),
-        extra_ports: &resolved.allow_ports,
-        localhost_ports: &resolved.allow_localhost,
-        proxy_port: proxy_port_for_profile,
-        proxy_forced: resolved.proxy_forced,
-        allow_env_files: resolved.allow_env_files,
-        allow_localhost_any: resolved.allow_localhost_any,
-        scratch_dir: scratch_path,
-        allow_tmp_exec: resolved.allow_tmp_exec,
-        // exec has no agent install dir to grant special access to
-        copilot_install_dir: None,
-        java_home: java_home_dir.as_deref(),
-        git_hooks_path: git_hooks_path.as_deref(),
-        git_common_dir: git_common_dir.as_deref(),
-        allow_gpg_signing: resolved.allow_gpg_signing,
-        deny_clipboard: resolved.deny_clipboard,
-        allow_jvm_attach: resolved.allow_jvm_attach,
-        allow_docker: resolved.allow_docker,
-        electron_app_dir: None,
-        agent: active_agent,
-        agent_dirs: &agent_dirs,
-        allow_cache_exec: &resolved.allow_cache_exec,
-        allow_cache_exec_any: resolved.allow_cache_exec_any,
-        allow_browser: resolved.allow_browser,
-        use_bubblewrap: resolved.use_bubblewrap,
-    }) {
-        Ok(s) => s,
-        Err(e) => bail!("{e}"),
-    };
+    // Build the resolved Shell sandbox (discovery → proxy → prepare). Shared
+    // with `cplt check`, which runs its probes under the identical policy.
+    let ShellSandbox {
+        prepared,
+        proxy_handle,
+        scratch_guard: _scratch_guard,
+        ..
+    } = prepare_shell_sandbox(
+        cli,
+        &mut resolved,
+        config_path.as_ref(),
+        &home_dir,
+        &project_dir,
+    )?;
 
     if cli.print_profile {
         println!("{}", sandbox::describe(&prepared));
@@ -2496,6 +2642,689 @@ fn run_exec_command(
     }
 
     Ok(ExitCode::from(exit_code))
+}
+
+// ── cplt check ─────────────────────────────────────────────────────────────
+
+/// The canonical CLI/config name for a preset (inverse of `Preset::from_name`).
+fn preset_label(p: config::Preset) -> &'static str {
+    match p {
+        config::Preset::Strict => "strict",
+        config::Preset::Standard => "standard",
+        config::Preset::Permissive => "permissive",
+        config::Preset::FullTrust => "full-trust",
+    }
+}
+
+/// Sentinel exit code meaning "the sandbox probe could not even be spawned".
+/// Distinct from any code a probe script itself returns.
+const PROBE_SPAWN_FAILED: u8 = 200;
+
+/// Wrap a string as a single-quoted shell literal (safe for arbitrary paths).
+fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Run a hermetic shell probe inside the resolved sandbox and return its exit
+/// code. `PROBE_SPAWN_FAILED` means the shell could not be resolved/spawned.
+fn probe_shell(
+    prepared: &sandbox::PreparedSandbox,
+    resolved: &config::Resolved,
+    disabled: &[sandbox::HardeningCategory],
+    script: &str,
+) -> u8 {
+    let Ok(shell) = agent::Agent::Shell.resolve_binary() else {
+        return PROBE_SPAWN_FAILED;
+    };
+    let args = vec!["-c".to_string(), script.to_string()];
+    sandbox::exec_sandboxed(
+        prepared,
+        &shell,
+        &args,
+        &resolved.pass_env,
+        resolved.inherit_env,
+        disabled,
+        &resolved.deny_env,
+        &resolved.gh_guard,
+        &resolved.git_guard,
+    )
+}
+
+/// Interpret a read/write probe exit code as a [`check::Decision`].
+fn decode_fs_probe(code: u8) -> check::Decision {
+    match code {
+        0 => check::Decision::Allowed,
+        PROBE_SPAWN_FAILED => check::Decision::Inconclusive,
+        _ => check::Decision::Blocked,
+    }
+}
+
+/// Probe read access to `path` inside the sandbox (opens for read, reads
+/// nothing). Works for files and directories.
+fn probe_read(
+    prepared: &sandbox::PreparedSandbox,
+    resolved: &config::Resolved,
+    disabled: &[sandbox::HardeningCategory],
+    path: &Path,
+) -> check::Decision {
+    let script = format!(
+        "exec >/dev/null 2>&1; : < {}",
+        sh_quote(&path.to_string_lossy())
+    );
+    decode_fs_probe(probe_shell(prepared, resolved, disabled, &script))
+}
+
+/// Probe write access to `path` inside the sandbox without mutating user state.
+///
+/// - Directory: create and immediately remove a uniquely-named probe file.
+/// - Existing file: append-open (no bytes written; content-preserving).
+/// - Missing file: reported [`check::Decision::Inconclusive`] (creating it would
+///   mutate state).
+fn probe_write(
+    prepared: &sandbox::PreparedSandbox,
+    resolved: &config::Resolved,
+    disabled: &[sandbox::HardeningCategory],
+    path: &Path,
+) -> check::Decision {
+    let q = sh_quote(&path.to_string_lossy());
+    let script = if path.is_dir() {
+        format!("exec >/dev/null 2>&1; f={q}/.cplt-check-write.$$; : > \"$f\" && rm -f \"$f\"")
+    } else if path.exists() {
+        // Append-open an existing file: opens for write, writes nothing.
+        format!("exec >/dev/null 2>&1; : >> {q}")
+    } else {
+        return check::Decision::Inconclusive;
+    };
+    decode_fs_probe(probe_shell(prepared, resolved, disabled, &script))
+}
+
+/// Probe whether a binary staged in a writable-but-non-executable location can
+/// be executed (binary-drop prevention). Stages in `~/.cache` — writable on both
+/// platforms yet deliberately non-executable, the canonical binary-drop vector
+/// (the scratch dir / `$TMPDIR` is intentionally executable for real tooling, so
+/// it is NOT the right target). Distinguishes a staging failure (inconclusive)
+/// from an actual exec denial (blocked).
+fn probe_tmp_exec(
+    prepared: &sandbox::PreparedSandbox,
+    resolved: &config::Resolved,
+    disabled: &[sandbox::HardeningCategory],
+) -> (check::Decision, Option<String>) {
+    let script = "\
+exec >/dev/null 2>&1
+d=\"$HOME/.cache\"
+mkdir -p \"$d\" || exit 90
+f=\"$d/.cplt-check-exec.$$\"
+printf '#!/bin/sh\\nexit 0\\n' > \"$f\" || exit 90
+chmod +x \"$f\" || { rm -f \"$f\"; exit 91; }
+\"$f\"
+r=$?
+rm -f \"$f\"
+exit $r";
+    match probe_shell(prepared, resolved, disabled, script) {
+        0 => (check::Decision::Allowed, None),
+        90 | 91 => (
+            check::Decision::Inconclusive,
+            Some("could not stage the probe binary".to_string()),
+        ),
+        PROBE_SPAWN_FAILED => (
+            check::Decision::Inconclusive,
+            Some("sandbox probe could not be spawned".to_string()),
+        ),
+        _ => (check::Decision::Blocked, None),
+    }
+}
+
+/// Pick a known-protected credential path that exists on this host, for the
+/// enforcement battery's "read is blocked" demonstration. Falls back to the
+/// home directory root (always present and never listable in the sandbox).
+fn pick_protected_read(home: &Path) -> (PathBuf, String) {
+    const CANDIDATES: &[&str] = &[
+        ".ssh/id_rsa",
+        ".ssh/id_ed25519",
+        ".ssh",
+        ".aws/credentials",
+        ".aws",
+        ".config/gh/hosts.yml",
+        ".netrc",
+        ".gnupg",
+    ];
+    for c in CANDIDATES {
+        let p = home.join(c);
+        if p.exists() {
+            return (p, format!("read ~/{c}"));
+        }
+    }
+    (home.to_path_buf(), "read $HOME (root)".to_string())
+}
+
+/// The blocklist file cplt would use, mirroring `start_proxy_if_enabled`.
+fn default_blocklist_path(resolved: &config::Resolved) -> Option<PathBuf> {
+    if let Some(ref p) = resolved.blocked_domains {
+        return Some(p.clone());
+    }
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_path_buf))?;
+    for name in ["blocked-domains.txt", "blocked.txt"] {
+        let candidate = exe_dir.join(name);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Build the effective CONNECT policy snapshot from resolved config — the same
+/// merge `start_proxy_if_enabled` performs, so `classify_connect` sees exactly
+/// what the live proxy would enforce.
+fn build_net_policy(resolved: &config::Resolved, agent: agent::Agent) -> proxy::NetPolicy {
+    let mut ports = vec![443u16];
+    ports.extend_from_slice(&resolved.allow_ports);
+    ports.sort_unstable();
+    ports.dedup();
+
+    let default_allowlist: Vec<String> = if resolved.default_allowlist {
+        agent
+            .default_allowed_domains()
+            .iter()
+            .map(|d| (*d).to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let file_domains: Vec<String> = if resolved.allow_all_domains {
+        Vec::new()
+    } else if let Some(ref path) = resolved.allowed_domains {
+        proxy::parse_domain_file(path).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let allowed_domains = if default_allowlist.is_empty() {
+        file_domains
+    } else {
+        let mut merged = default_allowlist;
+        merged.extend(file_domains);
+        merged.sort_unstable();
+        merged.dedup();
+        merged
+    };
+
+    let blocked_domains = default_blocklist_path(resolved)
+        .and_then(|p| proxy::parse_domain_file(&p).ok())
+        .unwrap_or_default();
+
+    proxy::NetPolicy {
+        allowed_ports: ports,
+        allowed_domains,
+        blocked_domains,
+        allow_localhost_ports: resolved.allow_localhost.clone(),
+        allow_localhost_any: resolved.allow_localhost_any,
+    }
+}
+
+/// Split a `host[:port]` target into `(host, port)` (default 443).
+fn split_host_port(target: &str) -> (String, u16) {
+    // IPv6 literal in brackets, optional :port after the closing bracket.
+    if let Some(stripped) = target.strip_prefix('[')
+        && let Some(end) = stripped.find(']')
+    {
+        let host = &stripped[..end];
+        let rest = &stripped[end + 1..];
+        let port = rest
+            .strip_prefix(':')
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(443);
+        return (host.to_string(), port);
+    }
+    match target.rsplit_once(':') {
+        Some((h, p)) if p.chars().all(|c| c.is_ascii_digit()) && !p.is_empty() => {
+            (h.to_string(), p.parse().unwrap_or(443))
+        }
+        _ => (target.to_string(), 443),
+    }
+}
+
+/// Best-effort outbound reachability check (cplt runs outside the sandbox).
+/// Only used for an ALLOWED target to confirm "cplt is not blocking this";
+/// never affects the decision.
+fn probe_reachable(host: &str, port: u16) -> String {
+    use std::net::ToSocketAddrs;
+    let addr = format!("{host}:{port}");
+    let Ok(mut addrs) = addr.to_socket_addrs() else {
+        return format!("policy allows it, but {host} did not resolve here");
+    };
+    let Some(sa) = addrs.next() else {
+        return format!("policy allows it, but {host} did not resolve here");
+    };
+    match std::net::TcpStream::connect_timeout(&sa, std::time::Duration::from_secs(4)) {
+        Ok(_) => format!("reachable — connected to {sa} then closed"),
+        Err(_) => "policy allows it, but the host was not reachable from here".to_string(),
+    }
+}
+
+fn run_check_command(
+    cli: &Cli,
+    target: Option<CheckTarget>,
+    json: bool,
+) -> anyhow::Result<ExitCode> {
+    if cfg!(not(any(target_os = "macos", target_os = "linux"))) {
+        bail!("cplt check requires macOS or Linux");
+    }
+    if std::env::var("__CPLT_WRAPPED").is_ok() {
+        bail!(
+            "cplt check: already inside a cplt sandbox (recursion detected). \
+             Run this command outside the sandbox."
+        );
+    }
+
+    let ResolvedContext {
+        mut resolved,
+        config_path,
+        home_dir,
+        project_dir,
+        active_agent,
+        unapproved_proposals: _,
+    } = resolve_context(cli)?;
+
+    // check prints its own report; never prompt.
+    resolved.yes = true;
+
+    let agent_name = active_agent.display_name().to_string();
+    let preset_name = resolved.preset.map(|p| preset_label(p).to_string());
+    // Snapshot the effective net policy BEFORE prepare_shell_sandbox mutates
+    // resolved (it only changes the proxy port and tool-path env, neither of
+    // which affects domain/port classification, but snapshot early to be safe).
+    let net_policy = build_net_policy(&resolved, active_agent);
+
+    let ShellSandbox {
+        prepared,
+        policy,
+        proxy_handle,
+        scratch_guard: _scratch_guard,
+    } = prepare_shell_sandbox(
+        cli,
+        &mut resolved,
+        config_path.as_ref(),
+        &home_dir,
+        &project_dir,
+    )?;
+
+    let proxy_enabled = proxy_handle.is_some();
+    let disabled = resolved.disabled_hardening_categories();
+
+    let report = match target {
+        None => build_battery(
+            &prepared,
+            &policy,
+            &net_policy,
+            proxy_enabled,
+            &resolved,
+            &disabled,
+            &home_dir,
+            &project_dir,
+            active_agent,
+            agent_name,
+            preset_name,
+        ),
+        Some(CheckTarget::Path { path, write }) => {
+            let abs = canonicalize_check_path(&path);
+            build_path_check(
+                &prepared,
+                &policy,
+                &resolved,
+                &disabled,
+                &home_dir,
+                &project_dir,
+                agent_name,
+                preset_name,
+                &abs,
+                write,
+            )
+        }
+        Some(CheckTarget::Net {
+            target: dom,
+            no_connect,
+        }) => build_net_check(
+            &net_policy,
+            proxy_enabled,
+            &dom,
+            no_connect,
+            agent_name,
+            preset_name,
+        ),
+        Some(CheckTarget::Exec { cmd }) => {
+            build_exec_check(&resolved, &project_dir, &cmd, agent_name, preset_name)
+        }
+    };
+
+    if let Some(handle) = proxy_handle {
+        handle.shutdown();
+    }
+
+    if json {
+        println!("{}", report.to_json());
+    } else {
+        print!("{}", report.render());
+    }
+
+    if report.exit_nonzero() {
+        Ok(ExitCode::FAILURE)
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+/// Resolve a user-supplied check path to an absolute path without requiring it
+/// to exist (canonicalize the existing ancestor, then re-append the tail).
+fn canonicalize_check_path(path: &Path) -> PathBuf {
+    if let Ok(c) = std::fs::canonicalize(path) {
+        return c;
+    }
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        match std::env::current_dir() {
+            Ok(d) => d.join(path),
+            Err(_) => path.to_path_buf(),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_battery(
+    prepared: &sandbox::PreparedSandbox,
+    policy: &sandbox::LandlockPolicy,
+    net_policy: &proxy::NetPolicy,
+    proxy_enabled: bool,
+    resolved: &config::Resolved,
+    disabled: &[sandbox::HardeningCategory],
+    home_dir: &Path,
+    project_dir: &Path,
+    agent: agent::Agent,
+    agent_name: String,
+    preset_name: Option<String>,
+) -> check::Report {
+    let mut items = Vec::new();
+
+    // ── Filesystem ──
+    // Sanity: reading & writing the project dir must be ALLOWED.
+    let read_proj = probe_read(prepared, resolved, disabled, project_dir);
+    let read_proj_expl = check::explain_path(policy, home_dir, project_dir, project_dir);
+    items.push(check::CheckItem {
+        name: "read project dir".to_string(),
+        category: "filesystem".to_string(),
+        target: project_dir.display().to_string(),
+        decision: read_proj,
+        expected: Some(check::Decision::Allowed),
+        reason: read_proj_expl.reason,
+        fix: read_proj_expl.fix,
+        note: baseline_note(read_proj),
+    });
+
+    let write_proj = probe_write(prepared, resolved, disabled, project_dir);
+    items.push(check::CheckItem {
+        name: "write project dir".to_string(),
+        category: "filesystem".to_string(),
+        target: project_dir.display().to_string(),
+        decision: write_proj,
+        expected: Some(check::Decision::Allowed),
+        reason: "covered by the project-dir rule (read+write+execute).".to_string(),
+        fix: None,
+        note: baseline_note(write_proj),
+    });
+
+    // Protection: a credential path must be BLOCKED for read.
+    let (prot_path, prot_label) = pick_protected_read(home_dir);
+    let read_prot = probe_read(prepared, resolved, disabled, &prot_path);
+    let prot_expl = check::explain_path(policy, home_dir, project_dir, &prot_path);
+    items.push(check::CheckItem {
+        name: prot_label,
+        category: "filesystem".to_string(),
+        target: prot_path.display().to_string(),
+        decision: read_prot,
+        expected: Some(check::Decision::Blocked),
+        reason: prot_expl.reason,
+        fix: prot_expl.fix,
+        note: None,
+    });
+
+    // Protection: writing into the home root must be BLOCKED.
+    let write_home = probe_write(prepared, resolved, disabled, home_dir);
+    items.push(check::CheckItem {
+        name: "write $HOME (root)".to_string(),
+        category: "filesystem".to_string(),
+        target: home_dir.display().to_string(),
+        decision: write_home,
+        expected: Some(check::Decision::Blocked),
+        reason: "the home directory root is not in any write rule (deny-by-default).".to_string(),
+        fix: None,
+        note: None,
+    });
+
+    // ── Exec: binary-drop prevention ──
+    // ~/.cache is writable but non-executable unless allow_cache_exec_any opens
+    // the whole tree, so that flag — not allow_tmp_exec — governs this probe.
+    let (tmp_dec, tmp_note) = probe_tmp_exec(prepared, resolved, disabled);
+    let cache_expected = if resolved.allow_cache_exec_any {
+        check::Decision::Allowed
+    } else {
+        check::Decision::Blocked
+    };
+    items.push(check::CheckItem {
+        name: "exec staged binary (~/.cache)".to_string(),
+        category: "exec".to_string(),
+        target: "~/.cache/<probe>".to_string(),
+        decision: tmp_dec,
+        expected: Some(cache_expected),
+        reason: if resolved.allow_cache_exec_any {
+            "cache execution is enabled (allow_cache_exec_any=on).".to_string()
+        } else {
+            "executing a binary dropped into ~/.cache is blocked (writable-but-non-executable)."
+                .to_string()
+        },
+        fix: None,
+        note: tmp_note,
+    });
+
+    // ── Network ──
+    if proxy_enabled {
+        // Allowed: an agent-default domain (in the allowlist even under strict).
+        let allowed_host = agent
+            .default_allowed_domains()
+            .first()
+            .map_or_else(|| "github.com".to_string(), |s| (*s).to_string());
+        let a_expl = check::explain_domain(net_policy, &allowed_host, 443, true);
+        items.push(check::CheckItem {
+            name: format!("reach {allowed_host}"),
+            category: "network".to_string(),
+            target: format!("{allowed_host}:443"),
+            decision: a_expl.decision,
+            expected: Some(check::Decision::Allowed),
+            reason: a_expl.reason,
+            fix: a_expl.fix,
+            note: None,
+        });
+
+        // Blocked: the cloud-metadata IP (SSRF) — always refused, never leaves cplt.
+        let b_expl = check::explain_domain(net_policy, "169.254.169.254", 443, true);
+        items.push(check::CheckItem {
+            name: "reach metadata IP (SSRF)".to_string(),
+            category: "network".to_string(),
+            target: "169.254.169.254:443".to_string(),
+            decision: b_expl.decision,
+            expected: Some(check::Decision::Blocked),
+            reason: b_expl.reason,
+            fix: b_expl.fix,
+            note: None,
+        });
+    } else {
+        items.push(check::CheckItem {
+            name: "domain filtering".to_string(),
+            category: "network".to_string(),
+            target: "(proxy)".to_string(),
+            decision: check::Decision::Inconclusive,
+            expected: None,
+            reason: "the CONNECT proxy is disabled — cplt is not filtering domains this run."
+                .to_string(),
+            fix: Some(
+                "enable it with --with-proxy, or --preset strict for a full lockdown.".to_string(),
+            ),
+            note: Some("network enforcement not tested".to_string()),
+        });
+    }
+
+    check::Report::new(agent_name, preset_name, true, items)
+}
+
+/// A note for a baseline (expected-allowed) probe that unexpectedly failed —
+/// usually means the sandbox itself is unavailable here.
+fn baseline_note(decision: check::Decision) -> Option<String> {
+    match decision {
+        check::Decision::Allowed => None,
+        check::Decision::Inconclusive => Some("sandbox probe could not be spawned".to_string()),
+        check::Decision::Blocked => Some(
+            "baseline access failed — the sandbox may be unavailable here \
+             (e.g. running inside another sandbox)"
+                .to_string(),
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_path_check(
+    prepared: &sandbox::PreparedSandbox,
+    policy: &sandbox::LandlockPolicy,
+    resolved: &config::Resolved,
+    disabled: &[sandbox::HardeningCategory],
+    home_dir: &Path,
+    project_dir: &Path,
+    agent_name: String,
+    preset_name: Option<String>,
+    path: &Path,
+    write: bool,
+) -> check::Report {
+    let expl = check::explain_path(policy, home_dir, project_dir, path);
+    let mut items = Vec::new();
+
+    let read_dec = probe_read(prepared, resolved, disabled, path);
+    let note = mismatch_note(read_dec, expl.read_decision());
+    items.push(check::CheckItem {
+        name: "read".to_string(),
+        category: "filesystem".to_string(),
+        target: format!("{} (read)", path.display()),
+        decision: read_dec,
+        expected: None,
+        reason: expl.reason.clone(),
+        fix: expl.fix.clone(),
+        note,
+    });
+
+    if write {
+        let write_dec = probe_write(prepared, resolved, disabled, path);
+        let (reason, fix) = if expl.write {
+            ("covered by a writable rule.".to_string(), None)
+        } else if expl.credential {
+            (
+                "protected path — writes are denied (deny-by-default).".to_string(),
+                None,
+            )
+        } else {
+            (
+                "not covered by any write rule (deny-by-default).".to_string(),
+                Some("grant write with --allow-write <PATH>.".to_string()),
+            )
+        };
+        let note = if write_dec == check::Decision::Inconclusive {
+            Some("path does not exist — cannot probe write without creating it".to_string())
+        } else {
+            mismatch_note(write_dec, expl.write_decision())
+        };
+        items.push(check::CheckItem {
+            name: "write".to_string(),
+            category: "filesystem".to_string(),
+            target: format!("{} (write)", path.display()),
+            decision: write_dec,
+            expected: None,
+            reason,
+            fix,
+            note,
+        });
+    }
+
+    check::Report::new(agent_name, preset_name, false, items)
+}
+
+/// When the live probe disagrees with the static model, the probe is
+/// authoritative — surface the difference so the explanation stays honest
+/// (e.g. a macOS SBPL deny-subpath the Landlock model cannot express).
+fn mismatch_note(probe: check::Decision, model: check::Decision) -> Option<String> {
+    if probe == check::Decision::Inconclusive || probe == model {
+        None
+    } else {
+        Some(format!(
+            "live probe says {}, the policy model predicted {} (the probe is authoritative)",
+            probe.as_str(),
+            model.as_str()
+        ))
+    }
+}
+
+fn build_net_check(
+    net_policy: &proxy::NetPolicy,
+    proxy_enabled: bool,
+    target: &str,
+    no_connect: bool,
+    agent_name: String,
+    preset_name: Option<String>,
+) -> check::Report {
+    let (host, port) = split_host_port(target);
+    let expl = check::explain_domain(net_policy, &host, port, proxy_enabled);
+
+    let note = if !no_connect && expl.decision == check::Decision::Allowed && proxy_enabled {
+        Some(probe_reachable(&host, port))
+    } else {
+        None
+    };
+
+    let item = check::CheckItem {
+        name: expl.status.clone(),
+        category: "network".to_string(),
+        target: format!("{host}:{port}"),
+        decision: expl.decision,
+        expected: None,
+        reason: expl.reason,
+        fix: expl.fix,
+        note,
+    };
+    check::Report::new(agent_name, preset_name, false, vec![item])
+}
+
+fn build_exec_check(
+    resolved: &config::Resolved,
+    project_dir: &Path,
+    cmd: &[String],
+    agent_name: String,
+    preset_name: Option<String>,
+) -> check::Report {
+    let ctx = check::ExecContext {
+        allow_docker: resolved.allow_docker,
+        allow_tmp_exec: resolved.allow_tmp_exec,
+        gh_guard: &resolved.gh_guard,
+        git_guard: &resolved.git_guard,
+        project_dir,
+    };
+    let expl = check::explain_exec(cmd, &ctx);
+    let item = check::CheckItem {
+        name: "exec".to_string(),
+        category: "exec".to_string(),
+        target: cmd.join(" "),
+        decision: expl.decision,
+        expected: None,
+        reason: expl.reason,
+        fix: expl.fix,
+        note: None,
+    };
+    check::Report::new(agent_name, preset_name, false, vec![item])
 }
 
 fn run_doctor() -> ExitCode {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -455,6 +455,20 @@ impl ProxyState {
         merged.dedup();
         merged
     }
+
+    /// Snapshot the effective CONNECT policy for static classification.
+    ///
+    /// Reads the current (cache-refreshed) allowlist and blocklist so
+    /// [`classify_connect`] sees exactly what the live gates would see.
+    fn net_policy(&self) -> NetPolicy {
+        NetPolicy {
+            allowed_ports: self.allowed_ports.clone(),
+            allowed_domains: self.get_allowed_domains(),
+            blocked_domains: self.get_blocked_domains(),
+            allow_localhost_ports: self.allow_localhost_ports.clone(),
+            allow_localhost_any: self.allow_localhost_any,
+        }
+    }
 }
 
 /// Read cached domains, refreshing from disk if TTL has expired.
@@ -851,6 +865,108 @@ fn resolve_locally(state: &ProxyState, host: &str, port: u16) -> Option<std::net
     addr_str.to_socket_addrs().ok().and_then(|mut a| a.next())
 }
 
+/// The verdict of the proxy's pre-DNS CONNECT policy gates.
+///
+/// This is the static portion of the CONNECT decision — the checks that depend
+/// only on the target host/port and the configured policy, not on DNS
+/// resolution. It is the single source of truth shared by the live proxy
+/// ([`handle_connect`]) and the `cplt check net` diagnostic ([`classify_connect`]).
+///
+/// [`NetVerdict::Allowed`] means "no static gate blocks this" — the live path
+/// then proceeds to DNS resolution and the resolved-IP SSRF guard, which can
+/// still block a name that resolves to a private address. The diagnostic treats
+/// `Allowed` as "cplt is not blocking this by policy".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetVerdict {
+    /// No static policy gate blocks the target (would proceed to DNS/connect).
+    Allowed,
+    /// The target port is not in the allowed-ports set.
+    BlockedPort,
+    /// A fail-closed allowlist is active and the host is not in it.
+    BlockedAllowlist,
+    /// The host matches the blocklist.
+    Blocked,
+    /// The host is a known-private/loopback/link-local target (SSRF guard).
+    BlockedPrivate,
+}
+
+impl NetVerdict {
+    /// The `BLOCKED-*` status string used in the proxy audit log for this verdict.
+    /// `Allowed` maps to `ALLOWED` (the target would be permitted by policy).
+    #[must_use]
+    pub fn status(self) -> &'static str {
+        match self {
+            NetVerdict::Allowed => "ALLOWED",
+            NetVerdict::BlockedPort => "BLOCKED-PORT",
+            NetVerdict::BlockedAllowlist => "BLOCKED-ALLOWLIST",
+            NetVerdict::Blocked => "BLOCKED",
+            NetVerdict::BlockedPrivate => "BLOCKED-PRIVATE",
+        }
+    }
+
+    /// Whether this verdict permits the connection (no static gate blocked it).
+    #[must_use]
+    pub fn is_allowed(self) -> bool {
+        matches!(self, NetVerdict::Allowed)
+    }
+}
+
+/// A snapshot of the proxy's effective CONNECT policy for static classification.
+///
+/// Built either from a live [`ProxyState`] (via [`ProxyState::net_policy`]) or
+/// directly from resolved config by the `cplt check` command. The field values
+/// mean exactly what they mean inside [`handle_connect`]: `allowed_ports`
+/// already includes 443, `allowed_domains` is the *effective* (merged) allowlist
+/// where empty means allow-all.
+#[derive(Debug, Clone, Default)]
+pub struct NetPolicy {
+    pub allowed_ports: Vec<u16>,
+    pub allowed_domains: Vec<String>,
+    pub blocked_domains: Vec<String>,
+    pub allow_localhost_ports: Vec<u16>,
+    pub allow_localhost_any: bool,
+}
+
+/// Classify a CONNECT target against the static (pre-DNS) proxy policy gates.
+///
+/// This is the exact gate order [`handle_connect`] enforces before it resolves
+/// DNS — port policy, fail-closed allowlist, blocklist, then the
+/// private-hostname SSRF guard — reusing the same matchers ([`is_domain_match`],
+/// [`is_blocked_in_list`], [`is_private_hostname`]). Factoring it here keeps the
+/// live path and the diagnostic from drifting apart.
+#[must_use]
+pub fn classify_connect(policy: &NetPolicy, host: &str, port: u16) -> NetVerdict {
+    let host = normalize_hostname(host);
+
+    let localhost_opt_in =
+        policy.allow_localhost_any || policy.allow_localhost_ports.contains(&port);
+    let localhost_connect_allowed = {
+        let h = host.trim_start_matches('[').trim_end_matches(']');
+        let is_loopback = h == "localhost"
+            || h.ends_with(".localhost")
+            || h.parse::<std::net::IpAddr>()
+                .is_ok_and(|ip| ip.is_loopback());
+        is_loopback && localhost_opt_in
+    };
+
+    if !localhost_connect_allowed && !policy.allowed_ports.contains(&port) {
+        return NetVerdict::BlockedPort;
+    }
+    if !localhost_connect_allowed
+        && !policy.allowed_domains.is_empty()
+        && !is_domain_match(&host, &policy.allowed_domains)
+    {
+        return NetVerdict::BlockedAllowlist;
+    }
+    if is_blocked_in_list(&host, &policy.blocked_domains) {
+        return NetVerdict::Blocked;
+    }
+    if !localhost_connect_allowed && is_private_hostname(&host) {
+        return NetVerdict::BlockedPrivate;
+    }
+    NetVerdict::Allowed
+}
+
 /// Apply the resolved-IP SSRF / DNS-rebinding guard.
 ///
 /// Returns `true` when the target must be BLOCKED: it resolves to a
@@ -891,57 +1007,40 @@ fn handle_connect(mut client: TcpStream, target: &str, state: &ProxyState) {
         is_loopback && localhost_opt_in
     };
 
-    // Enforce port policy — only allow ports matching the sandbox network rules.
-    // Without this, the proxy would let sandboxed processes tunnel to arbitrary
-    // remote ports, bypassing the sandbox's port restrictions.
-    // Exception: explicitly-opened localhost ports bypass this check; the user's
-    // intent with --allow-localhost <PORT> is to reach that port regardless of
-    // whether it appears in the general allowed_ports list.
-    if !localhost_connect_allowed && !state.allowed_ports.contains(&port) {
-        log_connection("CONNECT", target, "BLOCKED-PORT", log_file, log_level);
-        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPort not allowed\r\n");
-        return;
-    }
-
-    // Enforce domain allowlist — when configured, only listed domains pass.
-    // Fail-closed: if the allowlist is non-empty and the domain isn't in it, deny.
-    //
-    // Localhost carve-out: skip the allowlist gate for an opted-in localhost
-    // target, consistent with the port-policy and private-hostname gates above
-    // (both also skip when `localhost_connect_allowed`). The agent-default
-    // allowlist never contains "localhost", so without this exemption a user
-    // combining fail-closed networking with a local dev-server carve-out
-    // (`--default-allowlist --allow-localhost 3000`) would get
-    // `CONNECT localhost:3000` blocked — a surprising break of a legitimate
-    // combo. Still safe: `localhost_connect_allowed` requires both an explicit
-    // opt-in AND a loopback-spelled host, and the resolved-IP loopback check
-    // below still enforces that the target actually resolves to a loopback IP,
-    // so this exemption cannot let a non-loopback host masquerade as localhost
-    // to bypass the allowlist.
-    let allowed_domains = state.get_allowed_domains();
-    if !localhost_connect_allowed
-        && !allowed_domains.is_empty()
-        && !is_domain_match(&host, &allowed_domains)
-    {
-        log_connection("CONNECT", target, "BLOCKED-ALLOWLIST", log_file, log_level);
-        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nDomain not in allowlist\r\n");
-        return;
-    }
-
-    // Check blocklist (hostname-level)
-    let blocked_domains = state.get_blocked_domains();
-    if is_blocked_in_list(&host, &blocked_domains) {
-        log_connection("CONNECT", target, "BLOCKED", log_file, log_level);
-        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nBlocked by cplt\r\n");
-        let _ = client.shutdown(std::net::Shutdown::Both);
-        return;
-    }
-    // Reject hostname patterns that are known private (fast path before DNS)
-    if !localhost_connect_allowed && is_private_hostname(&host) {
-        log_connection("CONNECT", target, "BLOCKED-PRIVATE", log_file, log_level);
-        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPrivate target blocked\r\n");
-        let _ = client.shutdown(std::net::Shutdown::Both);
-        return;
+    // Apply the static (pre-DNS) policy gates — port policy, fail-closed
+    // allowlist, blocklist, then the private-hostname SSRF guard — in that
+    // order. The decision logic lives in `classify_connect` so the live proxy
+    // and the `cplt check net` diagnostic can never drift apart; here we map
+    // each verdict to its audit-log status and 403 response. The `Blocked`
+    // (blocklist) and `BlockedPrivate` cases additionally half-close the socket,
+    // matching the original inline behaviour. `localhost_connect_allowed` is
+    // recomputed identically inside `classify_connect`; it is retained here
+    // because the post-DNS section below still consults it.
+    let snapshot = state.net_policy();
+    match classify_connect(&snapshot, &host, port) {
+        NetVerdict::BlockedPort => {
+            log_connection("CONNECT", target, "BLOCKED-PORT", log_file, log_level);
+            let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPort not allowed\r\n");
+            return;
+        }
+        NetVerdict::BlockedAllowlist => {
+            log_connection("CONNECT", target, "BLOCKED-ALLOWLIST", log_file, log_level);
+            let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nDomain not in allowlist\r\n");
+            return;
+        }
+        NetVerdict::Blocked => {
+            log_connection("CONNECT", target, "BLOCKED", log_file, log_level);
+            let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nBlocked by cplt\r\n");
+            let _ = client.shutdown(std::net::Shutdown::Both);
+            return;
+        }
+        NetVerdict::BlockedPrivate => {
+            log_connection("CONNECT", target, "BLOCKED-PRIVATE", log_file, log_level);
+            let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\nPrivate target blocked\r\n");
+            let _ = client.shutdown(std::net::Shutdown::Both);
+            return;
+        }
+        NetVerdict::Allowed => {}
     }
 
     // ── Upstream (corporate) proxy chaining ──────────────────────────────
@@ -1720,6 +1819,76 @@ use std::net::ToSocketAddrs;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── classify_connect: the shared static gate order ──
+
+    fn np(allowed: &[&str], blocked: &[&str], ports: &[u16]) -> NetPolicy {
+        NetPolicy {
+            allowed_ports: ports.to_vec(),
+            allowed_domains: allowed.iter().map(|s| (*s).to_string()).collect(),
+            blocked_domains: blocked.iter().map(|s| (*s).to_string()).collect(),
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+        }
+    }
+
+    #[test]
+    fn classify_gate_order_matches_live_proxy() {
+        // Port is checked first.
+        assert_eq!(
+            classify_connect(&np(&[], &[], &[443]), "github.com", 22),
+            NetVerdict::BlockedPort
+        );
+        // Then the fail-closed allowlist.
+        assert_eq!(
+            classify_connect(&np(&["github.com"], &[], &[443]), "evil.example", 443),
+            NetVerdict::BlockedAllowlist
+        );
+        // Empty allowlist = allow-all.
+        assert_eq!(
+            classify_connect(&np(&[], &[], &[443]), "anything.example", 443),
+            NetVerdict::Allowed
+        );
+        // Blocklist applies even when the allowlist would pass.
+        assert_eq!(
+            classify_connect(
+                &np(&["evil.example"], &["evil.example"], &[443]),
+                "evil.example",
+                443
+            ),
+            NetVerdict::Blocked
+        );
+        // Private/link-local SSRF guard (cloud metadata).
+        assert_eq!(
+            classify_connect(&np(&[], &[], &[443]), "169.254.169.254", 443),
+            NetVerdict::BlockedPrivate
+        );
+    }
+
+    #[test]
+    fn classify_localhost_opt_in_bypasses_gates() {
+        let mut policy = np(&["github.com"], &[], &[443]);
+        // Without opt-in, localhost:3000 fails the port gate.
+        assert_eq!(
+            classify_connect(&policy, "localhost", 3000),
+            NetVerdict::BlockedPort
+        );
+        // Opting the port in exempts it from port, allowlist, and SSRF gates.
+        policy.allow_localhost_ports = vec![3000];
+        assert_eq!(
+            classify_connect(&policy, "localhost", 3000),
+            NetVerdict::Allowed
+        );
+    }
+
+    #[test]
+    fn net_verdict_status_strings() {
+        assert_eq!(NetVerdict::Allowed.status(), "ALLOWED");
+        assert_eq!(NetVerdict::BlockedPort.status(), "BLOCKED-PORT");
+        assert_eq!(NetVerdict::BlockedAllowlist.status(), "BLOCKED-ALLOWLIST");
+        assert_eq!(NetVerdict::Blocked.status(), "BLOCKED");
+        assert_eq!(NetVerdict::BlockedPrivate.status(), "BLOCKED-PRIVATE");
+    }
 
     /// Create a unique temp directory for test isolation.
     fn test_dir(name: &str) -> PathBuf {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -467,6 +467,7 @@ impl ProxyState {
             blocked_domains: self.get_blocked_domains(),
             allow_localhost_ports: self.allow_localhost_ports.clone(),
             allow_localhost_any: self.allow_localhost_any,
+            private_domains: self.get_private_domains(),
         }
     }
 }
@@ -499,7 +500,15 @@ fn get_cached_domains(
 
 /// Parse a one-domain-per-line file (blocklist or allowlist format).
 /// Returns None on read failure (caller keeps last-good).
-fn parse_lines_file(path: &Path) -> Option<Vec<String>> {
+///
+/// This is the **single** parser the live proxy feeds into its allowlist and
+/// blocklist caches ([`get_cached_domains`]). `cplt check` must build its policy
+/// snapshot through this same function (not [`parse_domain_file`], which extra-
+/// normalizes by stripping scheme/path/port) so a non-canonical allowlist entry
+/// like `github.com:443` is stored byte-identically in both — otherwise check
+/// would report ALLOWED for a host the live `handle_connect` blocks with
+/// BLOCKED-ALLOWLIST.
+pub fn parse_lines_file(path: &Path) -> Option<Vec<String>> {
     let contents = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e)
@@ -861,6 +870,18 @@ fn resolve_locally(state: &ProxyState, host: &str, port: u16) -> Option<std::net
             return resolver(host, port);
         }
     }
+    let _ = state;
+    resolve_socket_addr(host, port)
+}
+
+/// Resolve `host:port` to a single socket address via the system resolver.
+///
+/// This is the real DNS path the live proxy uses ([`resolve_locally`], modulo
+/// the test-injected resolver) and the exact resolver `cplt check net` reuses so
+/// the diagnostic's post-DNS SSRF guard sees the same address the live proxy
+/// would resolve — never duplicating resolution logic.
+#[must_use]
+pub fn resolve_socket_addr(host: &str, port: u16) -> Option<std::net::SocketAddr> {
     let addr_str = format!("{host}:{port}");
     addr_str.to_socket_addrs().ok().and_then(|mut a| a.next())
 }
@@ -925,6 +946,12 @@ pub struct NetPolicy {
     pub blocked_domains: Vec<String>,
     pub allow_localhost_ports: Vec<u16>,
     pub allow_localhost_any: bool,
+    /// Hosts explicitly trusted to resolve to private IPs
+    /// (`allow_private_domains`). Consulted by the post-DNS resolved-IP guard
+    /// (`resolved_ip_is_blocked`), not by the pre-DNS [`classify_connect`] gates.
+    /// Mirrors `ProxyState::get_private_domains` so `cplt check net` applies the
+    /// same waiver the live proxy does.
+    pub private_domains: Vec<String>,
 }
 
 /// Classify a CONNECT target against the static (pre-DNS) proxy policy gates.
@@ -1829,6 +1856,7 @@ mod tests {
             blocked_domains: blocked.iter().map(|s| (*s).to_string()).collect(),
             allow_localhost_ports: Vec::new(),
             allow_localhost_any: false,
+            ..Default::default()
         }
     }
 
@@ -1879,6 +1907,46 @@ mod tests {
             classify_connect(&policy, "localhost", 3000),
             NetVerdict::Allowed
         );
+    }
+
+    #[test]
+    fn check_allowlist_parser_matches_live_enforcement() {
+        // FIX 1: `cplt check` must build its allowlist through the SAME parser the
+        // live cache uses (`parse_lines_file`), not `parse_domain_file`. A
+        // non-canonical entry like `github.com:443` is a divergence point:
+        //   - `parse_lines_file` (live + check now)  → stores "github.com:443"
+        //   - `parse_domain_file` (check, the bug)   → strips port to "github.com"
+        // With the port-stripping parser, check reported ALLOWED for `github.com`
+        // while the live proxy (matching the verbatim "github.com:443") returns
+        // BLOCKED-ALLOWLIST — a dangerous false ALLOWED. Prove the two parsers
+        // diverge and that the shared `parse_lines_file` path now agrees with live.
+        let dir = test_dir("allowlist-parity");
+        let path = dir.join("allowed_domains.txt");
+        std::fs::write(&path, "github.com:443\n").unwrap();
+
+        // The parser the live allowlist cache feeds (and now `build_net_policy`).
+        let live_list = parse_lines_file(&path).unwrap();
+        assert_eq!(live_list, vec!["github.com:443"]);
+        // The over-normalizing parser the check path used to use.
+        let stripped_list = parse_domain_file(&path).unwrap();
+        assert_eq!(stripped_list, vec!["github.com"]);
+
+        // Same host, same gate logic — the verdict now agrees with live: BLOCKED.
+        let live_policy = np(&["github.com:443"], &[], &[443]);
+        assert_eq!(
+            classify_connect(&live_policy, "github.com", 443),
+            NetVerdict::BlockedAllowlist,
+            "the live/check-parity allowlist blocks a host it does not verbatim match"
+        );
+        // The old stripped list would have wrongly reported ALLOWED — the bug.
+        let stripped_policy = np(&["github.com"], &[], &[443]);
+        assert_eq!(
+            classify_connect(&stripped_policy, "github.com", 443),
+            NetVerdict::Allowed,
+            "the over-normalized allowlist produced the false ALLOWED this fix removes"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4041,4 +4041,222 @@ mod e2e_tests {
             "exec --no-quiet should print sandbox summary.\nstderr: {stderr}"
         );
     }
+
+    // ============================================================
+    // `cplt check` — verify & explain sandbox enforcement (#142)
+    // ============================================================
+
+    /// A fresh, safe project directory for `check` (temp dirs are not rejected
+    /// as "too broad" the way /tmp itself is).
+    fn check_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A .git marker makes it a proper project root.
+        std::fs::create_dir_all(dir.path().join(".git")).ok();
+        dir
+    }
+
+    #[test]
+    fn e2e_check_battery_enforcing() {
+        require_sandbox!();
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .arg("check")
+            .output()
+            .expect("cplt check should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "battery should be enforcing (exit 0).\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        // A working sandbox: project ALLOWED, credentials/home/exec BLOCKED.
+        assert!(stdout.contains("ENFORCING"), "verdict:\n{stdout}");
+        assert!(
+            stdout.contains("ALLOWED"),
+            "should show allowed items:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("BLOCKED"),
+            "should show blocked items:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_battery_json_shape() {
+        require_sandbox!();
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args(["check", "--json"])
+            .output()
+            .expect("cplt check --json should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "json battery exit 0.\n{stdout}");
+        // Shape assertions.
+        assert!(stdout.contains("\"enforcing\": true"), "json:\n{stdout}");
+        assert!(stdout.contains("\"verified\":"), "json:\n{stdout}");
+        assert!(stdout.contains("\"items\":"), "json:\n{stdout}");
+        assert!(
+            stdout.contains("\"decision\": \"blocked\""),
+            "json should contain a blocked decision:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("\"decision\": \"allowed\""),
+            "json should contain an allowed decision:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_path_protected_blocked() {
+        require_sandbox!();
+        let proj = check_project();
+        let home = std::env::var("HOME").expect("HOME");
+        let ssh = format!("{home}/.ssh");
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args(["check", "path", &ssh])
+            .output()
+            .expect("cplt check path should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("BLOCKED"),
+            "~/.ssh read should be blocked:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("credential"),
+            "should explain it as a credential path:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_path_project_allowed() {
+        require_sandbox!();
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .arg("check")
+            .arg("path")
+            .arg(proj.path())
+            .arg("--write")
+            .output()
+            .expect("cplt check path should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "targeted check exits 0:\n{stdout}");
+        assert!(
+            stdout.matches("ALLOWED").count() >= 2,
+            "project dir read+write should both be ALLOWED:\n{stdout}"
+        );
+    }
+
+    // The net/exec explain layer is static (no kernel sandbox needed), so these
+    // run in CI regardless of sandbox-exec availability.
+
+    #[test]
+    fn e2e_check_net_metadata_blocked() {
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args(["check", "net", "169.254.169.254", "--no-connect"])
+            .output()
+            .expect("cplt check net should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("BLOCKED"),
+            "metadata IP should be blocked:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("SSRF"),
+            "should explain it as an SSRF block:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_net_default_allowed() {
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args(["check", "net", "githubcopilot.com", "--no-connect"])
+            .output()
+            .expect("cplt check net should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("ALLOWED"),
+            "an allow-listed default domain should be allowed:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_net_strict_allowlist_blocks_unknown() {
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args([
+                "--preset",
+                "strict",
+                "check",
+                "net",
+                "totally-unknown.example",
+                "--no-connect",
+            ])
+            .output()
+            .expect("cplt check net should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("BLOCKED") && stdout.contains("allowlist"),
+            "strict allowlist should block an unknown domain:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_exec_docker_blocked() {
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args(["check", "exec", "docker", "ps"])
+            .output()
+            .expect("cplt check exec should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("BLOCKED"),
+            "docker should be gated off by default:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("--allow-docker"),
+            "should name the exact fix flag:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_check_exec_docker_allowed_with_flag() {
+        let proj = check_project();
+        let output = cplt_cmd()
+            .arg("--project-dir")
+            .arg(proj.path())
+            .args(["--allow-docker", "check", "exec", "docker", "ps"])
+            .output()
+            .expect("cplt check exec should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("ALLOWED"),
+            "docker should be allowed with --allow-docker:\n{stdout}"
+        );
+    }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4059,7 +4059,10 @@ mod e2e_tests {
     fn e2e_check_battery_enforcing() {
         require_sandbox!();
         let proj = check_project();
+        // check is a diagnostic and must not require an installed agent in CI.
+        // Pin the always-available shell profile so the test is deterministic.
         let output = cplt_cmd()
+            .args(["--agent", "shell"])
             .arg("--project-dir")
             .arg(proj.path())
             .arg("check")
@@ -4089,6 +4092,7 @@ mod e2e_tests {
         require_sandbox!();
         let proj = check_project();
         let output = cplt_cmd()
+            .args(["--agent", "shell"])
             .arg("--project-dir")
             .arg(proj.path())
             .args(["check", "--json"])
@@ -4118,6 +4122,7 @@ mod e2e_tests {
         let home = std::env::var("HOME").expect("HOME");
         let ssh = format!("{home}/.ssh");
         let output = cplt_cmd()
+            .args(["--agent", "shell"])
             .arg("--project-dir")
             .arg(proj.path())
             .args(["check", "path", &ssh])
@@ -4140,6 +4145,7 @@ mod e2e_tests {
         require_sandbox!();
         let proj = check_project();
         let output = cplt_cmd()
+            .args(["--agent", "shell"])
             .arg("--project-dir")
             .arg(proj.path())
             .arg("check")
@@ -4166,7 +4172,14 @@ mod e2e_tests {
         let output = cplt_cmd()
             .arg("--project-dir")
             .arg(proj.path())
-            .args(["check", "net", "169.254.169.254", "--no-connect"])
+            .args([
+                "--agent",
+                "shell",
+                "check",
+                "net",
+                "169.254.169.254",
+                "--no-connect",
+            ])
             .output()
             .expect("cplt check net should run");
 
@@ -4187,7 +4200,14 @@ mod e2e_tests {
         let output = cplt_cmd()
             .arg("--project-dir")
             .arg(proj.path())
-            .args(["check", "net", "githubcopilot.com", "--no-connect"])
+            .args([
+                "--agent",
+                "shell",
+                "check",
+                "net",
+                "githubcopilot.com",
+                "--no-connect",
+            ])
             .output()
             .expect("cplt check net should run");
 
@@ -4205,6 +4225,8 @@ mod e2e_tests {
             .arg("--project-dir")
             .arg(proj.path())
             .args([
+                "--agent",
+                "shell",
                 "--preset",
                 "strict",
                 "check",
@@ -4228,7 +4250,7 @@ mod e2e_tests {
         let output = cplt_cmd()
             .arg("--project-dir")
             .arg(proj.path())
-            .args(["check", "exec", "docker", "ps"])
+            .args(["--agent", "shell", "check", "exec", "docker", "ps"])
             .output()
             .expect("cplt check exec should run");
 
@@ -4249,7 +4271,15 @@ mod e2e_tests {
         let output = cplt_cmd()
             .arg("--project-dir")
             .arg(proj.path())
-            .args(["--allow-docker", "check", "exec", "docker", "ps"])
+            .args([
+                "--agent",
+                "shell",
+                "--allow-docker",
+                "check",
+                "exec",
+                "docker",
+                "ps",
+            ])
             .output()
             .expect("cplt check exec should run");
 


### PR DESCRIPTION
Implements #142. `cplt check` runs probes inside the REAL resolved sandbox/proxy and reports allowed/blocked **plus why + the exact fix** — the enforcement counterpart to `doctor` (setup).

- `cplt check` (battery, exits non-zero if not enforcing), `check path|net|exec <arg>`, `--json`, honors `--preset`/`--agent`/`--allow-*`.
- Probe engine reuses `exec_sandboxed` (via a shared `prepare_shell_sandbox` extracted from `exec`) for fs/exec; net probes use the proxy verdict.
- Explain layer: `explain_path` (fs_rules longest-prefix + credential classes), `explain_domain`, `explain_exec` (guard + allow_* gating) → reason + fix.
- **Refactor:** the proxy's pre-DNS CONNECT gates (port→allowlist→blocklist→SSRF) are factored into `proxy::classify_connect`, a single source of truth for the live `handle_connect` AND the diagnostic (behavior-preserving; integration CONNECT tests pass).
- Sidesteps the Linux no-denial-log limit by re-running under observation; a passing net probe answers 'is it cplt or my app?'. Deferred: doctor teaser, macOS log-show fold-in. lib 646 + e2e 131.