### PR TITLE
fix: Cache Poisoning via caching of untrusted files 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,16 +72,6 @@ jobs:
           toolchain: "1.94"
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache@v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: release-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: release-${{ matrix.target }}-
-
       - name: Build release binary
         run: |
           CPLT_LONG_VERSION="${{ needs.version.outputs.version }}" cargo build --release --target ${{ matrix.target }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -910,6 +910,23 @@ The GitHub Actions workflow runs in two stages:
 1. **Linux (ubuntu-latest)**: formatting check (`cargo fmt`), linting (`cargo clippy -D warnings`), unit tests
 2. **macOS (macos-latest)**: full test suite including integration tests, release binary build and verification
 
+#### Cache poisoning
+
+The release workflow (`release.yaml`) deliberately uses **no** `actions/cache`
+step. It runs in a privileged context, triggered on the default branch via
+`workflow_run`, with `contents: write`, `id-token: write`, and
+`attestations: write`, and it publishes signed, attested binaries. A cache entry
+populated by a lower-trust run (a `pull_request` build, or a `workflow_dispatch`
+on an attacker-controlled branch) must never be able to reach that build, so the
+release job always compiles from a cold checkout. Releases are infrequent, so the
+extra few minutes are an acceptable price for keeping untrusted bytes out of the
+release artifact.
+
+The CI workflow (`ci.yaml`) keeps its caches: its jobs hold only
+`contents: read`, publish nothing privileged, and PR-run caches are scoped to the
+pull request's own ref, so there is no cross-context path by which one PR could
+poison another run or the default branch.
+
 ## Prior Art and References
 
 ### macOS Seatbelt / sandbox-exec


### PR DESCRIPTION
## release.yaml

Removes `actions/cache` from the release build job.

The job is reachable via `workflow_dispatch` on an arbitrary ref, where it runs in that ref's cache scope and restores whatever a prior run on that branch wrote under a `release-*` key. More generally, a workflow that publishes installable, signed, attested binaries should not consume a shared mutable cache, so the fix is to drop the cache rather than to narrow it.

## Trade-off

Release builds go from roughly 2 to 3 minutes warm to 5 to 8 minutes cold. Releases are infrequent, and a reproducible build from a clean `target/` is worth the wait.

## Not changed

`ci.yaml` keeps `target/` in its caches. PR runs write into the `refs/pull/N/merge` cache scope, which no other branch can read, and their keys do not overlap the release job's `release-*` prefix, so there is no path from a PR cache into a privileged build.

## Docs

`SECURITY.md` gains a "Cache poisoning" subsection recording why `release.yaml` runs cacheless and why `ci.yaml` does not need to.