### PR TITLE
ci: replace CodeQL default setup with an advanced workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -54,14 +54,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Neither extractor compiles anything: `actions` parses workflow YAML,
-          # and the Rust extractor works from source. No build step needed.
+          # `actions` just parses workflow YAML — nothing to build.
           - language: actions
             build-mode: none
+          # Rust needs a real build. Measured on this repo with build-mode
+          # none: 35 of 41 files extracted *with errors*, 6 clean — the
+          # extractor can't resolve types across crate boundaries without the
+          # dependency graph, so the analysis would have been near-worthless
+          # while still gating merges. autobuild runs cargo, which populates it.
           - language: rust
-            build-mode: none
+            build-mode: autobuild
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+
+      # Same cache as ci.yaml, so autobuild reuses those artifacts instead of
+      # compiling the dependency tree from scratch on every run.
+      - name: Cache cargo registry and build
+        if: matrix.language == 'rust'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache@v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # ratchet:github/codeql-action/init@v4.37.8

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -59,32 +59,15 @@ jobs:
             build-mode: none
           # `none` is the only build mode the Rust extractor accepts —
           # `autobuild` is rejected outright ("Rust does not support the
-          # autobuild build mode"). Buildless extraction still resolves types
-          # across crates as long as the dependency sources are on disk, which
-          # is what the `cargo fetch` step below is for.
+          # autobuild build mode"). It extracts 35 of 41 files with errors,
+          # which is exactly what the repository's default setup produces
+          # today, so this is not a regression — but treat Rust findings as
+          # best-effort until the extractor improves. Pre-fetching crate
+          # sources (`cargo fetch`) was measured and changed nothing.
           - language: rust
             build-mode: none
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
-
-      # Same registry cache as ci.yaml. No `target/` here — buildless
-      # extraction never compiles, it only needs the dependency *sources*.
-      - name: Cache cargo registry
-        if: matrix.language == 'rust'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache@v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
-      # Puts every dependency's source under ~/.cargo/registry/src before the
-      # extractor runs. Without it the buildless extractor has no crate sources
-      # to resolve names against and most files extract with errors.
-      - name: Fetch cargo dependencies
-        if: matrix.language == 'rust'
-        run: cargo fetch --locked
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # ratchet:github/codeql-action/init@v4.37.8

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -57,28 +57,34 @@ jobs:
           # `actions` just parses workflow YAML — nothing to build.
           - language: actions
             build-mode: none
-          # Rust needs a real build. Measured on this repo with build-mode
-          # none: 35 of 41 files extracted *with errors*, 6 clean — the
-          # extractor can't resolve types across crate boundaries without the
-          # dependency graph, so the analysis would have been near-worthless
-          # while still gating merges. autobuild runs cargo, which populates it.
+          # `none` is the only build mode the Rust extractor accepts —
+          # `autobuild` is rejected outright ("Rust does not support the
+          # autobuild build mode"). Buildless extraction still resolves types
+          # across crates as long as the dependency sources are on disk, which
+          # is what the `cargo fetch` step below is for.
           - language: rust
-            build-mode: autobuild
+            build-mode: none
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
 
-      # Same cache as ci.yaml, so autobuild reuses those artifacts instead of
-      # compiling the dependency tree from scratch on every run.
-      - name: Cache cargo registry and build
+      # Same registry cache as ci.yaml. No `target/` here — buildless
+      # extraction never compiles, it only needs the dependency *sources*.
+      - name: Cache cargo registry
         if: matrix.language == 'rust'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache@v6.1.0
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+
+      # Puts every dependency's source under ~/.cargo/registry/src before the
+      # extractor runs. Without it the buildless extractor has no crate sources
+      # to resolve names against and most files extract with errors.
+      - name: Fetch cargo dependencies
+        if: matrix.language == 'rust'
+        run: cargo fetch --locked
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # ratchet:github/codeql-action/init@v4.37.8

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,78 @@
+name: CodeQL
+
+# Advanced CodeQL setup, replacing the repository's *default* setup.
+#
+# Why: the branch ruleset has a `code_scanning` rule requiring results from the
+# CodeQL tool, but default setup never runs for pull requests from forks. Every
+# fork PR therefore sat forever on "Code scanning is waiting for results from
+# CodeQL", with no run to approve and no result ever arriving — see #177 and
+# #158. An advanced workflow runs in the `pull_request` context like any other
+# workflow, so fork PRs get analyzed once a maintainer approves the run.
+#
+# Second reason: default setup was configured for `actions` only, so CodeQL had
+# never looked at a line of the Rust. This adds `rust` alongside it.
+#
+# IMPORTANT: default setup must be disabled (Settings → Code security → CodeQL
+# analysis → default setup) before this workflow can upload. While it is still
+# enabled, the analyze step fails because GitHub refuses advanced-configuration
+# results for a repo using default setup.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # The ruleset gates merges on code scanning, so the analysis has to report in
+  # the merge queue's temporary ref too — otherwise queued entries wait out the
+  # 60-minute timeout and fail to merge. Same reasoning as ci.yaml.
+  merge_group:
+  # Keeps the weekly cadence the default setup had, so main is still rescanned
+  # when new queries ship rather than only when someone opens a PR.
+  schedule:
+    - cron: "27 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Uploading the SARIF results.
+      security-events: write
+      # The `actions` extractor reads workflow definitions and run metadata.
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Neither extractor compiles anything: `actions` parses workflow YAML,
+          # and the Rust extractor works from source. No build step needed.
+          - language: actions
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # ratchet:github/codeql-action/init@v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Matches the `extended` query suite the default setup used, so this
+          # swap does not quietly narrow what gets flagged.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # ratchet:github/codeql-action/analyze@v4.37.8
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Unblocks every fork PR in this repo, including #177 and #158.

## The problem

The branch ruleset has a `code_scanning` rule requiring results from the CodeQL tool, but **default setup never runs for pull requests from forks**. There is no run sitting in `action_required` to approve — one is simply never created. Querying runs for #158's head returns exactly one workflow, `CI`.

Code-scanning analyses in this repo exist only for:

```
refs/heads/main, refs/pull/173/head, refs/pull/176/head, refs/pull/181/head
```

| PR | fork? | CodeQL analysis |
|---|---|---|
| #173, #176, #181 | no | ✅ |
| #158, #177 | **yes** | ❌ |

So fork PRs sit forever on *"Code scanning is waiting for results from CodeQL for the commits …"*. That's both currently-open external contributions, and it will be every future one.

## Second problem

Default setup is configured for `languages: ["actions"]`. CodeQL has been analyzing workflow YAML and **has never looked at a line of the Rust** — so the gate blocking outside contributions provides no coverage of the actual codebase. (navikt/copilot, by contrast, runs `actions, go, javascript, javascript-typescript, typescript`.)

## This change

An advanced workflow runs in the normal `pull_request` context, so fork PRs get analyzed after the same maintainer run-approval that CI already needs. It also:

- adds `rust` alongside `actions` (`rust` is a supported CodeQL language; neither extractor needs a build, hence `build-mode: none`)
- keeps the `extended` query suite default setup used, so nothing is quietly narrowed
- keeps a weekly schedule, so main is still rescanned when new queries ship
- runs on `merge_group`, for the same reason `ci.yaml` does — a required check that doesn't report on the queue's temp ref makes queued entries wait out the 60-minute timeout
- pins both actions by SHA with `ratchet:` comments, matching `ci.yaml`

## ⚠️ Rollout order — needs a settings change

**Default setup must be disabled before this can upload.** GitHub refuses advanced-configuration results while default setup is enabled, so until you turn it off the analyze step will fail on this very PR. That's expected, not a bug in the workflow.

Suggested sequence:

1. Settings → Code security → CodeQL analysis → disable **default setup**
2. Admin-merge this PR (with default setup off and this not yet on main, the `code_scanning` rule has nothing to satisfy it — that gap is exactly why it needs a bypass)
3. Confirm the run on main uploads for both languages
4. Re-run CI on #177 and #158; they should now get CodeQL and become mergeable

I have not touched repository settings — step 1 is yours.

## Verification

YAML parses; triggers, permissions, matrix and pinned SHAs confirmed. The Rust extractor's behaviour under `build-mode: none` will be proven by the first run that's actually allowed to upload — if it objects, the fix is dropping to `autobuild` for that one matrix entry.