### PR TITLE
fix(opencode): redirect CLAUDE_CONFIG_DIR for oh-my-openagent transcripts

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -478,7 +478,7 @@ AI agents and their third-party packages often send usage analytics and crash re
 
 For the `oh-my-openagent` OpenCode plugin specifically, `OMO_DISABLE_POSTHOG=1` prevents PostHog from being initialised, so no network calls are made and no errors appear.
 
-> **oh-my-openagent transcripts:** the plugin's Claude Code hooks feature writes transcripts to `$CLAUDE_CONFIG_DIR/transcripts` (default `~/.claude`), which the sandbox denies for non-Claude agents — the write fails with `EACCES` and OpenCode aborts the prompt. cplt therefore injects `CLAUDE_CONFIG_DIR=<XDG_STATE_HOME>/opencode/claude-config` for OpenCode sessions (into the write-allowed OpenCode state dir). If you set `CLAUDE_CONFIG_DIR` yourself, cplt respects it — add that path to `allow.write` if it lives outside the OpenCode dirs.
+> **oh-my-openagent transcripts:** the plugin's Claude Code hooks feature writes transcripts to `$CLAUDE_CONFIG_DIR/transcripts` (default `~/.claude`), which the sandbox denies for non-Claude agents — the write fails with `EACCES` and OpenCode aborts the prompt. cplt therefore injects `CLAUDE_CONFIG_DIR=<XDG_STATE_HOME>/opencode/claude-config` (falling back to `~/.local/state/opencode/claude-config` when `XDG_STATE_HOME` is unset) for OpenCode sessions, into the write-allowed OpenCode state dir. If you set `CLAUDE_CONFIG_DIR` yourself, cplt respects it — add that path to `allow.write` if it lives outside the OpenCode dirs.
 
 **If you use `allowed_domains` (allowlist mode):** The proxy blocklist is not consulted in this mode — the env var injection still suppresses telemetry silently.
 

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -478,6 +478,8 @@ AI agents and their third-party packages often send usage analytics and crash re
 
 For the `oh-my-openagent` OpenCode plugin specifically, `OMO_DISABLE_POSTHOG=1` prevents PostHog from being initialised, so no network calls are made and no errors appear.
 
+> **oh-my-openagent transcripts:** the plugin's Claude Code hooks feature writes transcripts to `$CLAUDE_CONFIG_DIR/transcripts` (default `~/.claude`), which the sandbox denies for non-Claude agents — the write fails with `EACCES` and OpenCode aborts the prompt. cplt therefore injects `CLAUDE_CONFIG_DIR=<XDG_STATE_HOME>/opencode/claude-config` for OpenCode sessions (into the write-allowed OpenCode state dir). If you set `CLAUDE_CONFIG_DIR` yourself, cplt respects it — add that path to `allow.write` if it lives outside the OpenCode dirs.
+
 **If you use `allowed_domains` (allowlist mode):** The proxy blocklist is not consulted in this mode — the env var injection still suppresses telemetry silently.
 
 **Impact:** None — telemetry is non-essential and the agent functions normally without it.

--- a/src/sandbox_env.rs
+++ b/src/sandbox_env.rs
@@ -135,6 +135,30 @@ pub fn build_sandbox_env(
         }
     }
 
+    // The oh-my-openagent OpenCode plugin implements Claude Code hooks and writes
+    // transcripts to $CLAUDE_CONFIG_DIR/transcripts (default ~/.claude), which the
+    // sandbox denies for non-Claude agents — the append fails with EACCES and the
+    // OpenCode server aborts the prompt. Redirect the plugin's config dir into the
+    // OpenCode state dir (write-allowed, auto-created at startup) so the hooks
+    // feature works inside the sandbox. A user-set CLAUDE_CONFIG_DIR is respected;
+    // they are expected to --allow-write that path themselves.
+    if agent == Agent::OpenCode {
+        let user_set = extra_pass_env.iter().any(|v| v == "CLAUDE_CONFIG_DIR")
+            || parent_env.iter().any(|(k, _)| k == "CLAUDE_CONFIG_DIR");
+        if !user_set && let Some((_, home)) = parent_env.iter().find(|(k, _)| k == "HOME") {
+            let state_base = parent_env
+                .iter()
+                .find(|(k, _)| k == "XDG_STATE_HOME")
+                .map(|(_, v)| v.clone())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| format!("{home}/.local/state"));
+            env.vars.push((
+                "CLAUDE_CONFIG_DIR".to_string(),
+                format!("{state_base}/opencode/claude-config"),
+            ));
+        }
+    }
+
     // Redirect temp directories to scratch dir if provided.
     // --scratch-dir means "redirect TMPDIR to the scratch dir" — this overrides any
     // inherited or allowlisted TMPDIR value. The user can prevent this for a specific

--- a/src/sandbox_env.rs
+++ b/src/sandbox_env.rs
@@ -143,9 +143,15 @@ pub fn build_sandbox_env(
     // feature works inside the sandbox. A user-set CLAUDE_CONFIG_DIR is respected;
     // they are expected to --allow-write that path themselves.
     if agent == Agent::OpenCode {
+        // An empty CLAUDE_CONFIG_DIR is treated as unset: the plugin would resolve
+        // it to a relative "transcripts/" path inside the project and hit EACCES.
         let user_set = extra_pass_env.iter().any(|v| v == "CLAUDE_CONFIG_DIR")
-            || parent_env.iter().any(|(k, _)| k == "CLAUDE_CONFIG_DIR");
+            || parent_env
+                .iter()
+                .any(|(k, v)| k == "CLAUDE_CONFIG_DIR" && !v.is_empty());
         if !user_set && let Some((_, home)) = parent_env.iter().find(|(k, _)| k == "HOME") {
+            // Drop any empty entry the allowlist may have passed through.
+            env.vars.retain(|(k, _)| k != "CLAUDE_CONFIG_DIR");
             let state_base = parent_env
                 .iter()
                 .find(|(k, _)| k == "XDG_STATE_HOME")

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3345,6 +3345,25 @@ fn env_opencode_claude_config_dir_respects_user_override() {
 }
 
 #[test]
+fn env_opencode_claude_config_dir_empty_is_treated_as_unset() {
+    // An empty CLAUDE_CONFIG_DIR in parent env must not prevent injection —
+    // the plugin would resolve it to a relative "transcripts/" path and hit EACCES.
+    let parent = make_env(&[("HOME", "/home/test"), ("CLAUDE_CONFIG_DIR", "")]);
+    let env = build_sandbox_env(&parent, &[], false, &[], None, cplt::agent::Agent::OpenCode);
+
+    let matches: Vec<_> = env
+        .vars
+        .iter()
+        .filter(|(k, _)| k == "CLAUDE_CONFIG_DIR")
+        .collect();
+    assert_eq!(matches.len(), 1, "exactly one CLAUDE_CONFIG_DIR entry");
+    assert_eq!(
+        matches[0].1,
+        "/home/test/.local/state/opencode/claude-config"
+    );
+}
+
+#[test]
 fn env_claude_config_dir_not_injected_for_other_agents() {
     for agent in [cplt::agent::Agent::Copilot, cplt::agent::Agent::Claude] {
         let parent = make_env(&[("HOME", "/home/test"), ("PATH", "/usr/bin")]);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3298,6 +3298,65 @@ fn env_claude_injects_autoupdater_and_suppresses_copilot_vars() {
 }
 
 #[test]
+fn env_opencode_redirects_claude_config_dir() {
+    // oh-my-openagent writes transcripts to $CLAUDE_CONFIG_DIR/transcripts
+    // (default ~/.claude), which the sandbox denies for OpenCode — cplt must
+    // redirect it into the write-allowed OpenCode state dir.
+    let parent = make_env(&[("HOME", "/home/test"), ("PATH", "/usr/bin")]);
+    let env = build_sandbox_env(&parent, &[], false, &[], None, cplt::agent::Agent::OpenCode);
+
+    let found = env.vars.iter().find(|(k, _)| k == "CLAUDE_CONFIG_DIR");
+    assert!(
+        found.is_some(),
+        "should inject CLAUDE_CONFIG_DIR for OpenCode"
+    );
+    assert_eq!(
+        found.unwrap().1,
+        "/home/test/.local/state/opencode/claude-config"
+    );
+}
+
+#[test]
+fn env_opencode_claude_config_dir_respects_xdg_state_home() {
+    let parent = make_env(&[("HOME", "/home/test"), ("XDG_STATE_HOME", "/xdg/state")]);
+    let env = build_sandbox_env(&parent, &[], false, &[], None, cplt::agent::Agent::OpenCode);
+
+    let found = env.vars.iter().find(|(k, _)| k == "CLAUDE_CONFIG_DIR");
+    assert_eq!(found.unwrap().1, "/xdg/state/opencode/claude-config");
+}
+
+#[test]
+fn env_opencode_claude_config_dir_respects_user_override() {
+    // User-set CLAUDE_CONFIG_DIR passes through untouched (allowlisted) —
+    // cplt must not clobber it with the redirect.
+    let parent = make_env(&[
+        ("HOME", "/home/test"),
+        ("CLAUDE_CONFIG_DIR", "/custom/claude"),
+    ]);
+    let env = build_sandbox_env(&parent, &[], false, &[], None, cplt::agent::Agent::OpenCode);
+
+    let matches: Vec<_> = env
+        .vars
+        .iter()
+        .filter(|(k, _)| k == "CLAUDE_CONFIG_DIR")
+        .collect();
+    assert_eq!(matches.len(), 1, "exactly one CLAUDE_CONFIG_DIR entry");
+    assert_eq!(matches[0].1, "/custom/claude");
+}
+
+#[test]
+fn env_claude_config_dir_not_injected_for_other_agents() {
+    for agent in [cplt::agent::Agent::Copilot, cplt::agent::Agent::Claude] {
+        let parent = make_env(&[("HOME", "/home/test"), ("PATH", "/usr/bin")]);
+        let env = build_sandbox_env(&parent, &[], false, &[], None, agent);
+        assert!(
+            !env.vars.iter().any(|(k, _)| k == "CLAUDE_CONFIG_DIR"),
+            "CLAUDE_CONFIG_DIR redirect must not be injected for {agent:?}"
+        );
+    }
+}
+
+#[test]
 fn env_sanitized_injects_telemetry_opt_out_vars() {
     let parent = make_env(&[("HOME", "/Users/test"), ("PATH", "/usr/bin")]);
     let env = build_sandbox_env(&parent, &[], false, &[], None, cplt::agent::Agent::Copilot);


### PR DESCRIPTION
Closes #167

## Problem

OpenCode + oh-my-openagent plugin crashes under cplt: every prompt aborts with `EACCES` in `appendTranscriptEntry`. Verified against plugin source (4.19.4): the Claude Code hooks feature appends transcripts to `$CLAUDE_CONFIG_DIR/transcripts` (default `~/.claude`), which is deny-by-default for the OpenCode agent. Affects both macOS (Seatbelt) and Linux (Landlock).

## Root cause

The plugin writes transcripts to `getClaudeConfigDir()/transcripts` where `getClaudeConfigDir()` returns `$CLAUDE_CONFIG_DIR ?? ~/.claude`. cplt's OpenCode policy only write-allows the XDG opencode dirs; `~/.claude` is deny-by-default.

## Fix

Inject `CLAUDE_CONFIG_DIR=<XDG_STATE_HOME>/opencode/claude-config` for OpenCode sessions when unset (`src/sandbox_env.rs`). The OpenCode state dir is already write-allowed and auto-created at sandbox startup. Follows the existing `OMO_DISABLE_POSTHOG=1` injection precedent for this plugin. User-set values are respected unchanged.

## Tests

4 new unit tests (default path, XDG_STATE_HOME, user override, non-OpenCode agents unaffected). `mise run check` green: fmt, clippy, 259 unit + 695 lib tests.