### PR TITLE
feat(sandbox): enforce deny paths on Linux via bwrap mount masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1323,8 +1323,8 @@ Or for a single run: `cplt --allow-read ~/.m2/settings.xml`
 
 - **Kernel 5.13+ required** — Landlock LSM must be enabled
 - **TCP port filtering requires kernel 6.7+** — older kernels get filesystem-only enforcement
-- **Landlock cannot deny subpaths within allowed paths** — `.env` read/write/delete and `.git/hooks` writes inside the project dir are not kernel-enforced
-- **`--deny-path` has no effect** — Landlock is allowlist-only
+- **Landlock cannot deny subpaths within allowed paths** — `.env` read/write/delete inside the project dir is not kernel-enforced (`.git/hooks` writes are blocked when Bubblewrap is active)
+- **`--deny-path` requires Bubblewrap** — enforced via mount masks when bwrap is active; without it, Landlock is allowlist-only and the deny is warned about instead
 
 📖 **Full details:** [docs/security.md](docs/security.md#limitations)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ cplt assumes the sandboxed agent is **untrusted** — executing arbitrary code s
 | PID namespace isolation | N/A (not applicable) | ❌ Not available | ✅ Kernel namespace |
 | Mount namespace isolation | N/A (not applicable) | ❌ Not available | ✅ Kernel namespace |
 | User namespace (unprivileged) | N/A (not applicable) | ❌ Not available | ✅ Kernel namespace |
-| --deny-path | ✅ Kernel deny | ❌ No effect (warned) | ❌ No effect (warned) |
+| --deny-path / deny.paths | ✅ Kernel deny | ❌ No effect (warned) | ✅ Mount-masked (EACCES; dirs via unreadable tmpfs, files via unreadable placeholder bind) |
 
 Legend: ✅ = kernel-enforced, ⚠️ = defense-in-depth (proxy/env), ❌ = not available
 
@@ -179,7 +179,7 @@ sudo pacman -S bubblewrap
 - **Kernel exploits** — we rely on Apple's Seatbelt (macOS) and Landlock/seccomp (Linux) enforcement being correct
 - **Keychain isolation** (macOS) — Copilot requires Keychain access for auth; this is an accepted trade-off. `mach-lookup` is blanket because Node.js needs it for DNS, Security framework, and system services. The **clipboard** (`com.apple.pasteboard`) is reachable via the same blanket allow; use `--deny-clipboard` to add a targeted deny that blocks only the pasteboard service while leaving all others intact.
 - **sandbox-exec deprecation** (macOS) — Apple marks it deprecated but has not removed it; Chromium and VS Code still use it
-- **Landlock subpath limitations** (Linux) — Landlock cannot deny access to subpaths within allowed directories. If a parent directory is allowed, all children are allowed. This means certain fine-grained macOS rules (e.g., deny `.config/gh/extensions` while allowing `.config/gh/hosts.yml`) cannot be replicated on Linux.
+- **Landlock subpath limitations** (Linux) — Landlock cannot deny access to subpaths within allowed directories. If a parent directory is allowed, all children are allowed. This means certain fine-grained macOS rules (e.g., deny `.config/gh/extensions` while allowing `.config/gh/hosts.yml`) cannot be replicated on Linux. When Bubblewrap is active, user deny paths (`--deny-path` / `deny.paths`) ARE enforced despite this, via mount masks (see the platform comparison table); the built-in fine-grained rules remain macOS-only.
 - **Code quality** — the sandbox cannot judge whether code written by Copilot contains backdoors; that's a code review problem
 - **`~/.config/gh/hosts.yml` token** — contains the user's GitHub OAuth token. Copilot needs *a* GitHub token to function (via env var or this file). The token is readable inside the sandbox. If this is a concern, set `GH_TOKEN` env var (passes through allowlist) and add `--deny-path ~/.config/gh` to block the file.
 - **Interpreter-based temp execution** — the sandbox blocks *direct* exec from `/tmp` (Mach-O/ELF binaries, dlopen), but cannot block `bash /tmp/evil.sh` or `node /tmp/evil.js` because the exec target is the interpreter (`/bin/bash`, `/usr/bin/node`), not the script file. Sandboxing interpreters would break Copilot.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ cplt assumes the sandboxed agent is **untrusted** — executing arbitrary code s
 | PID namespace isolation | N/A (not applicable) | ❌ Not available | ✅ Kernel namespace |
 | Mount namespace isolation | N/A (not applicable) | ❌ Not available | ✅ Kernel namespace |
 | User namespace (unprivileged) | N/A (not applicable) | ❌ Not available | ✅ Kernel namespace |
-| --deny-path / deny.paths | ✅ Kernel deny | ❌ No effect (warned) | ✅ Mount-masked (EACCES; dirs via unreadable tmpfs, files via unreadable placeholder bind) |
+| --deny-path / deny.paths | ✅ Kernel deny | ❌ No effect (warned) | ✅ Mount-masked (files read as EACCES, dirs appear empty; the real content is unreachable) |
 
 Legend: ✅ = kernel-enforced, ⚠️ = defense-in-depth (proxy/env), ❌ = not available
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -304,13 +304,8 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
 #[cfg(target_os = "linux")]
 fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
     // Warn about config options that Linux cannot enforce at kernel level.
-    if !config.extra_deny.is_empty() {
-        ui::warn(
-            "--deny-path has no effect on Linux: \
-             Landlock cannot deny subpaths within allowed directories. \
-             Proxy and env hardening provide defense-in-depth.",
-        );
-    }
+    // (Deny paths are handled after bwrap resolution below — with Bubblewrap
+    // they ARE enforced, via mount masks.)
     if !config.allow_env_files {
         ui::warn(
             "allow_env_files=false is not fully enforceable on Linux: \
@@ -362,6 +357,11 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
     // the sandbox grants write access to), so pass it through to cover them too.
     let ro_protect = bubblewrap::git_persistence_paths(config.project_dir, config.git_common_dir);
 
+    // Deny-path masks: Landlock cannot deny subpaths within allowed
+    // directories, but Bubblewrap can shadow them at the mount level (EACCES),
+    // restoring macOS parity for --deny-path / deny.paths.
+    let deny_masks = bubblewrap::build_deny_masks(config.extra_deny, config.scratch_dir);
+
     // Decide bubblewrap wrapping before `precompute()` consumes `policy`.
     // `resolve()` only clones `fs_rules`/`net_rules` on the arms that actually
     // build a wrapper (explicit-on, or auto-detect with bwrap available) — the
@@ -372,7 +372,25 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
         &policy.net_rules,
         policy.restrict_net_connect,
         &ro_protect,
+        &deny_masks,
     )?;
+
+    if !config.extra_deny.is_empty() {
+        if bwrap_wrapper.is_some() {
+            let masked = deny_masks.mask_count();
+            if masked > 0 {
+                ui::info(&format!(
+                    "Deny paths enforced via Bubblewrap mount masks ({masked} masked)."
+                ));
+            }
+        } else {
+            ui::warn(
+                "Deny paths are NOT enforced without Bubblewrap: Landlock cannot \
+                 deny subpaths within allowed directories. Proxy and env hardening \
+                 provide defense-in-depth.",
+            );
+        }
+    }
 
     // Pre-compute everything in the parent process.
     // ABI check, BPF construction, and all allocation happens here.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -358,8 +358,9 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
     let ro_protect = bubblewrap::git_persistence_paths(config.project_dir, config.git_common_dir);
 
     // Deny-path masks: Landlock cannot deny subpaths within allowed
-    // directories, but Bubblewrap can shadow them at the mount level (EACCES),
-    // restoring macOS parity for --deny-path / deny.paths.
+    // directories, but Bubblewrap can shadow them at the mount level — denied
+    // files read as EACCES, denied dirs read as empty — restoring the macOS
+    // parity for --deny-path / deny.paths.
     let deny_masks = bubblewrap::build_deny_masks(config.extra_deny, config.scratch_dir);
 
     // Decide bubblewrap wrapping before `precompute()` consumes `policy`.
@@ -391,10 +392,13 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
                     .collect::<Vec<_>>()
                     .join(", ");
                 ui::warn(&format!(
-                    "{} deny path(s) not mount-masked (under a bwrap-managed \
-                     mount or /tmp, or no longer resolvable): {list}",
+                    "{} deny path(s) could not be mount-masked and are NOT \
+                     enforced: {list}",
                     skipped.len()
                 ));
+                if let Some(reason) = deny_masks.placeholder_error() {
+                    ui::warn(&format!("File deny paths were skipped: {reason}."));
+                }
             }
         } else {
             ui::warn(

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -383,6 +383,19 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
                     "Deny paths enforced via Bubblewrap mount masks ({masked} masked)."
                 ));
             }
+            let skipped = deny_masks.skipped();
+            if !skipped.is_empty() {
+                let list = skipped
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ui::warn(&format!(
+                    "{} deny path(s) not mount-masked (under a bwrap-managed \
+                     mount or /tmp, or no longer resolvable): {list}",
+                    skipped.len()
+                ));
+            }
         } else {
             ui::warn(
                 "Deny paths are NOT enforced without Bubblewrap: Landlock cannot \

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -359,8 +359,8 @@ fn prepare_impl(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
 
     // Deny-path masks: Landlock cannot deny subpaths within allowed
     // directories, but Bubblewrap can shadow them at the mount level — denied
-    // files read as EACCES, denied dirs read as empty — restoring the macOS
-    // parity for --deny-path / deny.paths.
+    // files read as EACCES, denied dirs read as empty (macOS gives EACCES for
+    // both; the content is unreachable either way).
     let deny_masks = bubblewrap::build_deny_masks(config.extra_deny, config.scratch_dir);
 
     // Decide bubblewrap wrapping before `precompute()` consumes `policy`.

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -338,12 +338,14 @@ impl DenyMasks {
 
 /// Build mount masks from the user's deny paths.
 ///
-/// Inputs arrive canonicalized — the CLI (`canonicalize_deny_paths`) and the
-/// config loader (`resolve_config_path`) both hard-fail on paths that do not
-/// resolve — so a symlinked deny path already names the resolved target. The
-/// absolute check and re-canonicalization here are defense against races (a
-/// path deleted since startup). Entries that cannot be masked are recorded in
-/// `skipped` for the caller to warn about:
+/// CLI and global-config inputs arrive canonicalized (`canonicalize_deny_paths`
+/// and `resolve_config_path` both hard-fail on paths that do not resolve), so
+/// for those the checks here only guard against races (a path deleted since
+/// startup). Repo `.cplt.toml` paths do NOT: they are merely `~`-expanded
+/// (navikt/cplt#179), so relative and unresolvable entries reach this function
+/// and the absolute check and re-canonicalization are real filtering for them.
+/// Entries that cannot be masked are recorded in `skipped` for the caller to
+/// warn about:
 ///
 /// - paths that fail to canonicalize (vanished since startup) or are relative
 /// - paths under bwrap-managed mounts (`/proc`, `/dev`, `/sys`) and under

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -1072,7 +1072,10 @@ mod tests {
             .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("target"));
         std::fs::create_dir_all(&base).expect("create tempdir base");
         assert!(
-            !base.canonicalize().expect("canonicalize base").starts_with("/tmp"),
+            !base
+                .canonicalize()
+                .expect("canonicalize base")
+                .starts_with("/tmp"),
             "test premise: no usable target dir outside /tmp"
         );
         tempfile::tempdir_in(base).expect("tempdir in target dir")

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -126,8 +126,9 @@ pub(crate) fn test_functionality(
     bwrap_path: &Path,
     fs_rules: &[FsRule],
     ro_protect: &[PathBuf],
+    deny_masks: &DenyMasks,
 ) -> Result<(), String> {
-    let mut args = build_bwrap_args(fs_rules, ro_protect);
+    let mut args = build_bwrap_args(fs_rules, ro_protect, deny_masks);
     args.push("--".to_string());
     args.push("/bin/true".to_string());
 
@@ -192,7 +193,17 @@ pub(crate) fn test_functionality(
 ///    still be created by the agent; and submodule hooks
 ///    (`.git/modules/<name>/hooks`) are not covered. Both are documented in
 ///    SECURITY.md.
-pub(crate) fn build_bwrap_args(fs_rules: &[FsRule], ro_protect: &[PathBuf]) -> Vec<String> {
+///
+/// 6. Deny-path masks last of all, so they shadow every earlier bind: file
+///    masks first (`--ro-bind <placeholder> <file>` — bind sources resolve
+///    against the mount tree built so far, so they must precede any tmpfs
+///    that could hide a source or mount point), then directory masks
+///    (`--perms 000 --tmpfs <dir>`). See [`build_deny_masks`].
+pub(crate) fn build_bwrap_args(
+    fs_rules: &[FsRule],
+    ro_protect: &[PathBuf],
+    deny_masks: &DenyMasks,
+) -> Vec<String> {
     let mut args = Vec::new();
 
     // ── Namespace isolation (network intentionally shared — see module docs) ──
@@ -249,7 +260,143 @@ pub(crate) fn build_bwrap_args(fs_rules: &[FsRule], ro_protect: &[PathBuf]) -> V
         args.extend(["--ro-bind".to_string(), path_str.clone(), path_str]);
     }
 
+    // ── Deny-path masks — emitted last so they shadow every earlier bind ──
+    if let Some(placeholder) = &deny_masks.placeholder {
+        let ph = placeholder.to_string_lossy().into_owned();
+        for file in &deny_masks.files {
+            let file_str = file.to_string_lossy().into_owned();
+            args.extend(["--ro-bind".to_string(), ph.clone(), file_str]);
+        }
+    }
+    for dir in &deny_masks.dirs {
+        let dir_str = dir.to_string_lossy().into_owned();
+        args.extend([
+            "--perms".to_string(),
+            "000".to_string(),
+            "--tmpfs".to_string(),
+            dir_str,
+        ]);
+    }
+
     args
+}
+
+/// Mount masks for the user's deny paths (`--deny-path` / `deny.paths`).
+///
+/// Landlock is grant-only — it cannot carve a deny out of an allowed subtree,
+/// so deny paths inside granted roots (most commonly the project dir) were
+/// previously warning-only on Linux. When Bubblewrap is active, each deny
+/// target is shadowed at the mount level instead: directories get an
+/// unreadable tmpfs (`--perms 000 --tmpfs`), files a read-only bind of an
+/// unreadable placeholder. Any access fails with EACCES, matching the macOS
+/// SBPL `(deny file-read* ...)` behavior. Masks cannot be removed from inside
+/// the sandbox: `mount`, `umount2`, `unshare`, and `pivot_root` are all
+/// seccomp-denied.
+#[derive(Debug, Default)]
+pub(crate) struct DenyMasks {
+    /// Canonicalized deny targets that are directories.
+    dirs: Vec<PathBuf>,
+    /// Canonicalized deny targets that are not directories.
+    files: Vec<PathBuf>,
+    /// Mode-000 empty source file bound over each entry in `files`; lives in
+    /// the per-session scratch dir. `None` when `files` is empty.
+    placeholder: Option<PathBuf>,
+}
+
+impl DenyMasks {
+    pub(crate) fn mask_count(&self) -> usize {
+        self.dirs.len() + self.files.len()
+    }
+}
+
+/// Build mount masks from the user's deny paths.
+///
+/// Entries are canonicalized first, so a symlinked deny path masks the
+/// resolved target rather than the link. Skipped entries (each protects
+/// nothing, or is already covered):
+///
+/// - relative paths — they have no defined base here; the macOS profile
+///   interpolates them literally into SBPL where they match nothing either
+/// - paths that fail to canonicalize (typically: absent on this machine)
+/// - paths under bwrap-managed mounts (`/proc`, `/dev`, `/sys`) and under
+///   `/tmp` — host `/tmp` is already invisible behind the private tmpfs.
+///   This deliberately leaves a deny subpath *inside a project dir that
+///   itself lives under `/tmp`* unmasked: its mount point may not exist in
+///   the private tmpfs and a failing mount would sink the whole wrapper
+/// - dirs nested under another masked dir, and files under any masked dir —
+///   the ancestor tmpfs already hides them, and their mount points vanish
+///   once it is mounted (bwrap would otherwise error and sink the wrapper)
+pub(crate) fn build_deny_masks(extra_deny: &[PathBuf], scratch_dir: Option<&Path>) -> DenyMasks {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let mut files: Vec<PathBuf> = Vec::new();
+    for path in extra_deny {
+        if !path.is_absolute() {
+            continue;
+        }
+        let Ok(canon) = path.canonicalize() else {
+            continue;
+        };
+        if canon.starts_with("/proc")
+            || canon.starts_with("/dev")
+            || canon.starts_with("/sys")
+            || canon.starts_with("/tmp")
+        {
+            continue;
+        }
+        if canon.is_dir() {
+            dirs.push(canon);
+        } else {
+            files.push(canon);
+        }
+    }
+
+    dirs.sort_by_key(|p| p.components().count());
+    let mut kept_dirs: Vec<PathBuf> = Vec::new();
+    for dir in dirs {
+        if !kept_dirs.iter().any(|k| dir.starts_with(k)) {
+            kept_dirs.push(dir);
+        }
+    }
+    files.retain(|f| !kept_dirs.iter().any(|k| f.starts_with(k)));
+    files.sort();
+    files.dedup();
+
+    let placeholder = if files.is_empty() {
+        None
+    } else {
+        match scratch_dir.map(create_mask_placeholder) {
+            Some(Ok(path)) => Some(path),
+            Some(Err(e)) => {
+                crate::ui::warn(&format!(
+                    "Cannot create deny-mask placeholder: {e}. \
+                     File deny paths will not be masked."
+                ));
+                files.clear();
+                None
+            }
+            None => {
+                crate::ui::warn("No scratch dir available; file deny paths will not be masked.");
+                files.clear();
+                None
+            }
+        }
+    };
+
+    DenyMasks {
+        dirs: kept_dirs,
+        files,
+        placeholder,
+    }
+}
+
+/// Create the mode-000 empty file used as the bind source for file masks.
+fn create_mask_placeholder(scratch: &Path) -> Result<PathBuf, String> {
+    use std::os::unix::fs::PermissionsExt;
+    let path = scratch.join("deny-mask");
+    std::fs::write(&path, b"").map_err(|e| format!("write {}: {e}", path.display()))?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000))
+        .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+    Ok(path)
 }
 
 /// Project-internal paths re-bound **read-only** when Bubblewrap is active, to
@@ -328,18 +475,33 @@ pub(crate) fn resolve(
     net_rules: &[NetRule],
     restrict_net_connect: bool,
     ro_protect: &[PathBuf],
+    deny_masks: &DenyMasks,
 ) -> Result<Option<BubblewrapWrapper>, String> {
     match use_bubblewrap {
         Some(false) => Ok(None),
-        Some(true) => build_wrapper(fs_rules, net_rules, restrict_net_connect, ro_protect, true)
-            .map(Some)
-            .map_err(|e| {
-                format!(
-                    "Bubblewrap explicitly requested but unavailable: {e}. \
-                     Install bubblewrap or remove --use-bubblewrap."
-                )
-            }),
-        None => match build_wrapper(fs_rules, net_rules, restrict_net_connect, ro_protect, false) {
+        Some(true) => build_wrapper(
+            fs_rules,
+            net_rules,
+            restrict_net_connect,
+            ro_protect,
+            deny_masks,
+            true,
+        )
+        .map(Some)
+        .map_err(|e| {
+            format!(
+                "Bubblewrap explicitly requested but unavailable: {e}. \
+                 Install bubblewrap or remove --use-bubblewrap."
+            )
+        }),
+        None => match build_wrapper(
+            fs_rules,
+            net_rules,
+            restrict_net_connect,
+            ro_protect,
+            deny_masks,
+            false,
+        ) {
             Ok(wrapper) => Ok(Some(wrapper)),
             Err(e) => {
                 crate::ui::warn(&format!(
@@ -356,11 +518,12 @@ fn build_wrapper(
     net_rules: &[NetRule],
     restrict_net_connect: bool,
     ro_protect: &[PathBuf],
+    deny_masks: &DenyMasks,
     strict: bool,
 ) -> Result<BubblewrapWrapper, String> {
     let bwrap_path = check_availability().ok_or_else(|| "bwrap not found in PATH".to_string())?;
-    test_functionality(&bwrap_path, fs_rules, ro_protect)?;
-    let bwrap_args = build_bwrap_args(fs_rules, ro_protect);
+    test_functionality(&bwrap_path, fs_rules, ro_protect, deny_masks)?;
+    let bwrap_args = build_bwrap_args(fs_rules, ro_protect, deny_masks);
     Ok(BubblewrapWrapper {
         bwrap_path,
         bwrap_args,
@@ -596,7 +759,7 @@ mod tests {
 
     #[test]
     fn args_isolate_expected_namespaces() {
-        let args = build_bwrap_args(&[], &[]);
+        let args = build_bwrap_args(&[], &[], &DenyMasks::default());
         assert!(args.contains(&"--unshare-pid".to_string()));
         assert!(args.contains(&"--unshare-ipc".to_string()));
         assert!(args.contains(&"--unshare-uts".to_string()));
@@ -609,7 +772,7 @@ mod tests {
 
     #[test]
     fn args_set_up_base_mounts() {
-        let args = build_bwrap_args(&[], &[]);
+        let args = build_bwrap_args(&[], &[], &DenyMasks::default());
         assert!(args.windows(3).any(|w| w == ["--ro-bind", "/", "/"]));
         assert!(args.windows(2).any(|w| w == ["--proc", "/proc"]));
         assert!(args.windows(2).any(|w| w == ["--dev", "/dev"]));
@@ -630,7 +793,7 @@ mod tests {
                 ioctl: false,
             },
         }];
-        let args = build_bwrap_args(&rules, &[]);
+        let args = build_bwrap_args(&rules, &[], &DenyMasks::default());
         let tmp_bind = args
             .windows(3)
             .any(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp");
@@ -649,7 +812,7 @@ mod tests {
             "test premise: tempdir lives under the system temp dir"
         );
         let rules = vec![writable_rule(&dir_str)];
-        let args = build_bwrap_args(&rules, &[]);
+        let args = build_bwrap_args(&rules, &[], &DenyMasks::default());
 
         let tmpfs_idx = args.iter().position(|a| a == "--tmpfs").expect("tmpfs");
         let bind_idx = args
@@ -672,7 +835,7 @@ mod tests {
         // non-bwrap configuration kernel-denies by default.
         let dir = tempfile::tempdir().expect("tempdir");
         let scratch_like = writable_rule(&dir.path().to_string_lossy());
-        let args = build_bwrap_args(&[scratch_like], &[]);
+        let args = build_bwrap_args(&[scratch_like], &[], &DenyMasks::default());
 
         // No mount operation may target /tmp as its destination other than the
         // tmpfs itself.
@@ -686,7 +849,7 @@ mod tests {
     #[test]
     fn nonexistent_writable_paths_are_skipped() {
         let rules = vec![writable_rule("/definitely/not/a/real/path/xyzzy")];
-        let args = build_bwrap_args(&rules, &[]);
+        let args = build_bwrap_args(&rules, &[], &DenyMasks::default());
         assert!(!args.iter().any(|a| a.contains("xyzzy")));
     }
 
@@ -697,7 +860,7 @@ mod tests {
             writable_rule("/proc/self"),
             writable_rule("/sys/fs/cgroup"),
         ];
-        let args = build_bwrap_args(&rules, &[]);
+        let args = build_bwrap_args(&rules, &[], &DenyMasks::default());
         assert!(
             !args
                 .windows(3)
@@ -717,7 +880,11 @@ mod tests {
 
     #[test]
     fn resolve_disabled_returns_none() {
-        assert!(resolve(Some(false), &[], &[], true, &[]).unwrap().is_none());
+        assert!(
+            resolve(Some(false), &[], &[], true, &[], &DenyMasks::default())
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -733,7 +900,7 @@ mod tests {
 
         let rules = vec![writable_rule(&proj_str)];
         let ro = git_persistence_paths(proj.path(), None);
-        let args = build_bwrap_args(&rules, &ro);
+        let args = build_bwrap_args(&rules, &ro, &DenyMasks::default());
 
         let proj_bind_idx = args
             .windows(3)
@@ -764,7 +931,7 @@ mod tests {
         let proj_str = proj.path().to_string_lossy().into_owned();
         let rules = vec![writable_rule(&proj_str)];
         let ro = git_persistence_paths(proj.path(), None);
-        let args = build_bwrap_args(&rules, &ro);
+        let args = build_bwrap_args(&rules, &ro, &DenyMasks::default());
 
         // .git/hooks and .cplt.toml are re-bound read-only.
         assert!(
@@ -799,7 +966,7 @@ mod tests {
         let proj = tempfile::tempdir().expect("tempdir");
         // No .git/hooks or .cplt.toml created.
         let ro = git_persistence_paths(proj.path(), None);
-        let args = build_bwrap_args(&[], &ro);
+        let args = build_bwrap_args(&[], &ro, &DenyMasks::default());
         assert!(
             !args
                 .iter()
@@ -828,7 +995,7 @@ mod tests {
         );
 
         // And once bound they are re-bound read-only (they exist on disk).
-        let args = build_bwrap_args(&[], &ro);
+        let args = build_bwrap_args(&[], &ro, &DenyMasks::default());
         let common_hooks_str = common_hooks.to_string_lossy().into_owned();
         assert!(
             args.windows(3).any(|w| w[0] == "--ro-bind"
@@ -851,5 +1018,156 @@ mod tests {
             1,
             "the project's .git/hooks must appear exactly once"
         );
+    }
+
+    // Deny masks are skipped under /tmp, so their tests need a base outside it.
+    fn non_tmp_tempdir() -> tempfile::TempDir {
+        let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+        tempfile::tempdir_in(base).expect("tempdir in target/")
+    }
+
+    #[test]
+    fn deny_mask_dir_is_unreadable_tmpfs_after_everything_else() {
+        let base = non_tmp_tempdir();
+        let secret = base.path().join("secrets");
+        std::fs::create_dir(&secret).expect("create secrets");
+        let hooks_proj = base.path().join("proj");
+        std::fs::create_dir_all(hooks_proj.join(".git/hooks")).expect("hooks");
+
+        let masks = build_deny_masks(std::slice::from_ref(&secret), None);
+        assert_eq!(masks.mask_count(), 1);
+
+        let rules = [writable_rule(&base.path().to_string_lossy())];
+        let ro = git_persistence_paths(&hooks_proj, None);
+        let args = build_bwrap_args(&rules, &ro, &masks);
+
+        let canon = secret
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let tmpfs_pos = args
+            .windows(4)
+            .position(|w| w[0] == "--perms" && w[1] == "000" && w[2] == "--tmpfs" && w[3] == canon)
+            .expect("dir mask must be emitted as --perms 000 --tmpfs");
+        let last_bind_pos = args
+            .iter()
+            .rposition(|a| a == "--bind" || a == "--ro-bind")
+            .expect("binds present");
+        assert!(
+            tmpfs_pos > last_bind_pos,
+            "dir masks must come after every bind so they shadow them"
+        );
+    }
+
+    #[test]
+    fn deny_mask_file_binds_unreadable_placeholder() {
+        let base = non_tmp_tempdir();
+        let secret = base.path().join("token.txt");
+        std::fs::write(&secret, "s").expect("write");
+        let scratch = base.path().join("scratch");
+        std::fs::create_dir(&scratch).expect("scratch");
+
+        let masks = build_deny_masks(std::slice::from_ref(&secret), Some(&scratch));
+        assert_eq!(masks.mask_count(), 1);
+        let placeholder = masks.placeholder.clone().expect("placeholder created");
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&placeholder)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0, "placeholder must be mode 000");
+
+        let args = build_bwrap_args(&[], &[], &masks);
+        let ph = placeholder.to_string_lossy().into_owned();
+        let target = secret
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            args.windows(3)
+                .any(|w| w[0] == "--ro-bind" && w[1] == ph && w[2] == target),
+            "file mask must bind the placeholder over the target"
+        );
+    }
+
+    #[test]
+    fn deny_mask_file_without_scratch_is_dropped() {
+        let base = non_tmp_tempdir();
+        let secret = base.path().join("token.txt");
+        std::fs::write(&secret, "s").expect("write");
+        let masks = build_deny_masks(&[secret], None);
+        assert_eq!(masks.mask_count(), 0, "no scratch dir → no file mask");
+        assert!(masks.placeholder.is_none());
+    }
+
+    #[test]
+    fn deny_mask_skips_relative_missing_and_tmp_paths() {
+        let under_tmp = tempfile::tempdir().expect("tempdir"); // lives under /tmp
+        let masks = build_deny_masks(
+            &[
+                PathBuf::from("relative/secrets"),
+                PathBuf::from("/nonexistent/cplt-test-path"),
+                under_tmp.path().to_path_buf(),
+            ],
+            None,
+        );
+        assert_eq!(masks.mask_count(), 0);
+    }
+
+    #[test]
+    fn deny_mask_symlink_masks_resolved_target() {
+        let base = non_tmp_tempdir();
+        let real = base.path().join("real-secrets");
+        std::fs::create_dir(&real).expect("create");
+        let link = base.path().join("link-secrets");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let masks = build_deny_masks(&[link], None);
+        assert_eq!(masks.dirs, vec![real.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn deny_mask_nested_entries_coalesce_into_ancestor() {
+        // A child mask's mount point vanishes once the ancestor tmpfs is
+        // mounted; bwrap would error and sink the whole wrapper. The ancestor
+        // already hides everything beneath it, so children must be dropped.
+        let base = non_tmp_tempdir();
+        let parent = base.path().join("secrets");
+        let child = parent.join("inner");
+        std::fs::create_dir_all(&child).expect("create");
+        let file_under = parent.join("pw.txt");
+        std::fs::write(&file_under, "s").expect("write");
+        let scratch = base.path().join("scratch");
+        std::fs::create_dir(&scratch).expect("scratch");
+
+        let masks = build_deny_masks(&[child, parent.clone(), file_under], Some(&scratch));
+        assert_eq!(masks.dirs, vec![parent.canonicalize().unwrap()]);
+        assert!(
+            masks.files.is_empty(),
+            "file under masked dir must be dropped"
+        );
+    }
+
+    #[test]
+    fn deny_mask_files_emitted_before_dirs() {
+        // Bind sources resolve against the mount tree built so far — a tmpfs
+        // mask emitted first could hide a later file-bind's mount point.
+        let base = non_tmp_tempdir();
+        let dir = base.path().join("d");
+        std::fs::create_dir(&dir).expect("create");
+        let file = base.path().join("f.txt");
+        std::fs::write(&file, "s").expect("write");
+        let scratch = base.path().join("scratch");
+        std::fs::create_dir(&scratch).expect("scratch");
+
+        let masks = build_deny_masks(&[dir, file], Some(&scratch));
+        let args = build_bwrap_args(&[], &[], &masks);
+        let file_pos = args.iter().position(|a| a.ends_with("f.txt")).unwrap();
+        // `--perms` is only ever emitted by dir masks (the base /tmp mount is a
+        // plain `--tmpfs`), so it uniquely marks the dir-mask block.
+        let dir_pos = args.iter().position(|a| a == "--perms").unwrap();
+        assert!(file_pos < dir_pos, "file masks must precede dir masks");
     }
 }

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -198,7 +198,12 @@ pub(crate) fn test_functionality(
 ///    masks first (`--ro-bind <placeholder> <file>` — bind sources resolve
 ///    against the mount tree built so far, so they must precede any tmpfs
 ///    that could hide a source or mount point), then directory masks
-///    (`--perms 000 --tmpfs <dir>`). See [`build_deny_masks`].
+///    (`--tmpfs <dir>`; `--perms 000` is deliberately not used — it requires
+///    bwrap >= 0.5.0 and the empty tmpfs already hides the content). The
+///    placeholder is ro-bound over its own path before any file mask: it
+///    lives inside the writable scratch bind, and without the self-mask the
+///    agent (who owns the inode) could chmod it readable and write to it
+///    through the scratch path. See [`build_deny_masks`].
 pub(crate) fn build_bwrap_args(
     fs_rules: &[FsRule],
     ro_protect: &[PathBuf],
@@ -263,6 +268,11 @@ pub(crate) fn build_bwrap_args(
     // ── Deny-path masks — emitted last so they shadow every earlier bind ──
     if let Some(placeholder) = &deny_masks.placeholder {
         let ph = placeholder.to_string_lossy().into_owned();
+        // Self-mask first: the placeholder lives inside the writable scratch
+        // bind, so without this the agent (who owns the inode) could chmod it
+        // readable and write to it through the scratch path. The ro-bind over
+        // its own path makes every route to the inode read-only (EROFS).
+        args.extend(["--ro-bind".to_string(), ph.clone(), ph.clone()]);
         for file in &deny_masks.files {
             let file_str = file.to_string_lossy().into_owned();
             args.extend(["--ro-bind".to_string(), ph.clone(), file_str]);
@@ -270,12 +280,7 @@ pub(crate) fn build_bwrap_args(
     }
     for dir in &deny_masks.dirs {
         let dir_str = dir.to_string_lossy().into_owned();
-        args.extend([
-            "--perms".to_string(),
-            "000".to_string(),
-            "--tmpfs".to_string(),
-            dir_str,
-        ]);
+        args.extend(["--tmpfs".to_string(), dir_str]);
     }
 
     args
@@ -286,12 +291,12 @@ pub(crate) fn build_bwrap_args(
 /// Landlock is grant-only — it cannot carve a deny out of an allowed subtree,
 /// so deny paths inside granted roots (most commonly the project dir) were
 /// previously warning-only on Linux. When Bubblewrap is active, each deny
-/// target is shadowed at the mount level instead: directories get an
-/// unreadable tmpfs (`--perms 000 --tmpfs`), files a read-only bind of an
-/// unreadable placeholder. Any access fails with EACCES, matching the macOS
-/// SBPL `(deny file-read* ...)` behavior. Masks cannot be removed from inside
-/// the sandbox: `mount`, `umount2`, `unshare`, and `pivot_root` are all
-/// seccomp-denied.
+/// target is shadowed at the mount level instead: directories get an empty
+/// tmpfs, files a read-only bind of an unreadable (mode 000) placeholder.
+/// The real content is unreachable either way: reads of a masked file fail
+/// with EACCES; a masked dir merely reads as empty (macOS SBPL denies both
+/// with EACCES). Masks cannot be removed from inside the sandbox: `mount`,
+/// `umount2`, `unshare`, and `pivot_root` are all seccomp-denied.
 #[derive(Debug, Default)]
 pub(crate) struct DenyMasks {
     /// Canonicalized deny targets that are directories.
@@ -301,39 +306,53 @@ pub(crate) struct DenyMasks {
     /// Mode-000 empty source file bound over each entry in `files`; lives in
     /// the per-session scratch dir. `None` when `files` is empty.
     placeholder: Option<PathBuf>,
+    /// Deny targets that could not be mount-masked (under a bwrap-managed
+    /// mount or `/tmp`, or no longer resolvable). The caller warns about
+    /// these when the wrapper is active.
+    skipped: Vec<PathBuf>,
 }
 
 impl DenyMasks {
     pub(crate) fn mask_count(&self) -> usize {
         self.dirs.len() + self.files.len()
     }
+
+    pub(crate) fn skipped(&self) -> &[PathBuf] {
+        &self.skipped
+    }
 }
 
 /// Build mount masks from the user's deny paths.
 ///
-/// Entries are canonicalized first, so a symlinked deny path masks the
-/// resolved target rather than the link. Skipped entries (each protects
-/// nothing, or is already covered):
+/// Inputs arrive canonicalized — the CLI (`canonicalize_deny_paths`) and the
+/// config loader (`resolve_config_path`) both hard-fail on paths that do not
+/// resolve — so a symlinked deny path already names the resolved target. The
+/// absolute check and re-canonicalization here are defense against races (a
+/// path deleted since startup). Entries that cannot be masked are recorded in
+/// `skipped` for the caller to warn about:
 ///
-/// - relative paths — they have no defined base here; the macOS profile
-///   interpolates them literally into SBPL where they match nothing either
-/// - paths that fail to canonicalize (typically: absent on this machine)
+/// - paths that fail to canonicalize (vanished since startup) or are relative
 /// - paths under bwrap-managed mounts (`/proc`, `/dev`, `/sys`) and under
 ///   `/tmp` — host `/tmp` is already invisible behind the private tmpfs.
 ///   This deliberately leaves a deny subpath *inside a project dir that
 ///   itself lives under `/tmp`* unmasked: its mount point may not exist in
 ///   the private tmpfs and a failing mount would sink the whole wrapper
-/// - dirs nested under another masked dir, and files under any masked dir —
-///   the ancestor tmpfs already hides them, and their mount points vanish
-///   once it is mounted (bwrap would otherwise error and sink the wrapper)
+///
+/// Dropped but *not* recorded as skipped (the ancestor mask already covers
+/// them): dirs nested under another masked dir, and files under any masked
+/// dir — their mount points vanish once the ancestor tmpfs is mounted (bwrap
+/// would otherwise error and sink the wrapper).
 pub(crate) fn build_deny_masks(extra_deny: &[PathBuf], scratch_dir: Option<&Path>) -> DenyMasks {
     let mut dirs: Vec<PathBuf> = Vec::new();
     let mut files: Vec<PathBuf> = Vec::new();
+    let mut skipped: Vec<PathBuf> = Vec::new();
     for path in extra_deny {
         if !path.is_absolute() {
+            skipped.push(path.clone());
             continue;
         }
         let Ok(canon) = path.canonicalize() else {
+            skipped.push(path.clone());
             continue;
         };
         if canon.starts_with("/proc")
@@ -341,6 +360,7 @@ pub(crate) fn build_deny_masks(extra_deny: &[PathBuf], scratch_dir: Option<&Path
             || canon.starts_with("/sys")
             || canon.starts_with("/tmp")
         {
+            skipped.push(canon);
             continue;
         }
         if canon.is_dir() {
@@ -386,6 +406,7 @@ pub(crate) fn build_deny_masks(extra_deny: &[PathBuf], scratch_dir: Option<&Path
         dirs: kept_dirs,
         files,
         placeholder,
+        skipped,
     }
 }
 
@@ -1022,12 +1043,19 @@ mod tests {
 
     // Deny masks are skipped under /tmp, so their tests need a base outside it.
     fn non_tmp_tempdir() -> tempfile::TempDir {
-        let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
-        tempfile::tempdir_in(base).expect("tempdir in target/")
+        let base = std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("target"));
+        std::fs::create_dir_all(&base).expect("create tempdir base");
+        assert!(
+            !base.canonicalize().expect("canonicalize base").starts_with("/tmp"),
+            "test premise: the target dir must not live under /tmp"
+        );
+        tempfile::tempdir_in(base).expect("tempdir in target dir")
     }
 
     #[test]
-    fn deny_mask_dir_is_unreadable_tmpfs_after_everything_else() {
+    fn deny_mask_dir_is_empty_tmpfs_after_everything_else() {
         let base = non_tmp_tempdir();
         let secret = base.path().join("secrets");
         std::fs::create_dir(&secret).expect("create secrets");
@@ -1046,10 +1074,15 @@ mod tests {
             .unwrap()
             .to_string_lossy()
             .into_owned();
+        // Plain --tmpfs, deliberately without --perms (needs bwrap >= 0.5.0).
         let tmpfs_pos = args
-            .windows(4)
-            .position(|w| w[0] == "--perms" && w[1] == "000" && w[2] == "--tmpfs" && w[3] == canon)
-            .expect("dir mask must be emitted as --perms 000 --tmpfs");
+            .windows(2)
+            .position(|w| w[0] == "--tmpfs" && w[1] == canon)
+            .expect("dir mask must be emitted as --tmpfs over the target");
+        assert!(
+            !args.iter().any(|a| a == "--perms"),
+            "--perms must not be emitted — it requires bwrap >= 0.5.0"
+        );
         let last_bind_pos = args
             .iter()
             .rposition(|a| a == "--bind" || a == "--ro-bind")
@@ -1090,6 +1123,19 @@ mod tests {
                 .any(|w| w[0] == "--ro-bind" && w[1] == ph && w[2] == target),
             "file mask must bind the placeholder over the target"
         );
+
+        // Self-mask: the placeholder sits in the writable scratch bind, so it
+        // must be ro-bound over its own path (before any file mask) or the
+        // agent could chmod/write its inode through the scratch path.
+        let self_mask = args
+            .windows(3)
+            .position(|w| w[0] == "--ro-bind" && w[1] == ph && w[2] == ph)
+            .expect("placeholder must be ro-bound over itself");
+        let target_mask = args
+            .windows(3)
+            .position(|w| w[0] == "--ro-bind" && w[1] == ph && w[2] == target)
+            .expect("target mask present");
+        assert!(self_mask < target_mask, "self-mask must precede file masks");
     }
 
     #[test]
@@ -1104,7 +1150,9 @@ mod tests {
 
     #[test]
     fn deny_mask_skips_relative_missing_and_tmp_paths() {
-        let under_tmp = tempfile::tempdir().expect("tempdir"); // lives under /tmp
+        // Deliberately under the REAL /tmp — tempfile::tempdir() honors
+        // TMPDIR, which may point elsewhere (e.g. a cplt scratch dir).
+        let under_tmp = tempfile::tempdir_in("/tmp").expect("tempdir in /tmp");
         let masks = build_deny_masks(
             &[
                 PathBuf::from("relative/secrets"),
@@ -1114,6 +1162,11 @@ mod tests {
             None,
         );
         assert_eq!(masks.mask_count(), 0);
+        assert_eq!(
+            masks.skipped().len(),
+            3,
+            "unmaskable deny paths must be recorded for the caller's warning"
+        );
     }
 
     #[test]
@@ -1148,6 +1201,10 @@ mod tests {
             masks.files.is_empty(),
             "file under masked dir must be dropped"
         );
+        assert!(
+            masks.skipped().is_empty(),
+            "coalesced entries are covered, not skipped"
+        );
     }
 
     #[test]
@@ -1162,12 +1219,14 @@ mod tests {
         let scratch = base.path().join("scratch");
         std::fs::create_dir(&scratch).expect("scratch");
 
-        let masks = build_deny_masks(&[dir, file], Some(&scratch));
+        let masks = build_deny_masks(&[dir.clone(), file], Some(&scratch));
         let args = build_bwrap_args(&[], &[], &masks);
         let file_pos = args.iter().position(|a| a.ends_with("f.txt")).unwrap();
-        // `--perms` is only ever emitted by dir masks (the base /tmp mount is a
-        // plain `--tmpfs`), so it uniquely marks the dir-mask block.
-        let dir_pos = args.iter().position(|a| a == "--perms").unwrap();
+        let dir_canon = dir.canonicalize().unwrap().to_string_lossy().into_owned();
+        let dir_pos = args
+            .windows(2)
+            .position(|w| w[0] == "--tmpfs" && w[1] == dir_canon)
+            .unwrap();
         assert!(file_pos < dir_pos, "file masks must precede dir masks");
     }
 }

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -1059,14 +1059,19 @@ mod tests {
 
     // Deny masks are skipped under /tmp, so their tests need a base outside it.
     fn non_tmp_tempdir() -> tempfile::TempDir {
-        let base = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
-            || Path::new(env!("CARGO_MANIFEST_DIR")).join("target"),
-            PathBuf::from,
-        );
+        // A CARGO_TARGET_DIR under /tmp (a common build-speed setup) falls
+        // back to the manifest's target/ — a /tmp base would void these tests.
+        let base = std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .filter(|d| {
+                std::fs::create_dir_all(d).is_ok()
+                    && d.canonicalize().is_ok_and(|c| !c.starts_with("/tmp"))
+            })
+            .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("target"));
         std::fs::create_dir_all(&base).expect("create tempdir base");
         assert!(
             !base.canonicalize().expect("canonicalize base").starts_with("/tmp"),
-            "test premise: the target dir must not live under /tmp"
+            "test premise: no usable target dir outside /tmp"
         );
         tempfile::tempdir_in(base).expect("tempdir in target dir")
     }

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -106,6 +106,11 @@ pub(crate) struct BubblewrapWrapper {
     /// `use_bubblewrap = true`). A spawn-time failure is then a hard error;
     /// on auto-detect it degrades gracefully to Landlock-only.
     pub strict: bool,
+    /// How many deny paths these args mask. Enforcement is announced at
+    /// prepare time, but bwrap can still fail to start (auto-detect then
+    /// falls back to Landlock-only), which silently un-enforces them — so
+    /// the fallback warning needs this to say what was lost.
+    pub deny_mask_count: usize,
 }
 
 /// Check if bubblewrap is available on this system.
@@ -307,9 +312,14 @@ pub(crate) struct DenyMasks {
     /// the per-session scratch dir. `None` when `files` is empty.
     placeholder: Option<PathBuf>,
     /// Deny targets that could not be mount-masked (under a bwrap-managed
-    /// mount or `/tmp`, or no longer resolvable). The caller warns about
-    /// these when the wrapper is active.
+    /// mount or `/tmp`, no longer resolvable, or file masks with no usable
+    /// placeholder). The caller warns about these when the wrapper is active.
     skipped: Vec<PathBuf>,
+    /// Why the placeholder could not be created, when that is what forced
+    /// file masks into `skipped`. Reported by the caller rather than warned
+    /// about here: this runs before we know whether bwrap will be used at
+    /// all, and under `--no-bubblewrap` the warning would be noise.
+    placeholder_error: Option<String>,
 }
 
 impl DenyMasks {
@@ -319,6 +329,10 @@ impl DenyMasks {
 
     pub(crate) fn skipped(&self) -> &[PathBuf] {
         &self.skipped
+    }
+
+    pub(crate) fn placeholder_error(&self) -> Option<&str> {
+        self.placeholder_error.as_deref()
     }
 }
 
@@ -381,22 +395,22 @@ pub(crate) fn build_deny_masks(extra_deny: &[PathBuf], scratch_dir: Option<&Path
     files.sort();
     files.dedup();
 
+    // A file mask needs the placeholder as its bind source; without one those
+    // deny paths are unenforced, so they move to `skipped` with the reason.
+    let mut placeholder_error = None;
     let placeholder = if files.is_empty() {
         None
     } else {
         match scratch_dir.map(create_mask_placeholder) {
             Some(Ok(path)) => Some(path),
             Some(Err(e)) => {
-                crate::ui::warn(&format!(
-                    "Cannot create deny-mask placeholder: {e}. \
-                     File deny paths will not be masked."
-                ));
-                files.clear();
+                placeholder_error = Some(format!("cannot create deny-mask placeholder: {e}"));
+                skipped.append(&mut files);
                 None
             }
             None => {
-                crate::ui::warn("No scratch dir available; file deny paths will not be masked.");
-                files.clear();
+                placeholder_error = Some("no scratch dir available".to_string());
+                skipped.append(&mut files);
                 None
             }
         }
@@ -407,6 +421,7 @@ pub(crate) fn build_deny_masks(extra_deny: &[PathBuf], scratch_dir: Option<&Path
         files,
         placeholder,
         skipped,
+        placeholder_error,
     }
 }
 
@@ -552,6 +567,7 @@ fn build_wrapper(
         net_rules: net_rules.to_vec(),
         restrict_net_connect,
         strict,
+        deny_mask_count: deny_masks.mask_count(),
     })
 }
 
@@ -1043,9 +1059,10 @@ mod tests {
 
     // Deny masks are skipped under /tmp, so their tests need a base outside it.
     fn non_tmp_tempdir() -> tempfile::TempDir {
-        let base = std::env::var_os("CARGO_TARGET_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("target"));
+        let base = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
+            || Path::new(env!("CARGO_MANIFEST_DIR")).join("target"),
+            PathBuf::from,
+        );
         std::fs::create_dir_all(&base).expect("create tempdir base");
         assert!(
             !base.canonicalize().expect("canonicalize base").starts_with("/tmp"),
@@ -1143,9 +1160,14 @@ mod tests {
         let base = non_tmp_tempdir();
         let secret = base.path().join("token.txt");
         std::fs::write(&secret, "s").expect("write");
-        let masks = build_deny_masks(&[secret], None);
+        let masks = build_deny_masks(std::slice::from_ref(&secret), None);
         assert_eq!(masks.mask_count(), 0, "no scratch dir → no file mask");
         assert!(masks.placeholder.is_none());
+        // The unmaskable file is reported rather than silently dropped, and
+        // the reason travels with it for the caller to warn about — this runs
+        // before we know whether bwrap will be used at all.
+        assert_eq!(masks.skipped(), [secret.canonicalize().unwrap()]);
+        assert_eq!(masks.placeholder_error(), Some("no scratch dir available"));
     }
 
     #[test]

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -645,6 +645,15 @@ pub fn exec(
             BwrapOutcome::Ran(code) => return code,
             BwrapOutcome::Fallback => {
                 ui::warn("Bubblewrap could not start; using Landlock + seccomp only.");
+                if wrapper.deny_mask_count > 0 {
+                    // prepare() already announced these as enforced.
+                    ui::warn(&format!(
+                        "{} deny path(s) are NOT enforced in this run: the mount masks \
+                         went with Bubblewrap, and Landlock cannot deny subpaths within \
+                         allowed directories.",
+                        wrapper.deny_mask_count
+                    ));
+                }
                 // fall through to the direct path
             }
         }

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1596,37 +1596,51 @@ else:
     // Landlock cannot deny subpaths within allowed directories, so
     // --deny-path targets inside the project tree are shadowed at the mount
     // level when bwrap is active (an empty tmpfs for dirs, an unreadable
-    // placeholder bind for files). Projects here live under the REAL HOME,
-    // not tempfile::tempdir(): deny targets under /tmp are deliberately
+    // placeholder bind for files). Projects here live under the cargo target
+    // dir, not tempfile::tempdir(): deny targets under /tmp are deliberately
     // skipped by build_deny_masks (host /tmp is already invisible behind the
     // private tmpfs), so a /tmp-based project cannot demonstrate the mask.
 
-    /// Create a project under real HOME with a secret dir and file inside.
-    fn create_home_project(tag: &str) -> PathBuf {
-        let dir = home_dir().join(format!("cplt-test-denymask-{tag}-{}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(dir.join("secrets")).expect("create project dirs");
-        fs::write(dir.join("secrets/pw.txt"), "TOP-SECRET-DIR").expect("write");
-        fs::write(dir.join("token.txt"), "TOP-SECRET-FILE").expect("write");
-        fs::write(dir.join("README.md"), "hello").expect("write");
+    /// Create a project with a secret dir and file inside, outside `/tmp`.
+    ///
+    /// Returns a `TempDir` guard so the tree is removed on Drop even when the
+    /// test panics mid-assert.
+    fn create_deny_project() -> tempfile::TempDir {
+        let base = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
+            || PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"),
+            PathBuf::from,
+        );
+        fs::create_dir_all(&base).expect("create project base");
+        assert!(
+            !base
+                .canonicalize()
+                .expect("canonicalize base")
+                .starts_with("/tmp"),
+            "test premise: the target dir must not live under /tmp, or the \
+             deny mask is skipped and these tests prove nothing"
+        );
+        let dir = tempfile::tempdir_in(base).expect("tempdir in target dir");
+        fs::create_dir_all(dir.path().join("secrets")).expect("create project dirs");
+        fs::write(dir.path().join("secrets/pw.txt"), "TOP-SECRET-DIR").expect("write");
+        fs::write(dir.path().join("token.txt"), "TOP-SECRET-FILE").expect("write");
+        fs::write(dir.path().join("README.md"), "hello").expect("write");
         dir
     }
 
     #[test]
     fn bwrap_deny_path_dir_content_is_hidden() {
         require_bwrap!();
-        let project = create_home_project("dir");
-        let deny = project.join("secrets");
+        let project = create_deny_project();
+        let deny = project.path().join("secrets");
         let script = format!(
             "cat '{}/pw.txt' 2>&1 && echo READ_OK || echo READ_DENIED",
             deny.display()
         );
         let (code, stdout, stderr) = run_sandboxed_with_flags(
-            &project,
+            project.path(),
             &["--use-bubblewrap", "--deny-path", &deny.to_string_lossy()],
             &script,
         );
-        let _ = fs::remove_dir_all(&project);
         assert!(
             stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
             "content under a --deny-path dir inside the project must be hidden under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
@@ -1636,18 +1650,17 @@ else:
     #[test]
     fn bwrap_deny_path_file_is_unreadable() {
         require_bwrap!();
-        let project = create_home_project("file");
-        let deny = project.join("token.txt");
+        let project = create_deny_project();
+        let deny = project.path().join("token.txt");
         let script = format!(
             "cat '{}' 2>&1 && echo READ_OK || echo READ_DENIED",
             deny.display()
         );
         let (code, stdout, stderr) = run_sandboxed_with_flags(
-            &project,
+            project.path(),
             &["--use-bubblewrap", "--deny-path", &deny.to_string_lossy()],
             &script,
         );
-        let _ = fs::remove_dir_all(&project);
         assert!(
             stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
             "a --deny-path file inside the project must be unreadable under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
@@ -1660,19 +1673,18 @@ else:
         // self ro-bind must make chmod through that path fail, or the agent
         // could flip it readable and defeat the file mask.
         require_bwrap!();
-        let project = create_home_project("ph");
-        let deny = project.join("token.txt");
+        let project = create_deny_project();
+        let deny = project.path().join("token.txt");
         let script = format!(
             "chmod 644 \"$TMPDIR/deny-mask\" 2>&1 && echo CHMOD_OK || echo CHMOD_DENIED; \
              cat '{}' 2>&1 && echo READ_OK || echo READ_DENIED",
             deny.display()
         );
         let (code, stdout, stderr) = run_sandboxed_with_flags(
-            &project,
+            project.path(),
             &["--use-bubblewrap", "--deny-path", &deny.to_string_lossy()],
             &script,
         );
-        let _ = fs::remove_dir_all(&project);
         assert!(
             stdout.contains("CHMOD_DENIED"),
             "the placeholder must not be chmod-able from inside the sandbox — code: {code}, stdout: {stdout}, stderr: {stderr}"
@@ -1688,18 +1700,17 @@ else:
         // Degradation contract: without bwrap the mask cannot exist, the file
         // stays readable (Landlock cannot sub-deny), and the user is told so.
         require_landlock!();
-        let project = create_home_project("nobwrap");
-        let deny = project.join("secrets");
+        let project = create_deny_project();
+        let deny = project.path().join("secrets");
         let script = format!(
             "cat '{}/pw.txt' 2>&1 && echo READ_OK || echo READ_DENIED",
             deny.display()
         );
         let (code, stdout, stderr) = run_sandboxed_with_flags(
-            &project,
+            project.path(),
             &["--no-bubblewrap", "--deny-path", &deny.to_string_lossy()],
             &script,
         );
-        let _ = fs::remove_dir_all(&project);
         assert!(
             stdout.contains("READ_OK"),
             "without bwrap the deny path stays readable — code: {code}, stdout: {stdout}"

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1606,18 +1606,24 @@ else:
     /// Returns a `TempDir` guard so the tree is removed on Drop even when the
     /// test panics mid-assert.
     fn create_deny_project() -> tempfile::TempDir {
-        let base = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
-            || PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"),
-            PathBuf::from,
-        );
+        // A CARGO_TARGET_DIR under /tmp (a common build-speed setup) falls
+        // back to the manifest's target/ — deny masks skip /tmp, so a /tmp
+        // base would void these tests.
+        let base = std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .filter(|d| {
+                fs::create_dir_all(d).is_ok()
+                    && d.canonicalize().is_ok_and(|c| !c.starts_with("/tmp"))
+            })
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
         fs::create_dir_all(&base).expect("create project base");
         assert!(
             !base
                 .canonicalize()
                 .expect("canonicalize base")
                 .starts_with("/tmp"),
-            "test premise: the target dir must not live under /tmp, or the \
-             deny mask is skipped and these tests prove nothing"
+            "test premise: no usable target dir outside /tmp — the deny mask \
+             skips /tmp, so these tests would prove nothing there"
         );
         let dir = tempfile::tempdir_in(base).expect("tempdir in target dir");
         fs::create_dir_all(dir.path().join("secrets")).expect("create project dirs");

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1591,6 +1591,96 @@ else:
         );
     }
 
+    // ── Deny-path mount masks ─────────────────────────────────────
+    //
+    // Landlock cannot deny subpaths within allowed directories, so
+    // --deny-path targets inside the project tree are shadowed at the mount
+    // level when bwrap is active (--perms 000 --tmpfs for dirs, an unreadable
+    // placeholder bind for files). Projects here live under the REAL HOME,
+    // not tempfile::tempdir(): deny targets under /tmp are deliberately
+    // skipped by build_deny_masks (host /tmp is already invisible behind the
+    // private tmpfs), so a /tmp-based project cannot demonstrate the mask.
+
+    /// Create a project under real HOME with a secret dir and file inside.
+    fn create_home_project(tag: &str) -> PathBuf {
+        let dir = home_dir().join(format!("cplt-test-denymask-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("secrets")).expect("create project dirs");
+        fs::write(dir.join("secrets/pw.txt"), "TOP-SECRET-DIR").expect("write");
+        fs::write(dir.join("token.txt"), "TOP-SECRET-FILE").expect("write");
+        fs::write(dir.join("README.md"), "hello").expect("write");
+        dir
+    }
+
+    #[test]
+    fn bwrap_deny_path_dir_is_unreadable() {
+        require_bwrap!();
+        let project = create_home_project("dir");
+        let deny = project.join("secrets");
+        let script = format!(
+            "cat '{}/pw.txt' 2>&1 && echo READ_OK || echo READ_DENIED",
+            deny.display()
+        );
+        let (code, stdout, stderr) = run_sandboxed_with_flags(
+            &project,
+            &["--use-bubblewrap", "--deny-path", &deny.to_string_lossy()],
+            &script,
+        );
+        let _ = fs::remove_dir_all(&project);
+        assert!(
+            stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
+            "a --deny-path dir inside the project must be unreadable under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn bwrap_deny_path_file_is_unreadable() {
+        require_bwrap!();
+        let project = create_home_project("file");
+        let deny = project.join("token.txt");
+        let script = format!(
+            "cat '{}' 2>&1 && echo READ_OK || echo READ_DENIED",
+            deny.display()
+        );
+        let (code, stdout, stderr) = run_sandboxed_with_flags(
+            &project,
+            &["--use-bubblewrap", "--deny-path", &deny.to_string_lossy()],
+            &script,
+        );
+        let _ = fs::remove_dir_all(&project);
+        assert!(
+            stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
+            "a --deny-path file inside the project must be unreadable under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn deny_path_without_bwrap_warns_and_stays_readable() {
+        // Degradation contract: without bwrap the mask cannot exist, the file
+        // stays readable (Landlock cannot sub-deny), and the user is told so.
+        require_landlock!();
+        let project = create_home_project("nobwrap");
+        let deny = project.join("secrets");
+        let script = format!(
+            "cat '{}/pw.txt' 2>&1 && echo READ_OK || echo READ_DENIED",
+            deny.display()
+        );
+        let (code, stdout, stderr) = run_sandboxed_with_flags(
+            &project,
+            &["--no-bubblewrap", "--deny-path", &deny.to_string_lossy()],
+            &script,
+        );
+        let _ = fs::remove_dir_all(&project);
+        assert!(
+            stdout.contains("READ_OK"),
+            "without bwrap the deny path stays readable — code: {code}, stdout: {stdout}"
+        );
+        assert!(
+            stderr.contains("NOT enforced"),
+            "the unenforced deny must be loudly warned about — stderr: {stderr}"
+        );
+    }
+
     // ── Proxy-forced networking (#53) ─────────────────────────────
     //
     // `--proxy-forced` makes the CONNECT proxy mandatory and restricts kernel

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1595,7 +1595,7 @@ else:
     //
     // Landlock cannot deny subpaths within allowed directories, so
     // --deny-path targets inside the project tree are shadowed at the mount
-    // level when bwrap is active (--perms 000 --tmpfs for dirs, an unreadable
+    // level when bwrap is active (an empty tmpfs for dirs, an unreadable
     // placeholder bind for files). Projects here live under the REAL HOME,
     // not tempfile::tempdir(): deny targets under /tmp are deliberately
     // skipped by build_deny_masks (host /tmp is already invisible behind the
@@ -1613,7 +1613,7 @@ else:
     }
 
     #[test]
-    fn bwrap_deny_path_dir_is_unreadable() {
+    fn bwrap_deny_path_dir_content_is_hidden() {
         require_bwrap!();
         let project = create_home_project("dir");
         let deny = project.join("secrets");
@@ -1629,7 +1629,7 @@ else:
         let _ = fs::remove_dir_all(&project);
         assert!(
             stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
-            "a --deny-path dir inside the project must be unreadable under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
+            "content under a --deny-path dir inside the project must be hidden under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
         );
     }
 
@@ -1651,6 +1651,35 @@ else:
         assert!(
             stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
             "a --deny-path file inside the project must be unreadable under bwrap — code: {code}, stdout: {stdout}, stderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn bwrap_deny_mask_placeholder_cannot_be_softened() {
+        // The placeholder lives inside the writable scratch bind (TMPDIR); a
+        // self ro-bind must make chmod through that path fail, or the agent
+        // could flip it readable and defeat the file mask.
+        require_bwrap!();
+        let project = create_home_project("ph");
+        let deny = project.join("token.txt");
+        let script = format!(
+            "chmod 644 \"$TMPDIR/deny-mask\" 2>&1 && echo CHMOD_OK || echo CHMOD_DENIED; \
+             cat '{}' 2>&1 && echo READ_OK || echo READ_DENIED",
+            deny.display()
+        );
+        let (code, stdout, stderr) = run_sandboxed_with_flags(
+            &project,
+            &["--use-bubblewrap", "--deny-path", &deny.to_string_lossy()],
+            &script,
+        );
+        let _ = fs::remove_dir_all(&project);
+        assert!(
+            stdout.contains("CHMOD_DENIED"),
+            "the placeholder must not be chmod-able from inside the sandbox — code: {code}, stdout: {stdout}, stderr: {stderr}"
+        );
+        assert!(
+            stdout.contains("READ_DENIED") && !stdout.contains("TOP-SECRET"),
+            "the file mask must hold — code: {code}, stdout: {stdout}, stderr: {stderr}"
         );
     }
 


### PR DESCRIPTION
Fixes #178 (phase 1) — makes `--deny-path` / `deny.paths` actually enforced on Linux; previously a warning with no effect.

- When Bubblewrap is active, deny dirs are masked with an unreadable tmpfs and deny files with an unreadable placeholder bind (EACCES, matching macOS)
- Masks are built into the probed production args and cannot be unmounted from inside (mount/umount2 already seccomp-blocked)
- Without Bubblewrap the warning now states clearly that the deny is unenforced
- SECURITY.md platform matrix updated; kernel integration tests cover dir mask, file mask, and the no-bwrap fallback

Design rationale and follow-ups (`DENIED_HOME_SUBPATHS`, `.env` patterns) are recorded in #178.
