### PR TITLE
fix(proxy): stop the TTL refresh from wiping trust-approved private domains

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -173,7 +173,7 @@ cplt config set proxy.allowed_domains "~/.config/cplt/allowed-domains.txt"
 
 > **Note:** Both the allowlist and blocklist are re-read from disk every ~5 seconds (TTL-cached), so you can edit them live mid-session. Changes take effect within seconds without restarting cplt. If a file becomes unreadable at runtime, the last-known-good list is kept (fail-safe). At startup, an unreadable allowlist causes cplt to exit with an error (fail-closed).
 >
-> The `allow_private_domains` list in `config.toml` is also re-read every ~5 seconds. Domains added via `--allow-private-domain` CLI flags are always preserved regardless of config changes.
+> The `allow_private_domains` list in `config.toml` is also re-read every ~5 seconds. Domains that do not come from that file — `--allow-private-domain` CLI flags and trust-approved `[propose.proxy] allow_private_domains` entries from a repo `.cplt.toml` — are preserved for the whole session regardless of config changes.
 
 ### Default allowlist (fail-closed networking)
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -257,9 +257,21 @@ impl Config {
         // Validates that entries are non-empty (empty string would bypass private IP
         // check for all domains that match is_domain_match("", _), which is none — but
         // reject it anyway for clarity).
-        let mut allow_private_domains =
-            self.proxy.allow_private_domains.clone().unwrap_or_default();
-        allow_private_domains.extend(cli.allow_private_domains);
+        // Normalized (lowercase, no trailing dot) at ingest: `is_domain_match`
+        // normalizes the hostname but compares it against the raw pattern, so an
+        // un-normalized entry like "Intern.NAV.no" or "a.nav.no." would never
+        // match anything — contradicting the documented case-insensitive,
+        // trailing-dot-stripped matching. File-sourced lists are already
+        // normalized by `parse_lines_file`; this is the config/CLI path.
+        let mut allow_private_domains: Vec<String> = self
+            .proxy
+            .allow_private_domains
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .chain(cli.allow_private_domains)
+            .map(|d| crate::proxy::normalize_hostname(&d))
+            .collect();
         allow_private_domains.sort_unstable();
         allow_private_domains.dedup();
         for domain in &allow_private_domains {
@@ -559,6 +571,7 @@ impl Config {
 
         Ok(Resolved {
             with_proxy,
+            repo_private_domains: Vec::new(),
             proxy_forced,
             proxy_port,
             blocked_domains,
@@ -1122,12 +1135,16 @@ impl Resolved {
         // Proxy proposals
         if is_approved("proxy.allow_private_domains") {
             for domain in &repo_config.propose.proxy.allow_private_domains {
-                if !self.allow_private_domains.contains(domain) {
+                let domain = crate::proxy::normalize_hostname(domain);
+                if !self.allow_private_domains.contains(&domain) {
                     self.allow_private_domains.push(domain.clone());
                 }
+                self.repo_private_domains.push(domain);
             }
             self.allow_private_domains.sort_unstable();
             self.allow_private_domains.dedup();
+            self.repo_private_domains.sort_unstable();
+            self.repo_private_domains.dedup();
         }
 
         // Return unapproved keys for display

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1136,6 +1136,12 @@ impl Resolved {
         if is_approved("proxy.allow_private_domains") {
             for domain in &repo_config.propose.proxy.allow_private_domains {
                 let domain = crate::proxy::normalize_hostname(domain);
+                // The config/CLI path rejects empty entries above; `.cplt.toml`
+                // validation rejects "" but not "." or " ", which normalize to
+                // the same nothing. Skip them here so the two paths agree.
+                if domain.is_empty() {
+                    continue;
+                }
                 if !self.allow_private_domains.contains(&domain) {
                     self.allow_private_domains.push(domain.clone());
                 }
@@ -1836,13 +1842,22 @@ validate = false
 
     #[test]
     fn apply_repo_config_proxy_proposals() {
-        let config = Config::default();
+        // The global config already allows one of the proposed domains, so the
+        // overlap case is the one under test: it must still be recorded as
+        // repo-approved, or the proxy leaves it in the TTL cache and the first
+        // config reload wipes it (#186).
+        let config = Config::parse("[proxy]\nallow_private_domains = [\"intern.nav.no\"]\n")
+            .expect("config parses");
         let mut resolved = config.merge(CliFlags::default()).unwrap();
 
         let repo_config = crate::repo_config::RepoConfig {
             propose: crate::repo_config::ProposeSection {
                 proxy: crate::repo_config::ProposeProxySection {
-                    allow_private_domains: vec!["intern.nav.no".to_string()],
+                    allow_private_domains: vec![
+                        "Intern.NAV.no".to_string(),
+                        "mimir.nav.cloud.nais.io.".to_string(),
+                        ".".to_string(),
+                    ],
                 },
                 ..Default::default()
             },
@@ -1851,10 +1866,21 @@ validate = false
 
         let unapproved = resolved.apply_repo_config(&repo_config, &["proxy.allow_private_domains"]);
         assert!(unapproved.is_empty());
-        assert!(
-            resolved
-                .allow_private_domains
-                .contains(&"intern.nav.no".to_string())
+        assert_eq!(
+            resolved.allow_private_domains,
+            vec![
+                "intern.nav.no".to_string(),
+                "mimir.nav.cloud.nais.io".to_string()
+            ]
+        );
+        assert_eq!(
+            resolved.repo_private_domains,
+            vec![
+                "intern.nav.no".to_string(),
+                "mimir.nav.cloud.nais.io".to_string()
+            ],
+            "every approved proposal is repo-approved, including one the global \
+             config already allowed"
         );
     }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -748,6 +748,11 @@ pub struct Resolved {
     /// UNIONed into the effective blocklist. GLOBAL-only, tighten-only, fail-open.
     pub proxy_subscriptions: crate::subscriptions::SubscriptionSet,
     pub allow_private_domains: Vec<String>,
+    /// The subset of `allow_private_domains` that came from a trust-approved
+    /// `[propose.proxy] allow_private_domains` in the repo `.cplt.toml`.
+    /// Tracked separately because nothing re-reads that source mid-session, so
+    /// the proxy must not put these under its 5-second config reload (#186).
+    pub repo_private_domains: Vec<String>,
     pub allow_read: Vec<PathBuf>,
     pub allow_write: Vec<PathBuf>,
     pub allow_socket: Vec<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1890,12 +1890,18 @@ fn start_proxy_if_enabled(
         allowed_domains_initial: Vec::new(),
         default_allowlist,
         cli_private_domains: cli.allow_private_domains.clone(),
+        // Reloadable portion: what the config file itself supplied. The two
+        // once-read sources go in as their own fields so the file's 5-second
+        // reload cannot drop them (#186).
         config_private_domains: resolved
             .allow_private_domains
             .iter()
-            .filter(|d| !cli.allow_private_domains.contains(d))
+            .filter(|d| {
+                !cli.allow_private_domains.contains(d) && !resolved.repo_private_domains.contains(d)
+            })
             .cloned()
             .collect(),
+        repo_private_domains: resolved.repo_private_domains.clone(),
         config_file: config_path.cloned(),
         log_file: resolved.proxy_log_file.clone(),
         log_level: resolved.proxy_log_level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1897,7 +1897,11 @@ fn start_proxy_if_enabled(
             .allow_private_domains
             .iter()
             .filter(|d| {
-                !cli.allow_private_domains.contains(d) && !resolved.repo_private_domains.contains(d)
+                // `cli.allow_private_domains` holds raw argv, `d` is normalized.
+                !cli.allow_private_domains
+                    .iter()
+                    .any(|c| proxy::normalize_hostname(c) == **d)
+                    && !resolved.repo_private_domains.contains(d)
             })
             .cloned()
             .collect(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1751,10 +1751,11 @@ pub fn is_blocked_in_content(hostname: &str, contents: &str) -> bool {
 }
 
 /// Normalize a hostname (or a domain *pattern*) for consistent matching:
-/// lowercase, strip trailing dot. Patterns must be normalized at ingest —
-/// [`is_domain_match`] normalizes only the hostname side.
-pub(crate) fn normalize_hostname(host: &str) -> String {
-    host.to_lowercase().trim_end_matches('.').to_string()
+/// trim, lowercase, strip trailing dot — the same rule `parse_lines_file`
+/// applies to file-sourced lists. Patterns must be normalized at ingest,
+/// because [`is_domain_match`] normalizes only the hostname side.
+pub fn normalize_hostname(host: &str) -> String {
+    host.trim().to_lowercase().trim_end_matches('.').to_string()
 }
 
 /// Check if a hostname matches any entry in a domain list.
@@ -2620,6 +2621,34 @@ mod tests {
         )
         .unwrap();
 
+        // Built the way main.rs builds it: the resolved set (CLI + config file +
+        // trust-approved repo proposal) minus the two once-read sources, which
+        // it passes as their own fields. Hand-writing the reloadable list would
+        // test a shape the real wiring never produces.
+        let cli_private_domains = vec!["cli.nav.no".to_string()];
+        let repo_private_domains = vec!["mimir.nav.cloud.nais.io".to_string()];
+        let resolved_private_domains = [
+            "cli.nav.no",
+            "global-a.nav.no",
+            "global-b.nav.no",
+            "mimir.nav.cloud.nais.io",
+        ];
+        let config_private_domains: Vec<String> = resolved_private_domains
+            .iter()
+            .map(|d| (*d).to_string())
+            .filter(|d| {
+                !cli_private_domains
+                    .iter()
+                    .any(|c| normalize_hostname(c) == *d)
+                    && !repo_private_domains.contains(d)
+            })
+            .collect();
+        assert_eq!(
+            config_private_domains,
+            vec!["global-a.nav.no", "global-b.nav.no"],
+            "only the config file's own entries are reloadable"
+        );
+
         let handle = start(ProxyOptions {
             port: 0,
             blocked_file: blocked,
@@ -2630,15 +2659,9 @@ mod tests {
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: vec!["cli.nav.no".to_string()],
-            // What main.rs passes: the whole resolved set (config file entries
-            // and the trust-approved repo proposal) minus the CLI ones.
-            config_private_domains: vec![
-                "global-a.nav.no".to_string(),
-                "global-b.nav.no".to_string(),
-                "mimir.nav.cloud.nais.io".to_string(),
-            ],
-            repo_private_domains: vec!["mimir.nav.cloud.nais.io".to_string()],
+            cli_private_domains,
+            config_private_domains,
+            repo_private_domains,
             config_file: Some(config_path.clone()),
             log_file: None,
             log_level: ProxyLogLevel::None,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -670,7 +670,16 @@ pub fn parse_lines_file(path: &Path) -> Option<Vec<String>> {
 }
 
 /// Parse `proxy.allow_private_domains` from a TOML config file.
-/// Returns None on read/parse failure (caller keeps last-good).
+///
+/// `Some(list)` means the file was read and parsed: an empty list is the real
+/// answer "this file allows no private domains", which is what revokes an entry
+/// removed from the config mid-session. `None` means the file could not be read
+/// or parsed, and the caller keeps its last-good list.
+///
+/// Uses the `toml` crate rather than scanning lines: the config file is written
+/// by `cplt init` (which emits multi-line arrays for more than one entry) and by
+/// hand, so a line scanner silently mis-reads multi-line arrays, trailing
+/// comments and dotted keys — all of which serde accepts elsewhere in cplt.
 fn parse_private_domains_from_toml(path: &Path) -> Option<Vec<String>> {
     let contents = match std::fs::read_to_string(path) {
         Ok(c) => c,
@@ -685,37 +694,25 @@ fn parse_private_domains_from_toml(path: &Path) -> Option<Vec<String>> {
         }
     };
 
-    // Minimal TOML parsing: find [proxy] section, extract allow_private_domains array.
-    // We avoid pulling in the full toml crate dependency here by doing line-based parsing.
-    let mut in_proxy_section = false;
-    let mut domains: Vec<String> = Vec::new();
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with('[') {
-            in_proxy_section = trimmed == "[proxy]";
-            continue;
-        }
-        if !in_proxy_section {
-            continue;
-        }
-        if let Some(value) = trimmed.strip_prefix("allow_private_domains") {
-            let value = value.trim_start().strip_prefix('=')?;
-            let value = value.trim();
-            // Parse simple TOML array: ["foo.com", "bar.com"]
-            if let Some(inner) = value.strip_prefix('[').and_then(|v| v.strip_suffix(']')) {
-                for entry in inner.split(',') {
-                    let entry = entry.trim().trim_matches('"').trim_matches('\'');
-                    let normalized = entry.to_lowercase().trim_end_matches('.').to_string();
-                    if !normalized.is_empty() {
-                        domains.push(normalized);
-                    }
-                }
-            }
-            break;
-        }
-    }
-    Some(domains)
+    let parsed: toml::Value = toml::from_str(&contents).ok()?;
+    let Some(value) = parsed
+        .get("proxy")
+        .and_then(|proxy| proxy.get("allow_private_domains"))
+    else {
+        // Key absent — the file genuinely allows nothing.
+        return Some(Vec::new());
+    };
+    // Wrong type: treat as unreadable (keep last-good) rather than as a
+    // revocation. Startup validation rejects it anyway.
+    let entries = value.as_array()?;
+    Some(
+        entries
+            .iter()
+            .filter_map(toml::Value::as_str)
+            .map(normalize_hostname)
+            .filter(|d| !d.is_empty())
+            .collect(),
+    )
 }
 
 pub struct ProxyHandle {
@@ -787,13 +784,16 @@ pub struct ProxyOptions {
     pub default_allowlist: Vec<String>,
     /// Domains allowed to resolve to private IPs — CLI portion (immutable).
     pub cli_private_domains: Vec<String>,
-    /// Domains allowed to resolve to private IPs — everything the resolved
-    /// config produced beyond the CLI flags: the global config file's
-    /// `proxy.allow_private_domains` plus any trust-approved
-    /// `[propose.proxy] allow_private_domains` from the repo `.cplt.toml`.
-    /// Only the entries `config_file` itself still lists follow that file's
-    /// 5-second reload; the rest are frozen for the session (#186).
+    /// Domains allowed to resolve to private IPs — the portion that came from
+    /// `config_file`'s own `proxy.allow_private_domains`. Only these follow its
+    /// 5-second reload, so editing that file still adds and revokes them.
     pub config_private_domains: Vec<String>,
+    /// Domains allowed to resolve to private IPs — the trust-approved
+    /// `[propose.proxy] allow_private_domains` entries from the repo
+    /// `.cplt.toml` (`Resolved::repo_private_domains`). Frozen for the session
+    /// like the CLI ones: their source is read once (git HEAD + trust store),
+    /// so the config-file reload must not be able to drop them (#186).
+    pub repo_private_domains: Vec<String>,
     /// Path to TOML config file for dynamic reload of private_domains.
     pub config_file: Option<PathBuf>,
     /// Path to append audit log lines. None = no file logging.
@@ -869,24 +869,17 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
             .map_err(|e| format!("Cannot open proxy log file {}: {e}", log_path.display()))?;
     }
 
-    // Split the startup private-domain set: entries the reloadable config file
-    // supplies stay under its TTL refresh, everything else is sticky for the
-    // session. Without this, a trust-approved repo `.cplt.toml` domain lives in
-    // a cache whose only refresh source is the *global* config file, so the
-    // first refresh 5s in silently drops it (#186).
-    let file_private_domains = opts
-        .config_file
-        .as_deref()
-        .filter(|p| p.exists())
-        .and_then(parse_private_domains_from_toml)
-        .unwrap_or_default();
-    let mut sticky_private_domains = opts.cli_private_domains;
-    sticky_private_domains.extend(
-        opts.config_private_domains
-            .iter()
-            .filter(|d| !file_private_domains.contains(d))
-            .cloned(),
-    );
+    // Private domains whose source is read exactly once — CLI flags and
+    // trust-approved repo `.cplt.toml` proposals — are held outside the
+    // TTL cache. That cache's only refresh source is the global config file,
+    // so anything else parked in it is silently dropped by the first refresh,
+    // 5s into the session (#186).
+    let mut sticky_private_domains: Vec<String> = opts
+        .cli_private_domains
+        .iter()
+        .chain(opts.repo_private_domains.iter())
+        .map(|d| normalize_hostname(d))
+        .collect();
     sticky_private_domains.sort_unstable();
     sticky_private_domains.dedup();
 
@@ -1757,8 +1750,10 @@ pub fn is_blocked_in_content(hostname: &str, contents: &str) -> bool {
     false
 }
 
-/// Normalize a hostname for consistent matching: lowercase, strip trailing dot.
-fn normalize_hostname(host: &str) -> String {
+/// Normalize a hostname (or a domain *pattern*) for consistent matching:
+/// lowercase, strip trailing dot. Patterns must be normalized at ingest —
+/// [`is_domain_match`] normalizes only the hostname side.
+pub(crate) fn normalize_hostname(host: &str) -> String {
     host.to_lowercase().trim_end_matches('.').to_string()
 }
 
@@ -2365,6 +2360,38 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// TOML shapes the previous line-scanning parser silently mis-read as "no
+    /// domains" (or, for the typo key, as an unreadable file): a multi-line
+    /// array — what `cplt init` writes for more than one entry — a trailing
+    /// comment, a dotted key, and a key that merely starts with the real one.
+    #[test]
+    fn parse_private_domains_from_toml_handles_real_world_shapes() {
+        let dir = test_dir("toml-shapes");
+        let cases = [
+            "[proxy]\nallow_private_domains = [\n  \"a.nav.no\",\n  \"b.nav.no\",\n]\n",
+            "[proxy]\nallow_private_domains = [\"a.nav.no\", \"B.NAV.no.\"]  # trailing comment\n",
+            "proxy.allow_private_domains = [\"a.nav.no\", \"b.nav.no\"]\n",
+            "[proxy]\nallow_private_domains_typo = []\nallow_private_domains = [\"a.nav.no\", \"b.nav.no\"]\n",
+        ];
+        for (i, contents) in cases.iter().enumerate() {
+            let path = dir.join(format!("config{i}.toml"));
+            std::fs::write(&path, contents).unwrap();
+            assert_eq!(
+                parse_private_domains_from_toml(&path),
+                Some(vec!["a.nav.no".to_string(), "b.nav.no".to_string()]),
+                "case {i}: {contents}"
+            );
+        }
+
+        // Unparseable TOML is "unreadable", not "allows nothing" — the caller
+        // keeps its last-good list instead of dropping every waiver.
+        let path = dir.join("broken.toml");
+        std::fs::write(&path, "[proxy\n").unwrap();
+        assert_eq!(parse_private_domains_from_toml(&path), None);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn parse_private_domains_from_toml_no_proxy_section() {
         let dir = test_dir("toml-noproxy");
@@ -2574,20 +2601,22 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// #186: a trust-approved `[propose.proxy] allow_private_domains` entry from
-    /// the repo `.cplt.toml` reaches the proxy through `config_private_domains`,
-    /// but nothing re-reads the repo config — the TTL refresh only re-reads the
-    /// global config file. It must therefore survive the refresh, while domains
-    /// the global file actually supplies keep following that file.
+    /// #186: private domains whose source is read once — CLI flags and
+    /// trust-approved `[propose.proxy] allow_private_domains` from the repo
+    /// `.cplt.toml` — must survive the global config file's 5-second reload,
+    /// while domains that file actually supplies keep following it (including
+    /// being revoked when removed).
     #[test]
-    fn repo_approved_private_domain_survives_ttl_refresh() {
+    fn private_domain_sources_survive_or_follow_the_config_reload() {
         let dir = test_dir("private-domains-186");
         let blocked = dir.join("blocked.txt");
         std::fs::write(&blocked, "").unwrap();
         let config_path = dir.join("config.toml");
+        // Multi-line array: the form `cplt init` writes for >1 entry
+        // (`init::write_string_array`), and the form the docs show.
         std::fs::write(
             &config_path,
-            "[allow]\nread = [\"~/.kube/config\"]\n\n[proxy]\nallow_private_domains = [\"global.nav.no\"]\n",
+            "[allow]\nread = [\"~/.kube/config\"]\n\n[proxy]\nallow_private_domains = [\n  \"global-a.nav.no\",\n  \"global-b.nav.no\",\n]\n",
         )
         .unwrap();
 
@@ -2601,13 +2630,15 @@ mod tests {
             allowed_domains_initial: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: Vec::new(),
-            // What main.rs passes: the resolved set, i.e. the global config
-            // file's domains plus the trust-approved repo proposal.
+            cli_private_domains: vec!["cli.nav.no".to_string()],
+            // What main.rs passes: the whole resolved set (config file entries
+            // and the trust-approved repo proposal) minus the CLI ones.
             config_private_domains: vec![
-                "global.nav.no".to_string(),
+                "global-a.nav.no".to_string(),
+                "global-b.nav.no".to_string(),
                 "mimir.nav.cloud.nais.io".to_string(),
             ],
+            repo_private_domains: vec!["mimir.nav.cloud.nais.io".to_string()],
             config_file: Some(config_path.clone()),
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -2619,37 +2650,58 @@ mod tests {
         .expect("proxy start failed");
         let state = handle.state.clone().expect("test state handle");
 
-        let domains = state.get_private_domains();
-        assert!(domains.contains(&"mimir.nav.cloud.nais.io".to_string()));
-        assert!(domains.contains(&"global.nav.no".to_string()));
+        let expire = || {
+            state.private_domains_cache.lock().unwrap().last_attempt = Instant::now()
+                .checked_sub(RELOAD_TTL + Duration::from_millis(100))
+                .unwrap();
+        };
+        let has = |d: &str| state.get_private_domains().iter().any(|x| x == d);
 
-        // The refresh that fires 5 seconds into a real session.
-        state.private_domains_cache.lock().unwrap().last_attempt = Instant::now()
-            .checked_sub(RELOAD_TTL + Duration::from_millis(100))
-            .unwrap();
+        for d in [
+            "cli.nav.no",
+            "global-a.nav.no",
+            "global-b.nav.no",
+            "mimir.nav.cloud.nais.io",
+        ] {
+            assert!(has(d), "{d} must be allowed at startup");
+        }
 
-        let domains = state.get_private_domains();
+        // The reload that fires 5 seconds into a real session.
+        expire();
         assert!(
-            domains.contains(&"mimir.nav.cloud.nais.io".to_string()),
-            "trust-approved repo domain must survive the config refresh"
+            has("mimir.nav.cloud.nais.io"),
+            "trust-approved repo domain must survive the config reload"
         );
-        assert!(domains.contains(&"global.nav.no".to_string()));
+        assert!(has("cli.nav.no"), "CLI domain must survive the reload");
+        assert!(
+            has("global-a.nav.no") && has("global-b.nav.no"),
+            "multi-line config array must still be read on reload"
+        );
 
-        // Domains the global config supplies still follow it: dropping the
-        // section revokes them within the TTL, unchanged from before.
+        // Revoking one entry from the config file takes effect within the TTL.
+        std::fs::write(
+            &config_path,
+            "[proxy]\nallow_private_domains = [\"global-a.nav.no\"]  # b revoked\n",
+        )
+        .unwrap();
+        expire();
+        assert!(has("global-a.nav.no"), "remaining config entry stays");
+        assert!(
+            !has("global-b.nav.no"),
+            "config-file domain must be revocable by editing the file"
+        );
+        assert!(has("mimir.nav.cloud.nais.io") && has("cli.nav.no"));
+
+        // Dropping the section revokes the rest of the file's entries.
         std::fs::write(&config_path, "[allow]\nread = []\n").unwrap();
-        state.private_domains_cache.lock().unwrap().last_attempt = Instant::now()
-            .checked_sub(RELOAD_TTL + Duration::from_millis(100))
-            .unwrap();
-
-        let domains = state.get_private_domains();
+        expire();
         assert!(
-            !domains.contains(&"global.nav.no".to_string()),
-            "config-file domain should be revoked when removed from the file"
+            !has("global-a.nav.no"),
+            "removing the section must revoke its domains"
         );
         assert!(
-            domains.contains(&"mimir.nav.cloud.nais.io".to_string()),
-            "trust-approved repo domain must not be revoked by a config edit"
+            has("mimir.nav.cloud.nais.io") && has("cli.nav.no"),
+            "once-read sources are not revoked by a config edit"
         );
 
         handle.shutdown();
@@ -2683,6 +2735,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -2719,6 +2772,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -3044,6 +3098,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -3256,6 +3311,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -3330,6 +3386,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -3554,6 +3611,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(), // NOT allow-listed
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -3614,6 +3672,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: vec!["corp.internal".to_string()], // allow-listed
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -4065,6 +4124,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -4275,6 +4335,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains,
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
@@ -4707,6 +4768,7 @@ mod tests {
             subscription_blocklist: Vec::new(),
             cli_private_domains,
             config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -430,8 +430,16 @@ pub struct ProxyState {
     // base and the user's additions both apply without re-listing either.
     default_allowlist: Vec<String>,
 
-    // Private domains: merged from immutable CLI args + dynamic TOML config
-    cli_private_domains: Vec<String>,
+    // Private domains: merged from a sticky set + the dynamic TOML config.
+    //
+    // `sticky_private_domains` holds every startup-resolved private domain that
+    // `config_file` does NOT supply: `--allow-private-domain` flags and
+    // trust-approved `[propose.proxy] allow_private_domains` from the repo
+    // `.cplt.toml`. They are frozen for the session because nothing re-reads
+    // their source — the repo config is read once from git HEAD, the CLI once
+    // from argv — so leaving them in the reloadable cache made the TTL refresh
+    // wipe them 5s into the session (#186).
+    sticky_private_domains: Vec<String>,
     config_file: Option<PathBuf>,
     private_domains_cache: Mutex<DomainCache>,
 
@@ -557,7 +565,7 @@ impl ProxyState {
         merged
     }
 
-    /// Get private domains: union of immutable CLI entries + dynamic config entries.
+    /// Get private domains: union of the sticky entries + dynamic config entries.
     fn get_private_domains(&self) -> Vec<String> {
         let config_domains = get_cached_domains(
             &self.private_domains_cache,
@@ -565,15 +573,15 @@ impl ProxyState {
             parse_private_domains_from_toml,
         );
 
-        if self.cli_private_domains.is_empty() {
+        if self.sticky_private_domains.is_empty() {
             return config_domains;
         }
         if config_domains.is_empty() {
-            return self.cli_private_domains.clone();
+            return self.sticky_private_domains.clone();
         }
 
-        // Merge CLI + config, deduplicate
-        let mut merged = self.cli_private_domains.clone();
+        // Merge sticky + config, deduplicate
+        let mut merged = self.sticky_private_domains.clone();
         merged.extend(config_domains);
         merged.sort_unstable();
         merged.dedup();
@@ -719,6 +727,10 @@ pub struct ProxyHandle {
     /// Cloned from the state so the observed set can be read after the session
     /// via [`ProxyHandle::observed_domains`].
     domain_collector: Arc<DomainCollector>,
+    /// Test-only view of the live state, so reload behaviour can be asserted
+    /// against the real `start()` wiring instead of a hand-built `ProxyState`.
+    #[cfg(test)]
+    state: Option<Arc<ProxyState>>,
 }
 
 impl ProxyHandle {
@@ -775,7 +787,12 @@ pub struct ProxyOptions {
     pub default_allowlist: Vec<String>,
     /// Domains allowed to resolve to private IPs — CLI portion (immutable).
     pub cli_private_domains: Vec<String>,
-    /// Domains allowed to resolve to private IPs — config portion (initial).
+    /// Domains allowed to resolve to private IPs — everything the resolved
+    /// config produced beyond the CLI flags: the global config file's
+    /// `proxy.allow_private_domains` plus any trust-approved
+    /// `[propose.proxy] allow_private_domains` from the repo `.cplt.toml`.
+    /// Only the entries `config_file` itself still lists follow that file's
+    /// 5-second reload; the rest are frozen for the session (#186).
     pub config_private_domains: Vec<String>,
     /// Path to TOML config file for dynamic reload of private_domains.
     pub config_file: Option<PathBuf>,
@@ -852,6 +869,27 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
             .map_err(|e| format!("Cannot open proxy log file {}: {e}", log_path.display()))?;
     }
 
+    // Split the startup private-domain set: entries the reloadable config file
+    // supplies stay under its TTL refresh, everything else is sticky for the
+    // session. Without this, a trust-approved repo `.cplt.toml` domain lives in
+    // a cache whose only refresh source is the *global* config file, so the
+    // first refresh 5s in silently drops it (#186).
+    let file_private_domains = opts
+        .config_file
+        .as_deref()
+        .filter(|p| p.exists())
+        .and_then(parse_private_domains_from_toml)
+        .unwrap_or_default();
+    let mut sticky_private_domains = opts.cli_private_domains;
+    sticky_private_domains.extend(
+        opts.config_private_domains
+            .iter()
+            .filter(|d| !file_private_domains.contains(d))
+            .cloned(),
+    );
+    sticky_private_domains.sort_unstable();
+    sticky_private_domains.dedup();
+
     // Observation collector, shared between the connection threads (via state)
     // and the returned handle so observed domains can be read after shutdown.
     let domain_collector: Arc<DomainCollector> = Arc::new(Mutex::new(BTreeMap::new()));
@@ -864,7 +902,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         allowed_domains_file: opts.allowed_domains_file,
         allowlist_cache: Mutex::new(DomainCache::new(allowlist_initial)),
         default_allowlist: opts.default_allowlist,
-        cli_private_domains: opts.cli_private_domains,
+        sticky_private_domains,
         config_file: opts.config_file,
         private_domains_cache: Mutex::new(DomainCache::new(opts.config_private_domains)),
         allowed_ports: ports,
@@ -884,6 +922,9 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         .set_nonblocking(false)
         .map_err(|e| format!("set_nonblocking: {e}"))?;
 
+    #[cfg(test)]
+    let state_for_tests = state.clone();
+
     let shutdown_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let flag = shutdown_flag.clone();
     let active_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -901,6 +942,8 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
         shutdown_flag,
         port: actual_port,
         domain_collector,
+        #[cfg(test)]
+        state: Some(state_for_tests),
     })
 }
 
@@ -2343,7 +2386,7 @@ mod tests {
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: vec!["cli.example.com".to_string()],
+            sticky_private_domains: vec!["cli.example.com".to_string()],
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec![
                 "config.example.com".to_string(),
@@ -2374,7 +2417,7 @@ mod tests {
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: vec!["shared.com".to_string()],
+            sticky_private_domains: vec!["shared.com".to_string()],
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(vec!["shared.com".to_string()])),
             allowed_ports: vec![443],
@@ -2408,7 +2451,7 @@ mod tests {
             ])),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: Vec::new(),
+            sticky_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
@@ -2445,7 +2488,7 @@ mod tests {
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: Vec::new(),
+            sticky_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
@@ -2483,7 +2526,7 @@ mod tests {
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: vec!["cli.nav.no".to_string()],
+            sticky_private_domains: vec!["cli.nav.no".to_string()],
             config_file: Some(config_path.clone()),
             private_domains_cache: Mutex::new(DomainCache {
                 domains: vec!["old.nav.no".to_string()],
@@ -2528,6 +2571,88 @@ mod tests {
             "old config domain should be gone after reload"
         );
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #186: a trust-approved `[propose.proxy] allow_private_domains` entry from
+    /// the repo `.cplt.toml` reaches the proxy through `config_private_domains`,
+    /// but nothing re-reads the repo config — the TTL refresh only re-reads the
+    /// global config file. It must therefore survive the refresh, while domains
+    /// the global file actually supplies keep following that file.
+    #[test]
+    fn repo_approved_private_domain_survives_ttl_refresh() {
+        let dir = test_dir("private-domains-186");
+        let blocked = dir.join("blocked.txt");
+        std::fs::write(&blocked, "").unwrap();
+        let config_path = dir.join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[allow]\nread = [\"~/.kube/config\"]\n\n[proxy]\nallow_private_domains = [\"global.nav.no\"]\n",
+        )
+        .unwrap();
+
+        let handle = start(ProxyOptions {
+            port: 0,
+            blocked_file: blocked,
+            allowed_ports: vec![],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
+            cli_private_domains: Vec::new(),
+            // What main.rs passes: the resolved set, i.e. the global config
+            // file's domains plus the trust-approved repo proposal.
+            config_private_domains: vec![
+                "global.nav.no".to_string(),
+                "mimir.nav.cloud.nais.io".to_string(),
+            ],
+            config_file: Some(config_path.clone()),
+            log_file: None,
+            log_level: ProxyLogLevel::None,
+            timeout: Duration::from_secs(60),
+            upstream: None,
+            upstream_no_proxy: Vec::new(),
+            resolver: None,
+        })
+        .expect("proxy start failed");
+        let state = handle.state.clone().expect("test state handle");
+
+        let domains = state.get_private_domains();
+        assert!(domains.contains(&"mimir.nav.cloud.nais.io".to_string()));
+        assert!(domains.contains(&"global.nav.no".to_string()));
+
+        // The refresh that fires 5 seconds into a real session.
+        state.private_domains_cache.lock().unwrap().last_attempt = Instant::now()
+            .checked_sub(RELOAD_TTL + Duration::from_millis(100))
+            .unwrap();
+
+        let domains = state.get_private_domains();
+        assert!(
+            domains.contains(&"mimir.nav.cloud.nais.io".to_string()),
+            "trust-approved repo domain must survive the config refresh"
+        );
+        assert!(domains.contains(&"global.nav.no".to_string()));
+
+        // Domains the global config supplies still follow it: dropping the
+        // section revokes them within the TTL, unchanged from before.
+        std::fs::write(&config_path, "[allow]\nread = []\n").unwrap();
+        state.private_domains_cache.lock().unwrap().last_attempt = Instant::now()
+            .checked_sub(RELOAD_TTL + Duration::from_millis(100))
+            .unwrap();
+
+        let domains = state.get_private_domains();
+        assert!(
+            !domains.contains(&"global.nav.no".to_string()),
+            "config-file domain should be revoked when removed from the file"
+        );
+        assert!(
+            domains.contains(&"mimir.nav.cloud.nais.io".to_string()),
+            "trust-approved repo domain must not be revoked by a config edit"
+        );
+
+        handle.shutdown();
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -2625,7 +2750,7 @@ mod tests {
             }),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
-            cli_private_domains: Vec::new(),
+            sticky_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
@@ -2672,7 +2797,7 @@ mod tests {
             allowed_domains_file: file,
             allowlist_cache: Mutex::new(DomainCache::new(initial)),
             default_allowlist,
-            cli_private_domains: Vec::new(),
+            sticky_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
@@ -2699,7 +2824,7 @@ mod tests {
             allowed_domains_file: None,
             allowlist_cache: Mutex::new(DomainCache::new(Vec::new())),
             default_allowlist: Vec::new(),
-            cli_private_domains: Vec::new(),
+            sticky_private_domains: Vec::new(),
             config_file: None,
             private_domains_cache: Mutex::new(DomainCache::new(Vec::new())),
             allowed_ports: vec![443],
@@ -2875,6 +3000,7 @@ mod tests {
             shutdown_flag: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             port: 0,
             domain_collector: collector,
+            state: None,
         };
         let observed = handle.observed_domains();
         let hosts: Vec<&str> = observed.iter().map(|o| o.host.as_str()).collect();

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -353,6 +353,38 @@ fn allow_private_domains_merge_cli_and_toml() {
     );
 }
 
+/// `is_domain_match` normalizes the hostname but compares it against the raw
+/// pattern, so config/CLI entries must be normalized at ingest — otherwise the
+/// case-insensitive, trailing-dot-stripped matching promised in docs/proxy.md
+/// silently never fires and the waiver does nothing.
+#[test]
+fn allow_private_domains_are_normalized_and_actually_match() {
+    use cplt::config::{CliFlags, Config};
+    use cplt::proxy::is_domain_match;
+    let toml = "[proxy]\nallow_private_domains = [\"Intern.NAV.no\", \"a.nav.no.\"]\n";
+    let cli = CliFlags {
+        allow_private_domains: vec!["DEV.corp.example.com".to_string()],
+        ..Default::default()
+    };
+    let resolved = Config::parse(toml).unwrap().merge(cli).unwrap();
+
+    for host in [
+        "intern.nav.no",
+        "sub.Intern.nav.no",
+        "a.nav.no",
+        "x.a.nav.no",
+    ] {
+        assert!(
+            is_domain_match(host, &resolved.allow_private_domains),
+            "{host} should match the configured private-domain waiver"
+        );
+    }
+    assert!(is_domain_match(
+        "dev.corp.example.com",
+        &resolved.allow_private_domains
+    ));
+}
+
 #[test]
 fn allow_private_domains_deduplicates() {
     use cplt::config::{CliFlags, Config};

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -361,7 +361,8 @@ fn allow_private_domains_merge_cli_and_toml() {
 fn allow_private_domains_are_normalized_and_actually_match() {
     use cplt::config::{CliFlags, Config};
     use cplt::proxy::is_domain_match;
-    let toml = "[proxy]\nallow_private_domains = [\"Intern.NAV.no\", \"a.nav.no.\"]\n";
+    let toml =
+        "[proxy]\nallow_private_domains = [\"Intern.NAV.no\", \"a.nav.no.\", \" pad.nav.no \"]\n";
     let cli = CliFlags {
         allow_private_domains: vec!["DEV.corp.example.com".to_string()],
         ..Default::default()
@@ -373,6 +374,7 @@ fn allow_private_domains_are_normalized_and_actually_match() {
         "sub.Intern.nav.no",
         "a.nav.no",
         "x.a.nav.no",
+        "pad.nav.no",
     ] {
         assert!(
             is_domain_match(host, &resolved.allow_private_domains),


### PR DESCRIPTION
## Symptom

A domain approved through `cplt trust accept` from a repo `.cplt.toml` resolves for about 5 seconds, then stops.

## Root cause

`private_domains_cache` is seeded with the fully-resolved set — CLI flags, global config, and trust-approved repo proposals merged in `src/config/loading.rs`. But the TTL refresh re-reads only `config_file`, the **global** `~/.config/cplt/config.toml`. Anything in that cache whose source is not that file is dropped by the first refresh.

Root cause stated plainly: a source that is read exactly once (repo trust approval, read from `git cat-file blob HEAD:.cplt.toml` at startup) was stored in a cache whose only refresh source is a different file.

Two things the issue suggests would not have fixed it. `parse_private_domains_from_toml` is never pointed at a repo `.cplt.toml` — repo config goes through serde in `src/repo_config.rs`. And returning `None` on absence would hide this case while breaking documented revocation: removing a domain from the global config must revoke it within 5s.

## Fix: carry provenance, do not infer it

- `Resolved::repo_private_domains` records the trust-approved subset where the merge already happens, in `apply_repo_config`.
- `main.rs` passes it as its own `ProxyOptions::repo_private_domains` and excludes it from `config_private_domains`, so the cache seed is exactly "what the config file supplied".
- `proxy::start`: `sticky = cli_private_domains ∪ repo_private_domains`, normalized. Everything else stays reloadable.

An earlier version of this PR derived provenance by re-parsing the config file at startup and string-diffing. That was wrong in a way worth recording: it made revocability depend on the line parser's fidelity, and any entry the parser missed became sticky — turning a private-IP waiver in the user's own `config.toml` into one that could not be revoked for the rest of the session. That is a fail-open failure, worse than the fail-closed bug being fixed. Caught in adversarial review.

## Second bug, same parser

Chasing that turned up a live bug independent of this issue. `parse_private_domains_from_toml` was a hand-rolled line parser that only understood a single-line array:

- a multi-line array — what `init::write_string_array` emits for more than one entry — parsed as "no domains"
- so did a trailing comment, and a dotted `proxy.allow_private_domains` key
- a `[proxy]` key merely *starting with* `allow_private_domains` (a typo like `..._extra`) returned `None` for the whole file

So users with those perfectly valid shapes had their global-config waivers silently dropped by the 5s reload too. Replaced with `toml::from_str` — the crate is already a dependency, so this is a net deletion. `Some(empty)` still means "the file allows none" (the revocation path); `None` still means unreadable or unparseable (keep last-good).

## Third: normalization

`is_domain_match` normalizes the hostname but compares it against the raw pattern, so a config entry like `"Intern.NAV.no"` or `"a.nav.no."` never matched anything — contradicting `docs/proxy.md:385`, which promises case-insensitive matching with dots stripped. Fixed at ingest in `loading.rs`, following the convention `parse_lines_file` already uses (patterns normalized on the way in). `normalize_hostname` is now `pub(crate)` and reused, so the rule exists in one place, and nothing is added to the per-request path.

## Tests

`private_domain_sources_survive_or_follow_the_config_reload` uses a CLI domain, **two** config-file domains in the **multi-line** form, and a repo-approved domain. It asserts startup, survival across a reload, per-entry revocation, and section-deletion revocation. Plus `parse_private_domains_from_toml_handles_real_world_shapes` (4 shapes + unparseable → `None`) and `allow_private_domains_are_normalized_and_actually_match`.

Four mutants applied and reverted:

| mutant | result |
|---|---|
| drop `repo_private_domains` from sticky | FAIL — "trust-approved repo domain must survive" |
| make `config_private_domains` sticky too (the fail-open shape review found) | FAIL — "config-file domain must be revocable by editing the file" |
| restore the old line parser verbatim from `main` | FAIL ×2 — parser shapes, and multi-line reload |
| drop the ingest normalization | FAIL — "intern.nav.no should match the configured waiver" |

The previous version of the test passed with every one of those defects present, which is why it was rewritten.

`cargo test --lib` 709 passed; integration 603 passed (6 ignored), 0 failed. fmt and clippy clean.

Closes #186.
