### PR TITLE
feat(proxy): blocklist subscriptions — auto-updatable, SHA-verified (#144 Phase 1, closes #10)

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -111,6 +111,39 @@ cplt config set proxy.blocked_domains "~/.config/cplt/blocked-domains.txt"
 
 The blocklist covers webhook capture services, paste sites, file sharing, tunneling services, and IP recon endpoints. See [`blocked-domains.txt`](../blocked-domains.txt) for the full list with sources.
 
+### Subscribing to blocklists
+
+The threat landscape moves faster than cplt releases. A **blocklist subscription** keeps a local cache fresh from a maintained upstream list (issue #144, Phase 1). Cached subscription domains are **UNIONed** into the effective blocklist alongside your local `blocked_domains` file and the built-in `blocked-domains.txt` — they only ever *add* blocks.
+
+Subscriptions are **global-only** (`~/.config/cplt/config.toml`) — a repo `.cplt.toml` cannot add one, so a malicious repository can never point cplt at an attacker-controlled list.
+
+Configure them under `[proxy.subscriptions]`:
+
+```toml
+[proxy.subscriptions]
+refresh = "manual"   # "manual" (default), "daily", or "weekly"
+blocklists = [
+    # The cplt-maintained default list (opt-in — add it yourself):
+    "https://raw.githubusercontent.com/navikt/cplt/main/blocked-domains.txt",
+    # Pin a sha256 to reject tampered downloads (recommended):
+    { url = "https://example.com/blocklist.txt", sha256 = "<64-hex-digest>" },
+]
+```
+
+Fetch and cache all configured lists explicitly:
+
+```bash
+cplt update-lists
+```
+
+`cplt update-lists` reports a per-list result: how many domains were fetched, whether a pinned `sha256` verified, whether the last-good cache was kept on a fetch failure, or whether verification **FAILED** (tamper). Caches live under `~/.config/cplt/subscriptions/` — **outside** the agent's sandbox-writable paths, so a running agent cannot poison them.
+
+**Refresh:** with `refresh = "daily"` or `"weekly"`, cplt lazily re-fetches a stale cache before a run, bounded by a short timeout so it never hangs the run. With the default `"manual"`, only `cplt update-lists` refreshes. A one-line warning is printed for a cache that has never been fetched or is very old.
+
+**Tighten-only / fail-open semantics.** Blocklists can only *add* blocks, so the worst case of a bad, stale, or unreachable list is that a domain simply isn't blocked — no worse than today. Accordingly, on a fetch failure cplt keeps and uses the last-good cache (or treats the list as empty if there is none) and **never** blocks the run on the network. When a subscription pins a `sha256`, a hash mismatch **rejects** the downloaded copy, keeps the last-good cache, and warns loudly about possible tampering — but pinning is *encouraged*, not required, because an unverified blocklist cannot open an exfiltration channel.
+
+> **Allowlist subscriptions are a separate future feature.** An *allowlist* subscription would define what is *permitted* and is therefore cplt's security boundary — a tampered or MITM'd allowlist opens an exfiltration channel for every subscriber. That tier must be fail-**closed** and verification-required, and is intentionally **not** part of Phase 1. Only blocklist subscriptions exist today.
+
 ### Allowlist
 
 Restrict connections to only specific domains. When set, the proxy blocks everything not in the list:

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -239,6 +239,26 @@ pub fn display_config(loaded: Option<&LoadedConfig>) {
         c.proxy.timeout.unwrap_or(60),
         src(c.proxy.timeout.is_some())
     );
+    // [proxy.subscriptions] — blocklist subscriptions (issue #144, Phase 1).
+    // Global-only, tighten-only. Shown only when configured.
+    if !c.proxy.subscriptions.blocklists.is_empty() {
+        println!(
+            "{blue}[cplt]{nc}    subscriptions.refresh   = \"{}\"",
+            c.proxy.subscriptions.refresh.as_deref().unwrap_or("manual")
+        );
+        println!(
+            "{blue}[cplt]{nc}    subscriptions.blocklists = ({} list(s))",
+            c.proxy.subscriptions.blocklists.len()
+        );
+        for source in &c.proxy.subscriptions.blocklists {
+            let pin = if source.sha256().is_some() {
+                " (sha256 pinned)"
+            } else {
+                ""
+            };
+            println!("{blue}[cplt]{nc}      - {}{pin}", source.url());
+        }
+    }
     println!();
 
     // [allow]

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use super::error::ConfigError;
-use super::path::{config_path, expand_tilde, resolve_config_path};
+use super::path::{config_dir, config_path, expand_tilde, resolve_config_path};
 use super::types::{
     CliFlags, Config, EnforcementMode, GhGuardPolicy, GitGuardPolicy, LoadedConfig, Preset,
     Resolved, ResolvedPushRule, UnknownCommandPolicy,
@@ -205,6 +205,41 @@ impl Config {
             merged.sort_unstable();
             merged.dedup();
             merged
+        };
+
+        // Blocklist subscriptions (issue #144, Phase 1). GLOBAL-only, tighten-only.
+        // Parsed here so an invalid `refresh` value fails config loading (a typo
+        // is surfaced, not silently ignored). The cache lives under the cplt
+        // config dir (`~/.config/cplt/subscriptions/`) — OUTSIDE the sandbox's
+        // writable set, so the agent cannot poison it. When no blocklists are
+        // configured the set is empty and networking is unchanged from today.
+        let proxy_subscriptions = {
+            let refresh = match self.proxy.subscriptions.refresh.as_deref() {
+                Some(s) => crate::subscriptions::RefreshInterval::parse(s)
+                    .map_err(|e| ConfigError::Validation(format!("proxy.subscriptions.{e}")))?,
+                None => crate::subscriptions::RefreshInterval::Manual,
+            };
+            let mut blocklists = Vec::new();
+            for entry in &self.proxy.subscriptions.blocklists {
+                let url = entry.url().trim().to_string();
+                if url.is_empty() {
+                    return Err(ConfigError::Validation(
+                        "proxy.subscriptions.blocklists entry has an empty url".to_string(),
+                    ));
+                }
+                blocklists.push(crate::subscriptions::BlocklistSubscription {
+                    url,
+                    sha256: entry.sha256().map(|s| s.trim().to_ascii_lowercase()),
+                });
+            }
+            let cache_dir = config_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("subscriptions");
+            crate::subscriptions::SubscriptionSet {
+                refresh,
+                blocklists,
+                cache_dir,
+            }
         };
 
         // Allow private domains: merge CLI + config list, sort+dedup.
@@ -512,6 +547,7 @@ impl Config {
             proxy_timeout,
             proxy_upstream,
             proxy_upstream_no_proxy,
+            proxy_subscriptions,
             allow_private_domains,
             allow_read,
             allow_write,

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -227,6 +227,17 @@ impl Config {
                         "proxy.subscriptions.blocklists entry has an empty url".to_string(),
                     ));
                 }
+                // Scheme allowlist, enforced at config-load time. Only https:// is
+                // fetched in production; file:// is permitted for a local mirror /
+                // offline + test path. Rejecting anything else here catches junk,
+                // `http://`, and `-`-prefixed values (which curl would otherwise try
+                // to parse as flags) before they ever reach the fetcher.
+                if !(url.starts_with("https://") || url.starts_with("file://")) {
+                    return Err(ConfigError::Validation(format!(
+                        "proxy.subscriptions.blocklists url {url:?} must start with \
+                         https:// (or file:// for a local mirror)"
+                    )));
+                }
                 blocklists.push(crate::subscriptions::BlocklistSubscription {
                     url,
                     sha256: entry.sha256().map(|s| s.trim().to_ascii_lowercase()),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,9 @@ pub use path::{collapse_tilde, config_dir, config_path, default_config_contents,
 pub use registry::{ConfigKeyInfo, ConfigValueType, all_config_keys, lookup_key};
 pub use repo::{RepoKeyTarget, repo_key_rejection_reason, repo_key_target, set_repo_value_in_doc};
 pub use types::{
-    AllowConfig, AuditConfig, CliFlags, Config, DenyConfig, EnforcementMode, FeatureToggle,
-    GhGuardConfig, GhGuardPolicy, GitGuardConfig, GitGuardPolicy, GitPushRule, LoadedConfig,
-    Preset, ProxyConfig, Resolved, ResolvedPushRule, SandboxConfig, UnknownCommandPolicy,
+    AllowConfig, AuditConfig, BlocklistSource, CliFlags, Config, DenyConfig, EnforcementMode,
+    FeatureToggle, GhGuardConfig, GhGuardPolicy, GitGuardConfig, GitGuardPolicy, GitPushRule,
+    LoadedConfig, Preset, ProxyConfig, Resolved, ResolvedPushRule, SandboxConfig,
+    SubscriptionsConfig, UnknownCommandPolicy,
 };
 pub use validation::{ConfigDiagnostic, DiagnosticLevel, validate_config};

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -77,6 +77,21 @@ pub fn default_config_contents() -> String {
 # is merged in automatically. All of cplt's domain/port/SSRF filtering still
 # applies — a listed host is just connected directly instead of forwarded.
 # upstream_no_proxy = ["internal.example.com"]
+#
+# Subscribable blocklists (issue #144). GLOBAL-only, tighten-only, opt-in — no
+# subscription is enabled by default, so leaving this unset keeps today's
+# behavior. Cached lists are UNIONed into the effective blocklist (they can only
+# ADD blocks). Fetch with `cplt update-lists`. A fetch/verify failure falls back
+# to the last-good cache (fail-open); an entry may pin a sha256 (recommended),
+# and a hash mismatch rejects the update with a tamper warning.
+# [proxy.subscriptions]
+# refresh = "manual"   # "manual" (default), "daily", or "weekly"
+# blocklists = [
+#     # cplt-maintained default blocklist (opt-in — add it yourself):
+#     "https://raw.githubusercontent.com/navikt/cplt/main/blocked-domains.txt",
+#     # Pin a sha256 to reject tampered downloads:
+#     # { url = "https://example.com/blocklist.txt", sha256 = "<64-hex>" },
+# ]
 
 # ─── Allowed paths ──────────────────────────────────────────
 # Additional paths the sandboxed process may access.

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -86,6 +86,17 @@ pub fn repo_key_rejection_reason(key_info: &ConfigKeyInfo) -> &'static str {
             "domain lists are machine-specific paths, not project policy"
         }
         ("proxy", "default_allowlist") => "proxy settings are machine-specific, not project policy",
+        // Blocklist subscriptions (issue #144) are GLOBAL-only: a malicious repo
+        // must not be able to point cplt at an attacker-controlled list. The
+        // repo config schema has no [proxy] table, so a `.cplt.toml` cannot even
+        // express these — this mirrors proxy.forced's rejection for the
+        // `config set --repo` path.
+        ("proxy", "subscriptions")
+        | ("proxy", "subscriptions.blocklists")
+        | ("proxy", "subscriptions.refresh") => {
+            "subscription sources are machine/network-specific and security-sensitive, \
+             not project policy — a repo must not be able to add a subscription"
+        }
         ("proxy", "upstream") => {
             "the corporate proxy is machine/network-specific, not project policy"
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -473,6 +473,64 @@ pub struct ProxyConfig {
     /// allow/block, port policy, resolved-IP SSRF guard); it is simply connected
     /// directly instead of being forwarded to the corporate proxy.
     pub upstream_no_proxy: Option<Vec<String>>,
+    /// Subscribable blocklists (issue #144, Phase 1). GLOBAL-only, tighten-only.
+    /// Cached lists UNION into the effective blocklist. Rejected in repo config.
+    pub subscriptions: SubscriptionsConfig,
+}
+
+/// `[proxy.subscriptions]` — subscribable domain lists (issue #144).
+///
+/// Phase 1 is BLOCKLIST subscriptions only: tighten-only, fail-open, low-risk.
+/// This is GLOBAL-only config (`~/.config/cplt/config.toml`) — the repo config
+/// schema has no `[proxy]` table, so a `.cplt.toml` can never add a subscription.
+/// Allowlist subscriptions (security-critical, fail-closed) are a future feature.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct SubscriptionsConfig {
+    /// Refresh cadence: "manual" (default), "daily", or "weekly".
+    pub refresh: Option<String>,
+    /// Blocklist subscription sources. Each entry is a bare URL string or a
+    /// `{ url, sha256 }` table with an optional pinned hash (recommended).
+    pub blocklists: Vec<BlocklistSource>,
+}
+
+/// One blocklist subscription source: a bare URL, or a table with an optional
+/// pinned SHA256. Deserialized untagged so both TOML forms work:
+///
+/// ```toml
+/// blocklists = [
+///   "https://example.com/blocklist.txt",
+///   { url = "https://example.com/pinned.txt", sha256 = "abc123..." },
+/// ]
+/// ```
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum BlocklistSource {
+    /// A bare URL string (unpinned — loads because blocklists are tighten-only).
+    Url(String),
+    /// A URL with an optional pinned SHA256 (verified after download).
+    Pinned {
+        url: String,
+        #[serde(default)]
+        sha256: Option<String>,
+    },
+}
+
+impl BlocklistSource {
+    /// The subscription URL, regardless of form.
+    pub fn url(&self) -> &str {
+        match self {
+            Self::Url(u) | Self::Pinned { url: u, .. } => u,
+        }
+    }
+
+    /// The pinned SHA256, if any.
+    pub fn sha256(&self) -> Option<&str> {
+        match self {
+            Self::Url(_) => None,
+            Self::Pinned { sha256, .. } => sha256.as_deref(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -671,6 +729,10 @@ pub struct Resolved {
     /// (NO_PROXY semantics). Merged from config, CLI, and the `NO_PROXY` env.
     /// A no-op when `proxy_upstream` is `None`.
     pub proxy_upstream_no_proxy: Vec<String>,
+    /// Resolved blocklist subscriptions (issue #144, Phase 1). Empty blocklists
+    /// = feature off (behaviour byte-identical to today). Cached lists are
+    /// UNIONed into the effective blocklist. GLOBAL-only, tighten-only, fail-open.
+    pub proxy_subscriptions: crate::subscriptions::SubscriptionSet,
     pub allow_private_domains: Vec<String>,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod proxy;
 pub mod repo_config;
 pub mod sandbox;
 pub mod scratch;
+pub mod subscriptions;
 pub mod trust;
 pub mod ui;
 pub mod update;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use cplt::{
-    agent, audit, config, discover, gh_proxy, proxy, repo_config, sandbox, scratch, trust, update,
+    agent, audit, config, discover, gh_proxy, proxy, repo_config, sandbox, scratch, subscriptions,
+    trust, update,
 };
 use std::collections::BTreeSet;
 use std::io::IsTerminal;
@@ -629,6 +630,17 @@ QUICK START:
         #[arg(long)]
         force: bool,
     },
+
+    /// Update subscribed blocklists (issue #144, Phase 1).
+    ///
+    /// Fetches, SHA256-verifies (when pinned), and caches every blocklist under
+    /// [proxy.subscriptions] in your global config, then reports a per-list
+    /// result. Cached lists are UNIONed into the effective blocklist on the next
+    /// run. Tighten-only and fail-open: a fetch failure keeps the last-good
+    /// cache; a pinned-hash mismatch rejects the download (tamper) and keeps the
+    /// last-good cache. Subscriptions are global-only — a repo cannot add one.
+    #[command(name = "update-lists")]
+    UpdateLists,
 
     /// Manage per-repo trust for .cplt.toml permissions.
     ///
@@ -1589,6 +1601,13 @@ fn start_proxy_if_enabled(
         );
     }
 
+    // Blocklist subscriptions (issue #144, Phase 1): union cached, verified
+    // subscription domains into the effective blocklist. Tighten-only and
+    // fail-open — a fetch/verify failure falls back to the last-good cache (or
+    // empty), and the run is NEVER blocked on the network beyond a bounded
+    // timeout. Empty when no subscriptions are configured (unchanged behaviour).
+    let subscription_blocklist = load_subscription_blocklist(resolved, resolved.quiet);
+
     let port_hint = if resolved.proxy_port == 0 {
         "ephemeral port".to_string()
     } else {
@@ -1601,6 +1620,7 @@ fn start_proxy_if_enabled(
     match proxy::start(proxy::ProxyOptions {
         port: resolved.proxy_port,
         blocked_file,
+        subscription_blocklist,
         allowed_ports: resolved.allow_ports.clone(),
         allow_localhost_ports: resolved.allow_localhost.clone(),
         allow_localhost_any: resolved.allow_localhost_any,
@@ -1646,6 +1666,146 @@ fn start_proxy_if_enabled(
             bail!("Failed to start proxy: {e}")
         }
     }
+}
+
+/// Resolve the effective subscription blocklist domains for a run (issue #144,
+/// Phase 1). Lazily refreshes stale caches when `refresh != manual` (bounded by
+/// the fetch timeout — never hangs the run), prints one-line staleness warnings,
+/// and returns the UNION of cached subscription domains to merge into the
+/// blocklist. Tighten-only and fail-open: any failure falls back to the
+/// last-good cache (or empty). Returns an empty vec when no subscriptions are
+/// configured, so networking is byte-identical to today.
+fn load_subscription_blocklist(resolved: &config::Resolved, quiet: bool) -> Vec<String> {
+    let set = &resolved.proxy_subscriptions;
+    if set.is_empty() {
+        return Vec::new();
+    }
+
+    // Lazy pre-run refresh (no-op under `refresh = "manual"`). Failures fall
+    // through to the cache; we surface tamper (verify) failures loudly.
+    let now = std::time::SystemTime::now();
+    for outcome in subscriptions::refresh_if_stale(set, &subscriptions::curl_fetch, now) {
+        if let subscriptions::UpdateOutcome::VerifyFailed {
+            url,
+            expected,
+            actual,
+        } = &outcome
+        {
+            ui::warn(&format!(
+                "SHA256 verification failed for blocklist subscription {url}!\n  \
+                 Expected: {expected}\n  Got:      {actual}\n  \
+                 Download may be corrupted or tampered with — keeping the last-good cache."
+            ));
+        }
+    }
+
+    if !quiet {
+        for warning in subscriptions::staleness_warnings(set, now) {
+            ui::warn(&warning);
+        }
+    }
+
+    let domains = subscriptions::load_cached_domains(set);
+    if !quiet && !domains.is_empty() {
+        ui::info(&format!(
+            "Blocklist subscriptions: {} domains from {} list(s)",
+            domains.len(),
+            set.blocklists.len()
+        ));
+    }
+    domains
+}
+
+/// `cplt update-lists`: fetch, verify, and cache all configured blocklist
+/// subscriptions (issue #144, Phase 1 — the explicit refresh path). Reports a
+/// per-list result. Tighten-only + fail-open: a fetch failure keeps the
+/// last-good cache; a pinned-hash mismatch REJECTS the download (tamper) and
+/// keeps the last-good cache. Never fails the process for a bad list.
+fn run_update_lists() -> ExitCode {
+    let resolved = match resolve_config_only() {
+        Ok(r) => r,
+        Err(e) => {
+            ui::error(&e.to_string());
+            return ExitCode::FAILURE;
+        }
+    };
+    let set = &resolved.proxy_subscriptions;
+
+    if set.is_empty() {
+        ui::info(
+            "No blocklist subscriptions configured. Add one under \
+             [proxy.subscriptions] in your global config, e.g.:",
+        );
+        println!(
+            "  [proxy.subscriptions]\n  blocklists = [\
+             \"https://raw.githubusercontent.com/navikt/cplt/main/blocked-domains.txt\"]"
+        );
+        return ExitCode::SUCCESS;
+    }
+
+    ui::info(&format!(
+        "Updating {} blocklist subscription(s) (refresh = {})...",
+        set.blocklists.len(),
+        set.refresh
+    ));
+
+    let now = std::time::SystemTime::now();
+    let outcomes = subscriptions::update_all(set, &subscriptions::curl_fetch, now);
+
+    let mut had_verify_failure = false;
+    for outcome in &outcomes {
+        match outcome {
+            subscriptions::UpdateOutcome::Fetched {
+                url,
+                domains,
+                verified,
+            } => {
+                let tag = if *verified { " (sha256 verified)" } else { "" };
+                ui::ok(&format!("{url}\n    fetched {domains} domains{tag}"));
+            }
+            subscriptions::UpdateOutcome::CacheKept { url, reason } => {
+                ui::warn(&format!(
+                    "{url}\n    fetch failed ({reason}) — keeping last-good cache"
+                ));
+            }
+            subscriptions::UpdateOutcome::EmptyNoCache { url, reason } => {
+                ui::warn(&format!(
+                    "{url}\n    fetch failed ({reason}) — no cache yet, treated as empty"
+                ));
+            }
+            subscriptions::UpdateOutcome::VerifyFailed {
+                url,
+                expected,
+                actual,
+            } => {
+                had_verify_failure = true;
+                ui::error(&format!(
+                    "{url}\n    SHA256 verification FAILED — download REJECTED (tamper?), \
+                     keeping last-good cache\n    Expected: {expected}\n    Got:      {actual}"
+                ));
+            }
+        }
+    }
+
+    // A verify failure is a loud, actionable signal but is not fatal: the
+    // last-good cache is retained (tighten-only). Exit non-zero so scripts/CI
+    // can detect the tamper condition.
+    if had_verify_failure {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+/// Load and resolve config (global + repo merge is not needed here — subscriptions
+/// are global-only). Used by `cplt update-lists`.
+fn resolve_config_only() -> anyhow::Result<config::Resolved> {
+    let loaded = config::Config::load_file()?;
+    let config = loaded.map(|l| l.config).unwrap_or_default();
+    let resolved = config
+        .merge(config::CliFlags::default())
+        .context("resolving configuration")?;
+    Ok(resolved)
 }
 
 fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
@@ -1694,6 +1854,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         return Ok(match command {
             Command::Config { action } => run_config_command(action),
             Command::Update { check, force } => run_update(check, force),
+            Command::UpdateLists => run_update_lists(),
             Command::Trust { action } => run_trust_command(action),
             Command::Init {
                 write,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1684,7 +1684,7 @@ fn load_subscription_blocklist(resolved: &config::Resolved, quiet: bool) -> Vec<
     // Lazy pre-run refresh (no-op under `refresh = "manual"`). Failures fall
     // through to the cache; we surface tamper (verify) failures loudly.
     let now = std::time::SystemTime::now();
-    for outcome in subscriptions::refresh_if_stale(set, &subscriptions::curl_fetch, now) {
+    for outcome in subscriptions::refresh_if_stale(set, &subscriptions::curl_fetch_lazy, now) {
         if let subscriptions::UpdateOutcome::VerifyFailed {
             url,
             expected,
@@ -1771,6 +1771,11 @@ fn run_update_lists() -> ExitCode {
             subscriptions::UpdateOutcome::EmptyNoCache { url, reason } => {
                 ui::warn(&format!(
                     "{url}\n    fetch failed ({reason}) — no cache yet, treated as empty"
+                ));
+            }
+            subscriptions::UpdateOutcome::WriteFailed { url, reason } => {
+                ui::warn(&format!(
+                    "{url}\n    fetched OK but cache write failed ({reason})"
                 ));
             }
             subscriptions::UpdateOutcome::VerifyFailed {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -342,6 +342,14 @@ pub struct ProxyState {
     blocked_file: PathBuf,
     blocked_cache: Mutex<DomainCache>,
 
+    // Blocklist subscriptions (issue #144, Phase 1): domains from cached,
+    // fetched-and-verified subscription lists, frozen at startup. Empty = no
+    // subscriptions configured (behaviour identical to today). When non-empty
+    // these are UNIONed with the reloadable `blocked_file` to form the effective
+    // blocklist — tighten-only, so this can only ever ADD blocks. See
+    // `crate::subscriptions` for the fetch/verify/cache + fail-open model.
+    subscription_blocklist: Vec<String>,
+
     // Allowlist: optional file of permitted domains (fail-closed when configured)
     allowed_domains_file: Option<PathBuf>,
     allowlist_cache: Mutex<DomainCache>,
@@ -394,11 +402,26 @@ impl ProxyState {
     /// Get the current blocklist, re-reading from disk if TTL expired.
     /// On read failure, keeps last-good list and resets TTL for retry.
     fn get_blocked_domains(&self) -> Vec<String> {
-        get_cached_domains(
+        let file_domains = get_cached_domains(
             &self.blocked_cache,
             Some(&self.blocked_file),
             parse_lines_file,
-        )
+        );
+
+        // No subscriptions configured — preserve today's exact behaviour
+        // (the reloadable file + built-ins are the sole source).
+        if self.subscription_blocklist.is_empty() {
+            return file_domains;
+        }
+
+        // UNION the cached subscription blocklist(s) with the local/built-in
+        // blocklist. Tighten-only: this can only ADD blocks. Deduplicated so the
+        // effective list matches what the existing matcher expects.
+        let mut merged = file_domains;
+        merged.extend(self.subscription_blocklist.iter().cloned());
+        merged.sort_unstable();
+        merged.dedup();
+        merged
     }
 
     /// Get the effective allowlist, re-reading the user file from disk if the
@@ -583,6 +606,10 @@ impl ProxyHandle {
 pub struct ProxyOptions {
     pub port: u16,
     pub blocked_file: PathBuf,
+    /// Domains from cached blocklist subscriptions (issue #144, Phase 1), frozen
+    /// at startup. Empty = no subscriptions (unchanged behaviour). UNIONed with
+    /// `blocked_file` to form the effective blocklist. Tighten-only.
+    pub subscription_blocklist: Vec<String>,
     pub allowed_ports: Vec<u16>,
     /// Specific localhost ports explicitly opened by `--allow-localhost`.
     /// The proxy bypasses its private-IP block for CONNECT to these ports.
@@ -682,6 +709,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
     let state = Arc::new(ProxyState {
         blocked_file: opts.blocked_file,
         blocked_cache: Mutex::new(DomainCache::new(blocked_initial)),
+        subscription_blocklist: opts.subscription_blocklist,
         allowed_domains_file: opts.allowed_domains_file,
         allowlist_cache: Mutex::new(DomainCache::new(allowlist_initial)),
         default_allowlist: opts.default_allowlist,
@@ -1915,6 +1943,7 @@ mod tests {
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: vec!["cli.example.com".to_string()],
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec![
@@ -1944,6 +1973,7 @@ mod tests {
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: vec!["shared.com".to_string()],
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec!["shared.com".to_string()])),
@@ -1976,6 +2006,7 @@ mod tests {
                 "should-not-appear.com".to_string(),
             ])),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
@@ -2011,6 +2042,7 @@ mod tests {
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
@@ -2047,6 +2079,7 @@ mod tests {
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: vec!["cli.nav.no".to_string()],
             config_file: Some(config_path.clone()),
             private_domains_cache: Mutex::new(DomainCache {
@@ -2118,6 +2151,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2153,6 +2187,7 @@ mod tests {
             allowed_domains_file: Some(allowlist_path),
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2185,6 +2220,7 @@ mod tests {
                     .unwrap(),
             }),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
@@ -2227,6 +2263,7 @@ mod tests {
         ProxyState {
             blocked_file: PathBuf::from("/dev/null"),
             blocked_cache: Mutex::new(DomainCache::new(Vec::new())),
+            subscription_blocklist: Vec::new(),
             allowed_domains_file: file,
             allowlist_cache: Mutex::new(DomainCache::new(initial)),
             default_allowlist,
@@ -2243,6 +2280,61 @@ mod tests {
             upstream_no_proxy: Vec::new(),
             resolver: None,
         }
+    }
+
+    /// Build a ProxyState with an in-memory blocklist + subscription blocklist
+    /// for issue #144 merge tests. `blocked_file` is `/dev/null` and the caches
+    /// are seeded fresh, so `get_blocked_domains` reads the in-memory values.
+    fn state_for_blocklist(file_domains: Vec<String>, subscription: Vec<String>) -> ProxyState {
+        ProxyState {
+            blocked_file: PathBuf::from("/dev/null"),
+            blocked_cache: Mutex::new(DomainCache::new(file_domains)),
+            subscription_blocklist: subscription,
+            allowed_domains_file: None,
+            allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
+            default_allowlist: Vec::new(),
+            cli_private_domains: Vec::new(),
+            config_file: None,
+            private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
+            allowed_ports: vec![443],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(60),
+            upstream: None,
+            upstream_no_proxy: Vec::new(),
+            resolver: None,
+        }
+    }
+
+    #[test]
+    fn subscription_blocklist_merges_into_effective_blocklist() {
+        // Cached subscription domains UNION with the local/built-in blocklist.
+        let state = state_for_blocklist(
+            vec!["local.example".to_string()],
+            vec!["sub.example".to_string()],
+        );
+        let eff = state.get_blocked_domains();
+        assert!(is_blocked_in_list("local.example", &eff), "local kept");
+        assert!(
+            is_blocked_in_list("sub.example", &eff),
+            "subscription added"
+        );
+        // Exact-or-subdomain matcher still applies to subscription domains.
+        assert!(is_blocked_in_list("host.sub.example", &eff));
+        assert!(!is_blocked_in_list("allowed.example", &eff));
+    }
+
+    #[test]
+    fn empty_subscription_blocklist_is_noop() {
+        // No-regression: empty subscription list → exactly the file domains,
+        // byte-identical to today's behaviour.
+        let with_empty = state_for_blocklist(vec!["local.example".to_string()], Vec::new());
+        assert_eq!(
+            with_empty.get_blocked_domains(),
+            vec!["local.example".to_string()]
+        );
     }
 
     #[test]
@@ -2327,6 +2419,7 @@ mod tests {
             allowed_domains_file,
             allowed_domains_initial: Vec::new(),
             default_allowlist,
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2478,6 +2571,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: copilot_defaults(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2551,6 +2645,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2774,6 +2869,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(), // NOT allow-listed
             config_private_domains: Vec::new(),
             config_file: None,
@@ -2833,6 +2929,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: vec!["corp.internal".to_string()], // allow-listed
             config_private_domains: Vec::new(),
             config_file: None,
@@ -3283,6 +3380,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
             config_file: None,
@@ -3492,6 +3590,7 @@ mod tests {
             allowed_domains_file,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains,
             config_private_domains: Vec::new(),
             config_file: None,
@@ -3923,6 +4022,7 @@ mod tests {
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
             cli_private_domains,
             config_private_domains: Vec::new(),
             config_file: None,

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -33,15 +33,33 @@
 //! security-critical, fail-closed, verification-required) are explicitly **out of
 //! scope** for this module — they are a separate future feature (#144 Phase 2).
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-/// Bounded per-fetch timeout (seconds). The run must never hang on the network.
+/// Bounded per-fetch timeout (seconds) for the explicit `cplt update-lists`
+/// path. The run must never hang on the network.
 const FETCH_TIMEOUT_SECS: u64 = 20;
+
+/// Much shorter per-fetch timeout (seconds) for the *lazy* pre-run refresh path.
+/// Startup must not stall on a black-holed host, so the lazy path uses a tight
+/// budget and degrades to the last-good cache; only the explicit `update-lists`
+/// path gets the full [`FETCH_TIMEOUT_SECS`] timeout.
+const LAZY_FETCH_TIMEOUT_SECS: u64 = 5;
+
+/// Hard ceiling on a fetched blocklist response (bytes). A 1M-domain blocklist
+/// is ~20 MB, so 50 MB is a safe, generous cap. Enforced two ways: `curl` aborts
+/// early via `--max-filesize` when the server sends a `Content-Length`, and we
+/// additionally cap the bytes we actually read/buffer (for chunked or
+/// unknown-length responses `--max-filesize` is skipped) so a malicious or
+/// MITM'd host cannot stream multi-GB within the timeout and OOM-kill the parent
+/// — nor slip an oversize body past a pinned-hash check by forcing us to buffer
+/// the whole body before it is hashed.
+const MAX_FETCH_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Warn about a cache that has not been refreshed in this long.
 const STALE_WARN: Duration = Duration::from_secs(30 * 24 * 60 * 60);
@@ -137,6 +155,11 @@ pub enum UpdateOutcome {
     },
     /// Fetch failed and there is no cache — treated as empty (safe, tighten-only).
     EmptyNoCache { url: String, reason: String },
+    /// Fetched OK but the cache could not be persisted (dir create / atomic write
+    /// failed). The last-good cache (if any) is kept and the state timestamp is
+    /// NOT advanced, so the next run retries instead of treating an unwritten
+    /// cache as "fresh".
+    WriteFailed { url: String, reason: String },
 }
 
 impl UpdateOutcome {
@@ -146,7 +169,8 @@ impl UpdateOutcome {
             Self::Fetched { url, .. }
             | Self::CacheKept { url, .. }
             | Self::VerifyFailed { url, .. }
-            | Self::EmptyNoCache { url, .. } => url,
+            | Self::EmptyNoCache { url, .. }
+            | Self::WriteFailed { url, .. } => url,
         }
     }
 
@@ -164,31 +188,85 @@ pub type Fetcher<'a> = dyn Fn(&str) -> Result<Vec<u8>, String> + 'a;
 /// timeout, https-only redirects). Mirrors the download discipline of
 /// `update.rs`. Runs in cplt's parent process, OUTSIDE the sandbox.
 pub fn curl_fetch(url: &str) -> Result<Vec<u8>, String> {
-    // Only https:// is fetched in production. file:// is permitted so operators
-    // can point at a locally-mirrored list; it is also what tests use.
-    let output = Command::new("/usr/bin/curl")
-        .args([
-            "--fail",
-            "--silent",
-            "--show-error",
-            "--location",
-            "--proto",
-            "=https,file",
-            "--proto-redir",
-            "=https",
-            "--max-time",
-            &FETCH_TIMEOUT_SECS.to_string(),
-            "--header",
-            &format!("User-Agent: cplt/{}", env!("CARGO_PKG_VERSION")),
-            url,
-        ])
-        .output()
+    curl_fetch_inner(url, FETCH_TIMEOUT_SECS)
+}
+
+/// Lazy-path fetcher: same download discipline as [`curl_fetch`] but with the
+/// tight [`LAZY_FETCH_TIMEOUT_SECS`] budget so a stale-cache refresh before a run
+/// cannot stall startup on a slow or black-holed host.
+pub fn curl_fetch_lazy(url: &str) -> Result<Vec<u8>, String> {
+    curl_fetch_inner(url, LAZY_FETCH_TIMEOUT_SECS)
+}
+
+/// Build the `curl` argument vector for `url`. Only https:// is fetched in
+/// production; file:// is permitted so operators can point at a locally-mirrored
+/// list (and tests use it). The `--` end-of-options marker is placed immediately
+/// before the URL so a value beginning with `-` (e.g. `-K/curlrc`, `--output x`)
+/// is always treated as the positional URL, never parsed as a curl flag.
+fn curl_args(url: &str, timeout_secs: u64) -> Vec<String> {
+    vec![
+        "--fail".into(),
+        "--silent".into(),
+        "--show-error".into(),
+        "--location".into(),
+        "--proto".into(),
+        "=https,file".into(),
+        "--proto-redir".into(),
+        "=https".into(),
+        "--max-time".into(),
+        timeout_secs.to_string(),
+        "--max-filesize".into(),
+        MAX_FETCH_BYTES.to_string(),
+        "--header".into(),
+        format!("User-Agent: cplt/{}", env!("CARGO_PKG_VERSION")),
+        "--".into(),
+        url.to_string(),
+    ]
+}
+
+/// Fetch with an explicit timeout. Streams `curl`'s stdout through a hard byte
+/// ceiling ([`MAX_FETCH_BYTES`]): `--max-filesize` aborts early only when the
+/// server sends a `Content-Length`, so we ALSO stop reading the moment the body
+/// exceeds the cap and kill `curl`, guaranteeing the parent never buffers a
+/// multi-GB size bomb (which would OOM-kill cplt and defeat a pinned-hash check
+/// that must see the whole body first).
+fn curl_fetch_inner(url: &str, timeout_secs: u64) -> Result<Vec<u8>, String> {
+    let mut child = Command::new("/usr/bin/curl")
+        .args(curl_args(url, timeout_secs))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| format!("cannot run /usr/bin/curl: {e}"))?;
 
-    if output.status.success() {
-        Ok(output.stdout)
+    // Read at most MAX_FETCH_BYTES + 1: if we get that many, the body is over the
+    // cap. `--silent` keeps stderr tiny (only errors), so reading stdout to EOF
+    // before draining stderr cannot deadlock on a full stderr pipe.
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut buf = Vec::new();
+    let read_res = stdout
+        .by_ref()
+        .take(MAX_FETCH_BYTES + 1)
+        .read_to_end(&mut buf);
+
+    if read_res.is_err() || buf.len() as u64 > MAX_FETCH_BYTES {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!(
+            "response exceeds {MAX_FETCH_BYTES}-byte limit — refusing (possible size bomb)"
+        ));
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("curl did not exit cleanly: {e}"))?;
+
+    if status.success() {
+        Ok(buf)
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let mut stderr = String::new();
+        if let Some(mut err) = child.stderr.take() {
+            let _ = err.read_to_string(&mut stderr);
+        }
         Err(stderr.trim().to_string())
     }
 }
@@ -347,6 +425,28 @@ fn update_one(
         }
     };
 
+    // Hard size ceiling, enforced BEFORE hashing or caching. `curl_fetch` already
+    // caps its streamed read, but re-check here so any fetcher (incl. a mirror or
+    // test double) cannot slip an oversize body past the pinned-hash check or into
+    // the cache. Oversize is rejected fail-open: the last-good cache is preserved.
+    if bytes.len() as u64 > MAX_FETCH_BYTES {
+        let reason = format!(
+            "response is {} bytes, over the {MAX_FETCH_BYTES}-byte limit — rejected",
+            bytes.len()
+        );
+        return if cache_exists {
+            UpdateOutcome::CacheKept {
+                url: sub.url.clone(),
+                reason,
+            }
+        } else {
+            UpdateOutcome::EmptyNoCache {
+                url: sub.url.clone(),
+                reason,
+            }
+        };
+    }
+
     // Optional integrity check. A mismatch REJECTS the update and keeps the
     // last-good cache — the tamper-refuse behaviour of update.rs.
     let mut verified = false;
@@ -365,11 +465,18 @@ fn update_one(
 
     let domains = parse_blocklist(&String::from_utf8_lossy(&bytes)).len();
 
-    // Best-effort cache write. If the directory or write fails we still report a
-    // fetch (tighten-only: a failed write just means the new domains are not
-    // persisted; the last-good cache — if any — remains).
-    if std::fs::create_dir_all(&set.cache_dir).is_ok() {
-        let _ = write_atomic(&path, &bytes);
+    // Persist the cache atomically, and record the fetch timestamp ONLY after the
+    // write is confirmed. If the dir create or atomic write fails we leave the
+    // prior timestamp untouched so the next run retries, rather than advancing the
+    // clock and skipping a re-fetch while serving a stale/absent cache.
+    let write_ok =
+        std::fs::create_dir_all(&set.cache_dir).is_ok() && write_atomic(&path, &bytes).is_ok();
+    if !write_ok {
+        return UpdateOutcome::WriteFailed {
+            url: sub.url.clone(),
+            reason: "could not write cache file — keeping prior state, next run retries"
+                .to_string(),
+        };
     }
 
     state.set(&sub.url, unix_secs(now), domains);
@@ -418,10 +525,22 @@ fn is_due(
     }
 }
 
-/// Lazy pre-run refresh: when `refresh != manual`, re-fetch any subscription
-/// whose cache is stale (bounded by the fetcher's timeout). Fails over to the
-/// cache — never blocks or fails the run. Returns outcomes for stale entries
-/// only (empty when nothing was due or refresh is manual).
+/// Lazy pre-run refresh: when `refresh != manual`, re-fetch AT MOST ONE stale
+/// subscription before the run, using the short lazy timeout supplied by the
+/// caller. Fails over to the cache — never blocks or fails the run.
+///
+/// # Startup-stall budget
+///
+/// A stale cache must not turn startup into an `N * timeout` stall: with N
+/// black-holed hosts, refreshing them all sequentially before every run could
+/// hang for minutes. So the lazy path spends a single small budget per run — it
+/// refreshes only the FIRST due subscription and stops. Remaining stale lists are
+/// picked up one-per-run on subsequent invocations, and every one degrades to the
+/// last-good cache on failure. The explicit `cplt update-lists` path
+/// ([`update_all`]) still refreshes every list with the full timeout.
+///
+/// Returns outcomes for the (at most one) refreshed entry, or empty when nothing
+/// was due or refresh is manual.
 pub fn refresh_if_stale(
     set: &SubscriptionSet,
     fetch: &Fetcher,
@@ -435,6 +554,9 @@ pub fn refresh_if_stale(
     for sub in &set.blocklists {
         if is_due(set, sub, &state, now) {
             outcomes.push(update_one(set, sub, fetch, now, &mut state));
+            // Spend the whole per-run lazy budget on this one list; the rest wait
+            // for future runs so startup can never stall on many dead hosts.
+            break;
         }
     }
     if !outcomes.is_empty() {
@@ -722,5 +844,136 @@ mod tests {
             assert_eq!(String::from_utf8_lossy(&bytes).trim(), "curl.example");
         }
         // curl may be unavailable in some CI images; a fetch error is tolerated.
+    }
+
+    // ── FIX 1: response size cap (DoS / pinning-bypass) ─────────────────────
+
+    #[test]
+    fn oversize_response_rejected_and_keeps_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        // Establish a last-good cache with a normal fetch.
+        update_all(&set, &|_| Ok(b"good.com\n".to_vec()), SystemTime::now());
+        assert_eq!(load_cached_domains(&set), vec!["good.com"]);
+
+        // Now the host streams a body one byte over the hard cap.
+        let oversize = vec![b'a'; (MAX_FETCH_BYTES + 1) as usize];
+        let outcomes = update_all(&set, &|_| Ok(oversize.clone()), SystemTime::now());
+        assert!(
+            matches!(outcomes[0], UpdateOutcome::CacheKept { .. }),
+            "oversize response must be rejected: {:?}",
+            outcomes[0]
+        );
+        // Last-good cache is preserved, NOT overwritten by the oversize body.
+        assert_eq!(load_cached_domains(&set), vec!["good.com"]);
+    }
+
+    #[test]
+    fn oversize_response_no_cache_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        let oversize = vec![b'a'; (MAX_FETCH_BYTES + 1) as usize];
+        let outcomes = update_all(&set, &|_| Ok(oversize.clone()), SystemTime::now());
+        assert!(matches!(outcomes[0], UpdateOutcome::EmptyNoCache { .. }));
+        assert!(load_cached_domains(&set).is_empty());
+    }
+
+    #[test]
+    fn at_cap_response_is_accepted() {
+        // Exactly at the cap is allowed; only strictly-over is rejected.
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        // A body at the cap that parses to one domain line.
+        let mut body = b"cap.example\n".to_vec();
+        body.resize(MAX_FETCH_BYTES as usize, b'#'); // pad with comment bytes
+        let outcomes = update_all(&set, &|_| Ok(body.clone()), SystemTime::now());
+        assert!(matches!(outcomes[0], UpdateOutcome::Fetched { .. }));
+    }
+
+    // ── FIX 2: curl `--` end-of-options guard ───────────────────────────────
+
+    #[test]
+    fn curl_args_place_double_dash_before_url() {
+        // A flag-like URL must sit AFTER `--` so curl never parses it as an option.
+        let args = curl_args("-K/tmp/evil-curlrc", FETCH_TIMEOUT_SECS);
+        let url_idx = args.iter().position(|a| a == "-K/tmp/evil-curlrc").unwrap();
+        assert_eq!(
+            args[url_idx - 1],
+            "--",
+            "the URL must be immediately preceded by the `--` end-of-options marker"
+        );
+        assert_eq!(
+            url_idx,
+            args.len() - 1,
+            "the URL must be the final argument"
+        );
+    }
+
+    #[test]
+    fn curl_args_carry_size_cap() {
+        let args = curl_args("https://example.com/list.txt", FETCH_TIMEOUT_SECS);
+        let idx = args.iter().position(|a| a == "--max-filesize").unwrap();
+        assert_eq!(args[idx + 1], MAX_FETCH_BYTES.to_string());
+    }
+
+    // ── FIX 3: lazy-refresh startup budget (one stale list per run) ──────────
+
+    #[test]
+    fn lazy_refresh_updates_at_most_one_stale_list_per_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Daily,
+            vec![
+                sub("mem://a", None),
+                sub("mem://b", None),
+                sub("mem://c", None),
+            ],
+        );
+        let t0 = UNIX_EPOCH + Duration::from_secs(1_000_000);
+        // All three are due (no cache). One run refreshes exactly ONE of them.
+        let o1 = refresh_if_stale(&set, &|_| Ok(b"x.com\n".to_vec()), t0);
+        assert_eq!(o1.len(), 1, "at most one stale list refreshes per run");
+        // Next run picks up another still-stale list — again exactly one.
+        let o2 = refresh_if_stale(&set, &|_| Ok(b"x.com\n".to_vec()), t0);
+        assert_eq!(o2.len(), 1);
+    }
+
+    // ── FIX 4: state timestamp only after a confirmed cache write ────────────
+
+    #[test]
+    fn write_failure_reports_and_leaves_state_unadvanced() {
+        let dir = tempfile::tempdir().unwrap();
+        // Make the cache_dir un-creatable: its parent is a regular file.
+        let blocker = dir.path().join("not-a-dir");
+        std::fs::write(&blocker, b"x").unwrap();
+        let cache_dir = blocker.join("subscriptions");
+        let set = SubscriptionSet {
+            refresh: RefreshInterval::Manual,
+            blocklists: vec![sub("mem://a", None)],
+            cache_dir,
+        };
+        let outcomes = update_all(&set, &|_| Ok(b"a.com\n".to_vec()), SystemTime::now());
+        assert!(
+            matches!(outcomes[0], UpdateOutcome::WriteFailed { .. }),
+            "a failed cache write must report WriteFailed: {:?}",
+            outcomes[0]
+        );
+        // State was NOT persisted (dir un-creatable), so a later run still sees the
+        // list as due rather than skipping it on a bogus "fresh" timestamp.
+        let state = State::load(&set.cache_dir);
+        assert!(state.get("mem://a").is_none());
     }
 }

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,0 +1,726 @@
+//! Subscribable blocklists (issue #144, Phase 1 — blocklist subscriptions only).
+//!
+//! A *blocklist subscription* keeps a local cache file fresh from a maintained
+//! upstream URL (e.g. cplt's own `blocked-domains.txt`). The cached domains are
+//! UNIONed into the effective blocklist alongside the local `blocked_domains`
+//! file and the built-in `blocked-domains.txt` — they are purely additive.
+//!
+//! # Security model (why this is the low-risk tier)
+//!
+//! Blocklists are **tighten-only**: the worst case of a bad, stale, or failed
+//! blocklist is that a domain *isn't* blocked — no worse than today. There is no
+//! way for a blocklist subscription to *widen* egress. Therefore:
+//!
+//! - **Fail-open is acceptable.** On fetch failure we keep and use the last-good
+//!   cache; if there is no cache we treat the subscription as empty (empty = no
+//!   extra blocks = byte-identical to not having the subscription at all). The
+//!   run is NEVER blocked on the network beyond a bounded timeout.
+//! - **Integrity is encouraged, not required.** A subscription entry may pin a
+//!   `sha256`. When pinned, a hash mismatch REJECTS the downloaded copy (keeping
+//!   the last-good cache) and warns loudly about possible tampering — reusing the
+//!   verification discipline of `update.rs`. Unpinned blocklists still load,
+//!   because tighten-only means an unverified blocklist cannot open exfil.
+//! - **Repo config can NOT add a subscription.** Subscriptions are GLOBAL-only
+//!   (`~/.config/cplt/config.toml`); the repo config schema (`.cplt.toml`) has no
+//!   `[proxy]` table at all, so a malicious repo cannot point cplt at an attacker
+//!   list.
+//! - **The cache lives outside the agent's writable set.** Caches are written to
+//!   the cplt config directory (`~/.config/cplt/subscriptions/`) by the parent
+//!   process BEFORE the sandbox is entered. The sandboxed agent cannot write
+//!   there, so it cannot poison the cache mid-session.
+//!
+//! Allowlist subscriptions (which DEFINE what is permitted and are therefore
+//! security-critical, fail-closed, verification-required) are explicitly **out of
+//! scope** for this module — they are a separate future feature (#144 Phase 2).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Bounded per-fetch timeout (seconds). The run must never hang on the network.
+const FETCH_TIMEOUT_SECS: u64 = 20;
+
+/// Warn about a cache that has not been refreshed in this long.
+const STALE_WARN: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// How often lazily-refreshed subscriptions are re-fetched before a run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefreshInterval {
+    /// Never auto-refresh; only `cplt update-lists` fetches (default).
+    Manual,
+    /// Refresh caches older than 24h before a run.
+    Daily,
+    /// Refresh caches older than 7 days before a run.
+    Weekly,
+}
+
+impl RefreshInterval {
+    /// Parse the `refresh` config value. Defaults to `Manual`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "manual" => Ok(Self::Manual),
+            "daily" => Ok(Self::Daily),
+            "weekly" => Ok(Self::Weekly),
+            other => Err(format!(
+                "invalid refresh value {other:?}: expected \"manual\", \"daily\", or \"weekly\""
+            )),
+        }
+    }
+
+    /// Maximum cache age before a lazy refresh is due. `None` = never (manual).
+    fn max_age(self) -> Option<Duration> {
+        match self {
+            Self::Manual => None,
+            Self::Daily => Some(Duration::from_secs(24 * 60 * 60)),
+            Self::Weekly => Some(Duration::from_secs(7 * 24 * 60 * 60)),
+        }
+    }
+}
+
+impl std::fmt::Display for RefreshInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Manual => "manual",
+            Self::Daily => "daily",
+            Self::Weekly => "weekly",
+        })
+    }
+}
+
+/// A single blocklist subscription source.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlocklistSubscription {
+    /// The URL the list is fetched from (https:// or, in tests, file://).
+    pub url: String,
+    /// Optional pinned SHA256 (lowercase hex). When set, a mismatch REJECTS the
+    /// downloaded copy and keeps the last-good cache (tamper protection).
+    pub sha256: Option<String>,
+}
+
+/// A resolved set of blocklist subscriptions plus the cache location.
+#[derive(Clone, Debug)]
+pub struct SubscriptionSet {
+    pub refresh: RefreshInterval,
+    pub blocklists: Vec<BlocklistSubscription>,
+    /// Directory holding cache files + `state.json`. Lives OUTSIDE the sandbox's
+    /// writable set (the cplt config dir), so the agent cannot poison it.
+    pub cache_dir: PathBuf,
+}
+
+impl SubscriptionSet {
+    /// True when no blocklist subscriptions are configured. When empty, cplt's
+    /// networking behaviour is byte-identical to having no subscriptions at all.
+    pub fn is_empty(&self) -> bool {
+        self.blocklists.is_empty()
+    }
+}
+
+/// The outcome of attempting to fetch/verify one subscription.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    /// Fetched and cached `domains` entries. `verified` = a pinned hash matched.
+    Fetched {
+        url: String,
+        domains: usize,
+        verified: bool,
+    },
+    /// Fetch failed but a last-good cache exists and is still used.
+    CacheKept { url: String, reason: String },
+    /// Pinned hash mismatch — download REJECTED, last-good cache kept.
+    VerifyFailed {
+        url: String,
+        expected: String,
+        actual: String,
+    },
+    /// Fetch failed and there is no cache — treated as empty (safe, tighten-only).
+    EmptyNoCache { url: String, reason: String },
+}
+
+impl UpdateOutcome {
+    /// The subscription URL this outcome refers to.
+    pub fn url(&self) -> &str {
+        match self {
+            Self::Fetched { url, .. }
+            | Self::CacheKept { url, .. }
+            | Self::VerifyFailed { url, .. }
+            | Self::EmptyNoCache { url, .. } => url,
+        }
+    }
+
+    /// Whether this outcome indicates a verification (tamper) failure.
+    pub fn is_verify_failure(&self) -> bool {
+        matches!(self, Self::VerifyFailed { .. })
+    }
+}
+
+/// A network fetcher: URL → bytes, or an error string. Injectable so the
+/// verify/cache/merge/staleness logic is unit-testable WITHOUT real network.
+pub type Fetcher<'a> = dyn Fn(&str) -> Result<Vec<u8>, String> + 'a;
+
+/// Default fetcher: download `url` with `/usr/bin/curl` (absolute path, bounded
+/// timeout, https-only redirects). Mirrors the download discipline of
+/// `update.rs`. Runs in cplt's parent process, OUTSIDE the sandbox.
+pub fn curl_fetch(url: &str) -> Result<Vec<u8>, String> {
+    // Only https:// is fetched in production. file:// is permitted so operators
+    // can point at a locally-mirrored list; it is also what tests use.
+    let output = Command::new("/usr/bin/curl")
+        .args([
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--proto",
+            "=https,file",
+            "--proto-redir",
+            "=https",
+            "--max-time",
+            &FETCH_TIMEOUT_SECS.to_string(),
+            "--header",
+            &format!("User-Agent: cplt/{}", env!("CARGO_PKG_VERSION")),
+            url,
+        ])
+        .output()
+        .map_err(|e| format!("cannot run /usr/bin/curl: {e}"))?;
+
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(stderr.trim().to_string())
+    }
+}
+
+/// Compute the lowercase-hex SHA256 of `bytes`.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Deterministic cache filename for a subscription URL. Uses a hash of the URL
+/// so arbitrary URLs map to safe, collision-resistant filenames.
+fn cache_filename(url: &str) -> String {
+    let hash = sha256_hex(url.as_bytes());
+    format!("{}.list", &hash[..16])
+}
+
+/// Absolute path of the cache file for `url` under `cache_dir`.
+fn cache_path(cache_dir: &Path, url: &str) -> PathBuf {
+    cache_dir.join(cache_filename(url))
+}
+
+/// Parse a one-domain-per-line blocklist into normalized bare domains.
+///
+/// Mirrors `proxy`'s blocklist normalization (trim, lowercase, strip a trailing
+/// dot, skip blank and `#` comment lines) so subscription domains match exactly
+/// like the local blocklist file and built-in list under the existing
+/// exact-or-subdomain matcher.
+pub fn parse_blocklist(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .map(|l| l.trim().to_lowercase().trim_end_matches('.').to_string())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect()
+}
+
+/// Load and UNION the cached domains from every configured blocklist
+/// subscription. Missing caches are skipped (fail-open: empty = safe). This is
+/// what the proxy merges into the effective blocklist at startup.
+///
+/// Returns an empty vec when no subscriptions are configured — so with nothing
+/// configured the effective blocklist is unchanged from today.
+pub fn load_cached_domains(set: &SubscriptionSet) -> Vec<String> {
+    let mut domains: Vec<String> = Vec::new();
+    for sub in &set.blocklists {
+        let path = cache_path(&set.cache_dir, &sub.url);
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            domains.extend(parse_blocklist(&contents));
+        }
+    }
+    domains.sort_unstable();
+    domains.dedup();
+    domains
+}
+
+// ── Persistent per-subscription metadata (last-fetch time) ───────────────────
+
+#[derive(Serialize, Deserialize, Default)]
+struct State {
+    #[serde(default)]
+    subscriptions: Vec<StateEntry>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct StateEntry {
+    url: String,
+    /// Unix seconds of the last successful fetch+cache.
+    last_fetch_secs: u64,
+    /// Number of domains in that cache.
+    domains: usize,
+}
+
+impl State {
+    fn path(cache_dir: &Path) -> PathBuf {
+        cache_dir.join("state.json")
+    }
+
+    fn load(cache_dir: &Path) -> Self {
+        std::fs::read_to_string(Self::path(cache_dir))
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    fn save(&self, cache_dir: &Path) {
+        if std::fs::create_dir_all(cache_dir).is_err() {
+            return;
+        }
+        if let Ok(json) = serde_json::to_string_pretty(self) {
+            let _ = write_atomic(&Self::path(cache_dir), json.as_bytes());
+        }
+    }
+
+    fn get(&self, url: &str) -> Option<&StateEntry> {
+        self.subscriptions.iter().find(|e| e.url == url)
+    }
+
+    fn set(&mut self, url: &str, last_fetch_secs: u64, domains: usize) {
+        if let Some(entry) = self.subscriptions.iter_mut().find(|e| e.url == url) {
+            entry.last_fetch_secs = last_fetch_secs;
+            entry.domains = domains;
+        } else {
+            self.subscriptions.push(StateEntry {
+                url: url.to_string(),
+                last_fetch_secs,
+                domains,
+            });
+        }
+    }
+}
+
+/// Write `bytes` to `path` atomically (write temp + rename) so a crash mid-write
+/// never leaves a truncated cache that would be parsed as a partial blocklist.
+fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, path)
+}
+
+fn unix_secs(now: SystemTime) -> u64 {
+    now.duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs())
+}
+
+/// Fetch, verify, and cache a single subscription. On any failure the last-good
+/// cache is preserved (never deleted). Returns a per-list outcome for reporting.
+fn update_one(
+    set: &SubscriptionSet,
+    sub: &BlocklistSubscription,
+    fetch: &Fetcher,
+    now: SystemTime,
+    state: &mut State,
+) -> UpdateOutcome {
+    let path = cache_path(&set.cache_dir, &sub.url);
+    let cache_exists = path.exists();
+
+    let bytes = match fetch(&sub.url) {
+        Ok(b) => b,
+        Err(reason) => {
+            // Fail-open: keep last-good cache, or treat as empty if none.
+            return if cache_exists {
+                UpdateOutcome::CacheKept {
+                    url: sub.url.clone(),
+                    reason,
+                }
+            } else {
+                UpdateOutcome::EmptyNoCache {
+                    url: sub.url.clone(),
+                    reason,
+                }
+            };
+        }
+    };
+
+    // Optional integrity check. A mismatch REJECTS the update and keeps the
+    // last-good cache — the tamper-refuse behaviour of update.rs.
+    let mut verified = false;
+    if let Some(expected) = &sub.sha256 {
+        let expected = expected.trim().to_ascii_lowercase();
+        let actual = sha256_hex(&bytes);
+        if actual != expected {
+            return UpdateOutcome::VerifyFailed {
+                url: sub.url.clone(),
+                expected,
+                actual,
+            };
+        }
+        verified = true;
+    }
+
+    let domains = parse_blocklist(&String::from_utf8_lossy(&bytes)).len();
+
+    // Best-effort cache write. If the directory or write fails we still report a
+    // fetch (tighten-only: a failed write just means the new domains are not
+    // persisted; the last-good cache — if any — remains).
+    if std::fs::create_dir_all(&set.cache_dir).is_ok() {
+        let _ = write_atomic(&path, &bytes);
+    }
+
+    state.set(&sub.url, unix_secs(now), domains);
+
+    UpdateOutcome::Fetched {
+        url: sub.url.clone(),
+        domains,
+        verified,
+    }
+}
+
+/// Fetch + verify + cache ALL configured blocklist subscriptions (the explicit
+/// `cplt update-lists` refresh path). Returns a per-list outcome.
+pub fn update_all(set: &SubscriptionSet, fetch: &Fetcher, now: SystemTime) -> Vec<UpdateOutcome> {
+    let mut state = State::load(&set.cache_dir);
+    let outcomes: Vec<UpdateOutcome> = set
+        .blocklists
+        .iter()
+        .map(|sub| update_one(set, sub, fetch, now, &mut state))
+        .collect();
+    state.save(&set.cache_dir);
+    outcomes
+}
+
+/// Whether a subscription is due for a lazy refresh: no cache yet, or the cache
+/// is older than the refresh interval. `Manual` is never due.
+fn is_due(
+    set: &SubscriptionSet,
+    sub: &BlocklistSubscription,
+    state: &State,
+    now: SystemTime,
+) -> bool {
+    let Some(max_age) = set.refresh.max_age() else {
+        return false;
+    };
+    if !cache_path(&set.cache_dir, &sub.url).exists() {
+        return true;
+    }
+    match state.get(&sub.url) {
+        Some(entry) => {
+            let age = unix_secs(now).saturating_sub(entry.last_fetch_secs);
+            age >= max_age.as_secs()
+        }
+        // Cache exists but no metadata — refresh to establish a timestamp.
+        None => true,
+    }
+}
+
+/// Lazy pre-run refresh: when `refresh != manual`, re-fetch any subscription
+/// whose cache is stale (bounded by the fetcher's timeout). Fails over to the
+/// cache — never blocks or fails the run. Returns outcomes for stale entries
+/// only (empty when nothing was due or refresh is manual).
+pub fn refresh_if_stale(
+    set: &SubscriptionSet,
+    fetch: &Fetcher,
+    now: SystemTime,
+) -> Vec<UpdateOutcome> {
+    if set.refresh == RefreshInterval::Manual {
+        return Vec::new();
+    }
+    let mut state = State::load(&set.cache_dir);
+    let mut outcomes = Vec::new();
+    for sub in &set.blocklists {
+        if is_due(set, sub, &state, now) {
+            outcomes.push(update_one(set, sub, fetch, now, &mut state));
+        }
+    }
+    if !outcomes.is_empty() {
+        state.save(&set.cache_dir);
+    }
+    outcomes
+}
+
+/// One-line warnings for caches that have never been fetched or are older than
+/// the stale threshold. Purely advisory (tighten-only: stale = safe).
+pub fn staleness_warnings(set: &SubscriptionSet, now: SystemTime) -> Vec<String> {
+    let state = State::load(&set.cache_dir);
+    let mut warnings = Vec::new();
+    for sub in &set.blocklists {
+        let cache_exists = cache_path(&set.cache_dir, &sub.url).exists();
+        if !cache_exists {
+            warnings.push(format!(
+                "blocklist subscription {} has never been fetched — run `cplt update-lists`",
+                sub.url
+            ));
+            continue;
+        }
+        if let Some(entry) = state.get(&sub.url) {
+            let age = unix_secs(now).saturating_sub(entry.last_fetch_secs);
+            if age >= STALE_WARN.as_secs() {
+                let days = age / (24 * 60 * 60);
+                warnings.push(format!(
+                    "blocklist subscription {} cache is {days} days old — run `cplt update-lists`",
+                    sub.url
+                ));
+            }
+        }
+    }
+    warnings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_with(
+        dir: &Path,
+        refresh: RefreshInterval,
+        subs: Vec<BlocklistSubscription>,
+    ) -> SubscriptionSet {
+        SubscriptionSet {
+            refresh,
+            blocklists: subs,
+            cache_dir: dir.to_path_buf(),
+        }
+    }
+
+    fn sub(url: &str, sha: Option<&str>) -> BlocklistSubscription {
+        BlocklistSubscription {
+            url: url.to_string(),
+            sha256: sha.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn refresh_interval_parse() {
+        assert_eq!(
+            RefreshInterval::parse("manual").unwrap(),
+            RefreshInterval::Manual
+        );
+        assert_eq!(
+            RefreshInterval::parse("Daily").unwrap(),
+            RefreshInterval::Daily
+        );
+        assert_eq!(
+            RefreshInterval::parse(" weekly ").unwrap(),
+            RefreshInterval::Weekly
+        );
+        assert!(RefreshInterval::parse("hourly").is_err());
+    }
+
+    #[test]
+    fn parse_blocklist_normalizes() {
+        let raw = "# comment\nEvil.COM\n\n  bad.example.  \nfoo.test\n";
+        let got = parse_blocklist(raw);
+        assert_eq!(got, vec!["evil.com", "bad.example", "foo.test"]);
+    }
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        // echo -n "abc" | sha256sum
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn update_all_fetches_and_caches() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        let fetch = |_url: &str| Ok(b"evil.com\nbad.test\n".to_vec());
+        let outcomes = update_all(&set, &fetch, SystemTime::now());
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            UpdateOutcome::Fetched {
+                domains: 2,
+                verified: false,
+                ..
+            }
+        ));
+        // Cached domains load and merge.
+        let domains = load_cached_domains(&set);
+        assert_eq!(domains, vec!["bad.test", "evil.com"]);
+    }
+
+    #[test]
+    fn sha256_verify_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = b"evil.com\n".to_vec();
+        let hash = sha256_hex(&body);
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", Some(&hash))],
+        );
+        let outcomes = update_all(&set, &|_| Ok(body.clone()), SystemTime::now());
+        assert!(matches!(
+            outcomes[0],
+            UpdateOutcome::Fetched { verified: true, .. }
+        ));
+        assert_eq!(load_cached_domains(&set), vec!["evil.com"]);
+    }
+
+    #[test]
+    fn sha256_mismatch_rejects_and_keeps_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        // First: a good fetch establishes a last-good cache.
+        let set_good = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        update_all(
+            &set_good,
+            &|_| Ok(b"good.com\n".to_vec()),
+            SystemTime::now(),
+        );
+        assert_eq!(load_cached_domains(&set_good), vec!["good.com"]);
+
+        // Now: a pinned subscription whose fetched bytes don't match the hash.
+        let set_pinned = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", Some(&"0".repeat(64)))],
+        );
+        let outcomes = update_all(
+            &set_pinned,
+            &|_| Ok(b"tampered.com\n".to_vec()),
+            SystemTime::now(),
+        );
+        assert!(outcomes[0].is_verify_failure());
+        // Last-good cache is UNCHANGED — the tampered copy was rejected.
+        assert_eq!(load_cached_domains(&set_pinned), vec!["good.com"]);
+    }
+
+    #[test]
+    fn fetch_failure_keeps_last_good_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        update_all(&set, &|_| Ok(b"good.com\n".to_vec()), SystemTime::now());
+
+        let outcomes = update_all(&set, &|_| Err("offline".to_string()), SystemTime::now());
+        assert!(matches!(outcomes[0], UpdateOutcome::CacheKept { .. }));
+        assert_eq!(load_cached_domains(&set), vec!["good.com"]);
+    }
+
+    #[test]
+    fn fetch_failure_no_cache_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        let outcomes = update_all(&set, &|_| Err("offline".to_string()), SystemTime::now());
+        assert!(matches!(outcomes[0], UpdateOutcome::EmptyNoCache { .. }));
+        assert!(load_cached_domains(&set).is_empty());
+    }
+
+    #[test]
+    fn no_subscriptions_is_empty_and_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(dir.path(), RefreshInterval::Manual, vec![]);
+        assert!(set.is_empty());
+        assert!(load_cached_domains(&set).is_empty());
+        assert!(update_all(&set, &|_| Ok(vec![]), SystemTime::now()).is_empty());
+        assert!(refresh_if_stale(&set, &|_| Ok(vec![]), SystemTime::now()).is_empty());
+    }
+
+    #[test]
+    fn manual_refresh_never_lazy_fetches() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        // No cache, but manual → refresh_if_stale does nothing.
+        let outcomes = refresh_if_stale(
+            &set,
+            &|_| panic!("must not fetch under manual"),
+            SystemTime::now(),
+        );
+        assert!(outcomes.is_empty());
+    }
+
+    #[test]
+    fn lazy_refresh_fetches_when_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Daily,
+            vec![sub("mem://a", None)],
+        );
+        let t0 = UNIX_EPOCH + Duration::from_secs(1_000_000);
+        // First refresh: no cache → due.
+        let o1 = refresh_if_stale(&set, &|_| Ok(b"a.com\n".to_vec()), t0);
+        assert_eq!(o1.len(), 1);
+
+        // Shortly after: cache is fresh → not due.
+        let t1 = t0 + Duration::from_secs(60 * 60);
+        let o2 = refresh_if_stale(&set, &|_| panic!("should not refetch a fresh cache"), t1);
+        assert!(o2.is_empty());
+
+        // Two days later: cache is stale → due again.
+        let t2 = t0 + Duration::from_secs(2 * 24 * 60 * 60);
+        let o3 = refresh_if_stale(&set, &|_| Ok(b"a.com\nb.com\n".to_vec()), t2);
+        assert_eq!(o3.len(), 1);
+        assert_eq!(load_cached_domains(&set), vec!["a.com", "b.com"]);
+    }
+
+    #[test]
+    fn staleness_warning_for_never_fetched() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        let warns = staleness_warnings(&set, SystemTime::now());
+        assert_eq!(warns.len(), 1);
+        assert!(warns[0].contains("never been fetched"));
+    }
+
+    #[test]
+    fn staleness_warning_for_old_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let set = set_with(
+            dir.path(),
+            RefreshInterval::Manual,
+            vec![sub("mem://a", None)],
+        );
+        let t0 = UNIX_EPOCH + Duration::from_secs(1_000_000);
+        update_all(&set, &|_| Ok(b"a.com\n".to_vec()), t0);
+        // 40 days later.
+        let later = t0 + Duration::from_secs(40 * 24 * 60 * 60);
+        let warns = staleness_warnings(&set, later);
+        assert_eq!(warns.len(), 1);
+        assert!(warns[0].contains("days old"));
+    }
+
+    #[test]
+    fn file_url_fetch_via_curl() {
+        // Exercises the real curl fetcher against a local file:// URL — no network.
+        let dir = tempfile::tempdir().unwrap();
+        let list = dir.path().join("list.txt");
+        std::fs::write(&list, "curl.example\n").unwrap();
+        let url = format!("file://{}", list.display());
+        if let Ok(bytes) = curl_fetch(&url) {
+            assert_eq!(String::from_utf8_lossy(&bytes).trim(), "curl.example");
+        }
+        // curl may be unavailable in some CI images; a fetch error is tolerated.
+    }
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -442,6 +442,45 @@ blocklists = [\"https://attacker.example/evil.txt\"]
     );
 }
 
+#[test]
+fn subscriptions_reject_non_https_scheme() {
+    // Only https:// (and file:// for a local mirror) are accepted. http://,
+    // junk, and `-`-prefixed values (which curl could otherwise parse as flags)
+    // must fail at config-load time.
+    use cplt::config::{CliFlags, Config};
+    for bad in [
+        "http://example.com/list.txt",
+        "ftp://example.com/list.txt",
+        "-K/tmp/evil-curlrc",
+        "--output=/tmp/pwned",
+        "example.com/list.txt",
+    ] {
+        let toml = format!("[proxy.subscriptions]\nblocklists = [\"{bad}\"]\n");
+        let result = Config::parse(&toml).unwrap().merge(CliFlags::default());
+        assert!(
+            result.is_err(),
+            "subscription url {bad:?} must be rejected at config load"
+        );
+    }
+}
+
+#[test]
+fn subscriptions_accept_https_and_file_scheme() {
+    use cplt::config::{CliFlags, Config};
+    let toml = "\
+[proxy.subscriptions]
+blocklists = [
+  \"https://example.com/list.txt\",
+  \"file:///tmp/local-mirror.txt\",
+]
+";
+    let resolved = Config::parse(toml)
+        .unwrap()
+        .merge(CliFlags::default())
+        .unwrap();
+    assert_eq!(resolved.proxy_subscriptions.blocklists.len(), 2);
+}
+
 // #126 Tier 2: `allow_private_domains_bypasses_private_ip_check` used to live
 // here, but it only re-implemented the guard's boolean expression with local
 // constants and never drove `handle_connect`, so deleting the real private-IP

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -379,6 +379,69 @@ fn allow_private_domains_rejects_empty_string() {
     assert!(result.is_err(), "empty domain should be rejected");
 }
 
+// ── Blocklist subscriptions (issue #144, Phase 1) ────────────────────────────
+
+#[test]
+fn subscriptions_parse_bare_url_and_pinned() {
+    use cplt::config::{CliFlags, Config};
+    let toml = "\
+[proxy.subscriptions]
+refresh = \"daily\"
+blocklists = [
+  \"https://example.com/blocklist.txt\",
+  { url = \"https://example.com/pinned.txt\", sha256 = \"ABCDEF\" },
+]
+";
+    let resolved = Config::parse(toml)
+        .unwrap()
+        .merge(CliFlags::default())
+        .unwrap();
+    let set = &resolved.proxy_subscriptions;
+    assert_eq!(set.refresh, cplt::subscriptions::RefreshInterval::Daily);
+    assert_eq!(set.blocklists.len(), 2);
+    assert_eq!(set.blocklists[0].url, "https://example.com/blocklist.txt");
+    assert_eq!(set.blocklists[0].sha256, None);
+    assert_eq!(set.blocklists[1].url, "https://example.com/pinned.txt");
+    // Pinned hash is normalized to lowercase.
+    assert_eq!(set.blocklists[1].sha256.as_deref(), Some("abcdef"));
+}
+
+#[test]
+fn subscriptions_invalid_refresh_rejected() {
+    use cplt::config::{CliFlags, Config};
+    let toml = "[proxy.subscriptions]\nrefresh = \"hourly\"\n";
+    let result = Config::parse(toml).unwrap().merge(CliFlags::default());
+    assert!(result.is_err(), "invalid refresh value must be rejected");
+}
+
+#[test]
+fn subscriptions_absent_means_empty_no_regression() {
+    // No [proxy.subscriptions] configured → empty set → behaviour identical to
+    // today (nothing merged into the effective blocklist).
+    use cplt::config::{CliFlags, Config};
+    let resolved = Config::parse("")
+        .unwrap()
+        .merge(CliFlags::default())
+        .unwrap();
+    assert!(resolved.proxy_subscriptions.is_empty());
+    assert!(cplt::subscriptions::load_cached_domains(&resolved.proxy_subscriptions).is_empty());
+}
+
+#[test]
+fn repo_config_rejects_proxy_subscriptions() {
+    // A malicious repo must not be able to add a subscription. The repo config
+    // schema has no [proxy] table, so `.cplt.toml` cannot express one at all.
+    let cplt_toml = "\
+[proxy.subscriptions]
+blocklists = [\"https://attacker.example/evil.txt\"]
+";
+    let result = cplt::repo_config::parse_and_validate(cplt_toml);
+    assert!(
+        result.is_err(),
+        "repo .cplt.toml must reject [proxy.subscriptions]"
+    );
+}
+
 // #126 Tier 2: `allow_private_domains_bypasses_private_ip_check` used to live
 // here, but it only re-implemented the guard's boolean expression with local
 // constants and never drove `handle_connect`, so deleting the real private-IP


### PR DESCRIPTION
Phase 1 of #144 (subsumes #10): subscribe to remotely-hosted **blocklists** (tighten-only, low-risk). Allowlist subscriptions (security-critical Phase 2) are deliberately NOT included.

- `[proxy.subscriptions] blocklists = [url | {url, sha256}], refresh = manual|daily|weekly` — GLOBAL-only (rejected in repo config, structurally + repo.rs).
- Fetch/verify/cache in `src/subscriptions.rs` reusing `update.rs`'s discipline (absolute curl, bounded timeout, in-process SHA256). Cache at `~/.config/cplt/subscriptions/` — outside the agent's writable set. Atomic writes + per-list state.json.
- **Fail-open, tighten-only:** fetch failure → last-good cache (or empty = no extra blocks); pinned-hash mismatch → REJECT update, keep cache, loud tamper warning, non-zero exit.
- `cplt update-lists` (manual fetch+report); lazy pre-run refresh when refresh≠manual, bounded, cache-failover, staleness warnings.
- Merges (union) into the effective blocklist; **no-regression** when unconfigured (byte-identical — early-return). Default cplt list is opt-in/documented, never auto-fetched.
- Fetch is injectable → fully offline-testable. lib 642 + unit 253.