### PR TITLE
fix(sandbox): canonicalize agent config dirs before emitting rules

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -849,6 +849,28 @@ pub struct AgentDir {
     pub write_files: Vec<&'static str>,
 }
 
+/// Resolve each agent dir to its real path, in place.
+///
+/// Both backends match on the *resolved* path — Seatbelt resolves symlinks
+/// before matching a `subpath` rule, and Landlock rules attach to the inode —
+/// so a rule emitted for a symlinked config dir never matches. Dotfile managers
+/// symlink these constantly (`~/.config/opencode -> ~/dotfiles/opencode`), and
+/// the result is a hard startup crash: the agent cannot read its own config,
+/// and it fails before initializing its logger, so the log the TUI points the
+/// user at stays empty (#171).
+///
+/// User-supplied `allow.read`/`allow.write` paths already canonicalize; this
+/// brings the built-in agent dirs in line. Paths that cannot be resolved (a dir
+/// the caller has not created yet, a dangling link) are left as-is so the
+/// caller still emits a rule for the literal path rather than dropping it.
+pub fn canonicalize_agent_dirs(dirs: &mut [AgentDir]) {
+    for dir in dirs {
+        if let Ok(resolved) = std::fs::canonicalize(&dir.path) {
+            dir.path = resolved;
+        }
+    }
+}
+
 /// Check if a copilot binary is a VS Code/Cursor/editor shim script.
 fn is_editor_shim(path: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
@@ -957,6 +979,59 @@ impl std::fmt::Display for Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn agent_dir(path: PathBuf) -> AgentDir {
+        AgentDir {
+            path,
+            write: true,
+            map_exec: false,
+            process_exec: false,
+            write_files: vec![],
+        }
+    }
+
+    /// Dotfile managers routinely symlink `~/.config/<agent>` elsewhere. Both
+    /// sandbox backends match on the resolved path, so emitting a rule for the
+    /// link is a silent no-op and the agent cannot read its own config (#171).
+    #[test]
+    #[cfg(unix)]
+    fn canonicalize_agent_dirs_resolves_symlinked_config_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("dotfiles-opencode");
+        std::fs::create_dir(&real).expect("create real dir");
+        let link = tmp.path().join("config-opencode");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let mut dirs = vec![agent_dir(link)];
+        canonicalize_agent_dirs(&mut dirs);
+
+        assert_eq!(
+            dirs[0].path,
+            real.canonicalize().expect("canonicalize real dir"),
+            "a symlinked agent dir must be emitted as its resolved target"
+        );
+    }
+
+    /// A dir that does not resolve (never created, or a dangling link) keeps
+    /// its literal path — dropping it would silently remove the grant instead.
+    #[test]
+    fn canonicalize_agent_dirs_keeps_unresolvable_paths() {
+        let missing = PathBuf::from("/definitely/not/a/real/path/cplt-xyzzy");
+        let mut dirs = vec![agent_dir(missing.clone())];
+        canonicalize_agent_dirs(&mut dirs);
+        assert_eq!(dirs[0].path, missing);
+    }
+
+    /// Non-symlinked dirs must survive untouched apart from `..`/`.` cleanup.
+    #[test]
+    fn canonicalize_agent_dirs_leaves_real_dirs_alone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("plain");
+        std::fs::create_dir(&real).expect("create");
+        let mut dirs = vec![agent_dir(real.clone())];
+        canonicalize_agent_dirs(&mut dirs);
+        assert_eq!(dirs[0].path, real.canonicalize().expect("canonicalize"));
+    }
 
     #[test]
     fn parse_agent_names() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2307,7 +2307,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         .filter(|p| !crate::is_unsafe_root(p, &home_dir));
 
     // Compute agent-specific sandbox directories
-    let agent_dirs = active_agent.config_dirs(&home_dir);
+    let mut agent_dirs = active_agent.config_dirs(&home_dir);
 
     // Pre-create agent directories before entering sandbox.
     // Agents like OpenCode crash if their data/config dirs don't exist,
@@ -2317,6 +2317,8 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             let _ = std::fs::create_dir_all(&dir.path);
         }
     }
+    // After pre-creation, so a dir we just made resolves too. See #171.
+    agent::canonicalize_agent_dirs(&mut agent_dirs);
 
     // macOS-only, opt-in (sandbox.gradle_init): install the guarded Gradle
     // init script so sandboxed builds keep the preferIPv4Stack workaround for
@@ -2813,12 +2815,14 @@ fn prepare_shell_sandbox(
         .filter(|p| p.is_dir())
         .filter(|p| !crate::is_unsafe_root(p, home_dir));
 
-    let agent_dirs = active_agent.config_dirs(home_dir);
+    let mut agent_dirs = active_agent.config_dirs(home_dir);
     for dir in &agent_dirs {
         if !dir.path.exists() {
             let _ = std::fs::create_dir_all(&dir.path);
         }
     }
+    // See the agent-path call site: resolve symlinked agent dirs (#171).
+    agent::canonicalize_agent_dirs(&mut agent_dirs);
 
     // See the agent-path call site: guarded Gradle init script (opt-in via
     // sandbox.gradle_init) so sandboxed builds keep the preferIPv4Stack


### PR DESCRIPTION
Fixes #171.

## Problem

Both backends match on the **resolved** path — Seatbelt resolves symlinks before matching a `subpath` rule, and Landlock rules attach to the inode. cplt emits agent config-dir rules using the *link* path, so when a dotfile manager symlinks `~/.config/opencode -> ~/dotfiles/opencode` the rule never matches and the agent cannot read its own config.

The failure mode is nasty: OpenCode crashes during config load, *before* it initializes its logger, so the log file the TUI tells the user to check stays empty. @pearofducks' report has the full reproduction.

`allow.read`/`allow.write` already canonicalize — the bug is scoped to the built-in agent-dir generator.

## Fix

`agent::canonicalize_agent_dirs` resolves each `AgentDir` in place, called at both sandbox setup sites *after* the pre-create loop so a directory cplt just created resolves too. Paths that can't be resolved (never created, dangling link) keep their literal value — dropping them would silently remove the grant instead of just failing to follow a link.

Canonicalizing is sufficient on its own; emitting both link and resolved paths (the issue's alternative) isn't needed, since the kernel only ever matches the resolved one.

## Tests

Three unit tests: symlinked dir resolves to its target, unresolvable path is preserved, plain dir is unchanged.

`cargo fmt --check`, `clippy --all-targets -D warnings`, 704 lib + 260 integration tests all pass.

## Not covered

The issue's "Related" note — global skills/agents dirs (`~/.agents -> ~/dotfiles/agents`) — has the same root cause but a different shape: `HOME_TOOL_DIRS` entries are `&'static str` paths joined onto `$HOME` at emit time (`{home}/{p}`), so fixing them means changing that type to carry resolved absolute paths. Left out deliberately to keep this focused on the crash; happy to follow up if you want it in the same PR.