### PR TITLE
fix(sandbox): allow exec of Gradle toolchain JDKs under ~/.gradle/jdks

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -368,6 +368,10 @@ org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.paths=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home
 ```
 
+Note that the provisioning failure surfaces as `foojay (Unable to download toolchain ..., due to: java.io.IOException: Operation not permitted)`, which reads like a network problem. It is the write being denied, not the download — check the proxy only after ruling this out.
+
+Two limits worth knowing. Both rules match the *resolved* path, so if `~/.gradle/jdks` is a symlink to another volume they silently do not apply; the agent cannot create that symlink itself (the same rules deny writing or `mkdir` at that path), so it takes a pre-existing relocation. And a relocated `GRADLE_USER_HOME` misses the rules entirely — but that is pre-existing, since the whole `~/.gradle` grant is keyed to the default location.
+
 **Linux:** unaffected. Landlock has a single `EXECUTE` right covering both `execve` and executable mappings, so the map-exec grant on `~/.gradle` already implies exec there — the carve-out is macOS-only, and the read-only pairing cannot be expressed on Linux for the same reason [`DENIED_HOME_SUBPATHS`](#private-registries) cannot.
 
 ## JVM Attach API

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -356,6 +356,20 @@ forkOptions {
 
 Known affected: `ktlint-gradle` ([JLLeitschuh/ktlint-gradle#1110](https://github.com/JLLeitschuh/ktlint-gradle/issues/1110)). SBPL itself cannot be fixed — macOS sandbox profiles have no primitive for IPv4-mapped addresses, which is why cplt uses the `preferIPv4Stack` workaround at all.
 
+## Gradle toolchain JDKs
+
+`~/.gradle` is a dependency store: the sandbox grants read, write, and `file-map-executable` (for JNI libs) but **not** `process-exec`, so a rogue agent cannot drop a binary into the dependency cache and run it. Gradle's toolchain support auto-provisions JDKs into `~/.gradle/jdks`, which lands inside that non-executable tree — forking a toolchain `javac` or test JVM failed with `Operation not permitted`, and no config key could grant exec.
+
+cplt now carves `~/.gradle/jdks` back out as executable, and makes it **read-only** to keep the write-then-exec hole closed. Consequence: with `org.gradle.java.installations.auto-download=true`, a toolchain that is not already on disk fails at provisioning time with a write error instead of at exec time. Provision it once outside cplt, or use a JDK outside `~/.gradle`:
+
+```properties
+# ~/.gradle/gradle.properties
+org.gradle.java.installations.auto-download=false
+org.gradle.java.installations.paths=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home
+```
+
+**Linux:** unaffected. Landlock has a single `EXECUTE` right covering both `execve` and executable mappings, so the map-exec grant on `~/.gradle` already implies exec there — the carve-out is macOS-only, and the read-only pairing cannot be expressed on Linux for the same reason [`DENIED_HOME_SUBPATHS`](#private-registries) cannot.
+
 ## JVM Attach API
 
 JVM testing frameworks like **MockK** (inline mocking), **Mockito** (inline agents), and **ByteBuddy** use the JVM Attach API for runtime class instrumentation. This API creates a Unix domain socket at `/tmp/.java_pid<PID>` — which the sandbox blocks by default.

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -165,6 +165,7 @@ pub fn generate_profile(opts: &ProfileOptions) -> String {
         opts.allow_cache_exec_any,
     );
     emit_copilot_install(&mut sb, opts.copilot_install_dir);
+    emit_gradle_toolchain_exec(&mut sb, &home);
     emit_java_home(&mut sb, opts.java_home);
     emit_dotnet_root(&mut sb, opts.dotnet_root);
     emit_electron_app(&mut sb, opts.electron_app_dir);
@@ -200,6 +201,9 @@ pub fn generate_profile(opts: &ProfileOptions) -> String {
     // Same reason: keeps exec-allowed DOTNET_ROOT subtrees non-writable even
     // when a user allow.write covers them (write-then-exec).
     emit_dotnet_exec_denies(&mut sb, opts.dotnet_root);
+    // Same reason: keeps the exec-allowed Gradle toolchain dir non-writable
+    // even when a user allow.write covers ~/.gradle (write-then-exec).
+    emit_gradle_toolchain_write_deny(&mut sb, &home);
 
     sb
 }
@@ -802,6 +806,50 @@ fn emit_java_home(sb: &mut String, java_home: Option<&Path>) {
         sbpl!(sb, "(allow file-map-executable (subpath \"{p}\"))");
         sbpl!(sb);
     }
+}
+
+/// Allow executing JDKs that Gradle auto-provisions into `~/.gradle/jdks`.
+///
+/// `~/.gradle` is a dependency store in `HOME_TOOL_DIRS` (write + map-exec, no
+/// process-exec), so `emit_tool_dirs` emits an explicit
+/// `(deny process-exec (subpath "~/.gradle"))` to beat the blanket
+/// `(allow process-exec)`. That is right for dependency JARs, but Gradle's
+/// toolchain support drops provisioned JDKs under `~/.gradle/jdks` — inside the
+/// denied subtree. Forking a toolchain `javac` or test JVM then fails with
+/// "Operation not permitted", and no config key could grant it (`allow.read`
+/// emits `file-read*` only, and there is no `allow.exec`). Re-allow exec for
+/// just that subtree; the matching write-deny is emitted later, by
+/// `emit_gradle_toolchain_write_deny`.
+///
+/// Emitted AFTER `emit_tool_dirs` because SBPL is last-match-wins.
+fn emit_gradle_toolchain_exec(sb: &mut String, home: &str) {
+    sbpl!(sb, ";; Gradle toolchain JDKs — exec auto-provisioned JDKs");
+    sbpl!(sb, "(allow process-exec (subpath \"{home}/.gradle/jdks\"))");
+    sbpl!(sb);
+}
+
+/// Keep the exec-allowed Gradle toolchain directory read-only.
+///
+/// `~/.gradle` is agent-writable, so exec inside it without a write-deny is a
+/// write-then-exec primitive: drop a binary into `~/.gradle/jdks` and run it,
+/// bypassing the `allow_tmp_exec` / `allow_cache_exec` gates entirely. Gradle
+/// provisions toolchains outside the sandbox, so this costs nothing in normal
+/// use. The trade: with `auto-download=true`, a toolchain not already on disk
+/// now fails at provisioning time with a write error instead of at exec time
+/// with EPERM. Provision it outside cplt, or point
+/// `org.gradle.java.installations.paths` at a JDK outside `~/.gradle`.
+///
+/// Emitted AFTER `emit_user_allows` because SBPL is last-match-wins: a user
+/// `allow.write` covering `~/.gradle` (or any parent) would otherwise override
+/// a write-deny emitted alongside the exec allow and silently reopen the hole.
+/// Same rationale as `emit_dotnet_exec_denies`.
+fn emit_gradle_toolchain_write_deny(sb: &mut String, home: &str) {
+    sbpl!(
+        sb,
+        ";; Gradle toolchain JDKs — exec-allowed path stays read-only"
+    );
+    sbpl!(sb, "(deny file-write* (subpath \"{home}/.gradle/jdks\"))");
+    sbpl!(sb);
 }
 
 /// Allow executing the dotnet host and loading .NET SDK libraries from DOTNET_ROOT.
@@ -1603,6 +1651,48 @@ mod tests {
         assert_deny_after_allow(
             r#"(allow file-read* (subpath "/Users/test/.gradle"))"#,
             r#"(deny file-read* (literal "/Users/test/.gradle/gradle.properties"))"#,
+        );
+    }
+
+    /// #191: Gradle auto-provisions toolchain JDKs into `~/.gradle/jdks`, which
+    /// sits inside the `(deny process-exec (subpath "~/.gradle"))` that
+    /// `emit_tool_dirs` emits for dependency stores — `java`/`javac` from a
+    /// toolchain JDK got EPERM. The carve-out only works if it is emitted AFTER
+    /// that deny (last-match-wins), and the paired write-deny only closes the
+    /// write-then-exec hole if it is emitted after every write allow, including
+    /// a user `allow.write`. Byte offsets, not `contains`, because ordering is
+    /// the whole point.
+    #[test]
+    fn gradle_toolchain_exec_allow_comes_after_the_gradle_exec_deny() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let mut opts = test_options(project, home);
+        // Worst case for the write-deny: the user has opened up all of ~/.gradle.
+        let extra_write = [std::path::PathBuf::from("/Users/test/.gradle")];
+        opts.extra_write = &extra_write;
+        let p = generate_profile(&opts);
+
+        let at = |rule: &str| {
+            p.find(rule)
+                .unwrap_or_else(|| panic!("rule missing from profile: {rule}"))
+        };
+
+        let exec_deny = at(r#"(deny process-exec (subpath "/Users/test/.gradle"))"#);
+        let exec_allow = at(r#"(allow process-exec (subpath "/Users/test/.gradle/jdks"))"#);
+        assert!(
+            exec_deny < exec_allow,
+            "toolchain exec allow @ {exec_allow} must come AFTER the .gradle exec deny @ {exec_deny}"
+        );
+
+        let write_allow = at(r#"(allow file-write* (subpath "/Users/test/.gradle"))"#);
+        let user_write_allow = p
+            .rfind(r#"(allow file-write* (subpath "/Users/test/.gradle"))"#)
+            .expect("user allow.write rule missing");
+        let write_deny = at(r#"(deny file-write* (subpath "/Users/test/.gradle/jdks"))"#);
+        assert!(
+            write_allow < write_deny && user_write_allow < write_deny,
+            "toolchain write deny @ {write_deny} must come AFTER every .gradle write allow \
+             (tool dir @ {write_allow}, user allow.write @ {user_write_allow})"
         );
     }
 

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -1694,6 +1694,19 @@ mod tests {
             "toolchain write deny @ {write_deny} must come AFTER every .gradle write allow \
              (tool dir @ {write_allow}, user allow.write @ {user_write_allow})"
         );
+
+        // Stronger than the two known allows above: nothing emitted later may
+        // re-grant write over the exec-allowed subtree. Guards against a future
+        // emit_* being appended after emit_gradle_toolchain_write_deny.
+        let last_write_allow = p
+            .rfind("(allow file-write*")
+            .expect("profile has no write allows at all");
+        assert!(
+            last_write_allow < write_deny,
+            "the toolchain write deny @ {write_deny} must be the LAST rule \
+             touching write on this subtree; a later (allow file-write*) @ \
+             {last_write_allow} would reopen write-then-exec"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Reported by a user whose Gradle build failed with `Operation not permitted` even after granting read access to the JDK.

`~/.gradle` is a dependency store in `HOME_TOOL_DIRS` — `write: true, map_exec: true, process_exec: false` (`src/sandbox_policy.rs:885-891`). Since the macOS profile opens with a blanket `(allow process-exec)`, `emit_tool_dirs` has to emit an explicit deny, visible at line 166 of a real `--print-profile`:

```
130:(allow file-write* (subpath "~/.gradle"))
166:(deny process-exec (subpath "~/.gradle"))
```

That policy is right for dependency JARs. But Gradle's toolchain support auto-provisions JDKs into `~/.gradle/jdks/`, inside the denied subtree, so forking a toolchain `javac` or test JVM gets EPERM.

Nothing could work around it: `[allow] read` emits `file-read*` only, there is no `[allow] exec`, and `emit_java_home` grants read + map-exec but no `process-exec`.

## Fix

Two rules, following the `emit_dotnet_root` / `emit_dotnet_exec_denies` precedent for the same shape:

```
(allow process-exec (subpath "~/.gradle/jdks"))
(deny file-write* (subpath "~/.gradle/jdks"))
```

The write-deny is load-bearing, not decoration. `~/.gradle` is agent-writable, so exec inside it without the deny is a write-then-exec primitive that bypasses the `allow_tmp_exec` / `allow_cache_exec` gates entirely.

Placement is the whole trick, since SBPL is last-match-wins. The exec allow goes after `emit_tool_dirs`; the write deny goes after `emit_user_allows`, so a user `allow.write` covering `~/.gradle` cannot silently reopen the hole. Verified on real `--print-profile` output:

```
166:(deny process-exec (subpath "~/.gradle"))
280:(allow process-exec (subpath "~/.gradle/jdks"))
419:(deny file-write* (subpath "~/.gradle/jdks"))
```

## Trade-off

With `org.gradle.java.installations.auto-download=true`, a toolchain not already on disk now fails at provisioning time with a write error rather than at exec time with EPERM. That is deliberate — provision outside cplt, or point `org.gradle.java.installations.paths` at a JDK outside `~/.gradle`. Documented in `docs/known-impacts.md`.

## Linux is unaffected

`src/sandbox_landlock.rs:372` builds home-tool-dir rules as `execute: dir.process_exec || dir.map_exec`. `.gradle` has `map_exec: true`, and Landlock has a single `EXECUTE` right covering both `execve` and executable mappings with no way to separate them — so exec of a toolchain JDK under `~/.gradle` already worked on Linux. This is a macOS-only bug, and the read-only pairing is not expressible on Linux. No Linux code changed; the gap is noted in the docs alongside the existing `DENIED_HOME_SUBPATHS` one.

## Test

`gradle_toolchain_exec_allow_comes_after_the_gradle_exec_deny` asserts on byte offsets rather than `contains`, because ordering is the entire fix. It sets `extra_write = ["~/.gradle"]` so it also pins the write deny after a *user* `allow.write`, not just the tool-dir one. Confirmed it bites: moving the emit call before `emit_tool_dirs` fails it.

`cargo test --lib` → 705 passed, 0 failed. fmt + clippy clean.

## Not done

`src/check.rs:367` `explain_exec` would be the natural home for a "this is a Gradle toolchain JDK" hint, and `check.rs:479` has a branch of exactly the right shape. It isn't cheap: `explain_exec` classifies against the Linux-shaped `LandlockPolicy.fs_rules`, where exec under `~/.gradle` *is* granted, so a hint would report a false `Blocked` on Linux unless duplicated or `cfg`-gated — and `ExecContext` has no `home` field. Left out deliberately; noted here as the insertion point if we want it later.

Closes #191.
