### PR TITLE
fix(gh-guard): pin verified repository scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,7 +1162,7 @@ Certain git operations are blocked to prevent persistence attacks that survive t
 | `git fetch/pull/push` (HTTPS)      | ✅ Works     | Port 443 allowed, credentials via `gh` credential helper          |
 | `git fetch/pull/push` (SSH)        | ❌ Blocked   | SSH agent socket denied — use HTTPS                               |
 | `git config` (local)               | ❌ Blocked   | `.git/config` is write-protected (prevents `url.*.insteadOf` hijacking) |
-| `git config --global`              | ❌ Blocked   | `~/.gitconfig` and `.gitconfig.local` are read-only               |
+| `git config --global`              | ❌ Blocked   | Git config and `~/.gitignore_global` are read-only                 |
 | `git remote set-url`               | ❌ Blocked   | Writes to `.git/config`                                           |
 | `git submodule add`                | ❌ Blocked   | `.gitmodules` is write-protected (supply chain vector)            |
 | Creating git hooks                 | ❌ Blocked   | `.git/hooks/` is write-protected (hooks run unsandboxed)          |

--- a/README.md
+++ b/README.md
@@ -1162,7 +1162,7 @@ Certain git operations are blocked to prevent persistence attacks that survive t
 | `git fetch/pull/push` (HTTPS)      | ✅ Works     | Port 443 allowed, credentials via `gh` credential helper          |
 | `git fetch/pull/push` (SSH)        | ❌ Blocked   | SSH agent socket denied — use HTTPS                               |
 | `git config` (local)               | ❌ Blocked   | `.git/config` is write-protected (prevents `url.*.insteadOf` hijacking) |
-| `git config --global`              | ❌ Blocked   | `~/.gitconfig` is read-only                                      |
+| `git config --global`              | ❌ Blocked   | `~/.gitconfig` and `.gitconfig.local` are read-only               |
 | `git remote set-url`               | ❌ Blocked   | Writes to `.git/config`                                           |
 | `git submodule add`                | ❌ Blocked   | `.gitmodules` is write-protected (supply chain vector)            |
 | Creating git hooks                 | ❌ Blocked   | `.git/hooks/` is write-protected (hooks run unsandboxed)          |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -279,10 +279,16 @@ A curated blocklist of these domains is included in [`blocked-domains.txt`](bloc
 
 *Possible mitigation:* A repo-scoped MCP proxy or fine-grained PAT that limits token scope to the current repository only. See issue #4 for investigation.
 
-**The gh/git guards are a best-effort command filter, not a kernel boundary.** The "gh guard" and "git guard" rows in the threat-model table above describe command-level interception, and two properties bound what they can promise:
+**The gh/git guards are a best-effort command filter, not a kernel boundary.** The "gh guard" and "git guard" rows in the threat-model table above describe command-level interception, and three properties bound what they can promise:
 
 - **Opt-in.** Both guards default to `enabled = false` (soft rollout). Out of the box cplt performs **no** gh/git command filtering — the fail-closed posture (block mode, default-deny unknown subcommands, scope check, `block_auth_token`, `allow_api_write=false`) only takes effect once an operator sets `gh_guard.enabled = true` / `git_guard.enabled = true` (or passes the equivalent flags). A user who assumes "cplt guards git" without opting in gets nothing.
 - **PATH-shim enforcement.** The guards work by writing `gh`/`git` shims into a scratch `bin/` dir and prepending it to `PATH`; the shim calls back into cplt for a policy decision before `exec`ing the real binary. The real `/usr/bin/git` and `/usr/bin/gh` are untouched, so any agent that invokes the binary by **absolute path** (`/usr/bin/git push`), **escapes the alias** (`\git`, `env git`), **resets `PATH`**, or **shells out from another runtime** (`subprocess.run(["/usr/bin/git", "push"])`) bypasses the guard entirely. Command classification (force-push detection, scope checks, `gh auth token` blocking, DELETE blocking) therefore only constrains a *cooperative* agent that goes through the shim — it is not a boundary against an adversarial one.
+- **Repository scope is pinned inside the shim.** Scope checks invoke the pre-resolved
+  Git binary directly and read only the local `remote.origin.url`, with config
+  includes and inherited `GIT_*` variables disabled. Successful checks set
+  `GH_REPO` before executing `gh`; failure to determine scope blocks the command.
+  This prevents a cooperative caller from retargeting the check through `PATH`,
+  `GIT_DIR`, config overrides, or a check/execute race.
 
 The guards raise the bar against accidental and prompt-injected-but-cooperative misuse; they are not a substitute for the kernel-enforced filesystem/exec isolation that does hold against an adversarial agent. On the *network* side, proxy-forced mode (issues #53 / #117) is the kernel-backed complement: it forces all egress through the cplt proxy at the packet level rather than via tamperable `HTTPS_PROXY` env vars, so a bypassed `git push` / `gh api` write still has to traverse the proxy. Command-level intent (e.g. `GET` vs `DELETE` to `api.github.com`) remains invisible to a CONNECT proxy, so the guards and the proxy cover different layers.
 
@@ -326,6 +332,14 @@ By default, `cplt` clears the child process environment and re-adds only safe va
 **OpenTelemetry (`OTEL_*`):** OTel configuration vars (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`) are allowed via the `OTEL_` prefix. `OTEL_EXPORTER_OTLP_HEADERS` may carry opt-in auth headers (e.g. `Authorization=Bearer <token>`) — this is an accepted trade-off in the same class as `GH_TOKEN`, only present when the user has configured an exporter. The `is_secret_suffix` deny-list still strips any `OTEL_*_TOKEN` / `_AUTH` / `_SECRET` / `_KEY` / `_PASSWORD` / `_CREDENTIALS` vars.
 
 **Deliberately blocked:** `AWS_*`, `AZURE_*`, `NPM_TOKEN`, `DATABASE_URL`, `VAULT_TOKEN`, `SSH_AUTH_SOCK`, Docker vars, CI tokens.
+
+**Git configuration:** `~/.gitconfig` and `~/.gitconfig.local` are exact
+read-only exceptions so normal Git and `gh` workflows can load conventional
+user configuration. The standard XDG Git config is also read-only (the
+`~/.config/git` directory on Linux because Landlock rules are recursive).
+Other include files remain blocked unless explicitly allowed. These files
+should not contain plaintext credentials; credential directories and SSH/GPG
+private keys remain denied.
 
 **Escape hatch:** `--inherit-env` disables sanitization and inherits all env vars (still strips `ENV_ALWAYS_DENY`). This is dangerous and should only be used for debugging.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -283,12 +283,14 @@ A curated blocklist of these domains is included in [`blocked-domains.txt`](bloc
 
 - **Opt-in.** Both guards default to `enabled = false` (soft rollout). Out of the box cplt performs **no** gh/git command filtering — the fail-closed posture (block mode, default-deny unknown subcommands, scope check, `block_auth_token`, `allow_api_write=false`) only takes effect once an operator sets `gh_guard.enabled = true` / `git_guard.enabled = true` (or passes the equivalent flags). A user who assumes "cplt guards git" without opting in gets nothing.
 - **PATH-shim enforcement.** The guards work by writing `gh`/`git` shims into a scratch `bin/` dir and prepending it to `PATH`; the shim calls back into cplt for a policy decision before `exec`ing the real binary. The real `/usr/bin/git` and `/usr/bin/gh` are untouched, so any agent that invokes the binary by **absolute path** (`/usr/bin/git push`), **escapes the alias** (`\git`, `env git`), **resets `PATH`**, or **shells out from another runtime** (`subprocess.run(["/usr/bin/git", "push"])`) bypasses the guard entirely. Command classification (force-push detection, scope checks, `gh auth token` blocking, DELETE blocking) therefore only constrains a *cooperative* agent that goes through the shim — it is not a boundary against an adversarial one.
-- **Repository scope is pinned inside the shim.** Scope checks invoke the pre-resolved
-  Git binary directly and read only the local `remote.origin.url`, with config
-  includes and inherited `GIT_*` variables disabled. Successful checks set
-  `GH_REPO` before executing `gh`; failure to determine scope blocks the command.
-  This prevents a cooperative caller from retargeting the check through `PATH`,
-  `GIT_DIR`, config overrides, or a check/execute race.
+- **Repository scope is pinned at sandbox startup.** Before the agent starts, cplt
+  invokes the pre-resolved Git binary and reads only the project root's local
+  `remote.origin.url`, with config includes and inherited `GIT_*` variables disabled.
+  The verified scope is baked into the shim. Successful checks set a host-qualified
+  `GH_REPO`, clear `GH_HOST`, and reject conflicting hostname flags before executing
+  `gh`; failure to determine startup scope blocks the command. Runtime working
+  directories, nested repositories, mutable Git configuration, and environment
+  overrides therefore cannot retarget the check.
 
 The guards raise the bar against accidental and prompt-injected-but-cooperative misuse; they are not a substitute for the kernel-enforced filesystem/exec isolation that does hold against an adversarial agent. On the *network* side, proxy-forced mode (issues #53 / #117) is the kernel-backed complement: it forces all egress through the cplt proxy at the packet level rather than via tamperable `HTTPS_PROXY` env vars, so a bypassed `git push` / `gh api` write still has to traverse the proxy. Command-level intent (e.g. `GET` vs `DELETE` to `api.github.com`) remains invisible to a CONNECT proxy, so the guards and the proxy cover different layers.
 
@@ -333,13 +335,13 @@ By default, `cplt` clears the child process environment and re-adds only safe va
 
 **Deliberately blocked:** `AWS_*`, `AZURE_*`, `NPM_TOKEN`, `DATABASE_URL`, `VAULT_TOKEN`, `SSH_AUTH_SOCK`, Docker vars, CI tokens.
 
-**Git configuration:** `~/.gitconfig` and `~/.gitconfig.local` are exact
-read-only exceptions so normal Git and `gh` workflows can load conventional
-user configuration. The standard XDG Git config is also read-only (the
-`~/.config/git` directory on Linux because Landlock rules are recursive).
-Other include files remain blocked unless explicitly allowed. These files
-should not contain plaintext credentials; credential directories and SSH/GPG
-private keys remain denied.
+**Git configuration:** `~/.gitconfig`, `~/.gitconfig.local`, and
+`~/.gitignore_global` are exact read-only exceptions so normal Git and `gh`
+workflows can load conventional user configuration. The standard XDG Git config
+is also read-only (the `~/.config/git` directory on Linux because Landlock rules
+are recursive). Other include files remain blocked unless explicitly allowed.
+These files should not contain plaintext credentials; credential directories and
+SSH/GPG private keys remain denied.
 
 **Escape hatch:** `--inherit-env` disables sanitization and inherits all env vars (still strips `ENV_ALWAYS_DENY`). This is dangerous and should only be used for debugging.
 

--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -77,11 +77,12 @@ git_push_prevention = true   # maps to [git_guard] enabled=true with defaults
 
 ### Security: Policy baked at launch
 
-The policy flags and absolute paths to the real `gh` and `git` binaries are baked
-into the wrapper script at sandbox launch time. The `gh-gate` subcommand receives
-`--scope-check`, `--block-auth-token`, `--unknown-command=block`, and
-`--allow-api-write`/`--no-allow-api-write` as CLI flags, preventing the agent
-from influencing policy by editing config files or replacing `git` in `PATH`.
+The policy flags, absolute path to the real `gh` binary, and verified repository
+scope are baked into the wrapper script at sandbox launch time. The `gh-gate`
+subcommand receives `--repo-scope`, `--scope-check`, `--block-auth-token`,
+`--unknown-command=block`, and `--allow-api-write`/`--no-allow-api-write` as CLI
+flags. Runtime working directories, nested repositories, Git configuration, and
+`PATH` cannot redefine the approved scope.
 
 ## How it works
 
@@ -94,7 +95,7 @@ Agent calls gh → wrapper script (in PATH) → cplt gh-gate → policy check
 
 1. At sandbox launch (when scratch directory is enabled), cplt writes a small wrapper to `{scratch}/bin/gh`
 2. `{scratch}/bin` is prepended to PATH, shadowing the real `gh`
-3. The wrapper calls `cplt gh-gate --real-gh /path/to/gh --real-git /path/to/git -- <args>`
+3. The wrapper calls `cplt gh-gate --real-gh /path/to/gh --repo-scope owner/repo -- <args>`
 4. cplt evaluates the command against the policy table
 5. If allowed, `exec()` replaces the process with the real `gh` (zero overhead)
 6. If blocked, prints an error explaining why and exits non-zero
@@ -123,12 +124,12 @@ Agent calls gh → wrapper script (in PATH) → cplt gh-gate → policy check
 When a command is classified as `ScopeCheck`, cplt verifies that the command
 targets the current repository:
 
-1. Reads `remote.origin.url` from local repository config using the trusted Git binary
+1. At sandbox startup, reads `remote.origin.url` from the project root using the trusted Git binary
 2. Ignores global/system config, config includes, and inherited `GIT_*` variables
-3. If the command has `-R`/`--repo` flag, compares it to current repo
-4. If `-R` matches (case-insensitive, `.git` suffix stripped) → allowed
-5. If `-R` targets a different repo, or scope cannot be detected → blocked
-6. If no `-R` flag → sets `GH_REPO` to the verified repo before executing `gh`
+3. Bakes the verified `owner/repo` into the wrapper; unavailable scope remains fail-closed
+4. If the command has `-R`/`--repo`, compares it to the startup scope
+5. Rejects a conflicting `--hostname` or fully qualified non-GitHub API endpoint
+6. Sets `GH_REPO=github.com/owner/repo` and clears `GH_HOST` before executing `gh`
 
 ## Command classifications
 

--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -77,11 +77,11 @@ git_push_prevention = true   # maps to [git_guard] enabled=true with defaults
 
 ### Security: Policy baked at launch
 
-The policy flags are baked into the wrapper script at sandbox launch time.
-The `gh-gate` subcommand receives `--scope-check`, `--block-auth-token`,
-`--unknown-command=block`, and `--allow-api-write`/`--no-allow-api-write` as
-CLI flags, preventing the agent from influencing policy by editing config files
-inside the sandbox.
+The policy flags and absolute paths to the real `gh` and `git` binaries are baked
+into the wrapper script at sandbox launch time. The `gh-gate` subcommand receives
+`--scope-check`, `--block-auth-token`, `--unknown-command=block`, and
+`--allow-api-write`/`--no-allow-api-write` as CLI flags, preventing the agent
+from influencing policy by editing config files or replacing `git` in `PATH`.
 
 ## How it works
 
@@ -94,7 +94,7 @@ Agent calls gh → wrapper script (in PATH) → cplt gh-gate → policy check
 
 1. At sandbox launch (when scratch directory is enabled), cplt writes a small wrapper to `{scratch}/bin/gh`
 2. `{scratch}/bin` is prepended to PATH, shadowing the real `gh`
-3. The wrapper calls `cplt gh-gate --real-gh /path/to/gh -- <args>`
+3. The wrapper calls `cplt gh-gate --real-gh /path/to/gh --real-git /path/to/git -- <args>`
 4. cplt evaluates the command against the policy table
 5. If allowed, `exec()` replaces the process with the real `gh` (zero overhead)
 6. If blocked, prints an error explaining why and exits non-zero
@@ -123,11 +123,12 @@ Agent calls gh → wrapper script (in PATH) → cplt gh-gate → policy check
 When a command is classified as `ScopeCheck`, cplt verifies that the command
 targets the current repository:
 
-1. Detects the current repo from `git remote get-url origin`
-2. If the command has `-R`/`--repo` flag, compares it to current repo
-3. If `-R` matches (case-insensitive, `.git` suffix stripped) → allowed
-4. If `-R` targets a different repo → blocked
-5. If no `-R` flag → allowed (implicitly targets current repo)
+1. Reads `remote.origin.url` from local repository config using the trusted Git binary
+2. Ignores global/system config, config includes, and inherited `GIT_*` variables
+3. If the command has `-R`/`--repo` flag, compares it to current repo
+4. If `-R` matches (case-insensitive, `.git` suffix stripped) → allowed
+5. If `-R` targets a different repo, or scope cannot be detected → blocked
+6. If no `-R` flag → sets `GH_REPO` to the verified repo before executing `gh`
 
 ## Command classifications
 

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -258,7 +258,7 @@ Certain git operations are blocked to prevent persistence attacks that survive t
 | `git fetch/pull/push` (HTTPS)      | ✅ Works     | Port 443 allowed, `gh auth token` provides credentials            |
 | `git fetch/pull/push` (SSH)        | ❌ Blocked   | SSH agent socket denied — use HTTPS                               |
 | `git config` (local)               | ❌ Blocked   | `.git/config` is write-protected (prevents `url.*.insteadOf` hijacking) |
-| `git config --global`              | ❌ Blocked   | `~/.gitconfig` and `.gitconfig.local` are read-only               |
+| `git config --global`              | ❌ Blocked   | Git config and `~/.gitignore_global` are read-only                 |
 | `git remote set-url`               | ❌ Blocked   | Writes to `.git/config`                                           |
 | `git submodule add`                | ❌ Blocked   | `.gitmodules` is write-protected (supply chain vector)            |
 | Creating git hooks                 | ❌ Blocked   | `.git/hooks/` is write-protected (hooks run unsandboxed)          |

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -258,7 +258,7 @@ Certain git operations are blocked to prevent persistence attacks that survive t
 | `git fetch/pull/push` (HTTPS)      | ✅ Works     | Port 443 allowed, `gh auth token` provides credentials            |
 | `git fetch/pull/push` (SSH)        | ❌ Blocked   | SSH agent socket denied — use HTTPS                               |
 | `git config` (local)               | ❌ Blocked   | `.git/config` is write-protected (prevents `url.*.insteadOf` hijacking) |
-| `git config --global`              | ❌ Blocked   | `~/.gitconfig` is read-only                                      |
+| `git config --global`              | ❌ Blocked   | `~/.gitconfig` and `.gitconfig.local` are read-only               |
 | `git remote set-url`               | ❌ Blocked   | Writes to `.git/config`                                           |
 | `git submodule add`                | ❌ Blocked   | `.gitmodules` is write-protected (supply chain vector)            |
 | Creating git hooks                 | ❌ Blocked   | `.git/hooks/` is write-protected (hooks run unsandboxed)          |

--- a/src/check.rs
+++ b/src/check.rs
@@ -459,7 +459,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
             allow_api_write: ctx.gh_guard.allow_api_write,
         };
         return match crate::gh_proxy::gate(&rest, ctx.project_dir, &policy) {
-            Ok(()) => ExecExplain {
+            Ok(_) => ExecExplain {
                 decision: Decision::Allowed,
                 reason: "allowed by the gh guard.".to_string(),
                 fix: None,

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1230,6 +1230,9 @@ pub fn is_repo_in_scope(cmd: &ParsedCommand, current_repo: &str) -> bool {
     // For gh api: extract repo from endpoint path like /repos/{owner}/{repo}/...
     if cmd.command == "api" {
         if let Some(ref endpoint) = cmd.api_endpoint {
+            let Ok(endpoint) = github_api_endpoint_path(endpoint) else {
+                return false;
+            };
             if let Some(endpoint_repo) = extract_repo_from_api_path(endpoint) {
                 let current_clean = current_repo.to_lowercase();
                 return endpoint_repo.to_lowercase() == current_clean;
@@ -1301,7 +1304,7 @@ fn extract_repo_from_api_path(endpoint: &str) -> Option<String> {
     }
 }
 
-/// Detect the current repository from the working directory.
+/// Detect the repository rooted at the supplied project directory.
 ///
 /// Reads `remote.origin.url` from local repository config only and parses the
 /// owner/repo from it. Global/system config, includes, and inherited `GIT_*`
@@ -1409,18 +1412,21 @@ fn shell_escape(s: &str) -> String {
 /// with an error message.
 ///
 /// `real_gh` is the path to the real `gh` binary.
+/// `repo_scope` is the repository verified before the sandboxed agent starts.
 /// `cplt_bin` is the path to the cplt binary (for calling `gh-gate`).
 /// Policy flags are baked into the wrapper invocation so the gate doesn't
 /// re-read config at runtime (security: agent could edit config files).
 pub fn generate_wrapper_script(
     real_gh: &str,
-    real_git: &str,
+    repo_scope: Option<&str>,
     cplt_bin: &str,
     policy: &crate::config::GhGuardPolicy,
 ) -> String {
     let cplt_escaped = shell_escape(cplt_bin);
     let gh_escaped = shell_escape(real_gh);
-    let git_escaped = shell_escape(real_git);
+    let repo_scope_flag = repo_scope
+        .map(|repo| format!("--repo-scope {}", shell_escape(repo)))
+        .unwrap_or_default();
     let mode_flag = match policy.mode {
         crate::config::EnforcementMode::Block => "--mode=block",
         crate::config::EnforcementMode::Warn => "--mode=warn",
@@ -1450,7 +1456,7 @@ pub fn generate_wrapper_script(
 # cplt gh proxy — blocks destructive gh operations in sandboxed agents.
 # This wrapper is auto-generated. Do not edit.
 
-exec {cplt_escaped} gh-gate --real-gh {gh_escaped} --real-git {git_escaped} {mode_flag} {scope_flag} {auth_flag} {unknown_flag} {api_write_flag} -- "$@"
+exec {cplt_escaped} gh-gate --real-gh {gh_escaped} {repo_scope_flag} {mode_flag} {scope_flag} {auth_flag} {unknown_flag} {api_write_flag} -- "$@"
 "#
     )
 }
@@ -1489,7 +1495,7 @@ pub enum UnknownCommandDecision {
 /// Information established by the guard and required when invoking `gh`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GateApproval {
-    /// Repository verified for a scope-checked command.
+    /// Host-qualified repository verified for a scope-checked command.
     ///
     /// The caller must set `GH_REPO` to this value before executing `gh`, pinning
     /// the operation to the same repository the guard approved.
@@ -1558,6 +1564,27 @@ pub fn gate_with_git(
     policy: &GatePolicy,
     real_git: &Path,
 ) -> Result<GateApproval, String> {
+    gate_with_scope_resolver(args, policy, || detect_current_repo(real_git, project_dir))
+}
+
+/// Evaluate a `gh` command using repository scope captured before agent startup.
+pub fn gate_with_repo_scope(
+    args: &[&str],
+    policy: &GatePolicy,
+    repo_scope: Option<&str>,
+) -> Result<GateApproval, String> {
+    gate_with_scope_resolver(args, policy, || {
+        repo_scope
+            .map(str::to_owned)
+            .ok_or_else(|| "repository scope was unavailable at sandbox startup".to_string())
+    })
+}
+
+fn gate_with_scope_resolver(
+    args: &[&str],
+    policy: &GatePolicy,
+    resolve_scope: impl FnOnce() -> Result<String, String>,
+) -> Result<GateApproval, String> {
     let Some(cmd) = parse_command(args) else {
         // No command parsed — this happens for `gh --help`, `gh --version`, `gh help`, etc.
         // These are read-only informational invocations — always allow.
@@ -1599,7 +1626,33 @@ pub fn gate_with_git(
                 return Ok(GateApproval::default());
             }
 
-            let current_repo = detect_current_repo(real_git, project_dir).map_err(|reason| {
+            if cmd.command == "api"
+                && let Some(endpoint) = cmd.api_endpoint.as_deref()
+                && github_api_endpoint_path(endpoint).is_err()
+            {
+                return Err(
+                    "⚠️ BLOCKED by sandbox: 'gh api' targets an endpoint outside \
+                     'https://api.github.com'.\n\
+                     This operation is restricted by the cplt sandbox environment.\n\
+                     Please make a note of this for the human operator and continue with your remaining work."
+                        .to_string(),
+                );
+            }
+
+            if let Some(hostname) = requested_hostname(args)
+                && hostname != "github.com"
+            {
+                return Err(format!(
+                    "⚠️ BLOCKED by sandbox: 'gh {} {}' targets GitHub host '{hostname}', \
+                     outside the approved host 'github.com'.\n\
+                     This operation is restricted by the cplt sandbox environment.\n\
+                     Please make a note of this for the human operator and continue with your remaining work.",
+                    cmd.command,
+                    cmd.subcommand.as_deref().unwrap_or("")
+                ));
+            }
+
+            let current_repo = resolve_scope().map_err(|reason| {
                 format!(
                     "⚠️ BLOCKED by sandbox: 'gh {} {}' cannot verify target repository scope.\n\
                      Reason: {reason}.\n\
@@ -1612,7 +1665,7 @@ pub fn gate_with_git(
 
             if is_repo_in_scope(&cmd, &current_repo) {
                 Ok(GateApproval {
-                    repo_scope: Some(current_repo),
+                    repo_scope: Some(format!("github.com/{current_repo}")),
                 })
             } else {
                 Err(format!(
@@ -1634,6 +1687,7 @@ pub fn gate_with_git(
                 ))
             }
         }
+
         Decision::Block => Err(format!(
             "⚠️ BLOCKED by sandbox: 'gh {}{}' is not allowed in this environment.\n\
              Reason: {}\n\
@@ -1660,6 +1714,26 @@ pub fn gate_with_git(
                     .unwrap_or_default(),
             )),
         },
+    }
+}
+
+fn requested_hostname<'a>(args: &'a [&str]) -> Option<&'a str> {
+    for (index, arg) in args.iter().enumerate() {
+        if let Some(hostname) = arg.strip_prefix("--hostname=") {
+            return Some(hostname);
+        }
+        if *arg == "--hostname" {
+            return args.get(index + 1).copied().or(Some(""));
+        }
+    }
+    None
+}
+
+fn github_api_endpoint_path(endpoint: &str) -> Result<&str, ()> {
+    if endpoint.contains("://") {
+        endpoint.strip_prefix("https://api.github.com/").ok_or(())
+    } else {
+        Ok(endpoint)
     }
 }
 
@@ -2861,12 +2935,12 @@ mod tests {
         let policy = crate::config::GhGuardPolicy::default();
         let script = generate_wrapper_script(
             "/usr/bin/gh",
-            "/usr/bin/git",
+            Some("navikt/cplt"),
             "/usr/local/bin/cplt",
             &policy,
         );
         assert!(script.contains("/usr/bin/gh"));
-        assert!(script.contains("/usr/bin/git"));
+        assert!(script.contains("--repo-scope 'navikt/cplt'"));
         assert!(script.contains("/usr/local/bin/cplt"));
         assert!(script.starts_with("#!/bin/sh"));
         assert!(script.contains("--mode=block"));
@@ -2884,7 +2958,7 @@ mod tests {
         };
         let script = generate_wrapper_script(
             "/usr/bin/gh",
-            "/usr/bin/git",
+            Some("navikt/cplt"),
             "/usr/local/bin/cplt",
             &policy,
         );
@@ -3128,7 +3202,7 @@ mod tests {
         let policy = crate::config::GhGuardPolicy::default();
         let script = generate_wrapper_script(
             "/path/with'quote/gh",
-            "/path/with'quote/git",
+            Some("navikt/repo'with-quote"),
             "/path/with\"dq/cplt",
             &policy,
         );

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1619,37 +1619,43 @@ fn gate_with_scope_resolver(
 
     let result = evaluate_with_policy(&cmd, policy.allow_api_write);
 
+    if policy.scope_check {
+        if cmd.command == "api"
+            && let Some(endpoint) = cmd.api_endpoint.as_deref()
+            && github_api_endpoint_path(endpoint).is_err()
+        {
+            return Err(
+                "⚠️ BLOCKED by sandbox: 'gh api' targets an endpoint outside \
+                 'https://api.github.com'.\n\
+                 This operation is restricted by the cplt sandbox environment.\n\
+                 Please make a note of this for the human operator and continue with your remaining work."
+                    .to_string(),
+            );
+        }
+
+        if let Some(hostname) = requested_hostname(args)
+            && hostname != "github.com"
+        {
+            return Err(format!(
+                "⚠️ BLOCKED by sandbox: 'gh {} {}' targets GitHub host '{hostname}', \
+                 outside the approved host 'github.com'.\n\
+                 This operation is restricted by the cplt sandbox environment.\n\
+                 Please make a note of this for the human operator and continue with your remaining work.",
+                cmd.command,
+                cmd.subcommand.as_deref().unwrap_or("")
+            ));
+        }
+    }
+
     match result.decision {
-        Decision::Allow => Ok(GateApproval::default()),
+        Decision::Allow => Ok(if policy.scope_check {
+            approval_from_scope(resolve_scope().ok())
+        } else {
+            GateApproval::default()
+        }),
         Decision::ScopeCheck => {
             if !policy.scope_check {
                 return Ok(GateApproval::default());
-            }
-
-            if cmd.command == "api"
-                && let Some(endpoint) = cmd.api_endpoint.as_deref()
-                && github_api_endpoint_path(endpoint).is_err()
-            {
-                return Err(
-                    "⚠️ BLOCKED by sandbox: 'gh api' targets an endpoint outside \
-                     'https://api.github.com'.\n\
-                     This operation is restricted by the cplt sandbox environment.\n\
-                     Please make a note of this for the human operator and continue with your remaining work."
-                        .to_string(),
-                );
-            }
-
-            if let Some(hostname) = requested_hostname(args)
-                && hostname != "github.com"
-            {
-                return Err(format!(
-                    "⚠️ BLOCKED by sandbox: 'gh {} {}' targets GitHub host '{hostname}', \
-                     outside the approved host 'github.com'.\n\
-                     This operation is restricted by the cplt sandbox environment.\n\
-                     Please make a note of this for the human operator and continue with your remaining work.",
-                    cmd.command,
-                    cmd.subcommand.as_deref().unwrap_or("")
-                ));
             }
 
             let current_repo = resolve_scope().map_err(|reason| {
@@ -1701,7 +1707,11 @@ fn gate_with_scope_resolver(
             result.reason,
         )),
         Decision::Unknown => match policy.unknown_command {
-            UnknownCommandDecision::Allow => Ok(GateApproval::default()),
+            UnknownCommandDecision::Allow => Ok(if policy.scope_check {
+                approval_from_scope(resolve_scope().ok())
+            } else {
+                GateApproval::default()
+            }),
             UnknownCommandDecision::Block => Err(format!(
                 "⚠️ BLOCKED by sandbox: 'gh {}{}' is not recognized by the policy table.\n\
                      This command may have been added in a newer gh CLI version.\n\
@@ -1714,6 +1724,12 @@ fn gate_with_scope_resolver(
                     .unwrap_or_default(),
             )),
         },
+    }
+}
+
+fn approval_from_scope(repo_scope: Option<String>) -> GateApproval {
+    GateApproval {
+        repo_scope: repo_scope.map(|repo| format!("github.com/{repo}")),
     }
 }
 

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1303,21 +1303,41 @@ fn extract_repo_from_api_path(endpoint: &str) -> Option<String> {
 
 /// Detect the current repository from the working directory.
 ///
-/// Tries `git remote get-url origin` and parses the owner/repo from it.
-/// Returns None if not in a git repo or remote URL can't be parsed.
-pub fn detect_current_repo(project_dir: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(project_dir)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
+/// Reads `remote.origin.url` from local repository config only and parses the
+/// owner/repo from it. Global/system config, includes, and inherited `GIT_*`
+/// variables are ignored because they could retarget the guard's scope.
+pub fn detect_current_repo(real_git: &Path, project_dir: &Path) -> Result<String, String> {
+    let mut command = std::process::Command::new(real_git);
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("GIT_") {
+            command.env_remove(key);
+        }
     }
 
-    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    parse_repo_from_url(&url)
+    let output = command
+        .args([
+            "config",
+            "--local",
+            "--no-includes",
+            "--get",
+            "remote.origin.url",
+        ])
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .current_dir(project_dir)
+        .output()
+        .map_err(|e| format!("failed to run trusted git binary: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "trusted git could not read the local origin ({})",
+            output.status
+        ));
+    }
+
+    let url = String::from_utf8_lossy(&output.stdout);
+    parse_repo_from_url(url.trim())
+        .ok_or_else(|| "local origin is not a supported GitHub repository URL".to_string())
 }
 
 /// Parse owner/repo from a git remote URL.
@@ -1394,11 +1414,13 @@ fn shell_escape(s: &str) -> String {
 /// re-read config at runtime (security: agent could edit config files).
 pub fn generate_wrapper_script(
     real_gh: &str,
+    real_git: &str,
     cplt_bin: &str,
     policy: &crate::config::GhGuardPolicy,
 ) -> String {
     let cplt_escaped = shell_escape(cplt_bin);
     let gh_escaped = shell_escape(real_gh);
+    let git_escaped = shell_escape(real_git);
     let mode_flag = match policy.mode {
         crate::config::EnforcementMode::Block => "--mode=block",
         crate::config::EnforcementMode::Warn => "--mode=warn",
@@ -1428,7 +1450,7 @@ pub fn generate_wrapper_script(
 # cplt gh proxy — blocks destructive gh operations in sandboxed agents.
 # This wrapper is auto-generated. Do not edit.
 
-exec {cplt_escaped} gh-gate --real-gh {gh_escaped} {mode_flag} {scope_flag} {auth_flag} {unknown_flag} {api_write_flag} -- "$@"
+exec {cplt_escaped} gh-gate --real-gh {gh_escaped} --real-git {git_escaped} {mode_flag} {scope_flag} {auth_flag} {unknown_flag} {api_write_flag} -- "$@"
 "#
     )
 }
@@ -1462,6 +1484,16 @@ pub struct GatePolicy {
 pub enum UnknownCommandDecision {
     Block,
     Allow,
+}
+
+/// Information established by the guard and required when invoking `gh`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GateApproval {
+    /// Repository verified for a scope-checked command.
+    ///
+    /// The caller must set `GH_REPO` to this value before executing `gh`, pinning
+    /// the operation to the same repository the guard approved.
+    pub repo_scope: Option<String>,
 }
 
 impl Default for GatePolicy {
@@ -1506,12 +1538,30 @@ fn arg_reveals_token(arg: &str) -> bool {
 /// Evaluate a full command and return a human-friendly verdict.
 ///
 /// This is the entry point used by the `gh-gate` subcommand.
-/// Returns `Ok(())` if the command should be allowed, or `Err(message)` if blocked.
-pub fn gate(args: &[&str], project_dir: &Path, policy: &GatePolicy) -> Result<(), String> {
+/// Returns the verified repository scope when allowed, or an error when blocked.
+pub fn gate(
+    args: &[&str],
+    project_dir: &Path,
+    policy: &GatePolicy,
+) -> Result<GateApproval, String> {
+    gate_with_git(args, project_dir, policy, Path::new("git"))
+}
+
+/// Evaluate a `gh` command using a pre-resolved Git binary for repository scope.
+///
+/// The Git subprocess ignores global/system configuration, local includes, and
+/// inherited `GIT_*` variables so agent-controlled process state cannot retarget
+/// the repository used by the scope decision.
+pub fn gate_with_git(
+    args: &[&str],
+    project_dir: &Path,
+    policy: &GatePolicy,
+    real_git: &Path,
+) -> Result<GateApproval, String> {
     let Some(cmd) = parse_command(args) else {
         // No command parsed — this happens for `gh --help`, `gh --version`, `gh help`, etc.
         // These are read-only informational invocations — always allow.
-        return Ok(());
+        return Ok(GateApproval::default());
     };
 
     // Handle token-revealing `gh auth` commands (credential exfiltration prevention).
@@ -1543,29 +1593,27 @@ pub fn gate(args: &[&str], project_dir: &Path, policy: &GatePolicy) -> Result<()
     let result = evaluate_with_policy(&cmd, policy.allow_api_write);
 
     match result.decision {
-        Decision::Allow => Ok(()),
+        Decision::Allow => Ok(GateApproval::default()),
         Decision::ScopeCheck => {
             if !policy.scope_check {
-                return Ok(());
+                return Ok(GateApproval::default());
             }
-            let current_repo = detect_current_repo(project_dir).unwrap_or_default();
 
-            if current_repo.is_empty() {
-                if cmd.repo_flag.is_some() {
-                    Err(format!(
-                        "⚠️ BLOCKED by sandbox: 'gh {} {}' cannot verify target repository scope.\n\
-                         The -R flag targets {:?} but the current repo could not be detected.\n\
-                         This operation is restricted by the cplt sandbox environment.\n\
-                        Please make a note of this for the human operator and continue with your remaining work.",
-                        cmd.command,
-                        cmd.subcommand.as_deref().unwrap_or(""),
-                        cmd.repo_flag.as_deref().unwrap_or("unknown")
-                    ))
-                } else {
-                    Ok(())
-                }
-            } else if is_repo_in_scope(&cmd, &current_repo) {
-                Ok(())
+            let current_repo = detect_current_repo(real_git, project_dir).map_err(|reason| {
+                format!(
+                    "⚠️ BLOCKED by sandbox: 'gh {} {}' cannot verify target repository scope.\n\
+                     Reason: {reason}.\n\
+                     This operation is restricted by the cplt sandbox environment.\n\
+                     Please make a note of this for the human operator and continue with your remaining work.",
+                    cmd.command,
+                    cmd.subcommand.as_deref().unwrap_or("")
+                )
+            })?;
+
+            if is_repo_in_scope(&cmd, &current_repo) {
+                Ok(GateApproval {
+                    repo_scope: Some(current_repo),
+                })
             } else {
                 Err(format!(
                     "⚠️ BLOCKED by sandbox: 'gh {}{}' targets '{}' which is outside the current repo '{}'.\n\
@@ -1599,7 +1647,7 @@ pub fn gate(args: &[&str], project_dir: &Path, policy: &GatePolicy) -> Result<()
             result.reason,
         )),
         Decision::Unknown => match policy.unknown_command {
-            UnknownCommandDecision::Allow => Ok(()),
+            UnknownCommandDecision::Allow => Ok(GateApproval::default()),
             UnknownCommandDecision::Block => Err(format!(
                 "⚠️ BLOCKED by sandbox: 'gh {}{}' is not recognized by the policy table.\n\
                      This command may have been added in a newer gh CLI version.\n\
@@ -2811,8 +2859,14 @@ mod tests {
     #[test]
     fn wrapper_script_contains_paths() {
         let policy = crate::config::GhGuardPolicy::default();
-        let script = generate_wrapper_script("/usr/bin/gh", "/usr/local/bin/cplt", &policy);
+        let script = generate_wrapper_script(
+            "/usr/bin/gh",
+            "/usr/bin/git",
+            "/usr/local/bin/cplt",
+            &policy,
+        );
         assert!(script.contains("/usr/bin/gh"));
+        assert!(script.contains("/usr/bin/git"));
         assert!(script.contains("/usr/local/bin/cplt"));
         assert!(script.starts_with("#!/bin/sh"));
         assert!(script.contains("--mode=block"));
@@ -2828,7 +2882,12 @@ mod tests {
             allow_api_write: true,
             ..Default::default()
         };
-        let script = generate_wrapper_script("/usr/bin/gh", "/usr/local/bin/cplt", &policy);
+        let script = generate_wrapper_script(
+            "/usr/bin/gh",
+            "/usr/bin/git",
+            "/usr/local/bin/cplt",
+            &policy,
+        );
         assert!(
             script.contains("--allow-api-write"),
             "wrapper must bake in --allow-api-write when policy has allow_api_write=true"
@@ -3067,7 +3126,12 @@ mod tests {
     #[test]
     fn shell_escape_handles_quotes() {
         let policy = crate::config::GhGuardPolicy::default();
-        let script = generate_wrapper_script("/path/with'quote/gh", "/path/with\"dq/cplt", &policy);
+        let script = generate_wrapper_script(
+            "/path/with'quote/gh",
+            "/path/with'quote/git",
+            "/path/with\"dq/cplt",
+            &policy,
+        );
         assert!(script.contains("gh-gate"));
         // Should use single-quote escaping, no unescaped double quotes in paths
         assert!(!script.contains(r#""/path/with'quote/gh""#));

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,9 +777,9 @@ NOTE:
         #[arg(long)]
         real_gh: PathBuf,
 
-        /// Path to the trusted git binary used for repository scope verification.
+        /// Repository scope captured before the sandboxed agent started.
         #[arg(long)]
-        real_git: PathBuf,
+        repo_scope: Option<String>,
 
         /// Enforcement mode: block, warn, or audit.
         #[arg(long, default_value = "block")]
@@ -2130,7 +2130,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             Command::Doctor => run_doctor(),
             Command::GhGate {
                 real_gh,
-                real_git,
+                repo_scope,
                 mode,
                 scope_check,
                 no_scope_check,
@@ -2156,7 +2156,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
                     },
                     allow_api_write: allow_api_write && !no_allow_api_write,
                 };
-                run_gh_gate(&real_gh, &real_git, &args, &policy)
+                run_gh_gate(&real_gh, repo_scope.as_deref(), &args, &policy)
             }
             Command::GitGate {
                 real_git,
@@ -2535,7 +2535,7 @@ fn build_copilot_args(cli: &Cli, agent: &agent::Agent) -> Vec<String> {
 /// If blocked, prints an error message and exits with code 1.
 fn run_gh_gate(
     real_gh: &Path,
-    real_git: &Path,
+    repo_scope: Option<&str>,
     args: &[String],
     policy: &gh_proxy::GatePolicy,
 ) -> ExitCode {
@@ -2546,10 +2546,9 @@ fn run_gh_gate(
         return serve_cached_gh_token();
     }
 
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-    match gh_proxy::gate_with_git(&arg_refs, &cwd, policy, real_git) {
+    match gh_proxy::gate_with_repo_scope(&arg_refs, policy, repo_scope) {
         Ok(approval) => exec_gh(real_gh, args, approval.repo_scope.as_deref()),
         Err(msg) => match policy.mode {
             config::EnforcementMode::Block => {
@@ -2576,6 +2575,7 @@ fn exec_gh(real_gh: &Path, args: &[String], repo_scope: Option<&str>) -> ExitCod
     let mut command = std::process::Command::new(real_gh);
     command.args(args);
     if let Some(repo) = repo_scope {
+        command.env_remove("GH_HOST");
         command.env("GH_REPO", repo);
     }
     let err = command.exec();

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,6 +777,10 @@ NOTE:
         #[arg(long)]
         real_gh: PathBuf,
 
+        /// Path to the trusted git binary used for repository scope verification.
+        #[arg(long)]
+        real_git: PathBuf,
+
         /// Enforcement mode: block, warn, or audit.
         #[arg(long, default_value = "block")]
         mode: String,
@@ -2126,6 +2130,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             Command::Doctor => run_doctor(),
             Command::GhGate {
                 real_gh,
+                real_git,
                 mode,
                 scope_check,
                 no_scope_check,
@@ -2151,7 +2156,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
                     },
                     allow_api_write: allow_api_write && !no_allow_api_write,
                 };
-                run_gh_gate(&real_gh, &args, &policy)
+                run_gh_gate(&real_gh, &real_git, &args, &policy)
             }
             Command::GitGate {
                 real_git,
@@ -2528,7 +2533,12 @@ fn build_copilot_args(cli: &Cli, agent: &agent::Agent) -> Vec<String> {
 /// Called from the wrapper script placed in the sandbox's PATH. If the command
 /// is allowed, this replaces the current process with the real gh binary.
 /// If blocked, prints an error message and exits with code 1.
-fn run_gh_gate(real_gh: &Path, args: &[String], policy: &gh_proxy::GatePolicy) -> ExitCode {
+fn run_gh_gate(
+    real_gh: &Path,
+    real_git: &Path,
+    args: &[String],
+    policy: &gh_proxy::GatePolicy,
+) -> ExitCode {
     // Intercept `gh auth token` — serve from cached file instead of blocking.
     // This allows Copilot to authenticate without exposing the token as an env var
     // to all child processes. The token file is written to scratch dir at startup.
@@ -2539,15 +2549,8 @@ fn run_gh_gate(real_gh: &Path, args: &[String], policy: &gh_proxy::GatePolicy) -
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-    match gh_proxy::gate(&arg_refs, &cwd, policy) {
-        Ok(()) => {
-            // Allowed — exec the real gh binary (replaces this process)
-            use std::os::unix::process::CommandExt;
-            let err = std::process::Command::new(real_gh).args(args).exec();
-            // exec() only returns on error
-            ui::error(&format!("Failed to exec gh: {err}"));
-            ExitCode::FAILURE
-        }
+    match gh_proxy::gate_with_git(&arg_refs, &cwd, policy, real_git) {
+        Ok(approval) => exec_gh(real_gh, args, approval.repo_scope.as_deref()),
         Err(msg) => match policy.mode {
             config::EnforcementMode::Block => {
                 eprintln!("{msg}");
@@ -2556,21 +2559,28 @@ fn run_gh_gate(real_gh: &Path, args: &[String], policy: &gh_proxy::GatePolicy) -
             config::EnforcementMode::Warn => {
                 eprintln!("⚠️  WARNING (would block): {msg}");
                 // Allow through in warn mode
-                use std::os::unix::process::CommandExt;
-                let err = std::process::Command::new(real_gh).args(args).exec();
-                ui::error(&format!("Failed to exec gh: {err}"));
-                ExitCode::FAILURE
+                exec_gh(real_gh, args, None)
             }
             config::EnforcementMode::Audit => {
                 // Log the decision to stderr for audit trail
                 eprintln!("[audit] gh-gate: would block: {msg}");
-                use std::os::unix::process::CommandExt;
-                let err = std::process::Command::new(real_gh).args(args).exec();
-                ui::error(&format!("Failed to exec gh: {err}"));
-                ExitCode::FAILURE
+                exec_gh(real_gh, args, None)
             }
         },
     }
+}
+
+fn exec_gh(real_gh: &Path, args: &[String], repo_scope: Option<&str>) -> ExitCode {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = std::process::Command::new(real_gh);
+    command.args(args);
+    if let Some(repo) = repo_scope {
+        command.env("GH_REPO", repo);
+    }
+    let err = command.exec();
+    ui::error(&format!("Failed to exec gh: {err}"));
+    ExitCode::FAILURE
 }
 
 /// Check if args represent a `gh auth token` invocation.

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -164,7 +164,7 @@ fn configure_command(
                 cache_gh_token_to_file(scratch, agent);
             }
         }
-        install_command_wrappers(cmd, scratch, gh_guard, git_guard);
+        install_command_wrappers(cmd, scratch, project_dir, gh_guard, git_guard);
     }
 }
 
@@ -283,6 +283,7 @@ fn cache_gh_token_to_file(scratch_dir: &Path, agent: Agent) {
 fn install_command_wrappers(
     cmd: &mut Command,
     scratch_dir: &Path,
+    project_dir: &Path,
     gh_guard: &crate::config::GhGuardPolicy,
     git_guard: &crate::config::GitGuardPolicy,
 ) {
@@ -304,11 +305,32 @@ fn install_command_wrappers(
     // Install gh wrapper (only if gh_proxy enabled)
     if gh_guard.enabled
         && let Some(real_gh) = which_binary("gh")
-        && let Some(real_git) = which_binary("git")
     {
+        let repo_scope = if gh_guard.scope_check {
+            if let Some(real_git) = which_binary("git") {
+                match crate::gh_proxy::detect_current_repo(&real_git, project_dir) {
+                    Ok(repo) => Some(repo),
+                    Err(reason) => {
+                        ui::warn(&format!(
+                            "gh guard could not capture repository scope: {reason}. \
+                             Scope-checked commands will be blocked."
+                        ));
+                        None
+                    }
+                }
+            } else {
+                ui::warn(
+                    "gh guard could not find Git to capture repository scope. \
+                     Scope-checked commands will be blocked.",
+                );
+                None
+            }
+        } else {
+            None
+        };
         let script = crate::gh_proxy::generate_wrapper_script(
             &real_gh.to_string_lossy(),
-            &real_git.to_string_lossy(),
+            repo_scope.as_deref(),
             &cplt_str,
             gh_guard,
         );

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -304,9 +304,11 @@ fn install_command_wrappers(
     // Install gh wrapper (only if gh_proxy enabled)
     if gh_guard.enabled
         && let Some(real_gh) = which_binary("gh")
+        && let Some(real_git) = which_binary("git")
     {
         let script = crate::gh_proxy::generate_wrapper_script(
             &real_gh.to_string_lossy(),
+            &real_git.to_string_lossy(),
             &cplt_str,
             gh_guard,
         );

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -224,6 +224,7 @@ const LINUX_TOOL_DIRS: &[&str] = &[
 const LINUX_HOME_CONFIG_FILES: &[&str] = &[
     // Git configuration (includes user-config, attributes, ignore, etc.)
     ".gitconfig",
+    ".gitconfig.local",
     ".config/git",
     // GitHub CLI auth (specific files only)
     ".config/gh/hosts.yml",

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -225,6 +225,7 @@ const LINUX_HOME_CONFIG_FILES: &[&str] = &[
     // Git configuration (includes user-config, attributes, ignore, etc.)
     ".gitconfig",
     ".gitconfig.local",
+    ".gitignore_global",
     ".config/git",
     // GitHub CLI auth (specific files only)
     ".config/gh/hosts.yml",

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -519,6 +519,10 @@ fn emit_system_access(
     );
     sbpl!(
         sb,
+        "(allow file-read* (literal \"{home}/.gitignore_global\"))"
+    );
+    sbpl!(
+        sb,
         "(allow file-read* (literal \"{home}/.config/git/config\"))"
     );
     sbpl!(sb);

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -515,6 +515,10 @@ fn emit_system_access(
     sbpl!(sb, "(allow file-read* (literal \"{home}/.gitconfig\"))");
     sbpl!(
         sb,
+        "(allow file-read* (literal \"{home}/.gitconfig.local\"))"
+    );
+    sbpl!(
+        sb,
         "(allow file-read* (literal \"{home}/.config/git/config\"))"
     );
     sbpl!(sb);

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -971,6 +971,16 @@ fn emit_deny_rules(sb: &mut String, home: &str, extra_deny: &[PathBuf]) {
         sbpl!(sb, "(deny file-read* (literal \"{home}/{file}\"))");
         sbpl!(sb, "(deny file-write* (literal \"{home}/{file}\"))");
     }
+    // These files must stay read-only even when an overlapping path is writable
+    // (for example a temporary HOME under /private/var/folders).
+    for file in [
+        ".gitconfig",
+        ".gitconfig.local",
+        ".gitignore_global",
+        ".config/git/config",
+    ] {
+        sbpl!(sb, "(deny file-write* (literal \"{home}/{file}\"))");
+    }
     for path in extra_deny {
         let p = path.to_string_lossy();
         sbpl!(sb, "(deny file-read* (subpath \"{p}\"))");

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -50,8 +50,8 @@ fn gh_gate_with_opts(args: &[&str], opts: &[&str]) -> (String, String, bool) {
     cmd.arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true") // if allowed, exec this harmless binary
-        .arg("--real-git")
-        .arg(binary_in_path("git"))
+        .arg("--repo-scope")
+        .arg("navikt/cplt")
         .args(opts)
         .arg("--")
         .args(args)
@@ -313,48 +313,52 @@ fn gh_gate_allows_same_repo_pr_close() {
 }
 
 #[test]
-fn gh_gate_ignores_agent_controlled_git_environment_and_path() {
-    use std::os::unix::fs::PermissionsExt;
-
+fn gh_gate_rejects_nested_repo_retargeting() {
     let temp = tempfile::tempdir().unwrap();
-    let fake_git = temp.path().join("git");
-    std::fs::write(
-        &fake_git,
-        "#!/bin/sh\nprintf '%s\\n' 'https://github.com/evil-org/other.git'\n",
-    )
-    .unwrap();
-    std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let git = binary_in_path("git");
+    assert!(
+        Command::new(&git)
+            .args(["init", "--quiet"])
+            .current_dir(temp.path())
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        Command::new(&git)
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/evil-org/other.git"
+            ])
+            .current_dir(temp.path())
+            .status()
+            .unwrap()
+            .success()
+    );
 
     let output = Command::new(binary_path())
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
-        .arg("--real-git")
-        .arg(binary_in_path("git"))
+        .arg("--repo-scope")
+        .arg("navikt/cplt")
         .arg("--")
-        .args(["pr", "close", "42", "-R", "navikt/cplt"])
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .env("PATH", temp.path())
-        .env("GIT_DIR", temp.path())
-        .env("GIT_CONFIG_GLOBAL", temp.path().join("attacker-config"))
-        .env("GIT_CONFIG_COUNT", "1")
-        .env("GIT_CONFIG_KEY_0", "remote.origin.url")
-        .env(
-            "GIT_CONFIG_VALUE_0",
-            "https://github.com/evil-org/other.git",
-        )
+        .args(["pr", "close", "42", "-R", "evil-org/other"])
+        .current_dir(temp.path())
         .output()
         .expect("cplt gh-gate should run");
 
     assert!(
-        output.status.success(),
-        "trusted local origin should win: {}",
+        !output.status.success(),
+        "nested repository must not replace startup scope: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }
 
 #[test]
-fn gh_gate_ignores_local_git_config_includes_for_scope() {
+fn gh_gate_ignores_runtime_git_config_for_scope() {
     let temp = tempfile::tempdir().unwrap();
     let git = binary_in_path("git");
     let run_git = |args: &[&str]| {
@@ -377,6 +381,11 @@ fn gh_gate_ignores_local_git_config_includes_for_scope() {
         ])
         .success()
     );
+    assert_eq!(
+        cplt::gh_proxy::detect_current_repo(&git, temp.path()).unwrap(),
+        "navikt/cplt",
+        "startup detection must ignore local config includes"
+    );
     let included = temp.path().join("included.gitconfig");
     std::fs::write(
         &included,
@@ -397,8 +406,8 @@ fn gh_gate_ignores_local_git_config_includes_for_scope() {
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
-        .arg("--real-git")
-        .arg(&git)
+        .arg("--repo-scope")
+        .arg("navikt/cplt")
         .arg("--")
         .args(["pr", "close", "42", "-R", "navikt/cplt"])
         .current_dir(temp.path())
@@ -419,8 +428,6 @@ fn gh_gate_fails_closed_when_repo_scope_is_unavailable() {
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
-        .arg("--real-git")
-        .arg(binary_in_path("git"))
         .arg("--")
         .args(["pr", "comment", "42", "--body", "test"])
         .current_dir(temp.path())
@@ -444,26 +451,62 @@ fn gh_gate_pins_verified_repo_in_gh_repo() {
 
     let temp = tempfile::tempdir().unwrap();
     let fake_gh = temp.path().join("gh");
-    std::fs::write(&fake_gh, "#!/bin/sh\nprintf '%s\\n' \"$GH_REPO\"\n").unwrap();
+    std::fs::write(
+        &fake_gh,
+        "#!/bin/sh\nprintf '%s|%s\\n' \"$GH_REPO\" \"${GH_HOST-}\"\n",
+    )
+    .unwrap();
     std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let output = Command::new(binary_path())
         .arg("gh-gate")
         .arg("--real-gh")
         .arg(&fake_gh)
-        .arg("--real-git")
-        .arg(binary_in_path("git"))
+        .arg("--repo-scope")
+        .arg("navikt/cplt")
         .arg("--")
         .args(["pr", "comment", "42", "--body", "test"])
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .env("GH_REPO", "evil-org/other")
+        .env("GH_HOST", "evil.example")
         .output()
         .expect("cplt gh-gate should run");
 
     assert!(output.status.success());
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "navikt/cplt"
+        "github.com/navikt/cplt|"
+    );
+}
+
+#[test]
+fn gh_gate_blocks_conflicting_hostname_flag() {
+    let (_, stderr, ok) = gh_gate(&[
+        "api",
+        "--hostname",
+        "evil.example",
+        "/repos/navikt/cplt/pulls",
+    ]);
+    assert!(!ok, "conflicting GitHub host must be blocked");
+    assert!(stderr.contains("outside the approved host"), "{stderr}");
+}
+
+#[test]
+fn gh_gate_blocks_fully_qualified_external_api_endpoint() {
+    let (_, stderr, ok) = gh_gate(&["api", "https://evil.example/repos/navikt/cplt"]);
+    assert!(!ok, "external fully qualified API endpoint must be blocked");
+    assert!(
+        stderr.contains("outside 'https://api.github.com'"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn gh_gate_allows_fully_qualified_github_api_endpoint_in_scope() {
+    let (_, stderr, ok) = gh_gate(&["api", "https://api.github.com/repos/navikt/cplt"]);
+    assert!(
+        ok,
+        "official GitHub API endpoint should be allowed: {stderr}"
     );
 }
 
@@ -1192,8 +1235,7 @@ mod sandbox_integration {
 
         // Create gh wrapper script (same as cplt would generate)
         let wrapper_content = format!(
-            "#!/bin/sh\nexec {cplt_str} gh-gate --real-gh /usr/bin/true --real-git {} --mode=block --scope-check --block-auth-token --unknown-command=block -- \"$@\"\n",
-            binary_in_path("git").display()
+            "#!/bin/sh\nexec {cplt_str} gh-gate --real-gh /usr/bin/true --repo-scope navikt/cplt --mode=block --scope-check --block-auth-token --unknown-command=block -- \"$@\"\n"
         );
         let bin_dir = tmp.path().join("bin");
         fs::create_dir_all(&bin_dir).unwrap();

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -480,6 +480,39 @@ fn gh_gate_pins_verified_repo_in_gh_repo() {
 }
 
 #[test]
+fn gh_gate_pins_verified_repo_for_allow_command() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let fake_gh = temp.path().join("gh");
+    std::fs::write(
+        &fake_gh,
+        "#!/bin/sh\nprintf '%s|%s\\n' \"$GH_REPO\" \"${GH_HOST-}\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(binary_path())
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg(&fake_gh)
+        .arg("--repo-scope")
+        .arg("navikt/cplt")
+        .arg("--")
+        .args(["repo", "view"])
+        .env("GH_REPO", "evil-org/other")
+        .env("GH_HOST", "evil.example")
+        .output()
+        .expect("cplt gh-gate should run");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "github.com/navikt/cplt|"
+    );
+}
+
+#[test]
 fn gh_gate_blocks_conflicting_hostname_flag() {
     let (_, stderr, ok) = gh_gate(&[
         "api",
@@ -488,6 +521,13 @@ fn gh_gate_blocks_conflicting_hostname_flag() {
         "/repos/navikt/cplt/pulls",
     ]);
     assert!(!ok, "conflicting GitHub host must be blocked");
+    assert!(stderr.contains("outside the approved host"), "{stderr}");
+}
+
+#[test]
+fn gh_gate_blocks_conflicting_hostname_for_allow_command() {
+    let (_, stderr, ok) = gh_gate(&["--hostname", "evil.example", "repo", "view"]);
+    assert!(!ok, "allow command must not retarget the GitHub host");
     assert!(stderr.contains("outside the approved host"), "{stderr}");
 }
 

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -27,6 +27,17 @@ fn binary_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
 }
 
+fn binary_in_path(name: &str) -> PathBuf {
+    let system = PathBuf::from("/usr/bin").join(name);
+    if system.is_file() {
+        return system;
+    }
+    std::env::split_paths(&std::env::var_os("PATH").expect("PATH should be set"))
+        .map(|dir| dir.join(name))
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("{name} should be available in PATH"))
+}
+
 /// Run `cplt gh-gate` with default block policy.
 /// Returns (stdout, stderr, exit_success).
 fn gh_gate(args: &[&str]) -> (String, String, bool) {
@@ -39,6 +50,8 @@ fn gh_gate_with_opts(args: &[&str], opts: &[&str]) -> (String, String, bool) {
     cmd.arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true") // if allowed, exec this harmless binary
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
         .args(opts)
         .arg("--")
         .args(args)
@@ -297,6 +310,161 @@ fn gh_gate_allows_same_repo_pr_close() {
     // navikt/cplt is the git remote of the test project dir
     let (_, _, ok) = gh_gate(&["pr", "close", "42", "-R", "navikt/cplt"]);
     assert!(ok, "same-repo pr close should be allowed");
+}
+
+#[test]
+fn gh_gate_ignores_agent_controlled_git_environment_and_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let fake_git = temp.path().join("git");
+    std::fs::write(
+        &fake_git,
+        "#!/bin/sh\nprintf '%s\\n' 'https://github.com/evil-org/other.git'\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(binary_path())
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg("/usr/bin/true")
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
+        .arg("--")
+        .args(["pr", "close", "42", "-R", "navikt/cplt"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("PATH", temp.path())
+        .env("GIT_DIR", temp.path())
+        .env("GIT_CONFIG_GLOBAL", temp.path().join("attacker-config"))
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "remote.origin.url")
+        .env(
+            "GIT_CONFIG_VALUE_0",
+            "https://github.com/evil-org/other.git",
+        )
+        .output()
+        .expect("cplt gh-gate should run");
+
+    assert!(
+        output.status.success(),
+        "trusted local origin should win: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn gh_gate_ignores_local_git_config_includes_for_scope() {
+    let temp = tempfile::tempdir().unwrap();
+    let git = binary_in_path("git");
+    let run_git = |args: &[&str]| {
+        Command::new(&git)
+            .args(args)
+            .current_dir(temp.path())
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .status()
+            .expect("git should run")
+    };
+
+    assert!(run_git(&["init", "--quiet"]).success());
+    assert!(
+        run_git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/navikt/cplt.git"
+        ])
+        .success()
+    );
+    let included = temp.path().join("included.gitconfig");
+    std::fs::write(
+        &included,
+        "[remote \"origin\"]\nurl = https://github.com/evil-org/other.git\n",
+    )
+    .unwrap();
+    assert!(
+        run_git(&[
+            "config",
+            "--local",
+            "include.path",
+            included.to_str().unwrap()
+        ])
+        .success()
+    );
+
+    let output = Command::new(binary_path())
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg("/usr/bin/true")
+        .arg("--real-git")
+        .arg(&git)
+        .arg("--")
+        .args(["pr", "close", "42", "-R", "navikt/cplt"])
+        .current_dir(temp.path())
+        .output()
+        .expect("cplt gh-gate should run");
+
+    assert!(
+        output.status.success(),
+        "local includes must not retarget scope: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn gh_gate_fails_closed_when_repo_scope_is_unavailable() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = Command::new(binary_path())
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg("/usr/bin/true")
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
+        .arg("--")
+        .args(["pr", "comment", "42", "--body", "test"])
+        .current_dir(temp.path())
+        .output()
+        .expect("cplt gh-gate should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "missing repo scope must fail closed"
+    );
+    assert!(
+        stderr.contains("cannot verify target repository scope"),
+        "unexpected error: {stderr}"
+    );
+}
+
+#[test]
+fn gh_gate_pins_verified_repo_in_gh_repo() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let fake_gh = temp.path().join("gh");
+    std::fs::write(&fake_gh, "#!/bin/sh\nprintf '%s\\n' \"$GH_REPO\"\n").unwrap();
+    std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(binary_path())
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg(&fake_gh)
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
+        .arg("--")
+        .args(["pr", "comment", "42", "--body", "test"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("GH_REPO", "evil-org/other")
+        .output()
+        .expect("cplt gh-gate should run");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "navikt/cplt"
+    );
 }
 
 #[test]
@@ -1024,7 +1192,8 @@ mod sandbox_integration {
 
         // Create gh wrapper script (same as cplt would generate)
         let wrapper_content = format!(
-            "#!/bin/sh\nexec {cplt_str} gh-gate --real-gh /usr/bin/true --mode=block --scope-check --block-auth-token --unknown-command=block -- \"$@\"\n"
+            "#!/bin/sh\nexec {cplt_str} gh-gate --real-gh /usr/bin/true --real-git {} --mode=block --scope-check --block-auth-token --unknown-command=block -- \"$@\"\n",
+            binary_in_path("git").display()
         );
         let bin_dir = tmp.path().join("bin");
         fs::create_dir_all(&bin_dir).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -432,7 +432,12 @@ mod macos_tests {
         .unwrap();
         fs::write(
             home.path().join(".gitconfig.local"),
-            "[user]\nname = cplt-test-user\n",
+            "[user]\nname = cplt-test-user\n[core]\nexcludesFile = ~/.gitignore_global\n",
+        )
+        .unwrap();
+        fs::write(
+            home.path().join(".gitignore_global"),
+            "ignored-by-cplt-test\n",
         )
         .unwrap();
 
@@ -443,11 +448,21 @@ mod macos_tests {
             home.path().display()
         );
         let (output, success) = run_sandboxed(&profile, &cmd);
+        let read_ignore_cmd = format!(
+            "cat '{}' 2>&1",
+            home.path().join(".gitignore_global").display()
+        );
+        let (ignore_output, ignore_success) = run_sandboxed(&profile, &read_ignore_cmd);
         let write_cmd = format!(
             "echo injected >> '{}' 2>&1; echo EXIT:$?",
             home.path().join(".gitconfig.local").display()
         );
         let (write_output, _) = run_sandboxed(&profile, &write_cmd);
+        let write_ignore_cmd = format!(
+            "echo injected >> '{}' 2>&1; echo EXIT:$?",
+            home.path().join(".gitignore_global").display()
+        );
+        let (write_ignore_output, _) = run_sandboxed(&profile, &write_ignore_cmd);
 
         fs::remove_file(&profile).ok();
         assert!(
@@ -455,8 +470,17 @@ mod macos_tests {
             "git should read ~/.gitconfig.local through the include: {output}"
         );
         assert!(
+            ignore_success && ignore_output.contains("ignored-by-cplt-test"),
+            "git's conventional global ignore file should be readable: {ignore_output}"
+        );
+        assert!(
             write_output.contains("Operation not permitted") || write_output.contains("EXIT:1"),
             "~/.gitconfig.local must remain read-only: {write_output}"
+        );
+        assert!(
+            write_ignore_output.contains("Operation not permitted")
+                || write_ignore_output.contains("EXIT:1"),
+            "~/.gitignore_global must remain read-only: {write_ignore_output}"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -421,7 +421,7 @@ mod macos_tests {
     }
 
     #[test]
-    fn real_profile_allows_included_local_git_config() {
+    fn real_profile_allows_local_git_config_and_global_ignore() {
         require_sandbox!();
         let project = fs::canonicalize(".").unwrap();
         let home = tempfile::tempdir().unwrap();
@@ -444,13 +444,8 @@ mod macos_tests {
 
         let opts = default_opts(&project, home.path());
         let profile = write_real_profile(&opts);
-        let cmd = format!(
-            "HOME='{}' GIT_CONFIG_GLOBAL='{}/.gitconfig' GIT_CONFIG_NOSYSTEM=1 \
-             git config --global user.name 2>&1",
-            home.path().display(),
-            home.path().display()
-        );
-        let (output, success) = run_sandboxed(&profile, &cmd);
+        let read_config_cmd = format!("cat '{}' 2>&1", local_config.display());
+        let (config_output, config_success) = run_sandboxed(&profile, &read_config_cmd);
         let read_ignore_cmd = format!("cat '{}' 2>&1", global_ignore.display());
         let (ignore_output, ignore_success) = run_sandboxed(&profile, &read_ignore_cmd);
         let write_cmd = format!(
@@ -466,8 +461,8 @@ mod macos_tests {
 
         fs::remove_file(&profile).ok();
         assert!(
-            success && output.contains("cplt-test-user"),
-            "git should read ~/.gitconfig.local through the include: {output}"
+            config_success && config_output.contains("cplt-test-user"),
+            "~/.gitconfig.local should be readable: {config_output}"
         );
         assert!(
             ignore_success && ignore_output.contains("ignored-by-cplt-test"),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -425,21 +425,22 @@ mod macos_tests {
         require_sandbox!();
         let project = fs::canonicalize(".").unwrap();
         let home = tempfile::tempdir().unwrap();
+        let local_config = home.path().join(".gitconfig.local");
+        let global_ignore = home.path().join(".gitignore_global");
         fs::write(
             home.path().join(".gitconfig"),
-            "[include]\npath = ~/.gitconfig.local\n",
+            format!("[include]\npath = {}\n", local_config.display()),
         )
         .unwrap();
         fs::write(
-            home.path().join(".gitconfig.local"),
-            "[user]\nname = cplt-test-user\n[core]\nexcludesFile = ~/.gitignore_global\n",
+            &local_config,
+            format!(
+                "[user]\nname = cplt-test-user\n[core]\nexcludesFile = {}\n",
+                global_ignore.display()
+            ),
         )
         .unwrap();
-        fs::write(
-            home.path().join(".gitignore_global"),
-            "ignored-by-cplt-test\n",
-        )
-        .unwrap();
+        fs::write(&global_ignore, "ignored-by-cplt-test\n").unwrap();
 
         let opts = default_opts(&project, home.path());
         let profile = write_real_profile(&opts);
@@ -450,19 +451,16 @@ mod macos_tests {
             home.path().display()
         );
         let (output, success) = run_sandboxed(&profile, &cmd);
-        let read_ignore_cmd = format!(
-            "cat '{}' 2>&1",
-            home.path().join(".gitignore_global").display()
-        );
+        let read_ignore_cmd = format!("cat '{}' 2>&1", global_ignore.display());
         let (ignore_output, ignore_success) = run_sandboxed(&profile, &read_ignore_cmd);
         let write_cmd = format!(
             "echo injected >> '{}' 2>&1; echo EXIT:$?",
-            home.path().join(".gitconfig.local").display()
+            local_config.display()
         );
         let (write_output, _) = run_sandboxed(&profile, &write_cmd);
         let write_ignore_cmd = format!(
             "echo injected >> '{}' 2>&1; echo EXIT:$?",
-            home.path().join(".gitignore_global").display()
+            global_ignore.display()
         );
         let (write_ignore_output, _) = run_sandboxed(&profile, &write_ignore_cmd);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -424,11 +424,12 @@ mod macos_tests {
     fn real_profile_allows_local_git_config_and_global_ignore() {
         require_sandbox!();
         let project = fs::canonicalize(".").unwrap();
-        let home = tempfile::tempdir().unwrap();
-        let local_config = home.path().join(".gitconfig.local");
-        let global_ignore = home.path().join(".gitignore_global");
+        let temp_home = tempfile::tempdir().unwrap();
+        let home = fs::canonicalize(temp_home.path()).unwrap();
+        let local_config = home.join(".gitconfig.local");
+        let global_ignore = home.join(".gitignore_global");
         fs::write(
-            home.path().join(".gitconfig"),
+            home.join(".gitconfig"),
             format!("[include]\npath = {}\n", local_config.display()),
         )
         .unwrap();
@@ -442,7 +443,7 @@ mod macos_tests {
         .unwrap();
         fs::write(&global_ignore, "ignored-by-cplt-test\n").unwrap();
 
-        let opts = default_opts(&project, home.path());
+        let opts = default_opts(&project, &home);
         let profile = write_real_profile(&opts);
         let read_config_cmd = format!("cat '{}' 2>&1", local_config.display());
         let (config_output, config_success) = run_sandboxed(&profile, &read_config_cmd);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -420,6 +420,46 @@ mod macos_tests {
         }
     }
 
+    #[test]
+    fn real_profile_allows_included_local_git_config() {
+        require_sandbox!();
+        let project = fs::canonicalize(".").unwrap();
+        let home = tempfile::tempdir().unwrap();
+        fs::write(
+            home.path().join(".gitconfig"),
+            "[include]\npath = ~/.gitconfig.local\n",
+        )
+        .unwrap();
+        fs::write(
+            home.path().join(".gitconfig.local"),
+            "[user]\nname = cplt-test-user\n",
+        )
+        .unwrap();
+
+        let opts = default_opts(&project, home.path());
+        let profile = write_real_profile(&opts);
+        let cmd = format!(
+            "HOME='{}' GIT_CONFIG_NOSYSTEM=1 git config --global user.name 2>&1",
+            home.path().display()
+        );
+        let (output, success) = run_sandboxed(&profile, &cmd);
+        let write_cmd = format!(
+            "echo injected >> '{}' 2>&1; echo EXIT:$?",
+            home.path().join(".gitconfig.local").display()
+        );
+        let (write_output, _) = run_sandboxed(&profile, &write_cmd);
+
+        fs::remove_file(&profile).ok();
+        assert!(
+            success && output.contains("cplt-test-user"),
+            "git should read ~/.gitconfig.local through the include: {output}"
+        );
+        assert!(
+            write_output.contains("Operation not permitted") || write_output.contains("EXIT:1"),
+            "~/.gitconfig.local must remain read-only: {write_output}"
+        );
+    }
+
     // ── Git persistence prevention ────────────────────────────────
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -444,7 +444,9 @@ mod macos_tests {
         let opts = default_opts(&project, home.path());
         let profile = write_real_profile(&opts);
         let cmd = format!(
-            "HOME='{}' GIT_CONFIG_NOSYSTEM=1 git config --global user.name 2>&1",
+            "HOME='{}' GIT_CONFIG_GLOBAL='{}/.gitconfig' GIT_CONFIG_NOSYSTEM=1 \
+             git config --global user.name 2>&1",
+            home.path().display(),
             home.path().display()
         );
         let (output, success) = run_sandboxed(&profile, &cmd);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -903,6 +903,14 @@ fn profile_grants_project_access() {
         !p.contains("(allow file-write* (literal \"/Users/test/.gitconfig.local\"))"),
         "Included user Git config must remain read-only"
     );
+    assert!(
+        p.contains("(allow file-read* (literal \"/Users/test/.gitignore_global\"))"),
+        "Global Git ignore file should be readable"
+    );
+    assert!(
+        !p.contains("(allow file-write* (literal \"/Users/test/.gitignore_global\"))"),
+        "Global Git ignore file must remain read-only"
+    );
 }
 
 #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -895,6 +895,14 @@ fn profile_grants_project_access() {
         p.contains("(allow file-map-executable (subpath \"/projects/app\"))"),
         "Project dir must allow file-map-executable for native Node addons"
     );
+    assert!(
+        p.contains("(allow file-read* (literal \"/Users/test/.gitconfig.local\"))"),
+        "Included user Git config should be readable"
+    );
+    assert!(
+        !p.contains("(allow file-write* (literal \"/Users/test/.gitconfig.local\"))"),
+        "Included user Git config must remain read-only"
+    );
 }
 
 #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -900,7 +900,7 @@ fn profile_grants_project_access() {
         "Included user Git config should be readable"
     );
     assert!(
-        !p.contains("(allow file-write* (literal \"/Users/test/.gitconfig.local\"))"),
+        p.contains("(deny file-write* (literal \"/Users/test/.gitconfig.local\"))"),
         "Included user Git config must remain read-only"
     );
     assert!(
@@ -908,8 +908,16 @@ fn profile_grants_project_access() {
         "Global Git ignore file should be readable"
     );
     assert!(
-        !p.contains("(allow file-write* (literal \"/Users/test/.gitignore_global\"))"),
+        p.contains("(deny file-write* (literal \"/Users/test/.gitignore_global\"))"),
         "Global Git ignore file must remain read-only"
+    );
+    assert!(
+        p.contains("(deny file-write* (literal \"/Users/test/.gitconfig\"))"),
+        "Global Git config must remain read-only"
+    );
+    assert!(
+        p.contains("(deny file-write* (literal \"/Users/test/.config/git/config\"))"),
+        "XDG Git config must remain read-only"
     );
 }
 


### PR DESCRIPTION
## Summary

- capture the trusted repository scope before the sandboxed agent starts and bake it into the `gh` wrapper
- pin `GH_REPO` to `github.com/owner/repo`, clear `GH_HOST`, and block nested-repo, hostname, and external API endpoint retargeting
- allow conventional `.gitconfig.local` and `.gitignore_global` files read-only on macOS and Linux

## Security rationale

Runtime repository discovery allowed an agent to redefine scope through Git environment variables, config includes, or a writable nested repository. Startup pinning removes runtime CWD and mutable Git configuration from the trust decision while preserving fail-closed behavior.

## Testing

- `mise run check`
- `cargo test --test e2e_guards` (105 tests)
- `mise run test:integration` (52 tests)
- release-mode adversarial probes for nested repository and host retargeting