### PR TITLE
fix(trust): explain why cplt is not reading a .cplt.toml that exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4795,6 +4795,17 @@ fn trust_show(project_dir: &std::path::Path, loaded: &repo_config::LoadedRepoCon
     println!("{blue}[cplt]{nc}  Source: {}", source_label(loaded.source));
     println!();
 
+    // Anything but the committed copy is refused by the accept guard. Say so
+    // here, and below never advertise a `cplt trust accept` that would exit 1.
+    let blocked = match repo_config::repo_config_state(project_dir) {
+        repo_config::RepoConfigState::Committed => None,
+        state => state.explain(),
+    };
+    if let Some(msg) = &blocked {
+        ui::warn(msg);
+        println!();
+    }
+
     // Deny section
     if !loaded.config.deny.paths.is_empty() || !loaded.config.deny.env.is_empty() {
         println!("{blue}[cplt]{nc}  {green}[deny]{nc} {LABEL_DENY_APPLIED}");
@@ -4860,7 +4871,11 @@ fn trust_show(project_dir: &std::path::Path, loaded: &repo_config::LoadedRepoCon
 
         if hash_mismatch {
             println!("{blue}[cplt]{nc}  {red}⚠ Permissions have changed since last approval!{nc}");
-            println!("{blue}[cplt]{nc}  {red}  Run `cplt trust accept --all` to re-approve.{nc}");
+            if blocked.is_none() {
+                println!(
+                    "{blue}[cplt]{nc}  {red}  Run `cplt trust accept --all` to re-approve.{nc}"
+                );
+            }
         }
 
         // Finding 4: approval is bound to the local checkout path. If this repo's
@@ -4875,11 +4890,13 @@ fn trust_show(project_dir: &std::path::Path, loaded: &repo_config::LoadedRepoCon
                     &entry.repo.path
                 }
             );
-            println!(
-                "{blue}[cplt]{nc}  {red}  Run `cplt trust accept` to approve at this path.{nc}"
-            );
+            if blocked.is_none() {
+                println!(
+                    "{blue}[cplt]{nc}  {red}  Run `cplt trust accept` to approve at this path.{nc}"
+                );
+            }
         }
-    } else if has_pending {
+    } else if has_pending && blocked.is_none() {
         println!();
         println!("{blue}[cplt]{nc}  {yellow}To approve all pending permissions:{nc}");
         println!("{blue}[cplt]{nc}    cplt trust accept --all");
@@ -4920,16 +4937,13 @@ fn trust_accept(
         return ExitCode::SUCCESS;
     }
 
-    // Guard: refuse to approve a .cplt.toml that is not the committed one.
-    // This ensures approved configs are auditable in git history and prevents
-    // a malicious process from injecting permissions and immediately accepting them.
-    // Compared against the HEAD blob rather than `git status`, which stays silent
-    // for a gitignored .cplt.toml (#183).
+    // Guard: approve ONLY the committed config, so every granted permission is
+    // auditable in git history and no process can inject permissions and
+    // immediately accept them. Stated as "anything but Committed" on purpose —
+    // enumerating the bad states is how the not-a-git-repo case slipped through,
+    // and `git status` cannot see a gitignored .cplt.toml at all (#183).
     let state = repo_config::repo_config_state(project_dir);
-    if matches!(
-        state,
-        repo_config::RepoConfigState::Uncommitted | repo_config::RepoConfigState::Drifted
-    ) {
+    if state != repo_config::RepoConfigState::Committed {
         ui::error(&state.explain().unwrap_or_default());
         return ExitCode::FAILURE;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1439,10 +1439,13 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 .collect();
             unapproved_proposals = resolved.apply_repo_config(&loaded.config, &approved_refs);
         }
-        Ok(None) => {} // No .cplt.toml — nothing to do
+        Ok(None) => {} // No .cplt.toml in HEAD — warn_repo_config_discrepancy explains why
         Err(e) => {
             ui::warn(&format!("Failed to load .cplt.toml: {e}"));
         }
+    }
+    if !resolved.quiet {
+        warn_repo_config_discrepancy(&project_dir);
     }
 
     // Reconcile proxy.forced vs allow_localhost_any (#53). Done here, after all
@@ -4103,8 +4106,9 @@ fn run_config_show() -> ExitCode {
                     ui::color(ui::RESET)
                 );
             }
-            Ok(None) => {} // No .cplt.toml — nothing to show
+            Ok(None) => {} // No .cplt.toml in HEAD — explained below if one is on disk
         }
+        warn_repo_config_discrepancy(dir);
     }
 
     ExitCode::SUCCESS
@@ -4744,8 +4748,23 @@ fn run_trust_command(action: Option<TrustAction>) -> ExitCode {
     let loaded = match repo_config::load_repo_config(&project_dir) {
         Ok(Some(l)) => l,
         Ok(None) => {
-            ui::info("No .cplt.toml found in this repository.");
-            return ExitCode::SUCCESS;
+            // "Not found" means "not found in git HEAD" — say which of the very
+            // different on-disk situations this actually is (#183).
+            let state = repo_config::repo_config_state(&project_dir);
+            let msg = state.explain().unwrap_or_default();
+            return match state {
+                repo_config::RepoConfigState::Missing
+                | repo_config::RepoConfigState::NotAGitRepo { has_file: false } => {
+                    ui::info(&msg);
+                    ExitCode::SUCCESS
+                }
+                // A file is there but cplt cannot use it — the user asked for
+                // something that did not happen, so this is a failure.
+                _ => {
+                    ui::error(&msg);
+                    ExitCode::FAILURE
+                }
+            };
         }
         Err(e) => {
             ui::error(&format!("Failed to load .cplt.toml: {e}"));
@@ -4901,15 +4920,17 @@ fn trust_accept(
         return ExitCode::SUCCESS;
     }
 
-    // Guard: refuse to approve uncommitted .cplt.toml changes.
+    // Guard: refuse to approve a .cplt.toml that is not the committed one.
     // This ensures approved configs are auditable in git history and prevents
     // a malicious process from injecting permissions and immediately accepting them.
-    if is_cplt_toml_uncommitted(project_dir) {
-        ui::error(
-            ".cplt.toml has uncommitted changes.\n  \
-             Commit the file first so permissions are auditable in git history:\n    \
-             git add .cplt.toml && git commit -m \"chore: update cplt sandbox config\"",
-        );
+    // Compared against the HEAD blob rather than `git status`, which stays silent
+    // for a gitignored .cplt.toml (#183).
+    let state = repo_config::repo_config_state(project_dir);
+    if matches!(
+        state,
+        repo_config::RepoConfigState::Uncommitted | repo_config::RepoConfigState::Drifted
+    ) {
+        ui::error(&state.explain().unwrap_or_default());
         return ExitCode::FAILURE;
     }
 
@@ -5063,15 +5084,23 @@ fn trust_accept(
     ExitCode::SUCCESS
 }
 
-/// Check if .cplt.toml has uncommitted changes (staged or unstaged).
-fn is_cplt_toml_uncommitted(project_dir: &std::path::Path) -> bool {
-    let output = std::process::Command::new("git")
-        .args(["status", "--porcelain", "--", ".cplt.toml"])
-        .current_dir(project_dir)
-        .output();
-    match output {
-        Ok(o) if o.status.success() => !o.stdout.is_empty(),
-        _ => false, // If git fails (not a repo, etc.), don't block
+/// Warn when the `.cplt.toml` on disk is not the one cplt is reading.
+///
+/// cplt loads the config from git HEAD, so an uncommitted file — or one edited
+/// since the last commit — is silently not in effect. Says nothing when there is
+/// no `.cplt.toml` at all, or when the committed file is what the user sees.
+fn warn_repo_config_discrepancy(project_dir: &std::path::Path) {
+    let state = repo_config::repo_config_state(project_dir);
+    if matches!(
+        state,
+        repo_config::RepoConfigState::Committed
+            | repo_config::RepoConfigState::Missing
+            | repo_config::RepoConfigState::NotAGitRepo { has_file: false }
+    ) {
+        return;
+    }
+    if let Some(msg) = state.explain() {
+        ui::warn(&msg);
     }
 }
 

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -173,6 +173,97 @@ fn read_from_git_head(project_dir: &Path) -> Option<String> {
     }
 }
 
+/// Where `.cplt.toml` stands relative to git HEAD.
+///
+/// cplt reads the config from HEAD, not the working tree (see
+/// [`load_repo_config`]), so "no config" from cplt's point of view covers
+/// several very different situations on disk. Telling them apart is what turns
+/// a misleading "not found" into an actionable message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoConfigState {
+    /// Committed, and the working tree copy matches what cplt reads.
+    Committed,
+    /// Committed, but the working tree copy differs — local edits are not in effect.
+    Drifted,
+    /// In the working tree only: untracked (possibly gitignored), or staged but
+    /// not committed. Never read by cplt on Linux, and never trustworthy.
+    Uncommitted,
+    /// Not a git repository at all; `has_file` tells whether a `.cplt.toml` is
+    /// sitting there being ignored.
+    NotAGitRepo { has_file: bool },
+    /// No `.cplt.toml` in HEAD nor in the working tree.
+    Missing,
+}
+
+impl RepoConfigState {
+    /// A user-facing explanation of why cplt is not using the `.cplt.toml` the
+    /// user is looking at. `None` when there is nothing to explain.
+    #[must_use]
+    pub fn explain(self) -> Option<String> {
+        match self {
+            Self::Committed => None,
+            Self::Drifted => Some(format!(
+                "{REPO_CONFIG_FILE} differs from the version committed in git HEAD.\n  \
+                 cplt reads it from HEAD, so your local edits are not in effect until committed."
+            )),
+            Self::Uncommitted => Some(format!(
+                "{REPO_CONFIG_FILE} exists in the working tree but not in git HEAD.\n  \
+                 cplt reads it from git HEAD, so a sandboxed agent cannot grant itself \
+                 permissions mid-session — the file must be committed first:\n    \
+                 git add {REPO_CONFIG_FILE} && git commit -m \"chore: add cplt sandbox config\"\n  \
+                 (if {REPO_CONFIG_FILE} is listed in .gitignore, un-ignore it — an ignored \
+                 file can never reach HEAD)"
+            )),
+            Self::NotAGitRepo { has_file: true } => Some(format!(
+                "{REPO_CONFIG_FILE} exists here, but this is not a git repository.\n  \
+                 cplt reads it from git HEAD, so it takes effect only once the directory \
+                 is a git repo and the file is committed."
+            )),
+            Self::NotAGitRepo { has_file: false } => Some(format!(
+                "No {REPO_CONFIG_FILE} found, and this is not a git repository."
+            )),
+            Self::Missing => Some(format!("No {REPO_CONFIG_FILE} found in this repository.")),
+        }
+    }
+}
+
+/// Diagnose where `.cplt.toml` lives, for user-facing messages only.
+///
+/// Reading the working tree here does not make it trusted — only
+/// [`load_repo_config`] decides what is applied.
+#[must_use]
+pub fn repo_config_state(project_dir: &Path) -> RepoConfigState {
+    let head = read_from_git_head(project_dir);
+    let working = std::fs::read_to_string(project_dir.join(REPO_CONFIG_FILE)).ok();
+
+    match (head, working) {
+        (Some(head), Some(working)) if head != working => RepoConfigState::Drifted,
+        // Present in HEAD (whether or not it is checked out) — HEAD is what cplt reads.
+        (Some(_), _) => RepoConfigState::Committed,
+        (None, working) => {
+            if is_git_repo(project_dir) {
+                if working.is_some() {
+                    RepoConfigState::Uncommitted
+                } else {
+                    RepoConfigState::Missing
+                }
+            } else {
+                RepoConfigState::NotAGitRepo {
+                    has_file: working.is_some(),
+                }
+            }
+        }
+    }
+}
+
+fn is_git_repo(project_dir: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(project_dir)
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
 /// Parse and validate a `.cplt.toml` content string.
 /// Returns an error if the TOML is invalid or violates safety constraints.
 pub fn parse_and_validate(content: &str) -> Result<RepoConfig, String> {

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -195,9 +195,22 @@ pub enum RepoConfigState {
     Missing,
 }
 
+/// What an uncommitted `.cplt.toml` actually does — which differs by platform,
+/// so the message must too. Linux skips the working-tree fallback entirely; on
+/// macOS the file IS loaded (see [`load_repo_config`]), it just can never be
+/// approved. Claiming it is inert on macOS would be wrong in the permissive
+/// direction.
+const UNCOMMITTED_EFFECT: &str = if cfg!(target_os = "linux") {
+    "Until then cplt ignores it entirely."
+} else {
+    "Until then cplt loads it from the working tree — unaudited, so its [deny] keys \
+     apply but its [propose] keys cannot be approved."
+};
+
 impl RepoConfigState {
-    /// A user-facing explanation of why cplt is not using the `.cplt.toml` the
-    /// user is looking at. `None` when there is nothing to explain.
+    /// A user-facing explanation of why cplt is not treating the `.cplt.toml`
+    /// the user is looking at as trustworthy. `None` when there is nothing to
+    /// explain.
     #[must_use]
     pub fn explain(self) -> Option<String> {
         match self {
@@ -208,16 +221,18 @@ impl RepoConfigState {
             )),
             Self::Uncommitted => Some(format!(
                 "{REPO_CONFIG_FILE} exists in the working tree but not in git HEAD.\n  \
-                 cplt reads it from git HEAD, so a sandboxed agent cannot grant itself \
-                 permissions mid-session — the file must be committed first:\n    \
+                 cplt trusts only the committed copy, so permissions stay auditable in git \
+                 history and a sandboxed agent cannot grant itself more mid-session.\n  \
+                 {UNCOMMITTED_EFFECT}\n  \
+                 Commit it first:\n    \
                  git add {REPO_CONFIG_FILE} && git commit -m \"chore: add cplt sandbox config\"\n  \
                  (if {REPO_CONFIG_FILE} is listed in .gitignore, un-ignore it — an ignored \
                  file can never reach HEAD)"
             )),
             Self::NotAGitRepo { has_file: true } => Some(format!(
                 "{REPO_CONFIG_FILE} exists here, but this is not a git repository.\n  \
-                 cplt reads it from git HEAD, so it takes effect only once the directory \
-                 is a git repo and the file is committed."
+                 cplt trusts only a copy committed to git, so its permissions are auditable.\n  \
+                 {UNCOMMITTED_EFFECT}"
             )),
             Self::NotAGitRepo { has_file: false } => Some(format!(
                 "No {REPO_CONFIG_FILE} found, and this is not a git repository."
@@ -233,32 +248,42 @@ impl RepoConfigState {
 /// [`load_repo_config`] decides what is applied.
 #[must_use]
 pub fn repo_config_state(project_dir: &Path) -> RepoConfigState {
-    let head = read_from_git_head(project_dir);
-    let working = std::fs::read_to_string(project_dir.join(REPO_CONFIG_FILE)).ok();
+    let in_working_tree = project_dir.join(REPO_CONFIG_FILE).is_file();
 
-    match (head, working) {
-        (Some(head), Some(working)) if head != working => RepoConfigState::Drifted,
-        // Present in HEAD (whether or not it is checked out) — HEAD is what cplt reads.
-        (Some(_), _) => RepoConfigState::Committed,
-        (None, working) => {
-            if is_git_repo(project_dir) {
-                if working.is_some() {
-                    RepoConfigState::Uncommitted
-                } else {
-                    RepoConfigState::Missing
-                }
-            } else {
-                RepoConfigState::NotAGitRepo {
-                    has_file: working.is_some(),
-                }
-            }
+    // Existence in HEAD is what closes the gitignore hole: `git status` says
+    // nothing at all about an ignored file, so it cannot answer this.
+    if read_from_git_head(project_dir).is_some() {
+        // Whether the checkout still MATCHES HEAD is git's question to answer.
+        // Byte-comparing the raw blob against the file on disk would call every
+        // .gitattributes filter (eol=crlf, LFS, git-crypt, ident) permanent
+        // drift and make a correctly committed config ungrantable.
+        if !in_working_tree
+            || git_succeeds(
+                project_dir,
+                &["diff", "--quiet", "HEAD", "--", REPO_CONFIG_FILE],
+            )
+        {
+            return RepoConfigState::Committed;
+        }
+        return RepoConfigState::Drifted;
+    }
+
+    if git_succeeds(project_dir, &["rev-parse", "--git-dir"]) {
+        if in_working_tree {
+            RepoConfigState::Uncommitted
+        } else {
+            RepoConfigState::Missing
+        }
+    } else {
+        RepoConfigState::NotAGitRepo {
+            has_file: in_working_tree,
         }
     }
 }
 
-fn is_git_repo(project_dir: &Path) -> bool {
+fn git_succeeds(project_dir: &Path, args: &[&str]) -> bool {
     Command::new("git")
-        .args(["rev-parse", "--git-dir"])
+        .args(args)
         .current_dir(project_dir)
         .output()
         .is_ok_and(|o| o.status.success())

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -1476,3 +1476,160 @@ fi
         );
     }
 }
+
+// ── `cplt trust accept` commit guard (issue #183) ─────────────────────────────
+//
+// cplt trusts only the `.cplt.toml` committed to git HEAD, so every granted
+// permission is auditable. These tests drive the real binary, because the guard
+// — not the state machine behind it — is what decides whether an unauditable
+// config can be approved. Asserting only on the state enum is how the
+// not-a-git-repo case slipped through review.
+mod trust_accept_guard {
+    use super::binary_path;
+    use std::path::Path;
+    use std::process::Command;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@e.x")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@e.x")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .output()
+            .expect("git should run");
+        assert!(out.status.success(), "git {args:?} failed");
+    }
+
+    fn commit_all(dir: &Path) {
+        git(dir, &["add", "-A"]);
+        git(
+            dir,
+            &["-c", "commit.gpgSign=false", "commit", "-q", "-m", "cfg"],
+        );
+    }
+
+    const PROPOSE: &str = "[propose]\nallow_docker = true\n";
+
+    /// `cplt trust accept --all` in `dir`, with the trust store redirected out
+    /// of the developer's real `~/.config/cplt`. Returns (combined output, ok).
+    fn trust_accept_all(dir: &Path, store: &Path) -> (String, bool) {
+        let out = Command::new(binary_path())
+            .args(["trust", "accept", "--all"])
+            .current_dir(dir)
+            .env("CPLT_CONFIG", store.join("config.toml"))
+            .output()
+            .expect("cplt should run");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (combined, out.status.success())
+    }
+
+    /// A repo with one commit (so HEAD exists) plus an isolated trust store.
+    fn repo() -> (tempfile::TempDir, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-q", "-b", "main"]);
+        std::fs::write(dir.path().join("README"), "x\n").unwrap();
+        commit_all(dir.path());
+        (dir, store)
+    }
+
+    fn assert_refused(out: &str, ok: bool, expect: &str) {
+        assert!(!ok, "trust accept must exit non-zero.\n{out}");
+        assert!(!out.contains("Approved"), "nothing may be approved.\n{out}");
+        assert!(
+            out.contains(expect),
+            "message must contain {expect:?}.\n{out}"
+        );
+    }
+
+    #[test]
+    fn refuses_untracked_config() {
+        let (dir, store) = repo();
+        std::fs::write(dir.path().join(".cplt.toml"), PROPOSE).unwrap();
+        let (out, ok) = trust_accept_all(dir.path(), store.path());
+        assert_refused(&out, ok, "not in git HEAD");
+    }
+
+    /// The reported setup (#183): `.cplt.toml` in `.gitignore`. `git status`
+    /// reports nothing for an ignored file, so a status-based guard let this
+    /// through and approved a config that can never be audited.
+    #[test]
+    fn refuses_gitignored_config() {
+        let (dir, store) = repo();
+        std::fs::write(dir.path().join(".gitignore"), ".cplt.toml\n").unwrap();
+        commit_all(dir.path());
+        std::fs::write(dir.path().join(".cplt.toml"), PROPOSE).unwrap();
+        let (out, ok) = trust_accept_all(dir.path(), store.path());
+        assert_refused(&out, ok, "not in git HEAD");
+    }
+
+    #[test]
+    fn refuses_config_edited_since_commit() {
+        let (dir, store) = repo();
+        std::fs::write(dir.path().join(".cplt.toml"), PROPOSE).unwrap();
+        commit_all(dir.path());
+        std::fs::write(
+            dir.path().join(".cplt.toml"),
+            format!("{PROPOSE}allow_browser = true\n"),
+        )
+        .unwrap();
+        let (out, ok) = trust_accept_all(dir.path(), store.path());
+        assert_refused(&out, ok, "differs from the version committed");
+    }
+
+    /// Outside a git repo nothing can be audited, and on macOS the working-tree
+    /// fallback would still apply whatever got approved — the trust entry falls
+    /// back to the canonicalized path, so it persists.
+    #[test]
+    fn refuses_config_outside_a_git_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".cplt.toml"), PROPOSE).unwrap();
+        let (out, ok) = trust_accept_all(dir.path(), store.path());
+        assert_refused(&out, ok, "not a git repository");
+    }
+
+    #[test]
+    fn accepts_committed_config() {
+        let (dir, store) = repo();
+        std::fs::write(dir.path().join(".cplt.toml"), PROPOSE).unwrap();
+        commit_all(dir.path());
+        let (out, ok) = trust_accept_all(dir.path(), store.path());
+        assert!(ok, "a committed config must be approvable.\n{out}");
+        assert!(out.contains("allow_docker"), "{out}");
+    }
+
+    /// A `.gitattributes` filter (eol, LFS, git-crypt, ident) makes the checked
+    /// out bytes differ from the raw HEAD blob. Comparing the two directly would
+    /// call this permanent drift and leave the permission ungrantable forever,
+    /// with no workaround short of dropping the gitattribute.
+    #[test]
+    fn accepts_committed_config_behind_a_gitattributes_filter() {
+        let (dir, store) = repo();
+        std::fs::write(dir.path().join(".gitattributes"), "*.toml text eol=crlf\n").unwrap();
+        std::fs::write(dir.path().join(".cplt.toml"), PROPOSE).unwrap();
+        commit_all(dir.path());
+        // Re-checkout so the working tree holds the smudged (CRLF) bytes.
+        std::fs::remove_file(dir.path().join(".cplt.toml")).unwrap();
+        git(dir.path(), &["checkout", "-q", "--", ".cplt.toml"]);
+        assert!(
+            std::fs::read(dir.path().join(".cplt.toml"))
+                .unwrap()
+                .windows(2)
+                .any(|w| w == b"\r\n"),
+            "precondition: the checkout must differ from the blob"
+        );
+
+        let (out, ok) = trust_accept_all(dir.path(), store.path());
+        assert!(ok, "a committed config must stay approvable.\n{out}");
+        assert!(out.contains("allow_docker"), "{out}");
+    }
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8068,3 +8068,143 @@ fn audit_reports_incomplete_when_baseline_commit_pruned() {
         other => panic!("expected Incomplete after prune, got {other:?}"),
     }
 }
+
+// ── .cplt.toml diagnosis: working tree vs git HEAD (issue #183) ───────────────
+//
+// cplt reads `.cplt.toml` from git HEAD, never the working tree, so the agent
+// cannot grant itself permissions mid-session. That makes "not found" ambiguous:
+// the file may be sitting right there, just not committed. These tests pin the
+// distinction each message is supposed to make.
+
+use cplt::repo_config::{RepoConfigState, repo_config_state};
+
+/// A git repo with one commit, so HEAD exists.
+fn repo_with_commit() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    git_in(tmp.path(), &["init", "-q", "-b", "main"]);
+    std::fs::write(tmp.path().join("README"), "x\n").unwrap();
+    git_in(tmp.path(), &["add", "."]);
+    git_in(
+        tmp.path(),
+        &["-c", "commit.gpgSign=false", "commit", "-q", "-m", "init"],
+    );
+    tmp
+}
+
+fn commit_all(dir: &std::path::Path) {
+    git_in(dir, &["add", "-A"]);
+    git_in(
+        dir,
+        &["-c", "commit.gpgSign=false", "commit", "-q", "-m", "cfg"],
+    );
+}
+
+const PROPOSE: &str = "[propose]\nallow_docker = true\n";
+
+#[test]
+fn repo_config_state_missing_when_no_file_anywhere() {
+    let tmp = repo_with_commit();
+    let state = repo_config_state(tmp.path());
+    assert_eq!(state, RepoConfigState::Missing);
+    assert_eq!(
+        state.explain().unwrap(),
+        "No .cplt.toml found in this repository."
+    );
+}
+
+#[test]
+fn repo_config_state_uncommitted_when_untracked() {
+    let tmp = repo_with_commit();
+    std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
+    let state = repo_config_state(tmp.path());
+    assert_eq!(state, RepoConfigState::Uncommitted);
+    let msg = state.explain().unwrap();
+    assert!(
+        msg.contains("working tree but not in git HEAD"),
+        "must name the real problem, got: {msg}"
+    );
+    assert!(
+        msg.contains("git commit"),
+        "must tell the user to commit it, got: {msg}"
+    );
+}
+
+#[test]
+fn repo_config_state_uncommitted_when_staged_but_not_committed() {
+    let tmp = repo_with_commit();
+    std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
+    git_in(tmp.path(), &["add", ".cplt.toml"]);
+    assert_eq!(repo_config_state(tmp.path()), RepoConfigState::Uncommitted);
+}
+
+/// The reported case (#183): `.cplt.toml` in `.gitignore`, never committed.
+/// `git status --porcelain -- .cplt.toml` stays SILENT for an ignored file, so a
+/// status-based check calls this clean; only comparing against the HEAD blob
+/// catches it.
+#[test]
+fn repo_config_state_uncommitted_when_gitignored() {
+    let tmp = repo_with_commit();
+    std::fs::write(tmp.path().join(".gitignore"), ".cplt.toml\n").unwrap();
+    commit_all(tmp.path());
+    std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
+
+    // Precondition: git status really does report nothing here.
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain", "--", ".cplt.toml"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        status.stdout.is_empty(),
+        "precondition: an ignored .cplt.toml is invisible to git status"
+    );
+
+    assert_eq!(repo_config_state(tmp.path()), RepoConfigState::Uncommitted);
+}
+
+#[test]
+fn repo_config_state_committed_has_nothing_to_explain() {
+    let tmp = repo_with_commit();
+    std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
+    commit_all(tmp.path());
+    let state = repo_config_state(tmp.path());
+    assert_eq!(state, RepoConfigState::Committed);
+    assert_eq!(state.explain(), None);
+}
+
+#[test]
+fn repo_config_state_drifted_when_working_tree_edited_after_commit() {
+    let tmp = repo_with_commit();
+    std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
+    commit_all(tmp.path());
+    std::fs::write(
+        tmp.path().join(".cplt.toml"),
+        format!("{PROPOSE}allow_browser = true\n"),
+    )
+    .unwrap();
+
+    let state = repo_config_state(tmp.path());
+    assert_eq!(state, RepoConfigState::Drifted);
+    let msg = state.explain().unwrap();
+    assert!(
+        msg.contains("differs from the version committed"),
+        "drift must be named, got: {msg}"
+    );
+}
+
+#[test]
+fn repo_config_state_not_a_git_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(
+        repo_config_state(tmp.path()),
+        RepoConfigState::NotAGitRepo { has_file: false }
+    );
+
+    std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
+    let state = repo_config_state(tmp.path());
+    assert_eq!(state, RepoConfigState::NotAGitRepo { has_file: true });
+    assert!(
+        state.explain().unwrap().contains("not a git repository"),
+        "must say it is not a git repo"
+    );
+}


### PR DESCRIPTION
## The reported bug

`cplt trust accept --all` says `No .cplt.toml found in this repository.` when the file is plainly there.

It is not lying so much as describing the wrong thing. `load_repo_config` reads `.cplt.toml` from **git HEAD** (`git cat-file blob HEAD:.cplt.toml`), deliberately — a sandboxed agent must not be able to grant itself permissions mid-session by writing the file. An uncommitted file genuinely is absent *from HEAD*. The message never says so, and the reporter read the docs' "Commit sandbox settings to your repo" as advice rather than a requirement.

Reproduced on the Linux path, with the reporter's exact setup (file present, gitignored, never committed):

```
[cplt] No .cplt.toml found in this repository.
exit=0
```

`cplt config show` was silent about it too — no `.cplt.toml` section, no explanation.

After:

```
[cplt] .cplt.toml exists in the working tree but not in git HEAD.
  cplt reads it from git HEAD, so a sandboxed agent cannot grant itself permissions mid-session — the file must be committed first:
    git add .cplt.toml && git commit -m "chore: add cplt sandbox config"
  (if .cplt.toml is listed in .gitignore, un-ignore it — an ignored file can never reach HEAD)
exit=1
```

Exit code was 0 while doing nothing; it is 1 now when a file exists that cplt cannot use.

## The bug found on the way, which matters more

`is_cplt_toml_uncommitted` gated `trust accept` on `git status --porcelain -- .cplt.toml`. **That is silent for a gitignored file.** Verified directly:

```
$ echo ".cplt.toml" > .gitignore && git add .gitignore && git commit -qm ignore
$ printf '[propose]\nallow_docker = true\n' > .cplt.toml
$ git status --porcelain -- .cplt.toml
                                        # empty
```

So on macOS — where `load_repo_config` has a working-tree fallback — a gitignored, never-committed `.cplt.toml` sailed past the "commit it first" guard and was approved:

```
✓ Approved 1 permission(s)
```

The guard exists so that granted permissions are auditable in git history. An ignored file can never reach HEAD, so this bypassed exactly the property the guard is there to protect. The check now compares against the HEAD blob instead of asking `git status`, which closes it.

## Changes

- `src/repo_config.rs`: `RepoConfigState` (`Committed` / `Drifted` / `Uncommitted` / `NotAGitRepo{has_file}` / `Missing`) and `repo_config_state()`, comparing the HEAD blob against the working-tree file, with `explain()` carrying the per-state message. **Diagnosis only** — `load_repo_config` and what gets trusted are untouched, so the tamper-resistance property is unchanged.
- `src/main.rs`: all three sites use it. `run_trust_command` replaces the flat message; `trust_accept`'s guard replaces the deleted `is_cplt_toml_uncommitted`; `cplt config show` and sandbox launch share `warn_repo_config_discrepancy` — both previously stayed completely silent while ignoring a config the user had just written.

A committed-then-edited file now says so too: `.cplt.toml differs from the version committed in git HEAD. / cplt reads it from HEAD, so your local edits are not in effect until committed.`

## Known, not fixed: platform divergence

`src/repo_config.rs:136-153` — on Linux the working-tree fallback is skipped (Landlock cannot deny individual file writes inside the project dir); on macOS the working-tree file is loaded and applied with a `⚠ not committed` warning. Present since #34 (`f6969ab`), so it is deliberate.

The consequence is that **the same repo grants different sandbox permissions depending on the OS**: an untracked `.cplt.toml` is live on macOS and inert on Linux. Not fixed here, because neither direction is obviously correct — removing the macOS fallback breaks existing users, adding one to Linux weakens tamper-resistance. This PR at least makes the Linux side explain itself. Worth its own issue.

## Verification

7 new tests in `tests/unit_tests.rs`, one per message case, including staged-but-not-committed and the gitignored case (which asserts as a precondition that `git status` really is silent there).

Mutation-checked: reintroducing the old diagnosis (`repo_config_state` returning `Missing` whenever HEAD lacks the file) fails 3 tests.

lib 707, main 26, e2e 132 (+6 ignored), e2e_guards 107, e2e_projects 43, integration 54, unit_tests 273 — 0 failures. fmt and clippy clean.

Closes #183.
