### PR TITLE
fix(install): gate the Homebrew path on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ done
 
 # ─── Homebrew install (macOS) ────────────────────────────────────────────────
 
-if [[ "$NO_BREW" == false && -z "$VERSION" && -z "$INSTALL_DIR" ]] && command -v brew &>/dev/null; then
+if [[ "$(uname -s)" == "Darwin" && "$NO_BREW" == false && -z "$VERSION" && -z "$INSTALL_DIR" ]] && command -v brew &>/dev/null; then
   echo "→ Installing via Homebrew..."
   brew install navikt/tap/cplt
   echo ""


### PR DESCRIPTION
`install.sh` gated the Homebrew branch on `command -v brew` rather than on the OS, despite the header comment at `install.sh:6-7` promising:

```
# On macOS: uses Homebrew (brew install navikt/tap/cplt) when available.
# On Linux / CI: downloads the latest release binary from GitHub.
```

A Linuxbrew user on WSL2 running the documented `curl -fsSL ... | bash` therefore landed in the Homebrew branch and got:

```
Error: navikt/tap/cplt: formula requires at least a URL
```

The Linux download path directly below (`install.sh:65-85`, mapping to `${ARCH}-unknown-linux-gnu`) was never reached, even though the release ships both `cplt-x86_64-unknown-linux-gnu.tar.gz` and `cplt-aarch64-unknown-linux-gnu.tar.gz`.

One-line fix: add `[[ "$(uname -s)" == "Darwin" ]]` to the condition.

The tap formula's missing `on_linux` block is fixed separately in `navikt/homebrew-tap`, but this guard is correct regardless — the branch is documented as the macOS path, so it should test for macOS.

Closes part of #190.
