### PR TITLE
fix(init): drop the Gradle cache-exec suggestion, which pointed at a directory Gradle never uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ cplt init --global    # generate personal ~/.config/cplt/config.toml
 
 Supported ecosystems: JVM (Gradle/Maven), Node.js, Docker, Python, Rust, Go, Playwright, Spring Boot, Ktor, TestContainers, Next.js, Vite, Flyway, Cypress, and environment secrets (`.env.example`). Dangerous permissions include risk warnings in the generated TOML.
 
-`--global` detects machine-level tools (Gradle wrapper, Playwright browsers, GPG signing, alternative agents) and generates your personal config.
+`--global` detects machine-level tools (Playwright browsers, GPG signing, registry credentials, alternative agents) and generates your personal config.
 
 Use `cplt config set --repo` to manage without editing TOML by hand:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -359,7 +359,6 @@ cplt init --global --write  # Write to ~/.config/cplt/config.toml
 Detects:
 | Tool | Probes | Suggests |
 |------|--------|----------|
-| Gradle wrapper | `~/.gradle/wrapper/dists/` | `allow_cache_exec = ["gradle"]` |
 | Playwright browsers | `~/Library/Caches/ms-playwright/` | `allow_cache_exec = ["ms-playwright"]` |
 | GPG signing | `~/.gnupg/` + git config | `allow_gpg_signing = true` |
 | Gradle registry | `~/.gradle/gradle.properties` | `allow.read` for credentials file |

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1875,11 +1875,6 @@ pub struct GlobalDetectionReport {
 pub fn detect_global(home: &Path) -> GlobalDetectionReport {
     let mut detections = Vec::new();
 
-    // Gradle cache exec (for wrapper downloads)
-    if let Some(d) = detect_global_gradle(home) {
-        detections.push(d);
-    }
-
     // Playwright browser cache
     if let Some(d) = detect_global_playwright(home) {
         detections.push(d);
@@ -1911,19 +1906,6 @@ pub fn detect_global(home: &Path) -> GlobalDetectionReport {
     }
 
     GlobalDetectionReport { detections }
-}
-
-fn detect_global_gradle(home: &Path) -> Option<GlobalDetection> {
-    // Gradle wrapper downloads executables to ~/.gradle/wrapper/dists/
-    let wrapper_dir = home.join(".gradle/wrapper/dists");
-    if !wrapper_dir.is_dir() {
-        return None;
-    }
-    Some(GlobalDetection {
-        name: "Gradle wrapper",
-        reason: "~/.gradle/wrapper/dists/ exists (Gradle wrapper executables)".to_string(),
-        suggestions: vec![GlobalSuggestion::CacheExec("gradle".to_string())],
-    })
 }
 
 fn detect_global_playwright(home: &Path) -> Option<GlobalDetection> {
@@ -2894,28 +2876,24 @@ services:
     // ── Global detector tests ────────────────────────────────────────
 
     #[test]
-    fn global_detect_gradle_wrapper() {
+    fn global_gradle_wrapper_suggests_nothing() {
+        // The Gradle wrapper runs `java -jar gradle-wrapper.jar` and starts Gradle
+        // in-process from the unpacked distribution's JARs — nothing is exec'd out of
+        // ~/.gradle/wrapper/dists/, and allow_cache_exec can only reach
+        // ~/Library/Caches anyway. See issue #192.
         let home = tempfile::tempdir().unwrap();
         let dists = home.path().join(".gradle/wrapper/dists");
         std::fs::create_dir_all(&dists).unwrap();
         std::fs::write(dists.join("gradle-8.5-bin"), "").unwrap();
 
         let report = detect_global(home.path());
-        assert!(report.detections.iter().any(|d| d.name == "Gradle wrapper"));
         assert!(
-            report
+            !report
                 .detections
                 .iter()
                 .flat_map(|d| &d.suggestions)
                 .any(|s| matches!(s, GlobalSuggestion::CacheExec(v) if v == "gradle"))
         );
-    }
-
-    #[test]
-    fn global_detect_gradle_missing() {
-        let home = tempfile::tempdir().unwrap();
-        let report = detect_global(home.path());
-        assert!(!report.detections.iter().any(|d| d.name == "Gradle wrapper"));
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -1156,14 +1156,14 @@ mod tests {
     fn global_cache_exec_generates_sandbox_section() {
         let report = GlobalDetectionReport {
             detections: vec![GlobalDetection {
-                name: "Gradle wrapper",
-                reason: "~/.gradle/wrapper/dists/ exists".to_string(),
-                suggestions: vec![GlobalSuggestion::CacheExec("gradle".to_string())],
+                name: "Playwright browsers",
+                reason: "ms-playwright cache directory exists".to_string(),
+                suggestions: vec![GlobalSuggestion::CacheExec("ms-playwright".to_string())],
             }],
         };
         let toml = generate_global_toml(&report);
         assert!(toml.contains("[sandbox]"));
-        assert!(toml.contains("allow_cache_exec = [\"gradle\"]"));
+        assert!(toml.contains("allow_cache_exec = [\"ms-playwright\"]"));
     }
 
     #[test]
@@ -1213,9 +1213,9 @@ mod tests {
         let report = GlobalDetectionReport {
             detections: vec![
                 GlobalDetection {
-                    name: "Gradle wrapper",
+                    name: "pnpm dlx",
                     reason: "exists".to_string(),
-                    suggestions: vec![GlobalSuggestion::CacheExec("gradle".to_string())],
+                    suggestions: vec![GlobalSuggestion::CacheExec("pnpm/dlx".to_string())],
                 },
                 GlobalDetection {
                     name: "Playwright browsers",
@@ -1233,7 +1233,7 @@ mod tests {
         assert!(toml.contains("[sandbox]"));
         assert!(toml.contains("allow_gpg_signing = true"));
         // Both cache_exec entries merged into one array
-        assert!(toml.contains("\"gradle\""));
+        assert!(toml.contains("\"pnpm/dlx\""));
         assert!(toml.contains("\"ms-playwright\""));
     }
 
@@ -1242,10 +1242,10 @@ mod tests {
         let report = GlobalDetectionReport {
             detections: vec![
                 GlobalDetection {
-                    name: "Gradle",
+                    name: "Playwright",
                     reason: "test".to_string(),
                     suggestions: vec![
-                        GlobalSuggestion::CacheExec("gradle".to_string()),
+                        GlobalSuggestion::CacheExec("ms-playwright".to_string()),
                         GlobalSuggestion::AllowRead("~/.gradle/gradle.properties".to_string()),
                     ],
                 },

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3594,8 +3594,9 @@ mod e2e_tests {
     #[test]
     fn e2e_init_global_outputs_config() {
         let home = tempfile::tempdir().unwrap();
-        // Create gradle wrapper dir so detection triggers
-        std::fs::create_dir_all(home.path().join(".gradle/wrapper/dists/gradle-8.5")).unwrap();
+        // Create the Playwright browser cache so cache-exec detection triggers
+        std::fs::create_dir_all(home.path().join("Library/Caches/ms-playwright")).unwrap();
+        std::fs::create_dir_all(home.path().join(".cache/ms-playwright")).unwrap();
 
         let output = Command::new(binary_path())
             .args(["init", "--global"])
@@ -3610,14 +3611,18 @@ mod e2e_tests {
             stdout.contains("allow_cache_exec"),
             "should suggest cache_exec: {stdout}"
         );
-        assert!(stdout.contains("gradle"), "should detect gradle: {stdout}");
+        assert!(
+            stdout.contains("ms-playwright"),
+            "should detect Playwright: {stdout}"
+        );
     }
 
     #[test]
     fn e2e_init_global_write() {
         let home = tempfile::tempdir().unwrap();
-        // Create gradle wrapper to trigger detection
-        std::fs::create_dir_all(home.path().join(".gradle/wrapper/dists/gradle-8.5")).unwrap();
+        // Create the Playwright browser cache to trigger detection
+        std::fs::create_dir_all(home.path().join("Library/Caches/ms-playwright")).unwrap();
+        std::fs::create_dir_all(home.path().join(".cache/ms-playwright")).unwrap();
         let config_path = home.path().join("cplt/config.toml");
 
         let output = Command::new(binary_path())


### PR DESCRIPTION
## Problem

`cplt init --global` on any machine with a Gradle wrapper wrote:

```toml
[sandbox]
allow_cache_exec = ["gradle"]
```

That rule grants nothing. `allow_cache_exec` entries are interpolated into `~/Library/Caches/<subdir>` (`src/sandbox_profile.rs:765-774`), and Gradle on macOS uses `~/.gradle`, never `~/Library/Caches/gradle`. The detector made the mismatch explicit — it triggered on `~/.gradle/wrapper/dists` and then suggested a rule for an unrelated path.

The cost was not the dead line. Users debugging a Gradle sandbox failure saw `allow_cache_exec = ["gradle"]` in their own config, reasonably concluded Gradle had been granted exec, and looked elsewhere. That is exactly what happened while diagnosing #191.

## Why delete rather than relocate

Nothing in a normal `./gradlew build` execs out of `~/.gradle/wrapper/dists/`:

- `./gradlew` is a project-local script that execs `java -classpath gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain` — the exec target is the JVM in the JDK install, not anything under `dists/`.
- Gradle's own `BootstrapMainStarter` starts Gradle **in-process**: `new URLClassLoader(new URL[]{gradleJar…})` over `gradle-launcher-*.jar`, then reflective `main` invocation. No `ProcessBuilder`, no `bin/gradle`.
- `Install.java` does `chmod 755 <gradleHome>/bin/gradle` after unpacking, so the bit gets set — but nothing ever runs that script.
- Daemon forks exec the JVM plus a `-cp` of dist JARs. Reading and mmapping those is already covered: `~/.gradle` has `file-read*` + `file-map-executable`.

The one real exec gap under `~/.gradle` is toolchain JDKs, which #195 fixes properly and which `allow_cache_exec` could not express anyway.

## Changes

- `src/detect.rs`: deleted `detect_global_gradle` and its call site. The two old tests are replaced by one regression test asserting a wrapper dir alone produces no `CacheExec("gradle")`.
- `src/init.rs`: three test fixtures used `"gradle"` as sample cache-exec data, one of them named for the Gradle wrapper. Now `ms-playwright` / `pnpm/dlx`. Generator logic untouched.
- `tests/e2e.rs`: two `init --global` tests created a fake `~/.gradle/wrapper/dists/` to trigger detection; they now create the Playwright cache on both platforms.
- `docs/configuration.md`: Gradle wrapper row removed from the `init --global` table. The separate `Gradle registry` row (`~/.gradle/gradle.properties` → `allow.read`) is a different, correct detector and stays.
- `README.md:814`: feature list updated.

## Sibling audit

Only two detectors ever emitted `GlobalSuggestion::CacheExec`. The other, `detect_global_playwright`, checks out: `~/Library/Caches/ms-playwright` is Playwright's real macOS default and `~/.cache/ms-playwright` its Linux default, matching the interpolation targets in `sandbox_profile.rs:765` and `sandbox_landlock.rs:406`. The project-level `Suggestion::AllowCacheExec` at `src/detect.rs:702` also emits only `ms-playwright`. No other path mismatch.

`cargo test --lib` → 703 passed, 0 failed. Full suite green. fmt + clippy clean.

Closes #192.
