### PR TITLE
feat(gradle): make init script opt-in via sandbox.gradle_init

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -346,7 +346,7 @@ Symptom (even with `allow_localhost_any = true`):
 org.gradle.internal.remote.internal.ConnectException: Could not connect to server [... port:NNNNN, addresses:[/127.0.0.1]]
 ```
 
-**cplt mitigation (macOS, opt-in):** set `sandbox.gradle_init = true` and cplt installs a guarded init script at `~/.gradle/init.d/cplt-sandbox.gradle` on sandbox launch. It activates only inside the sandbox (`__CPLT_WRAPPED` guard) and applies `preferIPv4Stack` to the daemon plus `Test`/`JavaExec` forks. Opt-in because cplt does not write to tool config dirs by default. `WorkerExecutor` forks have no public configuration hook — for those, the plugin must propagate the environment itself:
+**cplt mitigation (macOS, opt-in):** set `sandbox.gradle_init = true` and cplt installs a guarded init script at `$GRADLE_USER_HOME/init.d/cplt-sandbox.gradle` (or `~/.gradle/init.d/` when unset) on sandbox launch. It activates only inside the sandbox (`__CPLT_WRAPPED` guard) and applies `preferIPv4Stack` to the daemon plus `Test`/`JavaExec` forks. Opt-in because cplt does not write to tool config dirs by default. `WorkerExecutor` forks have no public configuration hook — for those, the plugin must propagate the environment itself:
 
 ```kotlin
 forkOptions {

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -346,7 +346,7 @@ Symptom (even with `allow_localhost_any = true`):
 org.gradle.internal.remote.internal.ConnectException: Could not connect to server [... port:NNNNN, addresses:[/127.0.0.1]]
 ```
 
-**cplt mitigation (macOS):** cplt installs a guarded init script at `~/.gradle/init.d/cplt-sandbox.gradle` on sandbox launch. It activates only inside the sandbox (`__CPLT_WRAPPED` guard) and applies `preferIPv4Stack` to the daemon plus `Test`/`JavaExec` forks. `WorkerExecutor` forks have no public configuration hook — for those, the plugin must propagate the environment itself:
+**cplt mitigation (macOS, opt-in):** set `sandbox.gradle_init = true` and cplt installs a guarded init script at `~/.gradle/init.d/cplt-sandbox.gradle` on sandbox launch. It activates only inside the sandbox (`__CPLT_WRAPPED` guard) and applies `preferIPv4Stack` to the daemon plus `Test`/`JavaExec` forks. Opt-in because cplt does not write to tool config dirs by default. `WorkerExecutor` forks have no public configuration hook — for those, the plugin must propagate the environment itself:
 
 ```kotlin
 forkOptions {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1025,6 +1025,9 @@ impl Resolved {
         if repo_config.propose.allow_jvm_attach == Some(true) && is_approved("allow_jvm_attach") {
             self.allow_jvm_attach = true;
         }
+        if repo_config.propose.gradle_init == Some(true) && is_approved("gradle_init") {
+            self.gradle_init = true;
+        }
         if repo_config.propose.allow_docker == Some(true) && is_approved("allow_docker") {
             self.allow_docker = true;
         }
@@ -1737,6 +1740,35 @@ validate = false
         assert!(resolved.allow_localhost_any);
         assert!(!resolved.allow_docker); // not approved
         assert_eq!(unapproved, vec!["allow_docker"]);
+    }
+
+    #[test]
+    fn apply_repo_config_gradle_init_proposal_needs_approval() {
+        let repo_config = crate::repo_config::RepoConfig {
+            propose: crate::repo_config::ProposeSection {
+                gradle_init: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Proposed key surfaces in the trust review list
+        assert_eq!(
+            crate::repo_config::proposed_keys(&repo_config.propose),
+            vec!["gradle_init"]
+        );
+
+        // Without approval: stays off
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        let unapproved = resolved.apply_repo_config(&repo_config, &[]);
+        assert!(!resolved.gradle_init);
+        assert_eq!(unapproved, vec!["gradle_init"]);
+
+        // With approval: takes effect
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        let unapproved = resolved.apply_repo_config(&repo_config, &["gradle_init"]);
+        assert!(resolved.gradle_init);
+        assert!(unapproved.is_empty());
     }
 
     #[test]

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -397,6 +397,11 @@ impl Config {
             self.sandbox.allow_jvm_attach.unwrap_or(false)
         };
 
+        // Gradle init script: config-only opt-in (default false). Writes a
+        // cplt-managed file into the Gradle user home — behavior change the
+        // user must explicitly ask for.
+        let gradle_init = self.sandbox.gradle_init.unwrap_or(false);
+
         // Allow-docker: explicit CLI flag wins, then explicit config value,
         // then the preset baseline (false when no preset — blocked).
         let allow_docker = cli
@@ -575,6 +580,7 @@ impl Config {
             allow_gpg_signing,
             deny_clipboard,
             allow_jvm_attach,
+            gradle_init,
             allow_docker,
             allow_tmp_exec,
             allow_cache_exec,
@@ -1167,6 +1173,18 @@ validate = false
         assert_eq!(config.proxy.enabled, Some(true));
         assert!(config.proxy.port.is_none());
         assert!(config.allow.read.is_empty());
+    }
+
+    #[test]
+    fn gradle_init_defaults_false_and_config_enables() {
+        // Default: off (opt-in — cplt does not write tool config dirs unprompted)
+        let resolved = Config::default().merge(CliFlags::default()).unwrap();
+        assert!(!resolved.gradle_init);
+
+        // Config opt-in
+        let config: Config = toml::from_str("[sandbox]\ngradle_init = true\n").unwrap();
+        let resolved = config.merge(CliFlags::default()).unwrap();
+        assert!(resolved.gradle_init);
     }
 
     #[test]

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -330,7 +330,7 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         value_type: ConfigValueType::Bool,
         dangerous: false,
         default_display: "false",
-        description: "Install a cplt-managed Gradle init script (~/.gradle/init.d/cplt-sandbox.gradle) that applies the preferIPv4Stack workaround inside the sandbox. Inert outside sandbox builds.",
+        description: "Install a cplt-managed Gradle init script in the Gradle user home ($GRADLE_USER_HOME/init.d/ or ~/.gradle/init.d/cplt-sandbox.gradle) that applies the preferIPv4Stack workaround inside the sandbox. Inert outside sandbox builds.",
     },
     ConfigKeyInfo {
         section: "sandbox",

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -326,6 +326,14 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
     },
     ConfigKeyInfo {
         section: "sandbox",
+        key: "gradle_init",
+        value_type: ConfigValueType::Bool,
+        dangerous: false,
+        default_display: "false",
+        description: "Install a cplt-managed Gradle init script (~/.gradle/init.d/cplt-sandbox.gradle) that applies the preferIPv4Stack workaround inside the sandbox. Inert outside sandbox builds.",
+    },
+    ConfigKeyInfo {
+        section: "sandbox",
         key: "allow_docker",
         value_type: ConfigValueType::Bool,
         dangerous: true,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -592,9 +592,10 @@ pub struct SandboxConfig {
     /// Only allows sockets matching /tmp/.java_pid<PID> — SSH agent and
     /// all other unix sockets remain blocked.
     pub allow_jvm_attach: Option<bool>,
-    /// Install a cplt-managed Gradle init script at ~/.gradle/init.d/ that
-    /// applies the preferIPv4Stack workaround inside the sandbox (default:
-    /// false). Opt-in: writes to a tool config dir, so it is off unless the
+    /// Install a cplt-managed Gradle init script in the Gradle user home
+    /// (`$GRADLE_USER_HOME/init.d/` or `~/.gradle/init.d/`) that applies the
+    /// preferIPv4Stack workaround inside the sandbox (default: false).
+    /// Opt-in: writes to a tool config dir, so it is off unless the
     /// user asks for it.
     pub gradle_init: Option<bool>,
     /// DANGEROUS: Docker can mount any host path via container volumes, completely

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -592,7 +592,11 @@ pub struct SandboxConfig {
     /// Only allows sockets matching /tmp/.java_pid<PID> — SSH agent and
     /// all other unix sockets remain blocked.
     pub allow_jvm_attach: Option<bool>,
-    /// Allow Docker/Colima/OrbStack access inside the sandbox (default: false).
+    /// Install a cplt-managed Gradle init script at ~/.gradle/init.d/ that
+    /// applies the preferIPv4Stack workaround inside the sandbox (default:
+    /// false). Opt-in: writes to a tool config dir, so it is off unless the
+    /// user asks for it.
+    pub gradle_init: Option<bool>,
     /// DANGEROUS: Docker can mount any host path via container volumes, completely
     /// bypassing sandbox filesystem restrictions. Only enable if you trust the
     /// agent's container usage.
@@ -749,6 +753,7 @@ pub struct Resolved {
     pub allow_gpg_signing: bool,
     pub deny_clipboard: bool,
     pub allow_jvm_attach: bool,
+    pub gradle_init: bool,
     pub allow_docker: bool,
     pub allow_tmp_exec: bool,
     pub allow_cache_exec: Vec<String>,
@@ -819,6 +824,7 @@ pub struct CliFlags {
     pub allow_gpg_signing: bool,
     pub deny_clipboard: bool,
     pub allow_jvm_attach: bool,
+    pub gradle_init: bool,
     /// Preset-controlled toggle (see `allow_localhost_any`).
     pub allow_docker: FeatureToggle,
     /// Preset-controlled toggle (see `allow_localhost_any`).

--- a/src/gradle_init.rs
+++ b/src/gradle_init.rs
@@ -8,10 +8,11 @@
 //! environment — the flag is lost and their daemon connections on ephemeral
 //! localhost ports fail with `ConnectException`.
 //!
-//! cplt cannot reach into plugin-managed forks, so instead it installs a
-//! Gradle init script at `~/.gradle/init.d/cplt-sandbox.gradle`. The script
-//! is guarded by `__CPLT_WRAPPED` — it only activates inside the sandbox and
-//! is inert in normal builds.
+//! cplt cannot reach into plugin-managed forks, so instead it can install a
+//! Gradle init script at `~/.gradle/init.d/cplt-sandbox.gradle` — **opt-in**
+//! via `sandbox.gradle_init = true` (cplt does not write tool config dirs by
+//! default). The script is guarded by `__CPLT_WRAPPED` — it only activates
+//! inside the sandbox and is inert in normal builds.
 //!
 //! Scope: the script covers the daemon itself plus `Test`/`JavaExec` forks.
 //! `WorkerExecutor` process-isolation forks have no public configuration

--- a/src/gradle_init.rs
+++ b/src/gradle_init.rs
@@ -9,7 +9,8 @@
 //! localhost ports fail with `ConnectException`.
 //!
 //! cplt cannot reach into plugin-managed forks, so instead it can install a
-//! Gradle init script at `~/.gradle/init.d/cplt-sandbox.gradle` — **opt-in**
+//! Gradle init script in the Gradle user home (`$GRADLE_USER_HOME/init.d/` or
+//! `~/.gradle/init.d/cplt-sandbox.gradle`) — **opt-in**
 //! via `sandbox.gradle_init = true` (cplt does not write tool config dirs by
 //! default). The script is guarded by `__CPLT_WRAPPED` — it only activates
 //! inside the sandbox and is inert in normal builds.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1282,6 +1282,8 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         allow_gpg_signing: cli.allow_gpg_signing,
         deny_clipboard: cli.deny_clipboard,
         allow_jvm_attach: cli.allow_jvm_attach,
+        // Config-only opt-in; no CLI flag.
+        gradle_init: false,
         allow_docker: config::FeatureToggle::from_pair(cli.allow_docker, cli.no_allow_docker),
         allow_tmp_exec: config::FeatureToggle::from_pair(cli.allow_tmp_exec, cli.no_allow_tmp_exec),
         allow_cache_exec: cli.allow_cache_exec.clone(),
@@ -2316,13 +2318,15 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         }
     }
 
-    // macOS-only: install the guarded Gradle init script so sandboxed builds
-    // keep the preferIPv4Stack workaround for the daemon and Test/JavaExec
-    // forks (WorkerExecutor forks have no init-script hook — see gradle_init
-    // module docs). Inert outside the sandbox (__CPLT_WRAPPED guard); a no-op
-    // when ~/.gradle doesn't exist.
+    // macOS-only, opt-in (sandbox.gradle_init): install the guarded Gradle
+    // init script so sandboxed builds keep the preferIPv4Stack workaround for
+    // the daemon and Test/JavaExec forks (WorkerExecutor forks have no
+    // init-script hook — see gradle_init module docs). Inert outside the
+    // sandbox (__CPLT_WRAPPED guard); a no-op when ~/.gradle doesn't exist.
     #[cfg(target_os = "macos")]
-    if let Err(e) = gradle_init::ensure_init_script(&home_dir) {
+    if resolved.gradle_init
+        && let Err(e) = gradle_init::ensure_init_script(&home_dir)
+    {
         ui::warn(&format!(
             "Could not install Gradle sandbox init script: {e}"
         ));
@@ -2816,11 +2820,13 @@ fn prepare_shell_sandbox(
         }
     }
 
-    // See the agent-path call site: guarded Gradle init script so sandboxed
-    // builds keep the preferIPv4Stack workaround for the daemon and
-    // Test/JavaExec forks.
+    // See the agent-path call site: guarded Gradle init script (opt-in via
+    // sandbox.gradle_init) so sandboxed builds keep the preferIPv4Stack
+    // workaround for the daemon and Test/JavaExec forks.
     #[cfg(target_os = "macos")]
-    if let Err(e) = gradle_init::ensure_init_script(home_dir) {
+    if resolved.gradle_init
+        && let Err(e) = gradle_init::ensure_init_script(home_dir)
+    {
         ui::warn(&format!(
             "Could not install Gradle sandbox init script: {e}"
         ));

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -50,6 +50,10 @@ pub struct DenySection {
 pub struct ProposeSection {
     pub allow_localhost_any: Option<bool>,
     pub allow_jvm_attach: Option<bool>,
+    /// Propose installing the cplt-managed Gradle init script (see
+    /// `sandbox.gradle_init`). Writes to the Gradle user home, so it goes
+    /// through the same trust review as other sandbox relaxations.
+    pub gradle_init: Option<bool>,
     pub allow_docker: Option<bool>,
     pub allow_tmp_exec: Option<bool>,
     pub allow_gpg_signing: Option<bool>,
@@ -256,6 +260,9 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     }
     if propose.allow_jvm_attach == Some(true) {
         keys.push("allow_jvm_attach");
+    }
+    if propose.gradle_init == Some(true) {
+        keys.push("gradle_init");
     }
     if propose.allow_docker == Some(true) {
         keys.push("allow_docker");

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -7010,6 +7010,7 @@ use_bubblewrap = false
 quiet = false
 yes = false
 allow_jvm_attach = false
+gradle_init = false
 allow_docker = false
 allow_cache_exec = []
 allow_cache_exec_any = false


### PR DESCRIPTION
Follow-up to #170 (already merged via merge queue before review).

## Why

#170 installs a cplt-managed file into `~/.gradle/init.d/` **by default** on every sandbox launch. That is a behavior change to a tool config dir the user never asked for — the script runs on *every* Gradle build (guarded, but still present). cplt does not write tool config dirs unprompted; this should be opt-in.

## Change

New config key `sandbox.gradle_init` (bool, default **false**, config-only — no CLI flag):

```bash
cplt config set sandbox.gradle_init true
```

Both call sites (agent path + exec/shell path) gate on `resolved.gradle_init`. Everything else from #170 unchanged: guarded script (`__CPLT_WRAPPED`), atomic write, `GRADLE_USER_HOME` support, warnings on failure.

## Tests

- New merge test: defaults false, config enables
- Validation fixture updated for the new registry key
- `mise run check` green: 260 unit + 700 lib

## Docs

`known-impacts.md` updated: mitigation marked opt-in with the `cplt config set` command.