### PR TITLE
fix(install): stop the installer dying silently when a checksum is missing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,10 @@ fi
 
 echo "→ Verifying checksum..."
 if curl -fsSL -o "${TMP_DIR}/SHA256SUMS" "$CHECKSUM_URL" 2>/dev/null; then
-  EXPECTED=$(grep -F "${ASSET}" "${TMP_DIR}/SHA256SUMS" | awk '{print $1}')
+  # `|| true`: under `set -euo pipefail` a non-matching grep exits 1, pipefail
+  # propagates it, and the assignment trips `set -e` — killing the script with a
+  # bare `exit 1` and making the empty-EXPECTED branch below unreachable.
+  EXPECTED=$(grep -F "${ASSET}" "${TMP_DIR}/SHA256SUMS" | awk '{print $1}' || true)
   if [[ -z "$EXPECTED" ]]; then
     echo "  ⚠ No checksum entry found for ${ASSET} (skipping verification)"
   else


### PR DESCRIPTION
`install.sh:145`:

```bash
EXPECTED=$(grep -F "${ASSET}" "${TMP_DIR}/SHA256SUMS" | awk '{print $1}')
if [[ -z "$EXPECTED" ]]; then
  echo "  ⚠ No checksum entry found for ${ASSET} (skipping verification)"
```

The script runs under `set -euo pipefail`. A non-matching `grep` exits 1, `pipefail` propagates that through the pipe, and the command substitution's status trips `set -e`. So when SHA256SUMS has no entry for the asset, the installer dies at the assignment with a bare `exit 1` and no output — and the `[[ -z "$EXPECTED" ]]` branch written to handle exactly this case is unreachable dead code.

Reproduced:

```
$ bash -c 'set -euo pipefail
  printf "abc  other.tar.gz\n" > /tmp/s.txt
  E=$(grep -F "cplt-x.tar.gz" /tmp/s.txt | awk "{print \$1}")
  echo "reached: [$E]"'
$ echo $?
1
```

Nothing printed. With `|| true` added, the same script prints the fallback and exits 0.

One-line fix plus a comment naming the trap, so it doesn't get "cleaned up" later.

Found while reviewing #193, which I've closed — homebrew-tap#2 fixed the actual Linux install failure at the source, and gating install.sh's brew branch on macOS would have cost Linuxbrew users the managed install path now that `brew install navikt/tap/cplt` works there. This is the one real bug that review turned up.

Refs #190.
