### PR TITLE
feat(settings): add interactive configuration editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,7 +44,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +55,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -60,9 +66,9 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -71,6 +77,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -126,14 +147,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "cplt"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossterm",
  "directories",
  "landlock",
  "libc",
+ "ratatui",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -155,12 +192,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -191,8 +287,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "enumflags2"
@@ -227,7 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -272,6 +374,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -303,6 +407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,10 +425,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -360,6 +501,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -380,10 +527,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "once_cell"
@@ -427,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +635,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +677,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -489,9 +697,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -579,16 +799,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "syn"
@@ -630,8 +909,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -719,6 +998,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,10 +1097,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -802,6 +1141,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4", features = ["derive"] }
+crossterm = "0.28"
 directories = "6.0.0"
 libc = "0.2"
+ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1"
@@ -60,4 +62,3 @@ similar_names = "allow"               # domain-specific names (e.g. current/late
 manual_string_new = "allow"           # String::new() vs "".to_string() are both fine
 format_collect = "allow"              # hex formatting via map(format!).collect() is idiomatic
 unnested_or_patterns = "allow"        # explicit arms with comments are clearer for magic bytes
-

--- a/README.md
+++ b/README.md
@@ -729,6 +729,9 @@ cplt exec -c "npm install && npm test"
 cplt is configured at two levels: **global** (developer preferences) and **per-repo** (team policy).
 
 ```bash
+# Browse and change settings interactively
+cplt settings
+
 # Set global preferences
 cplt config set sandbox.quiet true
 cplt config set proxy.blocked_domains "~/.config/cplt/blocked-domains.txt"
@@ -743,6 +746,12 @@ cplt config set --repo deny.paths "~/secrets"
 cplt config show      # show effective config (file + defaults)
 cplt config explain   # list all keys with descriptions
 ```
+
+`cplt settings` is the interactive editor: it has **Effective**, **Global**, and
+**Repository** views, search, staged changes, and an explicit confirmation before
+saving security-sensitive values. `cplt config` remains the stable non-interactive
+interface for scripts and CI. Repository proposals are still committed and approved
+separately with `cplt trust`; the editor never commits or auto-approves them.
 
 **Precedence** (highest to lowest):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,9 @@ List values are merged, so repeated `cplt config set` commands accumulate for
 
 ## Quick setup
 
-Use `cplt config set` to configure cplt without editing files:
+Use `cplt settings` to browse and change settings interactively. It stages edits,
+shows their source and security impact, and writes validated TOML atomically. Use
+`cplt config set` for scripts, CI, or a direct non-interactive edit:
 
 ```bash
 cplt config set sandbox.quiet true

--- a/src/config/editing.rs
+++ b/src/config/editing.rs
@@ -1,6 +1,9 @@
 //! TOML document manipulation for `cplt config set/unset/add`.
 
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::error::ConfigError;
 use super::path::{config_path, expand_tilde};
@@ -264,13 +267,60 @@ pub fn security_confirmation(key_info: &ConfigKeyInfo, value: &str, unset: bool)
     if key_info.dangerous && value == "true" {
         return Some("weakens sandbox security".to_string());
     }
-    None
+    let weakens_security = matches!(
+        (key_info.section, key_info.key, value),
+        ("proxy", "enabled" | "forced" | "default_allowlist", "false")
+            | ("sandbox", "validate" | "audit", "false")
+            | ("sandbox", "use_bubblewrap", "false")
+            | (
+                "gh_guard",
+                "enabled" | "scope_check" | "block_auth_token",
+                "false"
+            )
+            | (
+                "git_guard",
+                "enabled" | "prevent_push" | "prevent_force_push",
+                "false"
+            )
+            | ("gh_guard", "inject_token" | "allow_api_write", "true")
+            | ("gh_guard", "unknown_command", "allow")
+            | ("gh_guard" | "git_guard", "mode", "warn" | "audit")
+    );
+    weakens_security.then(|| "weakens sandbox security".to_string())
 }
 
-/// Atomically write a config document after confirming that it is valid TOML.
+/// Validate a global config document with the same typed parsing and runtime
+/// merge used when launching the sandbox.
+pub fn validate_global_document(doc: &toml_edit::DocumentMut) -> Result<(), ConfigError> {
+    let config = super::types::Config::parse(&doc.to_string())?;
+    config.merge_with_no_proxy_env(super::types::CliFlags::default(), None)?;
+    Ok(())
+}
+
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Atomically write a private config document using a unique same-directory
+/// temp file. Existing permissions are preserved; new files default to 0600.
 pub fn write_document_atomically(
     path: &Path,
     doc: &toml_edit::DocumentMut,
+) -> Result<(), ConfigError> {
+    write_document_atomically_with_mode(path, doc, 0o600)
+}
+
+/// Atomically write a repository config document. Existing permissions are
+/// preserved; a new repository file defaults to 0644.
+pub fn write_repo_document_atomically(
+    path: &Path,
+    doc: &toml_edit::DocumentMut,
+) -> Result<(), ConfigError> {
+    write_document_atomically_with_mode(path, doc, 0o644)
+}
+
+fn write_document_atomically_with_mode(
+    path: &Path,
+    doc: &toml_edit::DocumentMut,
+    default_mode: u32,
 ) -> Result<(), ConfigError> {
     let output = doc.to_string();
     if output.parse::<toml::Table>().is_err() {
@@ -279,15 +329,68 @@ pub fn write_document_atomically(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(ConfigError::CreateDir)?;
     }
-    let temp = path.with_extension("toml.tmp");
-    std::fs::write(&temp, output).map_err(|e| ConfigError::Write {
-        path: temp.clone(),
-        source: e,
-    })?;
-    std::fs::rename(&temp, path).map_err(|e| ConfigError::Write {
-        path: path.to_path_buf(),
-        source: e,
-    })
+    let mode = existing_or_default_mode(path, default_mode);
+    let (temp, mut file) = create_unique_temp_file(path, mode)?;
+    let write_result = file
+        .write_all(output.as_bytes())
+        .and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(source) = write_result {
+        let _ = std::fs::remove_file(&temp);
+        return Err(ConfigError::Write { path: temp, source });
+    }
+    if let Err(source) = std::fs::rename(&temp, path) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(ConfigError::Write {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+    Ok(())
+}
+
+fn create_unique_temp_file(
+    path: &Path,
+    mode: u32,
+) -> Result<(PathBuf, std::fs::File), ConfigError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config");
+    for _ in 0..100 {
+        let id = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), id));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(mode);
+        }
+        match options.open(&temp) {
+            Ok(file) => return Ok((temp, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(source) => return Err(ConfigError::Write { path: temp, source }),
+        }
+    }
+    Err(ConfigError::Validation(format!(
+        "cannot allocate a unique temporary file for {}",
+        path.display()
+    )))
+}
+
+#[cfg(unix)]
+fn existing_or_default_mode(path: &Path, default_mode: u32) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o777)
+        .unwrap_or(default_mode)
+}
+
+#[cfg(not(unix))]
+fn existing_or_default_mode(_path: &Path, default_mode: u32) -> u32 {
+    default_mode
 }
 
 /// Read the current display value for a key from a toml_edit document.
@@ -352,10 +455,9 @@ impl ConfigSetOp {
         }
     }
 
-    /// Write the document back, creating parent dirs if needed.
-    /// Only verifies the result is valid TOML (not full key validation —
-    /// an existing typo elsewhere shouldn't block a valid set operation).
+    /// Validate and write the document back, creating parent dirs if needed.
     pub fn write_document(&self, doc: &toml_edit::DocumentMut) -> Result<(), ConfigError> {
+        validate_global_document(doc)?;
         write_document_atomically(&self.path, doc)
     }
 }
@@ -526,6 +628,35 @@ mod tests {
     }
 
     #[test]
+    fn security_confirmation_covers_disabled_protections_and_permissive_modes() {
+        for (key, value) in [
+            ("gh_guard.scope_check", "false"),
+            ("gh_guard.block_auth_token", "false"),
+            ("gh_guard.unknown_command", "allow"),
+            ("git_guard.prevent_push", "false"),
+            ("git_guard.mode", "warn"),
+        ] {
+            let info = lookup_key(key).unwrap();
+            assert!(
+                security_confirmation(info, value, false).is_some(),
+                "{key}={value} should require confirmation"
+            );
+        }
+    }
+
+    #[test]
+    fn global_validation_rejects_invalid_typed_and_runtime_values() {
+        for input in [
+            "[sandbox]\npreset = \"invalid\"\n",
+            "[proxy]\nlog_level = \"invalid\"\n",
+            "[proxy]\nupstream = \"https://wrong-scheme.example\"\n",
+        ] {
+            let doc = input.parse::<toml_edit::DocumentMut>().unwrap();
+            assert!(validate_global_document(&doc).is_err(), "{input}");
+        }
+    }
+
+    #[test]
     fn atomic_write_preserves_valid_document() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -534,6 +665,56 @@ mod tests {
             .unwrap();
         write_document_atomically(&path, &doc).unwrap();
         assert_eq!(std::fs::read_to_string(path).unwrap(), doc.to_string());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[sandbox]\nquiet = false\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let doc = "[sandbox]\nquiet = true\n"
+            .parse::<toml_edit::DocumentMut>()
+            .unwrap();
+
+        write_document_atomically(&path, &doc).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn concurrent_atomic_writes_do_not_share_temp_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let handles: Vec<_> = (0..8)
+            .map(|index| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    let doc = format!("[proxy]\ntimeout = {}\n", index + 1)
+                        .parse::<toml_edit::DocumentMut>()
+                        .unwrap();
+                    write_document_atomically(&path, &doc)
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.parse::<toml::Table>().is_ok());
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty());
     }
 
     #[test]

--- a/src/config/editing.rs
+++ b/src/config/editing.rs
@@ -1,6 +1,6 @@
 //! TOML document manipulation for `cplt config set/unset/add`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::error::ConfigError;
 use super::path::{config_path, expand_tilde};
@@ -241,6 +241,55 @@ pub fn unset_value_in_doc(doc: &mut toml_edit::DocumentMut, key_info: &ConfigKey
     }
 }
 
+/// Returns the security confirmation required to write `value`, if any.
+///
+/// This is shared by the scriptable config command and interactive settings UI
+/// so neither can silently enable a setting that weakens the sandbox.
+pub fn security_confirmation(key_info: &ConfigKeyInfo, value: &str, unset: bool) -> Option<String> {
+    if unset {
+        return None;
+    }
+    if key_info.section == "sandbox"
+        && key_info.key == "preset"
+        && let Some(preset) = super::types::Preset::from_name(value)
+    {
+        let enabled = preset.enabled_dangerous_names();
+        if !enabled.is_empty() {
+            return Some(format!(
+                "enables dangerous settings ({})",
+                enabled.join(", ")
+            ));
+        }
+    }
+    if key_info.dangerous && value == "true" {
+        return Some("weakens sandbox security".to_string());
+    }
+    None
+}
+
+/// Atomically write a config document after confirming that it is valid TOML.
+pub fn write_document_atomically(
+    path: &Path,
+    doc: &toml_edit::DocumentMut,
+) -> Result<(), ConfigError> {
+    let output = doc.to_string();
+    if output.parse::<toml::Table>().is_err() {
+        return Err(ConfigError::InvalidOutput);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(ConfigError::CreateDir)?;
+    }
+    let temp = path.with_extension("toml.tmp");
+    std::fs::write(&temp, output).map_err(|e| ConfigError::Write {
+        path: temp.clone(),
+        source: e,
+    })?;
+    std::fs::rename(&temp, path).map_err(|e| ConfigError::Write {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
 /// Read the current display value for a key from a toml_edit document.
 /// Returns `None` if the key is not set.
 pub fn get_value_from_doc(
@@ -307,22 +356,7 @@ impl ConfigSetOp {
     /// Only verifies the result is valid TOML (not full key validation —
     /// an existing typo elsewhere shouldn't block a valid set operation).
     pub fn write_document(&self, doc: &toml_edit::DocumentMut) -> Result<(), ConfigError> {
-        let output = doc.to_string();
-
-        // Sanity check: the result must still be valid TOML
-        if output.parse::<toml::Table>().is_err() {
-            return Err(ConfigError::InvalidOutput);
-        }
-
-        // Create parent dirs
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent).map_err(ConfigError::CreateDir)?;
-        }
-
-        std::fs::write(&self.path, output).map_err(|e| ConfigError::Write {
-            path: self.path.clone(),
-            source: e,
-        })
+        write_document_atomically(&self.path, doc)
     }
 }
 
@@ -478,6 +512,28 @@ mod tests {
         unset_value_in_doc(&mut doc, info);
         let result = doc.to_string();
         assert!(result.contains("validate = true"));
+    }
+
+    #[test]
+    fn security_confirmation_covers_dangerous_key_and_preset() {
+        let docker = lookup_key("sandbox.allow_docker").unwrap();
+        assert!(security_confirmation(docker, "true", false).is_some());
+        assert!(security_confirmation(docker, "false", false).is_none());
+
+        let preset = lookup_key("sandbox.preset").unwrap();
+        assert!(security_confirmation(preset, "permissive", false).is_some());
+        assert!(security_confirmation(preset, "strict", false).is_none());
+    }
+
+    #[test]
+    fn atomic_write_preserves_valid_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let doc = "[sandbox]\nquiet = true\n"
+            .parse::<toml_edit::DocumentMut>()
+            .unwrap();
+        write_document_atomically(&path, &doc).unwrap();
+        assert_eq!(std::fs::read_to_string(path).unwrap(), doc.to_string());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,8 @@ mod validation;
 pub use display::{display_config, explain_all, explain_key, get_config_value};
 pub use editing::{
     ConfigSetOp, append_value_in_doc, get_value_from_doc, remove_array_element_in_doc,
-    security_confirmation, set_value_in_doc, unset_value_in_doc, write_document_atomically,
+    security_confirmation, set_value_in_doc, unset_value_in_doc, validate_global_document,
+    write_document_atomically, write_repo_document_atomically,
 };
 pub use error::ConfigError;
 pub use path::{collapse_tilde, config_dir, config_path, default_config_contents, expand_tilde};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ mod validation;
 pub use display::{display_config, explain_all, explain_key, get_config_value};
 pub use editing::{
     ConfigSetOp, append_value_in_doc, get_value_from_doc, remove_array_element_in_doc,
-    set_value_in_doc, unset_value_in_doc,
+    security_confirmation, set_value_in_doc, unset_value_in_doc, write_document_atomically,
 };
 pub use error::ConfigError;
 pub use path::{collapse_tilde, config_dir, config_path, default_config_contents, expand_tilde};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod proxy;
 pub mod repo_config;
 pub mod sandbox;
 pub mod scratch;
+pub mod settings;
 pub mod subscriptions;
 pub mod trust;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4431,7 +4431,7 @@ fn run_config_set_repo(
         ));
         return ExitCode::FAILURE;
     }
-    if let Err(e) = config::write_document_atomically(&repo_config_path, &doc) {
+    if let Err(e) = config::write_repo_document_atomically(&repo_config_path, &doc) {
         ui::error(&format!("cannot write {}: {e}", repo_config_path.display()));
         return ExitCode::FAILURE;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,9 @@ EXAMPLES:
   cplt config explain sandbox.quiet
     Learn what a config key does and how to set it
 
+  cplt settings
+    Browse and edit settings interactively
+
   cplt update
     Update cplt to the latest release from GitHub
 
@@ -628,6 +631,12 @@ QUICK START:
         #[command(subcommand)]
         action: ConfigAction,
     },
+
+    /// Browse and edit global and repository settings interactively.
+    ///
+    /// Uses the same validation and TOML persistence as `cplt config set`.
+    /// Requires an interactive terminal; use `cplt config` in scripts and CI.
+    Settings,
 
     /// Update cplt to the latest release.
     ///
@@ -2111,6 +2120,13 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     if let Some(command) = cli.command {
         return Ok(match command {
             Command::Config { action } => run_config_command(action),
+            Command::Settings => match cplt::settings::run() {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(error) => {
+                    ui::error(&error);
+                    ExitCode::FAILURE
+                }
+            },
             Command::Update { check, force } => run_update(check, force),
             Command::UpdateLists => run_update_lists(),
             Command::Trust { action } => run_trust_command(action),
@@ -4240,41 +4256,15 @@ fn run_config_set(
         }
     };
 
-    // Dangerous-setting safeguard. Two cases weaken the sandbox and require
-    // --force:
-    //   1. A key flagged `dangerous` in the registry set to `true`
-    //      (allow_docker, allow_tmp_exec, …) — danger is in the KEY.
-    //   2. `sandbox.preset` set to a value that enables guarded toggles
-    //      (permissive/full-trust) — danger is in the VALUE, so this must be
-    //      value-aware. strict/standard are no-op baselines and are allowed.
     if !unset
         && !force
         && let Some(val) = value
+        && let Some(reason) = config::security_confirmation(op.key_info, val, false)
     {
-        // Value-aware preset check: warn and name what the preset enables.
-        if op.key_info.section == "sandbox"
-            && op.key_info.key == "preset"
-            && let Some(preset) = config::Preset::from_name(val)
-        {
-            let enabled = preset.enabled_dangerous_names();
-            if !enabled.is_empty() {
-                ui::error(&format!(
-                    "{key} = {val} enables dangerous settings ({}) — it weakens sandbox security.\n  \
-                     Add --force to confirm: cplt config set {key} {val} --force",
-                    enabled.join(", ")
-                ));
-                return ExitCode::FAILURE;
-            }
-        }
-
-        // Key-level dangerous-bool check.
-        if op.key_info.dangerous && val == "true" {
-            ui::error(&format!(
-                "{key} is a dangerous setting — it weakens sandbox security.\n  \
-                 Add --force to confirm: cplt config set {key} true --force"
-            ));
-            return ExitCode::FAILURE;
-        }
+        ui::error(&format!(
+            "{key} = {val} {reason}.\n  Add --force to confirm: cplt config set {key} {val} --force"
+        ));
+        return ExitCode::FAILURE;
     }
 
     // Load or create document
@@ -4434,20 +4424,16 @@ fn run_config_set_repo(
         return ExitCode::FAILURE;
     }
 
-    // Write back
     let output = doc.to_string();
-    if let Err(e) = std::fs::write(&repo_config_path, &output) {
-        ui::error(&format!("cannot write {}: {e}", repo_config_path.display()));
+    if let Err(e) = repo_config::parse_and_validate(&output) {
+        ui::error(&format!(
+            "refusing to write invalid .cplt.toml: {e}\n  No changes were saved."
+        ));
         return ExitCode::FAILURE;
     }
-
-    // Validate the result parses and passes safety checks
-    if let Err(e) = repo_config::parse_and_validate(&output) {
-        eprintln!(
-            "{}[cplt] Warning: written .cplt.toml has validation issues: {e}{}\n  The file was saved but may not load correctly.",
-            ui::color(ui::YELLOW),
-            ui::color(ui::RESET)
-        );
+    if let Err(e) = config::write_document_atomically(&repo_config_path, &doc) {
+        ui::error(&format!("cannot write {}: {e}", repo_config_path.display()));
+        return ExitCode::FAILURE;
     }
 
     // User feedback

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,750 @@
+//! Interactive settings editor backed by the same config documents as `cplt config`.
+//!
+//! The TUI stages changes and writes them atomically only after validation. It
+//! deliberately does not run inside a sandbox: a sandboxed agent must never be
+//! able to alter the user's policy or repository trust decisions.
+
+use std::io::{self, IsTerminal};
+use std::path::PathBuf;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Tabs, Wrap},
+};
+
+use crate::config::{
+    self, ConfigKeyInfo, ConfigValueType, RepoKeyTarget, all_config_keys, append_value_in_doc,
+    get_value_from_doc, repo_key_target, security_confirmation, set_repo_value_in_doc,
+    set_value_in_doc, unset_value_in_doc, write_document_atomically,
+};
+use crate::repo_config;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Scope {
+    Effective,
+    Global,
+    Repository,
+}
+
+impl Scope {
+    const ALL: [Self; 3] = [Self::Effective, Self::Global, Self::Repository];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Effective => "Effective",
+            Self::Global => "Global",
+            Self::Repository => "Repository",
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PendingChange {
+    key: &'static ConfigKeyInfo,
+    scope: Scope,
+    value: Option<String>,
+}
+
+struct SettingsApp {
+    scope: Scope,
+    selected: usize,
+    filter: String,
+    editing_filter: bool,
+    editing_value: bool,
+    value_input: String,
+    status: String,
+    pending: Vec<PendingChange>,
+    global_doc: toml_edit::DocumentMut,
+    global_path: PathBuf,
+    repo_doc: toml_edit::DocumentMut,
+    repo_path: PathBuf,
+    dangerous_confirmation: Option<String>,
+}
+
+impl SettingsApp {
+    fn load() -> Result<Self, String> {
+        let global_path = config::config_path().ok_or("$HOME is not set")?;
+        let global_doc = load_doc(&global_path)?;
+        let project_dir = detect_project_root()
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or("cannot determine project directory")?;
+        let repo_path = project_dir.join(repo_config::REPO_CONFIG_FILE);
+        let repo_doc = load_doc(&repo_path)?;
+        Ok(Self {
+            scope: Scope::Effective,
+            selected: 0,
+            filter: String::new(),
+            editing_filter: false,
+            editing_value: false,
+            value_input: String::new(),
+            status: "Use / to search, Tab to change scope, Enter to edit, Ctrl+S to save."
+                .to_string(),
+            pending: Vec::new(),
+            global_doc,
+            global_path,
+            repo_doc,
+            repo_path,
+            dangerous_confirmation: None,
+        })
+    }
+
+    fn visible_keys(&self) -> Vec<&'static ConfigKeyInfo> {
+        all_config_keys()
+            .iter()
+            .filter(|key| {
+                if self.scope == Scope::Repository && repo_key_target(key).is_none() {
+                    return false;
+                }
+                let needle = self.filter.to_ascii_lowercase();
+                needle.is_empty()
+                    || format!("{}.{} {}", key.section, key.key, key.description)
+                        .to_ascii_lowercase()
+                        .contains(&needle)
+            })
+            .collect()
+    }
+
+    fn selected_key(&self) -> Option<&'static ConfigKeyInfo> {
+        self.visible_keys().get(self.selected).copied()
+    }
+
+    fn set_scope(&mut self, scope: Scope) {
+        self.scope = scope;
+        self.selected = 0;
+        self.status = match scope {
+            Scope::Repository => {
+                "Repository edits update the working tree. Commit .cplt.toml, then review with `cplt trust`."
+                    .to_string()
+            }
+            _ => format!("{} settings", scope.label()),
+        };
+    }
+
+    fn stage(&mut self, key: &'static ConfigKeyInfo, value: Option<String>) {
+        self.pending.retain(|change| {
+            !(change.key.section == key.section
+                && change.key.key == key.key
+                && change.scope == self.scope)
+        });
+        self.pending.push(PendingChange {
+            key,
+            scope: self.scope,
+            value,
+        });
+        self.status = format!(
+            "Staged {}.{} for {}. Ctrl+S saves {} change(s).",
+            key.section,
+            key.key,
+            self.scope.label().to_ascii_lowercase(),
+            self.pending.len()
+        );
+    }
+
+    fn toggle_selected(&mut self) {
+        let Some(key) = self.selected_key() else {
+            return;
+        };
+        if key.value_type != ConfigValueType::Bool {
+            self.status =
+                "Only boolean settings can be toggled. Press Enter to edit this value.".to_string();
+            return;
+        }
+        if self.scope == Scope::Effective {
+            self.status =
+                "Effective values are read-only. Switch to Global or Repository.".to_string();
+            return;
+        }
+        if self.scope == Scope::Repository {
+            let Some(RepoKeyTarget::ProposeBool) = repo_key_target(key) else {
+                self.status = "Repository deny and list values are edited with Enter.".to_string();
+                return;
+            };
+            if repo_proposal_enabled(&self.repo_doc, key) {
+                self.stage(key, None);
+            } else {
+                self.stage(key, Some("true".to_string()));
+            }
+        } else {
+            let value = get_value_from_doc(&self.global_doc, key)
+                .unwrap_or_else(|| key.default_display.to_string());
+            self.stage(
+                key,
+                Some(if value == "true" { "false" } else { "true" }.to_string()),
+            );
+        }
+    }
+
+    fn begin_value_edit(&mut self) {
+        let Some(key) = self.selected_key() else {
+            return;
+        };
+        if self.scope == Scope::Effective {
+            self.status =
+                "Effective values are read-only. Switch to Global or Repository.".to_string();
+            return;
+        }
+        if key.value_type == ConfigValueType::ArrayOfTables {
+            self.status = format!(
+                "{}.{}, an array of tables, is read-only here. Edit TOML directly.",
+                key.section, key.key
+            );
+            return;
+        }
+        self.value_input = if self.scope == Scope::Global && !key.value_type.is_array() {
+            get_value_from_doc(&self.global_doc, key).unwrap_or_default()
+        } else {
+            String::new()
+        };
+        self.editing_value = true;
+        self.status = format!(
+            "Enter a value for {}.{}; Enter stages it, Esc cancels.",
+            key.section, key.key
+        );
+    }
+
+    fn submit_value(&mut self) {
+        let Some(key) = self.selected_key() else {
+            return;
+        };
+        let value = self.value_input.trim().to_string();
+        self.editing_value = false;
+        if value.is_empty() {
+            self.stage(key, None);
+        } else {
+            self.stage(key, Some(value));
+        }
+    }
+
+    fn dangerous_changes(&self) -> Vec<String> {
+        self.pending
+            .iter()
+            .filter_map(|change| {
+                if change.scope == Scope::Repository
+                    && change.value.is_some()
+                    && matches!(
+                        repo_key_target(change.key),
+                        Some(
+                            RepoKeyTarget::ProposeBool
+                                | RepoKeyTarget::ProposeAllow(_)
+                                | RepoKeyTarget::ProposeProxy(_)
+                        )
+                    )
+                {
+                    return Some(format!(
+                        "{}.{} requests a repository sandbox permission",
+                        change.key.section, change.key.key
+                    ));
+                }
+                change.value.as_deref().and_then(|value| {
+                    security_confirmation(change.key, value, false)
+                        .map(|reason| format!("{}.{} {reason}", change.key.section, change.key.key))
+                })
+            })
+            .collect()
+    }
+
+    fn save(&mut self, confirmed_dangerous: bool) -> Result<(), String> {
+        if self.pending.is_empty() {
+            self.status = "No staged changes.".to_string();
+            return Ok(());
+        }
+        let mut global = self.global_doc.clone();
+        let mut repo = self.repo_doc.clone();
+        let mut write_global = false;
+        let mut write_repo = false;
+        for change in &self.pending {
+            match change.scope {
+                Scope::Global => {
+                    apply_global_change(&mut global, change)?;
+                    write_global = true;
+                }
+                Scope::Repository => {
+                    apply_repo_change(&mut repo, change)?;
+                    write_repo = true;
+                }
+                Scope::Effective => {}
+            }
+        }
+        if !confirmed_dangerous && !self.dangerous_changes().is_empty() {
+            return Err("dangerous settings require confirmation".to_string());
+        }
+        if write_repo {
+            let text = repo.to_string();
+            repo_config::parse_and_validate(&text)
+                .map_err(|error| format!("refusing to write invalid .cplt.toml: {error}"))?;
+        }
+        if write_global {
+            write_document_atomically(&self.global_path, &global)
+                .map_err(|error| error.to_string())?;
+            self.global_doc = global;
+        }
+        if write_repo {
+            write_document_atomically(&self.repo_path, &repo).map_err(|error| error.to_string())?;
+            self.repo_doc = repo;
+        }
+        let count = self.pending.len();
+        self.pending.clear();
+        self.status = format!("Saved {count} change(s) atomically.");
+        Ok(())
+    }
+}
+
+fn apply_global_change(
+    doc: &mut toml_edit::DocumentMut,
+    change: &PendingChange,
+) -> Result<(), String> {
+    match &change.value {
+        None => {
+            unset_value_in_doc(doc, change.key);
+            Ok(())
+        }
+        Some(value) if change.key.value_type.is_array() => {
+            append_value_in_doc(doc, change.key, value).map_err(|error| error.to_string())
+        }
+        Some(value) => set_value_in_doc(doc, change.key, value).map_err(|error| error.to_string()),
+    }
+}
+
+fn apply_repo_change(
+    doc: &mut toml_edit::DocumentMut,
+    change: &PendingChange,
+) -> Result<(), String> {
+    let target = repo_key_target(change.key).ok_or_else(|| {
+        format!(
+            "{}.{} is not valid in repository config",
+            change.key.section, change.key.key
+        )
+    })?;
+    set_repo_value_in_doc(
+        doc,
+        change.key,
+        target,
+        change.value.as_deref().unwrap_or(""),
+        change.value.is_none(),
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn load_doc(path: &std::path::Path) -> Result<toml_edit::DocumentMut, String> {
+    if !path.exists() {
+        return Ok(toml_edit::DocumentMut::new());
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+    raw.parse()
+        .map_err(|error| format!("invalid TOML in {}: {error}", path.display()))
+}
+
+fn repo_proposal_enabled(doc: &toml_edit::DocumentMut, key: &ConfigKeyInfo) -> bool {
+    doc.get("propose")
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|table| table.get(key.key))
+        .and_then(toml_edit::Item::as_bool)
+        == Some(true)
+}
+
+fn detect_project_root() -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    output.status.success().then(|| {
+        String::from_utf8(output.stdout)
+            .ok()
+            .map(|value| PathBuf::from(value.trim()))
+    })?
+}
+
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter() -> io::Result<Self> {
+        enable_raw_mode()?;
+        execute!(io::stdout(), EnterAlternateScreen)?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+/// Run the interactive settings editor.
+pub fn run() -> Result<(), String> {
+    if std::env::var_os("__CPLT_TRUST_LOCKED").is_some() {
+        return Err("Cannot edit settings from inside the sandbox.".to_string());
+    }
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(
+            "cplt settings requires an interactive terminal. Use `cplt config set` in scripts or CI."
+                .to_string(),
+        );
+    }
+    let mut app = SettingsApp::load()?;
+    let _guard =
+        TerminalGuard::enter().map_err(|error| format!("cannot initialize terminal: {error}"))?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend).map_err(|error| error.to_string())?;
+    let result = run_loop(&mut terminal, &mut app);
+    let _ = terminal.show_cursor();
+    result
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut SettingsApp,
+) -> Result<(), String> {
+    loop {
+        terminal
+            .draw(|frame| render(frame, app))
+            .map_err(|error| error.to_string())?;
+        let Event::Key(key) = event::read().map_err(|error| error.to_string())? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        if app.editing_filter {
+            match key.code {
+                KeyCode::Esc | KeyCode::Enter => app.editing_filter = false,
+                KeyCode::Backspace => {
+                    app.filter.pop();
+                    app.selected = 0;
+                }
+                KeyCode::Char(value) => {
+                    app.filter.push(value);
+                    app.selected = 0;
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if app.dangerous_confirmation.is_some() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    app.dangerous_confirmation = None;
+                    if let Err(error) = app.save(true) {
+                        app.status = error;
+                    }
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    app.dangerous_confirmation = None;
+                    app.status = "Dangerous changes were not saved.".to_string();
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if app.editing_value {
+            match key.code {
+                KeyCode::Esc => app.editing_value = false,
+                KeyCode::Enter => app.submit_value(),
+                KeyCode::Backspace => {
+                    app.value_input.pop();
+                }
+                KeyCode::Char(value) => app.value_input.push(value),
+                _ => {}
+            }
+            continue;
+        }
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+            KeyCode::Char('/') => app.editing_filter = true,
+            KeyCode::Tab => {
+                let index = Scope::ALL
+                    .iter()
+                    .position(|scope| *scope == app.scope)
+                    .unwrap_or(0);
+                app.set_scope(Scope::ALL[(index + 1) % Scope::ALL.len()]);
+            }
+            KeyCode::Up | KeyCode::Char('k') => app.selected = app.selected.saturating_sub(1),
+            KeyCode::Down | KeyCode::Char('j') => {
+                app.selected = (app.selected + 1).min(app.visible_keys().len().saturating_sub(1));
+            }
+            KeyCode::Char(' ') => app.toggle_selected(),
+            KeyCode::Enter => app.begin_value_edit(),
+            KeyCode::Char('r') => {
+                if let Some(key) = app.selected_key() {
+                    if app.scope == Scope::Effective {
+                        app.status = "Effective values are read-only.".to_string();
+                    } else {
+                        app.stage(key, None);
+                    }
+                }
+            }
+            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let dangerous = app.dangerous_changes();
+                if !dangerous.is_empty() {
+                    app.dangerous_confirmation = Some(dangerous.join("\n"));
+                } else if let Err(error) = app.save(false) {
+                    app.status = error;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn render(frame: &mut ratatui::Frame, app: &mut SettingsApp) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(5),
+        ])
+        .split(frame.area());
+    let tab_index = Scope::ALL
+        .iter()
+        .position(|scope| *scope == app.scope)
+        .unwrap_or(0);
+    frame.render_widget(
+        Tabs::new(
+            Scope::ALL
+                .iter()
+                .map(|scope| Line::from(scope.label()))
+                .collect::<Vec<_>>(),
+        )
+        .select(tab_index)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" cplt settings "),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        layout[0],
+    );
+    let keys = app.visible_keys();
+    let rows = keys.iter().map(|key| {
+        let value = match app.scope {
+            Scope::Global | Scope::Effective => get_value_from_doc(&app.global_doc, key)
+                .unwrap_or_else(|| key.default_display.to_string()),
+            Scope::Repository => repo_value_label(&app.repo_doc, key),
+        };
+        let source = match app.scope {
+            Scope::Effective => {
+                if get_value_from_doc(&app.global_doc, key).is_some() {
+                    "global"
+                } else {
+                    "default"
+                }
+            }
+            Scope::Global => {
+                if get_value_from_doc(&app.global_doc, key).is_some() {
+                    "set"
+                } else {
+                    "inherited"
+                }
+            }
+            Scope::Repository => repo_key_target(key).map_or("not supported", |_| "proposal/deny"),
+        };
+        Row::new(vec![
+            Cell::from(format!("{}.{}", key.section, key.key)),
+            Cell::from(value),
+            Cell::from(source),
+        ])
+    });
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(39),
+            Constraint::Percentage(33),
+            Constraint::Percentage(28),
+        ],
+    )
+    .header(Row::new(["Setting", "Value", "Source"]).style(Style::default().fg(Color::Cyan)))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(if app.filter.is_empty() {
+                " Settings "
+            } else {
+                " Settings (filtered) "
+            }),
+    )
+    .row_highlight_style(Style::default().bg(Color::DarkGray))
+    .highlight_symbol("› ");
+    let mut state = TableState::default();
+    state.select(Some(app.selected.min(keys.len().saturating_sub(1))));
+    frame.render_stateful_widget(table, layout[1], &mut state);
+
+    let detail = app.selected_key().map_or_else(
+        || "No matching settings.".to_string(),
+        |key| {
+            let danger = if key.dangerous {
+                " WARNING: security-sensitive."
+            } else {
+                ""
+            };
+            format!(
+                "{}.{} — {}{}",
+                key.section, key.key, key.description, danger
+            )
+        },
+    );
+    let footer = format!(
+        "{}\nFilter: {}{}  Pending: {}  [/] search [Tab] scope [Space] toggle [Enter] edit [R] reset [Ctrl+S] save [Q] quit",
+        app.status,
+        app.filter,
+        if app.editing_filter { "▌" } else { "" },
+        app.pending.len()
+    );
+    frame.render_widget(
+        Paragraph::new(vec![Line::from(detail), Line::from(footer)])
+            .block(Block::default().borders(Borders::ALL).title(" Details "))
+            .wrap(Wrap { trim: true }),
+        layout[2],
+    );
+    if app.editing_value {
+        let area = centered_rect(70, 20, frame.area());
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new(format!(
+                "Value: {}\n\nEnter stages the change. Esc cancels.",
+                app.value_input
+            ))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Edit setting "),
+            ),
+            area,
+        );
+    }
+    if let Some(dangerous) = &app.dangerous_confirmation {
+        let area = centered_rect(75, 30, frame.area());
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new(format!(
+                "The following changes weaken sandbox security:\n\n{dangerous}\n\nSave anyway? [y/N]"
+            ))
+            .block(Block::default().borders(Borders::ALL).title(" Confirm security-sensitive changes "))
+            .wrap(Wrap { trim: true }),
+            area,
+        );
+    }
+}
+
+fn repo_value_label(doc: &toml_edit::DocumentMut, key: &ConfigKeyInfo) -> String {
+    match repo_key_target(key) {
+        Some(RepoKeyTarget::ProposeBool) => {
+            if repo_proposal_enabled(doc, key) {
+                "true".to_string()
+            } else {
+                "(unset)".to_string()
+            }
+        }
+        Some(_) => "(configured in .cplt.toml)".to_string(),
+        None => "(not supported)".to_string(),
+    }
+}
+
+fn centered_rect(
+    percent_x: u16,
+    percent_y: u16,
+    area: ratatui::layout::Rect,
+) -> ratatui::layout::Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::lookup_key;
+
+    #[test]
+    fn global_change_uses_config_editor_semantics() {
+        let key = lookup_key("sandbox.quiet").unwrap();
+        let change = PendingChange {
+            key,
+            scope: Scope::Global,
+            value: Some("true".to_string()),
+        };
+        let mut doc = toml_edit::DocumentMut::new();
+        apply_global_change(&mut doc, &change).unwrap();
+        assert_eq!(get_value_from_doc(&doc, key).as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn repository_bool_is_written_as_a_proposal() {
+        let key = lookup_key("sandbox.allow_jvm_attach").unwrap();
+        let change = PendingChange {
+            key,
+            scope: Scope::Repository,
+            value: Some("true".to_string()),
+        };
+        let mut doc = toml_edit::DocumentMut::new();
+        apply_repo_change(&mut doc, &change).unwrap();
+        assert!(repo_proposal_enabled(&doc, key));
+        assert!(repo_config::parse_and_validate(&doc.to_string()).is_ok());
+    }
+
+    #[test]
+    fn dangerous_change_requires_explicit_confirmation() {
+        let key = lookup_key("sandbox.allow_docker").unwrap();
+        let change = PendingChange {
+            key,
+            scope: Scope::Global,
+            value: Some("true".to_string()),
+        };
+        assert!(security_confirmation(key, "true", false).is_some());
+        assert_eq!(change.scope, Scope::Global);
+    }
+
+    #[test]
+    fn repository_proposals_always_require_confirmation() {
+        let key = lookup_key("sandbox.allow_jvm_attach").unwrap();
+        let change = PendingChange {
+            key,
+            scope: Scope::Repository,
+            value: Some("true".to_string()),
+        };
+        let app = SettingsApp {
+            scope: Scope::Repository,
+            selected: 0,
+            filter: String::new(),
+            editing_filter: false,
+            editing_value: false,
+            value_input: String::new(),
+            status: String::new(),
+            pending: vec![change],
+            global_doc: toml_edit::DocumentMut::new(),
+            global_path: PathBuf::from("config.toml"),
+            repo_doc: toml_edit::DocumentMut::new(),
+            repo_path: PathBuf::from(".cplt.toml"),
+            dangerous_confirmation: None,
+        };
+        assert_eq!(app.dangerous_changes().len(), 1);
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,8 +4,9 @@
 //! deliberately does not run inside a sandbox: a sandboxed agent must never be
 //! able to alter the user's policy or repository trust decisions.
 
+use std::collections::HashMap;
 use std::io::{self, IsTerminal};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -22,11 +23,12 @@ use ratatui::{
 };
 
 use crate::config::{
-    self, ConfigKeyInfo, ConfigValueType, RepoKeyTarget, all_config_keys, append_value_in_doc,
-    get_value_from_doc, repo_key_target, security_confirmation, set_repo_value_in_doc,
-    set_value_in_doc, unset_value_in_doc, write_document_atomically,
+    self, ConfigKeyInfo, ConfigValueType, RepoKeyTarget, Resolved, all_config_keys,
+    append_value_in_doc, get_value_from_doc, repo_key_target, security_confirmation,
+    set_repo_value_in_doc, set_value_in_doc, unset_value_in_doc, validate_global_document,
+    write_document_atomically, write_repo_document_atomically,
 };
-use crate::repo_config;
+use crate::{repo_config, trust};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Scope {
@@ -54,6 +56,12 @@ struct PendingChange {
     value: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+struct EffectiveSetting {
+    value: String,
+    source: &'static str,
+}
+
 struct SettingsApp {
     scope: Scope,
     selected: usize,
@@ -67,6 +75,8 @@ struct SettingsApp {
     global_path: PathBuf,
     repo_doc: toml_edit::DocumentMut,
     repo_path: PathBuf,
+    project_dir: PathBuf,
+    effective: HashMap<(&'static str, &'static str), EffectiveSetting>,
     dangerous_confirmation: Option<String>,
 }
 
@@ -79,6 +89,7 @@ impl SettingsApp {
             .ok_or("cannot determine project directory")?;
         let repo_path = project_dir.join(repo_config::REPO_CONFIG_FILE);
         let repo_doc = load_doc(&repo_path)?;
+        let effective = effective_snapshot(&global_doc, &project_dir)?;
         Ok(Self {
             scope: Scope::Effective,
             selected: 0,
@@ -93,6 +104,8 @@ impl SettingsApp {
             global_path,
             repo_doc,
             repo_path,
+            project_dir,
+            effective,
             dangerous_confirmation: None,
         })
     }
@@ -135,13 +148,37 @@ impl SettingsApp {
                 && change.key.key == key.key
                 && change.scope == self.scope)
         });
-        self.pending.push(PendingChange {
-            key,
-            scope: self.scope,
-            value,
-        });
+        let is_original = match self.scope {
+            Scope::Global => match value.as_deref() {
+                Some(value) if !key.value_type.is_array() => {
+                    get_value_from_doc(&self.global_doc, key)
+                        .unwrap_or_else(|| key.default_display.to_string())
+                        == value
+                }
+                None => get_value_from_doc(&self.global_doc, key).is_none(),
+                _ => false,
+            },
+            Scope::Repository => match value.as_deref() {
+                Some("true")
+                    if matches!(repo_key_target(key), Some(RepoKeyTarget::ProposeBool)) =>
+                {
+                    repo_proposal_enabled(&self.repo_doc, key)
+                }
+                None => repo_value_is_unset(&self.repo_doc, key),
+                _ => false,
+            },
+            Scope::Effective => true,
+        };
+        if !is_original {
+            self.pending.push(PendingChange {
+                key,
+                scope: self.scope,
+                value,
+            });
+        }
         self.status = format!(
-            "Staged {}.{} for {}. Ctrl+S saves {} change(s).",
+            "{} {}.{} for {}. Ctrl+S saves {} change(s).",
+            if is_original { "Reverted" } else { "Staged" },
             key.section,
             key.key,
             self.scope.label().to_ascii_lowercase(),
@@ -168,13 +205,15 @@ impl SettingsApp {
                 self.status = "Repository deny and list values are edited with Enter.".to_string();
                 return;
             };
-            if repo_proposal_enabled(&self.repo_doc, key) {
+            let preview = self.preview_repo_doc();
+            if repo_proposal_enabled(&preview, key) {
                 self.stage(key, None);
             } else {
                 self.stage(key, Some("true".to_string()));
             }
         } else {
-            let value = get_value_from_doc(&self.global_doc, key)
+            let preview = self.preview_global_doc();
+            let value = get_value_from_doc(&preview, key)
                 .unwrap_or_else(|| key.default_display.to_string());
             self.stage(
                 key,
@@ -199,16 +238,24 @@ impl SettingsApp {
             );
             return;
         }
-        self.value_input = if self.scope == Scope::Global && !key.value_type.is_array() {
-            get_value_from_doc(&self.global_doc, key).unwrap_or_default()
+        self.value_input = if is_sensitive(key) {
+            self.status = format!(
+                "Current {}.{} credentials are hidden. Enter a replacement; Esc cancels.",
+                key.section, key.key
+            );
+            String::new()
+        } else if self.scope == Scope::Global && !key.value_type.is_array() {
+            get_value_from_doc(&self.preview_global_doc(), key).unwrap_or_default()
         } else {
             String::new()
         };
         self.editing_value = true;
-        self.status = format!(
-            "Enter a value for {}.{}; Enter stages it, Esc cancels.",
-            key.section, key.key
-        );
+        if !is_sensitive(key) {
+            self.status = format!(
+                "Enter a value for {}.{}; Enter stages it, Esc cancels.",
+                key.section, key.key
+            );
+        }
     }
 
     fn submit_value(&mut self) {
@@ -283,18 +330,48 @@ impl SettingsApp {
                 .map_err(|error| format!("refusing to write invalid .cplt.toml: {error}"))?;
         }
         if write_global {
+            validate_global_document(&global)
+                .map_err(|error| format!("refusing to write invalid global config: {error}"))?;
+        }
+        if write_global {
             write_document_atomically(&self.global_path, &global)
                 .map_err(|error| error.to_string())?;
             self.global_doc = global;
         }
         if write_repo {
-            write_document_atomically(&self.repo_path, &repo).map_err(|error| error.to_string())?;
+            write_repo_document_atomically(&self.repo_path, &repo)
+                .map_err(|error| error.to_string())?;
             self.repo_doc = repo;
         }
+        self.effective = effective_snapshot(&self.global_doc, &self.project_dir)?;
         let count = self.pending.len();
         self.pending.clear();
         self.status = format!("Saved {count} change(s) atomically.");
         Ok(())
+    }
+
+    fn preview_global_doc(&self) -> toml_edit::DocumentMut {
+        let mut doc = self.global_doc.clone();
+        for change in self
+            .pending
+            .iter()
+            .filter(|change| change.scope == Scope::Global)
+        {
+            let _ = apply_global_change(&mut doc, change);
+        }
+        doc
+    }
+
+    fn preview_repo_doc(&self) -> toml_edit::DocumentMut {
+        let mut doc = self.repo_doc.clone();
+        for change in self
+            .pending
+            .iter()
+            .filter(|change| change.scope == Scope::Repository)
+        {
+            let _ = apply_repo_change(&mut doc, change);
+        }
+        doc
     }
 }
 
@@ -344,12 +421,230 @@ fn load_doc(path: &std::path::Path) -> Result<toml_edit::DocumentMut, String> {
         .map_err(|error| format!("invalid TOML in {}: {error}", path.display()))
 }
 
+fn effective_snapshot(
+    global_doc: &toml_edit::DocumentMut,
+    project_dir: &Path,
+) -> Result<HashMap<(&'static str, &'static str), EffectiveSetting>, String> {
+    let config =
+        config::Config::parse(&global_doc.to_string()).map_err(|error| error.to_string())?;
+    let mut base = config
+        .merge_with_no_proxy_env(config::CliFlags::default(), None)
+        .map_err(|error| error.to_string())?;
+    let _ = base.reconcile_proxy_forced();
+    let base_values = resolved_values(&base, global_doc);
+
+    let mut effective = config
+        .merge_with_no_proxy_env(config::CliFlags::default(), None)
+        .map_err(|error| error.to_string())?;
+    if let Ok(Some(loaded)) = repo_config::load_repo_config(project_dir) {
+        let approved = approved_repo_keys(project_dir, &loaded.config);
+        let approved_refs: Vec<&str> = approved.iter().map(String::as_str).collect();
+        effective.apply_repo_config(&loaded.config, &approved_refs);
+    }
+    let _ = effective.reconcile_proxy_forced();
+    let effective_values = resolved_values(&effective, global_doc);
+
+    Ok(all_config_keys()
+        .iter()
+        .map(|key| {
+            let id = (key.section, key.key);
+            let value = effective_values
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| key.default_display.to_string());
+            let source = if base_values.get(&id) != Some(&value) {
+                "repository"
+            } else if get_value_from_doc(global_doc, key).is_some() {
+                "global"
+            } else if value != key.default_display {
+                "preset"
+            } else {
+                "default"
+            };
+            (id, EffectiveSetting { value, source })
+        })
+        .collect())
+}
+
+fn approved_repo_keys(project_dir: &Path, repo: &repo_config::RepoConfig) -> Vec<String> {
+    let Some(entry) = trust::load_trust(project_dir) else {
+        return Vec::new();
+    };
+    let current_hash = trust::proposal_content_hash(&repo.propose);
+    if !trust::approved_path_matches(&entry, project_dir)
+        || trust::approval_is_stale(&entry.accepted.content_hash, &current_hash)
+    {
+        return Vec::new();
+    }
+    entry.accepted.keys
+}
+
+fn resolved_values(
+    resolved: &Resolved,
+    global_doc: &toml_edit::DocumentMut,
+) -> HashMap<(&'static str, &'static str), String> {
+    all_config_keys()
+        .iter()
+        .map(|key| {
+            let fallback = || {
+                get_value_from_doc(global_doc, key)
+                    .unwrap_or_else(|| key.default_display.to_string())
+            };
+            let value = match (key.section, key.key) {
+                ("proxy", "enabled") => resolved.with_proxy.to_string(),
+                ("proxy", "forced") => resolved.proxy_forced.to_string(),
+                ("proxy", "port") => resolved.proxy_port.to_string(),
+                ("proxy", "blocked_domains") => {
+                    format_optional_path(resolved.blocked_domains.as_ref())
+                }
+                ("proxy", "allowed_domains") => {
+                    format_optional_path(resolved.allowed_domains.as_ref())
+                }
+                ("proxy", "default_allowlist") => resolved.default_allowlist.to_string(),
+                ("proxy", "log_file") => format_optional_path(resolved.proxy_log_file.as_ref()),
+                ("proxy", "log_level") => resolved.proxy_log_level.as_str().to_string(),
+                ("proxy", "timeout") => resolved.proxy_timeout.as_secs().to_string(),
+                ("proxy", "upstream_no_proxy") => format_strings(&resolved.proxy_upstream_no_proxy),
+                ("proxy", "allow_private_domains") => {
+                    format_strings(&resolved.allow_private_domains)
+                }
+                ("allow", "read") => format_paths(&resolved.allow_read),
+                ("allow", "write") => format_paths(&resolved.allow_write),
+                ("allow", "socket") => format_paths(&resolved.allow_socket),
+                ("allow", "ports") => format_values(&resolved.allow_ports),
+                ("allow", "localhost") => format_values(&resolved.allow_localhost),
+                ("deny", "paths") => format_paths(&resolved.deny_paths),
+                ("deny", "env") => format_strings(&resolved.deny_env),
+                ("sandbox", "agent") => resolved.agent.clone().unwrap_or_default(),
+                ("sandbox", "preset") => resolved
+                    .preset
+                    .map_or_else(|| "standard".to_string(), |preset| preset.to_string()),
+                ("sandbox", "validate") => (!resolved.no_validate).to_string(),
+                ("sandbox", "allow_env_files") => resolved.allow_env_files.to_string(),
+                ("sandbox", "allow_localhost_any") => resolved.allow_localhost_any.to_string(),
+                ("sandbox", "pass_env") => format_strings(&resolved.pass_env),
+                ("sandbox", "inherit_env") => resolved.inherit_env.to_string(),
+                ("sandbox", "allow_lifecycle_scripts") => {
+                    resolved.allow_lifecycle_scripts.to_string()
+                }
+                ("sandbox", "allow_gpg_signing") => resolved.allow_gpg_signing.to_string(),
+                ("sandbox", "allow_tmp_exec") => resolved.allow_tmp_exec.to_string(),
+                ("sandbox", "scratch_dir") => resolved.scratch_dir.to_string(),
+                ("sandbox", "audit") => resolved.audit.to_string(),
+                ("sandbox", "use_bubblewrap") => resolved
+                    .use_bubblewrap
+                    .map_or_else(|| "auto-detect".to_string(), |value| value.to_string()),
+                ("sandbox", "quiet") => resolved.quiet.to_string(),
+                ("sandbox", "yes") => resolved.yes.to_string(),
+                ("sandbox", "allow_jvm_attach") => resolved.allow_jvm_attach.to_string(),
+                ("sandbox", "allow_docker") => resolved.allow_docker.to_string(),
+                ("sandbox", "allow_cache_exec") => format_strings(&resolved.allow_cache_exec),
+                ("sandbox", "allow_cache_exec_any") => resolved.allow_cache_exec_any.to_string(),
+                ("sandbox", "allow_browser") => resolved.allow_browser.to_string(),
+                ("sandbox", "gh_proxy") => resolved.gh_guard.enabled.to_string(),
+                ("sandbox", "git_push_prevention") => resolved.git_guard.enabled.to_string(),
+                ("gh_guard", "enabled") => resolved.gh_guard.enabled.to_string(),
+                ("gh_guard", "mode") => resolved.gh_guard.mode.to_string(),
+                ("gh_guard", "scope_check") => resolved.gh_guard.scope_check.to_string(),
+                ("gh_guard", "block_auth_token") => resolved.gh_guard.block_auth_token.to_string(),
+                ("gh_guard", "inject_token") => resolved.gh_guard.inject_token.to_string(),
+                ("gh_guard", "unknown_command") => resolved.gh_guard.unknown_command.to_string(),
+                ("gh_guard", "allow_api_write") => resolved.gh_guard.allow_api_write.to_string(),
+                ("git_guard", "enabled") => resolved.git_guard.enabled.to_string(),
+                ("git_guard", "mode") => resolved.git_guard.mode.to_string(),
+                ("git_guard", "prevent_push") => resolved.git_guard.prevent_push.to_string(),
+                ("git_guard", "prevent_force_push") => {
+                    resolved.git_guard.prevent_force_push.to_string()
+                }
+                ("git_guard", "protect_default_branch_only") => {
+                    resolved.git_guard.protect_default_branch_only.to_string()
+                }
+                _ => fallback(),
+            };
+            ((key.section, key.key), value)
+        })
+        .collect()
+}
+
+fn format_optional_path(path: Option<&PathBuf>) -> String {
+    path.map_or_else(String::new, |path| path.display().to_string())
+}
+
+fn format_paths(paths: &[PathBuf]) -> String {
+    format!(
+        "[{}]",
+        paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn format_strings(values: &[String]) -> String {
+    format!("[{}]", values.join(", "))
+}
+
+fn format_values<T: ToString>(values: &[T]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 fn repo_proposal_enabled(doc: &toml_edit::DocumentMut, key: &ConfigKeyInfo) -> bool {
     doc.get("propose")
         .and_then(toml_edit::Item::as_table)
         .and_then(|table| table.get(key.key))
         .and_then(toml_edit::Item::as_bool)
         == Some(true)
+}
+
+fn repo_value_is_unset(doc: &toml_edit::DocumentMut, key: &ConfigKeyInfo) -> bool {
+    match repo_key_target(key) {
+        Some(RepoKeyTarget::ProposeBool) => !repo_proposal_enabled(doc, key),
+        Some(RepoKeyTarget::ProposeAllow(name)) => nested_repo_value(doc, "propose", "allow", name),
+        Some(RepoKeyTarget::ProposeProxy(name)) => nested_repo_value(doc, "propose", "proxy", name),
+        Some(RepoKeyTarget::Deny(name)) => direct_repo_value(doc, "deny", name),
+        None => true,
+    }
+}
+
+fn nested_repo_value(
+    doc: &toml_edit::DocumentMut,
+    section: &str,
+    subsection: &str,
+    key: &str,
+) -> bool {
+    doc.get(section)
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|table| table.get(subsection))
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|table| table.get(key))
+        .is_none()
+}
+
+fn direct_repo_value(doc: &toml_edit::DocumentMut, section: &str, key: &str) -> bool {
+    doc.get(section)
+        .and_then(toml_edit::Item::as_table)
+        .and_then(|table| table.get(key))
+        .is_none()
+}
+
+fn is_sensitive(key: &ConfigKeyInfo) -> bool {
+    key.section == "proxy" && key.key == "upstream"
+}
+
+fn redact_value(key: &ConfigKeyInfo, value: String) -> String {
+    if is_sensitive(key) {
+        crate::proxy::redact_upstream_url(&value)
+    } else {
+        value
+    }
 }
 
 fn detect_project_root() -> Option<PathBuf> {
@@ -368,8 +663,23 @@ struct TerminalGuard;
 
 impl TerminalGuard {
     fn enter() -> io::Result<Self> {
-        enable_raw_mode()?;
-        execute!(io::stdout(), EnterAlternateScreen)?;
+        Self::enter_with(
+            enable_raw_mode,
+            || execute!(io::stdout(), EnterAlternateScreen),
+            disable_raw_mode,
+        )
+    }
+
+    fn enter_with(
+        enable: impl FnOnce() -> io::Result<()>,
+        enter_alternate_screen: impl FnOnce() -> io::Result<()>,
+        rollback_raw_mode: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<Self> {
+        enable()?;
+        if let Err(error) = enter_alternate_screen() {
+            let _ = rollback_raw_mode();
+            return Err(error);
+        }
         Ok(Self)
     }
 }
@@ -531,20 +841,28 @@ fn render(frame: &mut ratatui::Frame, app: &mut SettingsApp) {
         layout[0],
     );
     let keys = app.visible_keys();
+    let global_preview = app.preview_global_doc();
+    let repo_preview = app.preview_repo_doc();
     let rows = keys.iter().map(|key| {
+        let setting = app.effective.get(&(key.section, key.key));
         let value = match app.scope {
-            Scope::Global | Scope::Effective => get_value_from_doc(&app.global_doc, key)
+            Scope::Effective => setting.map_or_else(
+                || key.default_display.to_string(),
+                |setting| setting.value.clone(),
+            ),
+            Scope::Global => get_value_from_doc(&global_preview, key)
                 .unwrap_or_else(|| key.default_display.to_string()),
-            Scope::Repository => repo_value_label(&app.repo_doc, key),
+            Scope::Repository => repo_value_label(&repo_preview, key),
         };
+        let value = redact_value(key, value);
+        let staged = app.pending.iter().any(|change| {
+            change.scope == app.scope
+                && change.key.section == key.section
+                && change.key.key == key.key
+        });
         let source = match app.scope {
-            Scope::Effective => {
-                if get_value_from_doc(&app.global_doc, key).is_some() {
-                    "global"
-                } else {
-                    "default"
-                }
-            }
+            Scope::Effective => setting.map_or("default", |setting| setting.source),
+            Scope::Global if staged => "staged",
             Scope::Global => {
                 if get_value_from_doc(&app.global_doc, key).is_some() {
                     "set"
@@ -552,6 +870,7 @@ fn render(frame: &mut ratatui::Frame, app: &mut SettingsApp) {
                     "inherited"
                 }
             }
+            Scope::Repository if staged => "staged",
             Scope::Repository => repo_key_target(key).map_or("not supported", |_| "proposal/deny"),
         };
         Row::new(vec![
@@ -682,6 +1001,29 @@ fn centered_rect(
 mod tests {
     use super::*;
     use crate::config::lookup_key;
+    use ratatui::backend::TestBackend;
+    use std::cell::Cell;
+
+    fn test_app(global: &str) -> SettingsApp {
+        let global_doc = global.parse::<toml_edit::DocumentMut>().unwrap();
+        SettingsApp {
+            scope: Scope::Global,
+            selected: 0,
+            filter: String::new(),
+            editing_filter: false,
+            editing_value: false,
+            value_input: String::new(),
+            status: String::new(),
+            pending: Vec::new(),
+            global_doc,
+            global_path: PathBuf::from("config.toml"),
+            repo_doc: toml_edit::DocumentMut::new(),
+            repo_path: PathBuf::from(".cplt.toml"),
+            project_dir: PathBuf::from("."),
+            effective: HashMap::new(),
+            dangerous_confirmation: None,
+        }
+    }
 
     #[test]
     fn global_change_uses_config_editor_semantics() {
@@ -743,8 +1085,110 @@ mod tests {
             global_path: PathBuf::from("config.toml"),
             repo_doc: toml_edit::DocumentMut::new(),
             repo_path: PathBuf::from(".cplt.toml"),
+            project_dir: PathBuf::from("."),
+            effective: HashMap::new(),
             dangerous_confirmation: None,
         };
         assert_eq!(app.dangerous_changes().len(), 1);
+    }
+
+    #[test]
+    fn toggling_twice_reverts_the_staged_change() {
+        let mut app = test_app("");
+        app.selected = app
+            .visible_keys()
+            .iter()
+            .position(|key| key.section == "sandbox" && key.key == "quiet")
+            .unwrap();
+
+        app.toggle_selected();
+        assert_eq!(app.pending.len(), 1);
+        app.toggle_selected();
+
+        assert!(app.pending.is_empty());
+    }
+
+    #[test]
+    fn effective_snapshot_applies_strict_preset_baseline() {
+        let project = tempfile::tempdir().unwrap();
+        let doc = "[sandbox]\npreset = \"strict\"\n"
+            .parse::<toml_edit::DocumentMut>()
+            .unwrap();
+
+        let snapshot = effective_snapshot(&doc, project.path()).unwrap();
+
+        assert_eq!(snapshot.get(&("proxy", "forced")).unwrap().value, "true");
+        assert_eq!(
+            snapshot.get(&("gh_guard", "enabled")).unwrap().value,
+            "true"
+        );
+        assert_eq!(
+            snapshot.get(&("git_guard", "enabled")).unwrap().value,
+            "true"
+        );
+        assert_eq!(
+            snapshot.get(&("gh_guard", "enabled")).unwrap().source,
+            "preset"
+        );
+    }
+
+    #[test]
+    fn invalid_global_change_is_rejected_before_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = test_app("");
+        app.global_path = dir.path().join("config.toml");
+        app.project_dir = dir.path().to_path_buf();
+        app.pending.push(PendingChange {
+            key: lookup_key("sandbox.preset").unwrap(),
+            scope: Scope::Global,
+            value: Some("not-a-preset".to_string()),
+        });
+
+        let error = app.save(true).unwrap_err();
+
+        assert!(error.contains("invalid global config"));
+        assert!(!app.global_path.exists());
+    }
+
+    #[test]
+    fn rendered_settings_redact_upstream_credentials() {
+        let mut app =
+            test_app("[proxy]\nupstream = \"http://username:super-secret@proxy.example:8080\"\n");
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(!rendered.contains("super-secret"));
+        assert!(rendered.contains("username:***"));
+    }
+
+    #[test]
+    fn alternate_screen_failure_rolls_back_raw_mode() {
+        let raw_enabled = Cell::new(false);
+        let raw_disabled = Cell::new(false);
+
+        let result = TerminalGuard::enter_with(
+            || {
+                raw_enabled.set(true);
+                Ok(())
+            },
+            || Err(io::Error::other("alternate screen failed")),
+            || {
+                raw_disabled.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(raw_enabled.get());
+        assert!(raw_disabled.get());
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1910,6 +1910,25 @@ mod e2e_tests {
     }
 
     #[test]
+    fn e2e_settings_requires_interactive_terminal() {
+        let output = Command::new(binary_path())
+            .arg("settings")
+            .env_remove("__CPLT_TRUST_LOCKED")
+            .output()
+            .expect("should run");
+
+        assert!(
+            !output.status.success(),
+            "settings must not run without a controlling terminal"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("requires an interactive terminal"),
+            "should explain the scriptable alternative: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
     fn e2e_config_set_creates_file_and_sets_value() {
         let fake_home = make_config_home("set-create");
         let config_path = fake_home.join(".config/cplt/config.toml");


### PR DESCRIPTION
## Summary
- add `cplt settings`, a staged Ratatui/Crossterm editor for global and repository settings
- reuse config metadata, TOML mutations, security confirmations, and atomic persistence
- require confirmation for security-sensitive global changes and repository permission proposals
- document the interactive workflow and retain `cplt config` for scripts/CI

## Validation
- `mise run check`
- targeted settings/config E2E tests

## Note
The wider `mise run test:e2e` run has five existing `check net/exec` failures outside this change.