### PR TITLE
fix(agent): suppress the API-key warning for every OAuth-first agent, not just Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ cplt --agent opencode --pass-env ANTHROPIC_API_KEY
 ```
 
 **Security notes for OpenCode:**
-- **Copilot provider**: auth is handled via `/connect` device flow, stored in `~/.local/share/opencode/auth.json` — no env vars needed
+- **Copilot provider**: auth is handled via `/connect` device flow, stored in `~/.local/share/opencode/auth.json` — no env vars needed, and cplt does not nag about API keys
 - **Third-party providers**: API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) are **not** passed through by default — use `--pass-env`:
 
 ```bash

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -273,7 +273,8 @@ impl Agent {
     /// Gemini uses Keychain for extension integrity verification.
     /// Claude Code stores its OAuth token in the login Keychain on macOS
     /// ("Claude Code-credentials"); on Linux it uses ~/.claude/.credentials.json.
-    /// OpenCode uses API keys from env vars or config files.
+    /// OpenCode authenticates via the `/connect` device flow by default;
+    /// third-party providers use API keys from env vars or config files.
     pub fn needs_keychain(&self) -> bool {
         matches!(
             self,
@@ -573,6 +574,26 @@ impl Agent {
             Agent::Pi => false,
             // Not an AI agent: no auth of its own.
             Agent::Shell => false,
+        }
+    }
+
+    /// Whether this agent's OAuth login needs a browser cplt blocks by default.
+    ///
+    /// Device-flow agents (Copilot, OpenCode, Claude Code) print a code and a
+    /// URL, so a blocked browser costs nothing. Google's flow opens a browser
+    /// instead, and `--allow-browser` is off by default — so a first-time user
+    /// hits a dead end with no explanation once the API-key hint is suppressed
+    /// for OAuth-first agents (#187).
+    ///
+    /// Exhaustive match for the same reason as `oauth_first`.
+    pub fn oauth_needs_browser(&self) -> bool {
+        match self {
+            // Google OAuth browser flow on first run.
+            Agent::Gemini | Agent::Antigravity => true,
+            // Device flow: a code and a URL, no browser required from here.
+            Agent::Copilot | Agent::OpenCode | Agent::Claude => false,
+            // Not OAuth-first at all.
+            Agent::Pi | Agent::Shell => false,
         }
     }
 
@@ -1366,6 +1387,15 @@ mod tests {
                 "{agent:?} auth model changed — update the docs and the startup \
                  auth hint in main.rs deliberately"
             );
+            // Only OAuth-first agents can need the browser hint; a
+            // non-OAuth-first agent claiming to need one would print a
+            // login pointer to a login flow it does not have.
+            if !expected {
+                assert!(
+                    !agent.oauth_needs_browser(),
+                    "{agent:?} is not OAuth-first, so it cannot need a browser login"
+                );
+            }
             // The startup warning only fires for a non-OAuth-first agent, and
             // it prints `hints[0]` — so such an agent needs a hint to offer
             // (Shell excepted: it has no auth at all).

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -544,6 +544,38 @@ impl Agent {
         }
     }
 
+    /// Whether this agent authenticates OAuth-first: after an interactive
+    /// login its credentials live on disk in a granted config/data dir (or the
+    /// macOS Keychain), so the default path needs no environment variable.
+    ///
+    /// Used to suppress the "No API keys passed" hint, which otherwise fires
+    /// for a correctly configured user and reads like a startup failure (#187).
+    /// `auth_env_hint` still lists the vars for people who deliberately route
+    /// via an API key or an enterprise endpoint.
+    ///
+    /// Exhaustive match on purpose: a new agent must declare its auth model
+    /// instead of silently inheriting the wrong default.
+    pub fn oauth_first(&self) -> bool {
+        match self {
+            // GitHub device flow; token in the Keychain / ~/.copilot.
+            Agent::Copilot => true,
+            // `/connect` device flow against a GitHub Copilot subscription;
+            // credentials stored in ~/.local/share/opencode/auth.json.
+            Agent::OpenCode => true,
+            // Google OAuth browser flow by default; credentials in ~/.gemini/.
+            Agent::Gemini => true,
+            // Google OAuth with keychain/session storage.
+            Agent::Antigravity => true,
+            // Subscription OAuth token in ~/.claude (.credentials.json on
+            // Linux) or the macOS login Keychain.
+            Agent::Claude => true,
+            // Provider API keys only — no interactive login flow.
+            Agent::Pi => false,
+            // Not an AI agent: no auth of its own.
+            Agent::Shell => false,
+        }
+    }
+
     /// Environment variable names this agent may need for authentication.
     /// These are NOT added to the default allowlist — they must be
     /// explicitly passed via --pass-env or agent config.
@@ -1310,6 +1342,40 @@ mod tests {
         let hints = Agent::Gemini.auth_env_hint();
         assert!(hints.contains(&"GEMINI_API_KEY"));
         assert!(hints.contains(&"GOOGLE_CLOUD_PROJECT"));
+    }
+
+    #[test]
+    fn every_agent_declares_its_auth_model() {
+        // Pinned per agent so a new one has to make a deliberate choice: the
+        // exhaustive match in `oauth_first` forces the decision at compile
+        // time, this pins the answer. OAuth-first agents get no "No API keys
+        // passed" warning (#187) — their credentials land on disk or in the
+        // Keychain after an interactive login.
+        for (agent, expected) in [
+            (Agent::Copilot, true),     // GitHub device flow + Keychain
+            (Agent::OpenCode, true),    // /connect device flow -> auth.json
+            (Agent::Gemini, true),      // Google OAuth browser flow
+            (Agent::Antigravity, true), // Google OAuth + keychain
+            (Agent::Claude, true),      // subscription OAuth token
+            (Agent::Pi, false),         // provider API keys only
+            (Agent::Shell, false),      // not an AI agent, no auth
+        ] {
+            assert_eq!(
+                agent.oauth_first(),
+                expected,
+                "{agent:?} auth model changed — update the docs and the startup \
+                 auth hint in main.rs deliberately"
+            );
+            // The startup warning only fires for a non-OAuth-first agent, and
+            // it prints `hints[0]` — so such an agent needs a hint to offer
+            // (Shell excepted: it has no auth at all).
+            if !expected && agent != Agent::Shell {
+                assert!(
+                    !agent.auth_env_hint().is_empty(),
+                    "{agent:?} is not OAuth-first, so it needs an env hint to suggest"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1573,6 +1573,21 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             ));
         }
 
+        // Suppressing the API-key hint for OAuth-first agents leaves the
+        // browser-flow ones with no signal at all: Google's login opens a
+        // browser, and --allow-browser is off by default, so a first-time user
+        // hits a dead end. Point at the flag rather than the key.
+        if active_agent.oauth_first()
+            && active_agent.oauth_needs_browser()
+            && !resolved.allow_browser
+        {
+            ui::warn(&format!(
+                "{} signs in through a browser on first run — add --allow-browser \
+                 if you have not authenticated yet.",
+                active_agent.display_name()
+            ));
+        }
+
         // Warn if Copilot-only flags are used with a non-Copilot agent
         let copilot_flags_used: Vec<&str> = [
             cli.resume.as_ref().map(|_| "--resume"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1545,15 +1545,18 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         let has_api_key = hints.iter().any(|key| {
             parent_env.iter().any(|(k, _)| k == *key) && resolved.pass_env.iter().any(|v| v == *key)
         });
-        // Claude Code is OAuth-first: its subscription token lives in the granted
-        // config dir (or macOS Keychain), so it authenticates with no env var —
-        // same as Copilot. Don't nag about API keys; Claude prompts for login
-        // itself when unauthenticated. The hints stay for users who deliberately
-        // route via API/Bedrock/Vertex (documented in the README).
-        let oauth_first = active_agent == agent::Agent::Claude;
-        if !has_api_key && !resolved.inherit_env && !hints.is_empty() && !oauth_first {
+        // OAuth-first agents (Copilot, OpenCode, Gemini, Antigravity, Claude
+        // Code) keep their credentials on disk in a granted config dir or the
+        // macOS Keychain after an interactive login, so they authenticate with
+        // no env var. Don't nag them about API keys: they prompt for login
+        // themselves when unauthenticated, and the warning otherwise fires for
+        // a correctly configured user and reads like a startup failure (#187).
+        // The hints stay for users who deliberately route via an API key or an
+        // enterprise endpoint (documented in the README).
+        if !has_api_key && !resolved.inherit_env && !hints.is_empty() && !active_agent.oauth_first()
+        {
             ui::warn(&format!(
-                "No API keys passed. {} needs auth — either:",
+                "No API keys passed. {} needs a provider API key:",
                 active_agent.display_name()
             ));
             // Prefer showing a hint for a key that's already in the parent env
@@ -1568,11 +1571,6 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 active_agent.binary_name(),
                 hint_to_show
             ));
-            if active_agent == agent::Agent::OpenCode {
-                ui::warn("  or use /connect in OpenCode with your GitHub Copilot subscription");
-            } else if active_agent == agent::Agent::Gemini {
-                ui::warn("  or sign in with Google (OAuth flow on first run)");
-            }
         }
 
         // Warn if Copilot-only flags are used with a non-Copilot agent

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -404,7 +404,8 @@ fn emit_home_access(sb: &mut String, home: &str, agent: Agent, agent_dirs: &[Age
     sbpl!(sb);
 
     // macOS Keychain access — Copilot stores auth tokens here.
-    // OpenCode uses API keys from env/config files, no Keychain needed.
+    // OpenCode stores its /connect credentials in its own data dir, and
+    // third-party providers use env/config files — no Keychain needed.
     if agent.needs_keychain() {
         sbpl!(sb, ";; macOS Keychain (Copilot auth tokens)");
         sbpl!(


### PR DESCRIPTION
## Problem

`src/main.rs:1553` had:

```rust
let oauth_first = active_agent == agent::Agent::Claude;
```

So every OpenCode user without an API key env var — that is, every correctly configured `/connect` user — saw this as the last output before the agent started:

```
No API keys passed. OpenCode needs auth — either:
  ...
  or use /connect in OpenCode with your GitHub Copilot subscription
```

It reads like a startup failure. Nothing is wrong.

## Fix

`Agent::oauth_first()` in `src/agent.rs`, next to `auth_env_hint`, written as an **exhaustive match rather than `matches!`** so a new agent variant is a compile error instead of silently inheriting `false`. Same shape as `default_allowed_domains`.

| Agent | OAuth-first | Evidence |
|---|---|---|
| Copilot | yes | `auth_env_hint` empty; `needs_keychain` with "Copilot stores GitHub auth tokens in the Keychain"; `needs_copilot_dir` |
| OpenCode | yes | README:511 — `/connect` device flow, stored in `~/.local/share/opencode/auth.json`, no env vars needed |
| Gemini | yes | `auth_env_hint` comment "Gemini uses Google OAuth by default (browser flow, stored in ~/.gemini/)"; README:526 |
| Antigravity | yes | `auth_env_hint` empty, "uses Google OAuth with keychain/session storage"; README:556 |
| Claude Code | yes | README:599 — subscription OAuth token in `~/.claude`/Keychain; the existing behaviour this generalises |
| Pi | no | README:583 — multiple providers via API keys, no login flow; keychain disabled |
| Shell | no | not an AI agent |

Copilot was already excluded by an outer `if active_agent != Agent::Copilot` guard; that guard also gates the "Copilot-only flags ignored" warning, so it stays.

With Pi the only agent that can now reach the warning, the OpenCode and Gemini follow-up lines were dead code and are deleted, and the "either:" with one remaining option is reworded to "No API keys passed. Pi needs a provider API key:".

## Deliberate deviation from the issue

The issue's AC#2 asks for a reworded message when credentials are absent. That needs per-agent on-disk credential-path detection — new machinery — so OAuth-first agents now print nothing at all, exactly as Claude Code already did. The agents prompt for login themselves. Flagging it here so the issue author can push back.

## Test

`every_agent_declares_its_auth_model` pins the answer per agent, and additionally asserts that any non-OAuth-first agent has a non-empty `auth_env_hint`, since the warning prints `hints[0]`.

Mutation-checked: flipping `Agent::OpenCode => false` fails the test.

Manual: `cplt --agent opencode --print-profile` prints no auth line; `--agent pi` still prints the reworded hint.

`cargo test --lib` 708 passed; integration suites 132 (6 ignored), 107, 43, 54, 266 — 0 failed. fmt and clippy clean.

Closes #187.
