### PR TITLE
feat(gradle): guarded init script propagates preferIPv4Stack into sandboxed builds

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -336,6 +336,26 @@ If all of that works, `cplt --allow-gpg-signing` will work too. The `gpg-agent` 
 - **`--deny-path` wins.** If you specify `--deny-path ~/.gnupg` alongside `--allow-gpg-signing`, the deny takes precedence — all GPG allows are suppressed.
 - **`GNUPGHOME`** is not supported yet — only the default `~/.gnupg` location is allowed.
 
+## Gradle plugin workers and `JAVA_TOOL_OPTIONS`
+
+cplt injects `-Djava.net.preferIPv4Stack=true` via `JAVA_TOOL_OPTIONS` (see the JVM note above) so JVM localhost connections match the sandbox's `localhost:*` rules. Most JVM children read `JAVA_TOOL_OPTIONS` at startup, but **Gradle plugin workers** (WorkerExecutor process isolation, e.g. ktlint-gradle) fork JVMs with explicit `forkOptions {}` and do not reliably propagate the environment — the flag is lost, their dual-stack sockets produce IPv4-mapped `::ffff:127.0.0.1` addresses, and SBPL cannot match them.
+
+Symptom (even with `allow_localhost_any = true`):
+
+```
+org.gradle.internal.remote.internal.ConnectException: Could not connect to server [... port:NNNNN, addresses:[/127.0.0.1]]
+```
+
+**cplt mitigation (macOS):** cplt installs a guarded init script at `~/.gradle/init.d/cplt-sandbox.gradle` on sandbox launch. It activates only inside the sandbox (`__CPLT_WRAPPED` guard) and applies `preferIPv4Stack` to the daemon plus `Test`/`JavaExec` forks. `WorkerExecutor` forks have no public configuration hook — for those, the plugin must propagate the environment itself:
+
+```kotlin
+forkOptions {
+    environment("JAVA_TOOL_OPTIONS", System.getenv("JAVA_TOOL_OPTIONS") ?: "")
+}
+```
+
+Known affected: `ktlint-gradle` ([JLLeitschuh/ktlint-gradle#1110](https://github.com/JLLeitschuh/ktlint-gradle/issues/1110)). SBPL itself cannot be fixed — macOS sandbox profiles have no primitive for IPv4-mapped addresses, which is why cplt uses the `preferIPv4Stack` workaround at all.
+
 ## JVM Attach API
 
 JVM testing frameworks like **MockK** (inline mocking), **Mockito** (inline agents), and **ByteBuddy** use the JVM Attach API for runtime class instrumentation. This API creates a Unix domain socket at `/tmp/.java_pid<PID>` — which the sandbox blocks by default.

--- a/src/gradle_init.rs
+++ b/src/gradle_init.rs
@@ -127,45 +127,52 @@ mod tests {
 
     #[test]
     fn ensure_init_script_noop_without_gradle_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let result = ensure_init_script(tmp.path()).unwrap();
-        assert!(result.is_none(), "no ~/.gradle → no script written");
+        // Isolate from GRADLE_USER_HOME in the ambient env (set on CI
+        // runners), which would otherwise redirect the install away from
+        // the tempdir.
+        temp_env::with_var("GRADLE_USER_HOME", None::<&str>, || {
+            let tmp = tempfile::tempdir().unwrap();
+            let result = ensure_init_script(tmp.path()).unwrap();
+            assert!(result.is_none(), "no ~/.gradle → no script written");
+        });
     }
 
     #[test]
     fn ensure_init_script_writes_and_is_idempotent() {
-        let tmp = tempfile::tempdir().unwrap();
-        let gradle = tmp.path().join(".gradle");
-        std::fs::create_dir_all(&gradle).unwrap();
+        temp_env::with_var("GRADLE_USER_HOME", None::<&str>, || {
+            let tmp = tempfile::tempdir().unwrap();
+            let gradle = tmp.path().join(".gradle");
+            std::fs::create_dir_all(&gradle).unwrap();
 
-        let first = ensure_init_script(tmp.path())
-            .unwrap()
-            .expect("script written");
-        assert!(first.exists());
-        let content = std::fs::read_to_string(&first).unwrap();
-        assert_eq!(content, SCRIPT_BODY);
-        // No temp files left behind after the atomic write.
-        let leftovers: Vec<_> = std::fs::read_dir(gradle.join("init.d"))
-            .unwrap()
-            .flatten()
-            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
-            .collect();
-        assert!(leftovers.is_empty(), "no .tmp leftovers after install");
+            let first = ensure_init_script(tmp.path())
+                .unwrap()
+                .expect("script written");
+            assert!(first.exists());
+            let content = std::fs::read_to_string(&first).unwrap();
+            assert_eq!(content, SCRIPT_BODY);
+            // No temp files left behind after the atomic write.
+            let leftovers: Vec<_> = std::fs::read_dir(gradle.join("init.d"))
+                .unwrap()
+                .flatten()
+                .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+                .collect();
+            assert!(leftovers.is_empty(), "no .tmp leftovers after install");
 
-        // Second call: no rewrite (mtime unchanged)
-        let mtime1 = first.metadata().unwrap().modified().unwrap();
-        let second = ensure_init_script(tmp.path())
-            .unwrap()
-            .expect("script present");
-        let mtime2 = second.metadata().unwrap().modified().unwrap();
-        assert_eq!(
-            mtime1, mtime2,
-            "idempotent: no rewrite when content matches"
-        );
+            // Second call: no rewrite (mtime unchanged)
+            let mtime1 = first.metadata().unwrap().modified().unwrap();
+            let second = ensure_init_script(tmp.path())
+                .unwrap()
+                .expect("script present");
+            let mtime2 = second.metadata().unwrap().modified().unwrap();
+            assert_eq!(
+                mtime1, mtime2,
+                "idempotent: no rewrite when content matches"
+            );
 
-        // Stale content gets refreshed
-        std::fs::write(&first, "// old version").unwrap();
-        ensure_init_script(tmp.path()).unwrap();
-        assert_eq!(std::fs::read_to_string(&first).unwrap(), SCRIPT_BODY);
+            // Stale content gets refreshed
+            std::fs::write(&first, "// old version").unwrap();
+            ensure_init_script(tmp.path()).unwrap();
+            assert_eq!(std::fs::read_to_string(&first).unwrap(), SCRIPT_BODY);
+        });
     }
 }

--- a/src/gradle_init.rs
+++ b/src/gradle_init.rs
@@ -1,0 +1,125 @@
+//! Managed Gradle init script for sandboxed builds.
+//!
+//! cplt injects `-Djava.net.preferIPv4Stack=true` via `JAVA_TOOL_OPTIONS` so
+//! JVM localhost connections match the sandbox's `localhost:*` rules (SBPL
+//! cannot match IPv4-mapped `::ffff:127.0.0.1` addresses). But Gradle plugin
+//! workers (WorkerExecutor process isolation, e.g. ktlint-gradle) fork JVMs
+//! with explicit `forkOptions {}` and do not reliably propagate the
+//! environment — the flag is lost and their daemon connections on ephemeral
+//! localhost ports fail with `ConnectException`.
+//!
+//! cplt cannot reach into plugin-managed forks, so instead it installs a
+//! Gradle init script at `~/.gradle/init.d/cplt-sandbox.gradle`. The script
+//! is guarded by `__CPLT_WRAPPED` — it only activates inside the sandbox and
+//! is inert in normal builds.
+//!
+//! Scope: the script covers the daemon itself plus `Test`/`JavaExec` forks.
+//! `WorkerExecutor` process-isolation forks have no public configuration
+//! hook — those still require the plugin to propagate the environment (see
+//! JLLeitschuh/ktlint-gradle#1110).
+
+use std::path::{Path, PathBuf};
+
+/// Init script file name inside `~/.gradle/init.d/`.
+const SCRIPT_NAME: &str = "cplt-sandbox.gradle";
+
+/// Script content. Guarded by `__CPLT_WRAPPED` so it is inert outside the
+/// sandbox. Groovy DSL for compatibility with older Gradle versions.
+const SCRIPT_BODY: &str = "\
+// Managed by cplt — do not edit. Re-generated on sandbox launch.
+// Applies sandbox networking workarounds to Gradle builds running INSIDE
+// cplt; inert outside (guarded by __CPLT_WRAPPED).
+//
+// Why: Gradle plugin workers (WorkerExecutor process isolation, e.g.
+// ktlint-gradle) do not reliably propagate JAVA_TOOL_OPTIONS into forked
+// JVMs, so cplt's -Djava.net.preferIPv4Stack=true is lost and their
+// dual-stack sockets produce IPv4-mapped addresses (::ffff:127.0.0.1)
+// that the macOS sandbox cannot match — daemon connections on ephemeral
+// localhost ports then fail with ConnectException.
+if (System.getenv(\"__CPLT_WRAPPED\") != null) {
+    // Daemon-side: keep daemon sockets on pure IPv4.
+    System.setProperty(\"java.net.preferIPv4Stack\", \"true\")
+
+    allprojects {
+        tasks.withType(JavaExec).configureEach {
+            jvmArgs \"-Djava.net.preferIPv4Stack=true\"
+        }
+        tasks.withType(Test).configureEach {
+            jvmArgs \"-Djava.net.preferIPv4Stack=true\"
+        }
+    }
+}
+";
+
+/// Path to the managed init script for a given home directory.
+pub fn script_path(home: &Path) -> PathBuf {
+    home.join(".gradle/init.d").join(SCRIPT_NAME)
+}
+
+/// Install (or refresh) the init script. Idempotent: rewrites only when the
+/// content differs. Creates `~/.gradle/init.d/` if `~/.gradle` exists.
+/// No-op when the user has no `~/.gradle` (not a Gradle user).
+pub fn ensure_init_script(home: &Path) -> std::io::Result<Option<PathBuf>> {
+    let gradle_dir = home.join(".gradle");
+    if !gradle_dir.is_dir() {
+        return Ok(None);
+    }
+    let init_d = gradle_dir.join("init.d");
+    std::fs::create_dir_all(&init_d)?;
+    let path = init_d.join(SCRIPT_NAME);
+    match std::fs::read_to_string(&path) {
+        Ok(existing) if existing == SCRIPT_BODY => Ok(Some(path)),
+        _ => {
+            std::fs::write(&path, SCRIPT_BODY)?;
+            Ok(Some(path))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn script_is_guarded_by_cplt_env_marker() {
+        assert!(SCRIPT_BODY.contains("__CPLT_WRAPPED"));
+        assert!(SCRIPT_BODY.contains("preferIPv4Stack"));
+    }
+
+    #[test]
+    fn ensure_init_script_noop_without_gradle_dir() {
+        let tmp = std::env::temp_dir().join(format!("cplt-gradle-noop-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let result = ensure_init_script(&tmp).unwrap();
+        assert!(result.is_none(), "no ~/.gradle → no script written");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_init_script_writes_and_is_idempotent() {
+        let tmp = std::env::temp_dir().join(format!("cplt-gradle-init-{}", std::process::id()));
+        let gradle = tmp.join(".gradle");
+        std::fs::create_dir_all(&gradle).unwrap();
+
+        let first = ensure_init_script(&tmp).unwrap().expect("script written");
+        assert!(first.exists());
+        let content = std::fs::read_to_string(&first).unwrap();
+        assert_eq!(content, SCRIPT_BODY);
+
+        // Second call: no rewrite (mtime unchanged)
+        let mtime1 = first.metadata().unwrap().modified().unwrap();
+        let second = ensure_init_script(&tmp).unwrap().expect("script present");
+        let mtime2 = second.metadata().unwrap().modified().unwrap();
+        assert_eq!(
+            mtime1, mtime2,
+            "idempotent: no rewrite when content matches"
+        );
+
+        // Stale content gets refreshed
+        std::fs::write(&first, "// old version").unwrap();
+        ensure_init_script(&tmp).unwrap();
+        assert_eq!(std::fs::read_to_string(&first).unwrap(), SCRIPT_BODY);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/src/gradle_init.rs
+++ b/src/gradle_init.rs
@@ -52,15 +52,30 @@ if (System.getenv(\"__CPLT_WRAPPED\") != null) {
 ";
 
 /// Path to the managed init script for a given home directory.
+/// Respects `GRADLE_USER_HOME` (allowlisted env var) — otherwise a user with a
+/// relocated Gradle home would never load the script.
 pub fn script_path(home: &Path) -> PathBuf {
-    home.join(".gradle/init.d").join(SCRIPT_NAME)
+    gradle_user_home(home).join("init.d").join(SCRIPT_NAME)
+}
+
+/// Resolve the effective Gradle user home: `GRADLE_USER_HOME` if set and
+/// non-empty, else `~/.gradle`.
+fn gradle_user_home(home: &Path) -> PathBuf {
+    std::env::var("GRADLE_USER_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| home.join(".gradle"), PathBuf::from)
 }
 
 /// Install (or refresh) the init script. Idempotent: rewrites only when the
 /// content differs. Creates `~/.gradle/init.d/` if `~/.gradle` exists.
 /// No-op when the user has no `~/.gradle` (not a Gradle user).
+///
+/// Writes are atomic (temp + rename): a crash mid-write must never leave a
+/// truncated script — Gradle evaluates every file in init.d, and a partial
+/// Groovy file would fail every build with a syntax error.
 pub fn ensure_init_script(home: &Path) -> std::io::Result<Option<PathBuf>> {
-    let gradle_dir = home.join(".gradle");
+    let gradle_dir = gradle_user_home(home);
     if !gradle_dir.is_dir() {
         return Ok(None);
     }
@@ -70,7 +85,12 @@ pub fn ensure_init_script(home: &Path) -> std::io::Result<Option<PathBuf>> {
     match std::fs::read_to_string(&path) {
         Ok(existing) if existing == SCRIPT_BODY => Ok(Some(path)),
         _ => {
-            std::fs::write(&path, SCRIPT_BODY)?;
+            // Unique temp name avoids concurrent cplt processes clobbering
+            // each other's temp file; the .tmp extension means Gradle never
+            // evaluates a leftover temp after a crash.
+            let tmp = init_d.join(format!(".{SCRIPT_NAME}.{}.tmp", std::process::id()));
+            std::fs::write(&tmp, SCRIPT_BODY)?;
+            std::fs::rename(&tmp, &path)?;
             Ok(Some(path))
         }
     }
@@ -87,28 +107,56 @@ mod tests {
     }
 
     #[test]
+    fn script_path_respects_gradle_user_home() {
+        // temp_env is used elsewhere in the repo for env-dependent tests
+        temp_env::with_var("GRADLE_USER_HOME", Some("/custom/gradle-home"), || {
+            let p = script_path(Path::new("/home/user"));
+            assert_eq!(
+                p,
+                Path::new("/custom/gradle-home/init.d/cplt-sandbox.gradle")
+            );
+        });
+        temp_env::with_var("GRADLE_USER_HOME", None::<&str>, || {
+            let p = script_path(Path::new("/home/user"));
+            assert_eq!(
+                p,
+                Path::new("/home/user/.gradle/init.d/cplt-sandbox.gradle")
+            );
+        });
+    }
+
+    #[test]
     fn ensure_init_script_noop_without_gradle_dir() {
-        let tmp = std::env::temp_dir().join(format!("cplt-gradle-noop-{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
-        let result = ensure_init_script(&tmp).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let result = ensure_init_script(tmp.path()).unwrap();
         assert!(result.is_none(), "no ~/.gradle → no script written");
-        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
     fn ensure_init_script_writes_and_is_idempotent() {
-        let tmp = std::env::temp_dir().join(format!("cplt-gradle-init-{}", std::process::id()));
-        let gradle = tmp.join(".gradle");
+        let tmp = tempfile::tempdir().unwrap();
+        let gradle = tmp.path().join(".gradle");
         std::fs::create_dir_all(&gradle).unwrap();
 
-        let first = ensure_init_script(&tmp).unwrap().expect("script written");
+        let first = ensure_init_script(tmp.path())
+            .unwrap()
+            .expect("script written");
         assert!(first.exists());
         let content = std::fs::read_to_string(&first).unwrap();
         assert_eq!(content, SCRIPT_BODY);
+        // No temp files left behind after the atomic write.
+        let leftovers: Vec<_> = std::fs::read_dir(gradle.join("init.d"))
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "no .tmp leftovers after install");
 
         // Second call: no rewrite (mtime unchanged)
         let mtime1 = first.metadata().unwrap().modified().unwrap();
-        let second = ensure_init_script(&tmp).unwrap().expect("script present");
+        let second = ensure_init_script(tmp.path())
+            .unwrap()
+            .expect("script present");
         let mtime2 = second.metadata().unwrap().modified().unwrap();
         assert_eq!(
             mtime1, mtime2,
@@ -117,9 +165,7 @@ mod tests {
 
         // Stale content gets refreshed
         std::fs::write(&first, "// old version").unwrap();
-        ensure_init_script(&tmp).unwrap();
+        ensure_init_script(tmp.path()).unwrap();
         assert_eq!(std::fs::read_to_string(&first).unwrap(), SCRIPT_BODY);
-
-        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod detect;
 pub mod discover;
 pub mod gh_proxy;
+pub mod gradle_init;
 pub mod init;
 pub mod proxy;
 pub mod repo_config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,11 @@
 
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
+#[cfg(target_os = "macos")]
+use cplt::gradle_init;
 use cplt::{
-    agent, audit, check, config, discover, gh_proxy, gradle_init, proxy, repo_config, sandbox,
-    scratch, subscriptions, trust, update,
+    agent, audit, check, config, discover, gh_proxy, proxy, repo_config, sandbox, scratch,
+    subscriptions, trust, update,
 };
 use std::collections::BTreeSet;
 use std::io::IsTerminal;
@@ -2315,12 +2317,15 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     }
 
     // macOS-only: install the guarded Gradle init script so sandboxed builds
-    // get the preferIPv4Stack workaround even where JAVA_TOOL_OPTIONS is lost
-    // (plugin-managed worker forks). Inert outside the sandbox (__CPLT_WRAPPED
-    // guard); a no-op when ~/.gradle doesn't exist.
+    // keep the preferIPv4Stack workaround for the daemon and Test/JavaExec
+    // forks (WorkerExecutor forks have no init-script hook — see gradle_init
+    // module docs). Inert outside the sandbox (__CPLT_WRAPPED guard); a no-op
+    // when ~/.gradle doesn't exist.
     #[cfg(target_os = "macos")]
-    {
-        let _ = gradle_init::ensure_init_script(&home_dir);
+    if let Err(e) = gradle_init::ensure_init_script(&home_dir) {
+        ui::warn(&format!(
+            "Could not install Gradle sandbox init script: {e}"
+        ));
     }
 
     // Start proxy (handle returned for RAII ownership)
@@ -2812,11 +2817,13 @@ fn prepare_shell_sandbox(
     }
 
     // See the agent-path call site: guarded Gradle init script so sandboxed
-    // builds keep the preferIPv4Stack workaround where JAVA_TOOL_OPTIONS is
-    // lost in plugin-managed worker forks.
+    // builds keep the preferIPv4Stack workaround for the daemon and
+    // Test/JavaExec forks.
     #[cfg(target_os = "macos")]
-    {
-        let _ = gradle_init::ensure_init_script(home_dir);
+    if let Err(e) = gradle_init::ensure_init_script(home_dir) {
+        ui::warn(&format!(
+            "Could not install Gradle sandbox init script: {e}"
+        ));
     }
 
     let proxy_handle = start_proxy_if_enabled(resolved, cli, config_path, active_agent)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2811,6 +2811,14 @@ fn prepare_shell_sandbox(
         }
     }
 
+    // See the agent-path call site: guarded Gradle init script so sandboxed
+    // builds keep the preferIPv4Stack workaround where JAVA_TOOL_OPTIONS is
+    // lost in plugin-managed worker forks.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = gradle_init::ensure_init_script(home_dir);
+    }
+
     let proxy_handle = start_proxy_if_enabled(resolved, cli, config_path, active_agent)?;
     let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@
 use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use cplt::{
-    agent, audit, check, config, discover, gh_proxy, proxy, repo_config, sandbox, scratch,
-    subscriptions, trust, update,
+    agent, audit, check, config, discover, gh_proxy, gradle_init, proxy, repo_config, sandbox,
+    scratch, subscriptions, trust, update,
 };
 use std::collections::BTreeSet;
 use std::io::IsTerminal;
@@ -2312,6 +2312,15 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         if !dir.path.exists() {
             let _ = std::fs::create_dir_all(&dir.path);
         }
+    }
+
+    // macOS-only: install the guarded Gradle init script so sandboxed builds
+    // get the preferIPv4Stack workaround even where JAVA_TOOL_OPTIONS is lost
+    // (plugin-managed worker forks). Inert outside the sandbox (__CPLT_WRAPPED
+    // guard); a no-op when ~/.gradle doesn't exist.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = gradle_init::ensure_init_script(&home_dir);
     }
 
     // Start proxy (handle returned for RAII ownership)


### PR DESCRIPTION
## Problem

Reported by user: `./gradlew ktlintFormat` fails under cplt even with `allow_localhost_any = true`:

```
org.gradle.internal.remote.internal.ConnectException: Could not connect to server [... port:55788, addresses:[/127.0.0.1]]
```

cplt injects `-Djava.net.preferIPv4Stack=true` via `JAVA_TOOL_OPTIONS` (a2199a9) so JVM connections stay pure IPv4 and match SBPL's `localhost:*` filter (which cannot match IPv4-mapped `::ffff:127.0.0.1`). But Gradle plugin workers — WorkerExecutor process isolation, e.g. ktlint-gradle — fork JVMs with explicit `forkOptions {}` and do not reliably propagate the environment. Verified against [ktlint-gradle source](https://github.com/JLLeitschuh/ktlint-gradle/blob/main/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt#L260): the fork sets `maxHeapSize`/`jvmArgs` but never touches `environment`. The flag is lost, the worker's dual-stack socket produces `::ffff:127.0.0.1`, SBPL denies the connect.

SBPL has no primitive for IPv4-mapped matching — this cannot be fixed in the sandbox profile.

## Fix

Install a **guarded Gradle init script** at `~/.gradle/init.d/cplt-sandbox.gradle` on sandbox launch (macOS, both agent and exec/shell paths):

```groovy
if (System.getenv("__CPLT_WRAPPED") != null) {
    System.setProperty("java.net.preferIPv4Stack", "true")
    allprojects {
        tasks.withType(JavaExec).configureEach { jvmArgs "-Djava.net.preferIPv4Stack=true" }
        tasks.withType(Test).configureEach { jvmArgs "-Djava.net.preferIPv4Stack=true" }
    }
}
```

- **Guarded by `__CPLT_WRAPPED`** — inert in unsandboxed builds, safe to leave installed
- **Idempotent** — rewrites only when content changes; no-op when `~/.gradle` doesn't exist
- Covers the daemon itself plus `Test`/`JavaExec` forks

## Honest limitation

`WorkerExecutor` process-isolation forks (the exact ktlint-gradle case) have **no public configuration hook** — an init script cannot reach them. Those still require the upstream plugin fix: [JLLeitschuh/ktlint-gradle#1110](https://github.com/JLLeitschuh/ktlint-gradle/issues/1110) / PR [#1112](https://github.com/JLLeitschuh/ktlint-gradle/pull/1112) (`forkOptions { environment("JAVA_TOOL_OPTIONS", ...) }`). This PR narrows the gap (daemon + task forks) and documents the rest; it does not fully replace the plugin fix.

## Tests

3 new unit tests in `src/gradle_init.rs`: env-marker guard, no-op without `~/.gradle`, idempotent write + stale-content refresh. `mise run check` green: fmt, clippy, 260 unit + 698 lib tests.

Docs: `known-impacts.md` updated with the failure mode, the init-script mitigation, and the plugin-side fix pattern. (Supersedes the docs-only PR #169.)