### PR TITLE
fix(config): anchor relative repo-config paths to the repo root

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,7 +297,11 @@ Commit a `.cplt.toml` file to your repository for project-specific sandbox setti
 
 **Path expansion:** Paths in `[deny]` and `[propose.allow]` support `~/` expansion. A relative path is resolved against the **repository root** — the directory the `.cplt.toml` came from, which under `--project-dir <subdir>` is still the git root, not the subdir. So `paths = ["secrets"]` denies `<repo>/secrets` on every clone.
 
-`./secrets`, `secrets/.`, `secrets/`, and `a//b` all normalize to the same path, and a path naming a symlink is resolved to its target — the sandbox matches resolved paths, so the un-normalized spellings would compile into the profile and silently match nothing. `..` components are rejected outright.
+`./secrets`, `secrets/.`, `secrets/`, and `a//b` all normalize to the same path, and symlinks are resolved to their target — the sandbox matches resolved paths, so the un-normalized spellings would compile into the profile and silently match nothing. Resolution walks up to the deepest part of the path that exists, so a symlink is still resolved when the leaf below it has not been created yet (`link/secret` with `link -> real` becomes `<repo>/real/secret`).
+
+`..` components are rejected, as are entries naming a whole tree root — `""`, `"."`, `"./"` (the repo root) and `"/"` (the filesystem root). As a deny entry any of those would block read *and* write of the entire checkout, so a committed one would brick the repo for everyone who clones it.
+
+**Approved `[propose.allow]` paths must stay inside the repo.** A trust approval pins a hash of the `.cplt.toml` bytes, so it only vouches for what those bytes name. A relative entry names a location in the repo; if a symlink resolves it somewhere outside, the entry is refused with a warning rather than granted. Otherwise a repo could get `read = ["data"]` approved while `data -> ./safe` and then repoint `data -> /` in a later commit — `.cplt.toml` unchanged, hash unchanged, approval still live. Absolute and `~/` entries are exempt: they are written literally in the file, so the pinned hash does cover them. `[deny]` has no such restriction — it needs no approval and can only tighten.
 
 Unlike the global config, a repo path that does **not exist yet** is kept rather than being an error: macOS starts enforcing the deny once the directory appears, and one committed typo cannot brick cplt for everyone who clones the repo. On Linux such a path cannot be masked and cplt warns.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -295,6 +295,8 @@ Commit a `.cplt.toml` file to your repository for project-specific sandbox setti
 - Write to `.cplt.toml` is kernel-denied inside the sandbox
 - Trust approvals are content-pinned — if requested values change, approvals are invalidated
 
+**Path expansion:** Paths in `[deny]` and `[propose.allow]` support `~/` expansion. A relative path is resolved against the repository root (the directory holding `.cplt.toml`), so `paths = ["secrets"]` denies `<repo>/secrets` on every clone. Unlike the global config, repo paths are *not* canonicalized: a path that does not exist yet is kept (macOS starts enforcing the deny once it appears; Linux warns that it cannot mask it), so one committed typo cannot brick cplt for everyone who clones the repo. `..` components are rejected outright.
+
 ### Example `.cplt.toml`
 
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -295,7 +295,11 @@ Commit a `.cplt.toml` file to your repository for project-specific sandbox setti
 - Write to `.cplt.toml` is kernel-denied inside the sandbox
 - Trust approvals are content-pinned — if requested values change, approvals are invalidated
 
-**Path expansion:** Paths in `[deny]` and `[propose.allow]` support `~/` expansion. A relative path is resolved against the repository root (the directory holding `.cplt.toml`), so `paths = ["secrets"]` denies `<repo>/secrets` on every clone. Unlike the global config, repo paths are *not* canonicalized: a path that does not exist yet is kept (macOS starts enforcing the deny once it appears; Linux warns that it cannot mask it), so one committed typo cannot brick cplt for everyone who clones the repo. `..` components are rejected outright.
+**Path expansion:** Paths in `[deny]` and `[propose.allow]` support `~/` expansion. A relative path is resolved against the **repository root** — the directory the `.cplt.toml` came from, which under `--project-dir <subdir>` is still the git root, not the subdir. So `paths = ["secrets"]` denies `<repo>/secrets` on every clone.
+
+`./secrets`, `secrets/.`, `secrets/`, and `a//b` all normalize to the same path, and a path naming a symlink is resolved to its target — the sandbox matches resolved paths, so the un-normalized spellings would compile into the profile and silently match nothing. `..` components are rejected outright.
+
+Unlike the global config, a repo path that does **not exist yet** is kept rather than being an error: macOS starts enforcing the deny once the directory appears, and one committed typo cannot brick cplt for everyone who clones the repo. On Linux such a path cannot be masked and cplt warns.
 
 ### Example `.cplt.toml`
 

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -31,6 +31,26 @@ Or set it permanently:
 cplt config set sandbox.allow_env_files true
 ```
 
+## Relative paths in `.cplt.toml` now bite (behaviour change)
+
+A relative path in a repo `.cplt.toml` — `deny.paths = ["target"]`, `propose.allow.read = ["vendor"]` — used to be **silently unenforced**: macOS compiled it into the profile as a rule that matched nothing, and Linux dropped it. It is now resolved against the repository root and enforced for real.
+
+If your repo already ships one, it starts working on upgrade, and a deny entry that was previously inert will now block a directory that actually exists:
+
+| Entry that was inert                | What it does now                       |
+| ----------------------------------- | -------------------------------------- |
+| `deny.paths = ["target"]`           | blocks the Rust build dir — builds fail |
+| `deny.paths = [".git"]`             | blocks git entirely                     |
+| `deny.paths = ["node_modules"]`     | blocks installs and `node` resolution   |
+
+**Check before upgrading:**
+
+```bash
+cplt --print-profile | grep 'deny file-read'
+```
+
+**Fix:** remove the entry from `.cplt.toml`, or narrow it to the path you actually meant. Paths that do not exist yet are kept (macOS enforces them once created), so an entry naming a future directory is not an error.
+
 ## Lifecycle scripts (postinstall hooks)
 
 npm/yarn/pnpm lifecycle scripts are **blocked by default** via `npm_config_ignore_scripts=true` and `YARN_ENABLE_SCRIPTS=false`. This prevents supply chain attacks through postinstall hooks, but may break packages that require post-install steps:

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1006,20 +1006,25 @@ impl Resolved {
     /// the existing lists.
     ///
     /// Path values (`deny.paths`, `propose.allow.read/write/socket`) are
-    /// resolved against `project_dir` — the directory holding `.cplt.toml` —
-    /// so a relative entry can never reach the sandbox unenforced. See
-    /// `resolve_repo_path`.
+    /// resolved against `config_dir` so a relative entry can never reach the
+    /// sandbox unenforced. See `resolve_repo_path`.
+    ///
+    /// `config_dir` must be `LoadedRepoConfig::dir` — the directory the
+    /// `.cplt.toml` was actually read from — NOT the project dir. Under
+    /// `--project-dir <subdir>` the two differ: the config comes from the git
+    /// root, so anchoring to the subdir would emit deny rules for directories
+    /// the repo never named while looking perfectly enforced.
     ///
     /// Returns a list of unapproved proposal keys (for display to the user).
     pub fn apply_repo_config(
         &mut self,
         repo_config: &crate::repo_config::RepoConfig,
-        project_dir: &std::path::Path,
+        config_dir: &std::path::Path,
         approved_keys: &[&str],
     ) -> Vec<String> {
         // ── Deny section: applied automatically ──────────────────────────
         for path_str in &repo_config.deny.paths {
-            let path = resolve_repo_path(path_str, project_dir);
+            let path = resolve_repo_path(path_str, config_dir);
             if !self.deny_paths.contains(&path) {
                 self.deny_paths.push(path);
             }
@@ -1082,7 +1087,7 @@ impl Resolved {
         // Path proposals
         if is_approved("allow.read") {
             for path_str in &repo_config.propose.allow.read {
-                let path = resolve_repo_path(path_str, project_dir);
+                let path = resolve_repo_path(path_str, config_dir);
                 if !self.allow_read.contains(&path) {
                     self.allow_read.push(path);
                 }
@@ -1090,7 +1095,7 @@ impl Resolved {
         }
         if is_approved("allow.write") {
             for path_str in &repo_config.propose.allow.write {
-                let path = resolve_repo_path(path_str, project_dir);
+                let path = resolve_repo_path(path_str, config_dir);
                 if !self.allow_write.contains(&path) {
                     self.allow_write.push(path);
                 }
@@ -1098,7 +1103,7 @@ impl Resolved {
         }
         if is_approved("allow.socket") {
             for path_str in &repo_config.propose.allow.socket {
-                let path = resolve_repo_path(path_str, project_dir);
+                let path = resolve_repo_path(path_str, config_dir);
                 if !self.allow_socket.contains(&path) {
                     self.allow_socket.push(path);
                 }
@@ -1366,7 +1371,7 @@ validate = false
         };
         resolved.apply_repo_config(
             &repo_config,
-            std::path::Path::new("/repo"),
+            std::path::Path::new("/nonexistent-repo"),
             &["allow_localhost_any"],
         );
         assert!(resolved.allow_localhost_any);
@@ -1721,29 +1726,29 @@ validate = false
 
         resolved.apply_repo_config(
             &repo_config,
-            std::path::Path::new("/repo"),
+            std::path::Path::new("/nonexistent-repo"),
             &["allow.read", "allow.write", "allow.socket"],
         );
 
         assert!(
             resolved
                 .deny_paths
-                .contains(&PathBuf::from("/repo/secrets"))
+                .contains(&PathBuf::from("/nonexistent-repo/secrets"))
         );
         assert!(
             resolved
                 .allow_read
-                .contains(&PathBuf::from("/repo/docs/ref"))
+                .contains(&PathBuf::from("/nonexistent-repo/docs/ref"))
         );
         assert!(
             resolved
                 .allow_write
-                .contains(&PathBuf::from("/repo/build/out"))
+                .contains(&PathBuf::from("/nonexistent-repo/build/out"))
         );
         assert!(
             resolved
                 .allow_socket
-                .contains(&PathBuf::from("/repo/run/app.sock"))
+                .contains(&PathBuf::from("/nonexistent-repo/run/app.sock"))
         );
         // Nothing may be dropped, and nothing may stay relative.
         for path in resolved
@@ -1771,8 +1776,11 @@ validate = false
         };
 
         // Apply with NO approved keys — deny should still work
-        let unapproved =
-            resolved.apply_repo_config(&repo_config, std::path::Path::new("/repo"), &[]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/nonexistent-repo"),
+            &[],
+        );
         assert!(unapproved.is_empty()); // no proposals, so nothing unapproved
         assert!(
             resolved
@@ -1799,8 +1807,11 @@ validate = false
         };
 
         // No keys approved
-        let unapproved =
-            resolved.apply_repo_config(&repo_config, std::path::Path::new("/repo"), &[]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/nonexistent-repo"),
+            &[],
+        );
         assert!(!resolved.allow_jvm_attach);
         assert!(!resolved.allow_docker);
         assert_eq!(unapproved.len(), 2);
@@ -1826,7 +1837,7 @@ validate = false
         // Only approve jvm_attach and localhost_any
         let unapproved = resolved.apply_repo_config(
             &repo_config,
-            std::path::Path::new("/repo"),
+            std::path::Path::new("/nonexistent-repo"),
             &["allow_jvm_attach", "allow_localhost_any"],
         );
         assert!(resolved.allow_jvm_attach);
@@ -1853,8 +1864,11 @@ validate = false
 
         // Without approval: stays off
         let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
-        let unapproved =
-            resolved.apply_repo_config(&repo_config, std::path::Path::new("/repo"), &[]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/nonexistent-repo"),
+            &[],
+        );
         assert!(!resolved.gradle_init);
         assert_eq!(unapproved, vec!["gradle_init"]);
 
@@ -1862,7 +1876,7 @@ validate = false
         let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
         let unapproved = resolved.apply_repo_config(
             &repo_config,
-            std::path::Path::new("/repo"),
+            std::path::Path::new("/nonexistent-repo"),
             &["gradle_init"],
         );
         assert!(resolved.gradle_init);
@@ -1889,7 +1903,7 @@ validate = false
         // Approve read and ports
         let unapproved = resolved.apply_repo_config(
             &repo_config,
-            std::path::Path::new("/repo"),
+            std::path::Path::new("/nonexistent-repo"),
             &["allow.read", "allow.ports"],
         );
         assert!(unapproved.is_empty());
@@ -1920,7 +1934,7 @@ validate = false
 
         let unapproved = resolved.apply_repo_config(
             &repo_config,
-            std::path::Path::new("/repo"),
+            std::path::Path::new("/nonexistent-repo"),
             &["proxy.allow_private_domains"],
         );
         assert!(unapproved.is_empty());

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use super::error::ConfigError;
-use super::path::{config_dir, config_path, expand_tilde, resolve_config_path};
+use super::path::{config_dir, config_path, expand_tilde, resolve_config_path, resolve_repo_path};
 use super::types::{
     CliFlags, Config, EnforcementMode, GhGuardPolicy, GitGuardPolicy, LoadedConfig, Preset,
     Resolved, ResolvedPushRule, UnknownCommandPolicy,
@@ -1005,15 +1005,21 @@ impl Resolved {
     /// never override an explicit `true` back to `false`. Path/port proposals extend
     /// the existing lists.
     ///
+    /// Path values (`deny.paths`, `propose.allow.read/write/socket`) are
+    /// resolved against `project_dir` — the directory holding `.cplt.toml` —
+    /// so a relative entry can never reach the sandbox unenforced. See
+    /// `resolve_repo_path`.
+    ///
     /// Returns a list of unapproved proposal keys (for display to the user).
     pub fn apply_repo_config(
         &mut self,
         repo_config: &crate::repo_config::RepoConfig,
+        project_dir: &std::path::Path,
         approved_keys: &[&str],
     ) -> Vec<String> {
         // ── Deny section: applied automatically ──────────────────────────
         for path_str in &repo_config.deny.paths {
-            let path = expand_tilde(path_str);
+            let path = resolve_repo_path(path_str, project_dir);
             if !self.deny_paths.contains(&path) {
                 self.deny_paths.push(path);
             }
@@ -1076,7 +1082,7 @@ impl Resolved {
         // Path proposals
         if is_approved("allow.read") {
             for path_str in &repo_config.propose.allow.read {
-                let path = expand_tilde(path_str);
+                let path = resolve_repo_path(path_str, project_dir);
                 if !self.allow_read.contains(&path) {
                     self.allow_read.push(path);
                 }
@@ -1084,7 +1090,7 @@ impl Resolved {
         }
         if is_approved("allow.write") {
             for path_str in &repo_config.propose.allow.write {
-                let path = expand_tilde(path_str);
+                let path = resolve_repo_path(path_str, project_dir);
                 if !self.allow_write.contains(&path) {
                     self.allow_write.push(path);
                 }
@@ -1092,7 +1098,7 @@ impl Resolved {
         }
         if is_approved("allow.socket") {
             for path_str in &repo_config.propose.allow.socket {
-                let path = expand_tilde(path_str);
+                let path = resolve_repo_path(path_str, project_dir);
                 if !self.allow_socket.contains(&path) {
                     self.allow_socket.push(path);
                 }
@@ -1358,7 +1364,11 @@ validate = false
             },
             ..Default::default()
         };
-        resolved.apply_repo_config(&repo_config, &["allow_localhost_any"]);
+        resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/repo"),
+            &["allow_localhost_any"],
+        );
         assert!(resolved.allow_localhost_any);
         assert!(resolved.reconcile_proxy_forced());
         assert!(!resolved.allow_localhost_any);
@@ -1686,6 +1696,68 @@ validate = false
     }
 
     #[test]
+    fn apply_repo_config_anchors_relative_paths_to_the_repo() {
+        // Issue #179: relative repo-config paths were only tilde-expanded, so
+        // they reached the sandbox backends unusable and unenforced —
+        // `(deny file-read* (subpath "secrets"))` on macOS (compiles, matches
+        // nothing) and a silent drop on Linux (`!path.is_absolute()` in
+        // build_deny_masks). Every path must now come out absolute.
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        let repo_config = crate::repo_config::RepoConfig {
+            deny: crate::repo_config::DenySection {
+                paths: vec!["secrets".to_string()],
+                env: vec![],
+            },
+            propose: crate::repo_config::ProposeSection {
+                allow: crate::repo_config::ProposeAllowSection {
+                    read: vec!["docs/ref".to_string()],
+                    write: vec!["build/out".to_string()],
+                    socket: vec!["run/app.sock".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        };
+
+        resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/repo"),
+            &["allow.read", "allow.write", "allow.socket"],
+        );
+
+        assert!(
+            resolved
+                .deny_paths
+                .contains(&PathBuf::from("/repo/secrets"))
+        );
+        assert!(
+            resolved
+                .allow_read
+                .contains(&PathBuf::from("/repo/docs/ref"))
+        );
+        assert!(
+            resolved
+                .allow_write
+                .contains(&PathBuf::from("/repo/build/out"))
+        );
+        assert!(
+            resolved
+                .allow_socket
+                .contains(&PathBuf::from("/repo/run/app.sock"))
+        );
+        // Nothing may be dropped, and nothing may stay relative.
+        for path in resolved
+            .deny_paths
+            .iter()
+            .chain(&resolved.allow_read)
+            .chain(&resolved.allow_write)
+            .chain(&resolved.allow_socket)
+        {
+            assert!(path.is_absolute(), "{} is not absolute", path.display());
+        }
+    }
+
+    #[test]
     fn apply_repo_config_deny_always_applied() {
         let config = Config::default();
         let mut resolved = config.merge(CliFlags::default()).unwrap();
@@ -1699,7 +1771,8 @@ validate = false
         };
 
         // Apply with NO approved keys — deny should still work
-        let unapproved = resolved.apply_repo_config(&repo_config, &[]);
+        let unapproved =
+            resolved.apply_repo_config(&repo_config, std::path::Path::new("/repo"), &[]);
         assert!(unapproved.is_empty()); // no proposals, so nothing unapproved
         assert!(
             resolved
@@ -1726,7 +1799,8 @@ validate = false
         };
 
         // No keys approved
-        let unapproved = resolved.apply_repo_config(&repo_config, &[]);
+        let unapproved =
+            resolved.apply_repo_config(&repo_config, std::path::Path::new("/repo"), &[]);
         assert!(!resolved.allow_jvm_attach);
         assert!(!resolved.allow_docker);
         assert_eq!(unapproved.len(), 2);
@@ -1750,8 +1824,11 @@ validate = false
         };
 
         // Only approve jvm_attach and localhost_any
-        let unapproved =
-            resolved.apply_repo_config(&repo_config, &["allow_jvm_attach", "allow_localhost_any"]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/repo"),
+            &["allow_jvm_attach", "allow_localhost_any"],
+        );
         assert!(resolved.allow_jvm_attach);
         assert!(resolved.allow_localhost_any);
         assert!(!resolved.allow_docker); // not approved
@@ -1776,13 +1853,18 @@ validate = false
 
         // Without approval: stays off
         let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
-        let unapproved = resolved.apply_repo_config(&repo_config, &[]);
+        let unapproved =
+            resolved.apply_repo_config(&repo_config, std::path::Path::new("/repo"), &[]);
         assert!(!resolved.gradle_init);
         assert_eq!(unapproved, vec!["gradle_init"]);
 
         // With approval: takes effect
         let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
-        let unapproved = resolved.apply_repo_config(&repo_config, &["gradle_init"]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/repo"),
+            &["gradle_init"],
+        );
         assert!(resolved.gradle_init);
         assert!(unapproved.is_empty());
     }
@@ -1805,7 +1887,11 @@ validate = false
         };
 
         // Approve read and ports
-        let unapproved = resolved.apply_repo_config(&repo_config, &["allow.read", "allow.ports"]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/repo"),
+            &["allow.read", "allow.ports"],
+        );
         assert!(unapproved.is_empty());
         assert!(
             resolved
@@ -1832,7 +1918,11 @@ validate = false
             ..Default::default()
         };
 
-        let unapproved = resolved.apply_repo_config(&repo_config, &["proxy.allow_private_domains"]);
+        let unapproved = resolved.apply_repo_config(
+            &repo_config,
+            std::path::Path::new("/repo"),
+            &["proxy.allow_private_domains"],
+        );
         assert!(unapproved.is_empty());
         assert!(
             resolved

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1,6 +1,6 @@
 //! Config file loading, parsing, and CLI-flag merging.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::error::ConfigError;
 use super::path::{config_dir, config_path, expand_tilde, resolve_config_path, resolve_repo_path};
@@ -1087,7 +1087,11 @@ impl Resolved {
         // Path proposals
         if is_approved("allow.read") {
             for path_str in &repo_config.propose.allow.read {
-                let path = resolve_repo_path(path_str, config_dir);
+                let Some(path) =
+                    resolve_repo_allow_path(path_str, config_dir, "propose.allow.read")
+                else {
+                    continue;
+                };
                 if !self.allow_read.contains(&path) {
                     self.allow_read.push(path);
                 }
@@ -1095,7 +1099,11 @@ impl Resolved {
         }
         if is_approved("allow.write") {
             for path_str in &repo_config.propose.allow.write {
-                let path = resolve_repo_path(path_str, config_dir);
+                let Some(path) =
+                    resolve_repo_allow_path(path_str, config_dir, "propose.allow.write")
+                else {
+                    continue;
+                };
                 if !self.allow_write.contains(&path) {
                     self.allow_write.push(path);
                 }
@@ -1103,7 +1111,11 @@ impl Resolved {
         }
         if is_approved("allow.socket") {
             for path_str in &repo_config.propose.allow.socket {
-                let path = resolve_repo_path(path_str, config_dir);
+                let Some(path) =
+                    resolve_repo_allow_path(path_str, config_dir, "propose.allow.socket")
+                else {
+                    continue;
+                };
                 if !self.allow_socket.contains(&path) {
                     self.allow_socket.push(path);
                 }
@@ -1148,6 +1160,39 @@ impl Resolved {
             .map(std::string::ToString::to_string)
             .collect()
     }
+}
+
+/// Resolve an approved `propose.allow.*` path, refusing one that leaves the repo.
+///
+/// The trust store pins a hash of the `.cplt.toml` *bytes*
+/// (`trust::proposal_content_hash`), so an approval only ever vouches for what
+/// those bytes name. A relative entry names a location inside the repo. Once
+/// paths are resolved, a committed symlink can make that entry point anywhere —
+/// `allow.read = ["data"]` with `data -> ./safe` gets approved, a later commit
+/// repoints `data -> /`, and the hash is unchanged because `.cplt.toml` is
+/// unchanged. The stale approval would then grant read of `/` with no re-prompt.
+///
+/// So: a repo-anchored allow entry may only resolve to somewhere inside the
+/// repo. Escaping is refused and reported, never silently applied.
+///
+/// Absolute and `~/` entries are exempt: they are written literally in
+/// `.cplt.toml`, so the pinned hash does cover what they name.
+///
+/// Deny paths deliberately get no such check — `[deny]` needs no approval and
+/// can only tighten, so a repointed deny symlink cannot escalate.
+fn resolve_repo_allow_path(path_str: &str, config_dir: &Path, key: &str) -> Option<PathBuf> {
+    let resolved = resolve_repo_path(path_str, config_dir);
+    if expand_tilde(path_str).is_relative() && !resolved.starts_with(config_dir) {
+        ui::warn(&format!(
+            "{key} entry {path_str:?} resolves outside the repository ({}) — ignoring it.\n  \
+             A symlink target is not covered by the trust approval, so a later commit could \
+             repoint it without re-approval. Name the target directly in .cplt.toml if you \
+             mean to grant it.",
+            resolved.display()
+        ));
+        return None;
+    }
+    Some(resolved)
 }
 
 #[cfg(test)]
@@ -1760,6 +1805,81 @@ validate = false
         {
             assert!(path.is_absolute(), "{} is not absolute", path.display());
         }
+    }
+
+    #[test]
+    fn approved_allow_path_escaping_the_repo_is_refused() {
+        // The trust store pins a hash of the `.cplt.toml` bytes, so an approval
+        // only vouches for what those bytes name. A repo can commit
+        // `allow.read = ["data"]` with `data -> ./safe`, get it approved, then
+        // repoint `data -> /` in a later commit: `.cplt.toml` is untouched, the
+        // hash still matches, and the stale approval would grant read of `/`.
+        // A repo-anchored allow entry may therefore only resolve inside the repo.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        std::fs::create_dir(root.join("safe")).unwrap();
+        std::os::unix::fs::symlink("safe", root.join("inside")).unwrap();
+        std::os::unix::fs::symlink("/", root.join("escaped")).unwrap();
+
+        let apply = |entry: &str| {
+            let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+            let repo_config = crate::repo_config::RepoConfig {
+                propose: crate::repo_config::ProposeSection {
+                    allow: crate::repo_config::ProposeAllowSection {
+                        read: vec![entry.to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            resolved.apply_repo_config(&repo_config, &root, &["allow.read"]);
+            resolved.allow_read
+        };
+
+        // A symlink that stays inside the repo is fine — the pinned bytes do
+        // name a location in the repo, and that is where it lands.
+        assert!(
+            apply("inside").contains(&root.join("safe")),
+            "an in-repo symlink target must still be granted"
+        );
+        // One that leaves the repo is refused outright, not silently narrowed.
+        let escaped = apply("escaped");
+        assert!(
+            !escaped.iter().any(|p| p == std::path::Path::new("/")),
+            "must not grant read of / : {escaped:?}"
+        );
+        assert!(
+            escaped.iter().all(|p| p.starts_with(&root)),
+            "no granted path may sit outside the repo: {escaped:?}"
+        );
+    }
+
+    #[test]
+    fn approved_allow_path_named_literally_is_not_repo_confined() {
+        // Absolute and `~/` entries are written literally in `.cplt.toml`, so
+        // the pinned hash does cover them — they are exempt from the
+        // containment rule and must keep working outside the repo.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let outside = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        let repo_config = crate::repo_config::RepoConfig {
+            propose: crate::repo_config::ProposeSection {
+                allow: crate::repo_config::ProposeAllowSection {
+                    read: vec![outside.to_string_lossy().into_owned()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        resolved.apply_repo_config(&repo_config, &root, &["allow.read"]);
+        assert!(
+            resolved.allow_read.contains(&outside),
+            "a literally-named absolute path must still be granted"
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,6 +24,7 @@ pub use editing::{
     write_document_atomically, write_repo_document_atomically,
 };
 pub use error::ConfigError;
+pub(crate) use path::lexically_normalized;
 pub use path::{collapse_tilde, config_dir, config_path, default_config_contents, expand_tilde};
 pub use registry::{ConfigKeyInfo, ConfigValueType, all_config_keys, lookup_key};
 pub use repo::{RepoKeyTarget, repo_key_rejection_reason, repo_key_target, set_repo_value_in_doc};

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -1,6 +1,6 @@
 //! Config file path resolution.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::error::ConfigError;
 use super::types::{CONFIG_DIR, CONFIG_FILE};
@@ -324,6 +324,29 @@ pub fn collapse_tilde(path: &str) -> String {
     }
 }
 
+/// Resolve a path from a repo `.cplt.toml`: expand a leading `~/`, then anchor
+/// any still-relative path to the repo root (the directory holding the config).
+///
+/// A relative path must never reach the sandbox backends. Seatbelt accepts
+/// `(deny file-read* (subpath "secrets"))` without a compile error and the rule
+/// then matches nothing — a silent fail-open. Landlock/bwrap drop it. Anchoring
+/// here is also what the global config already promises for its own relative
+/// entries ("Relative paths are resolved from this config file's directory").
+///
+/// Deliberately does NOT canonicalize, unlike `resolve_config_path`. Repo config
+/// is the only source that can deny a path that does not exist yet (macOS starts
+/// enforcing once it appears), and hard-failing would let one committed typo
+/// brick cplt for everyone who clones the repo. Joining always succeeds, so no
+/// entry can be dropped.
+pub(super) fn resolve_repo_path(path: &str, project_dir: &Path) -> PathBuf {
+    let expanded = expand_tilde(path);
+    if expanded.is_relative() {
+        project_dir.join(expanded)
+    } else {
+        expanded
+    }
+}
+
 /// Expand tilde, resolve relative paths against config dir, and canonicalize.
 pub(super) fn resolve_config_path(
     path: &str,
@@ -387,6 +410,44 @@ mod tests {
         let contents = default_config_contents();
         let config: Config = toml::from_str(&contents).unwrap();
         assert!(config.proxy.enabled.is_none());
+    }
+
+    #[test]
+    fn resolve_repo_path_anchors_relative_to_repo_root() {
+        // Issue #179: a relative repo-config path used to reach the sandbox
+        // verbatim. Seatbelt compiles `(subpath "secrets")` and matches
+        // nothing; Landlock/bwrap drop it. Both are silent fail-open.
+        assert_eq!(
+            resolve_repo_path("secrets", Path::new("/repo")),
+            PathBuf::from("/repo/secrets")
+        );
+        assert_eq!(
+            resolve_repo_path("a/b/c.txt", Path::new("/repo")),
+            PathBuf::from("/repo/a/b/c.txt")
+        );
+    }
+
+    #[test]
+    fn resolve_repo_path_leaves_absolute_and_tilde_alone() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(
+            resolve_repo_path("/etc/shadow", Path::new("/repo")),
+            PathBuf::from("/etc/shadow")
+        );
+        assert_eq!(
+            resolve_repo_path("~/secrets", Path::new("/repo")),
+            PathBuf::from(format!("{home}/secrets"))
+        );
+    }
+
+    #[test]
+    fn resolve_repo_path_keeps_paths_that_do_not_exist_yet() {
+        // Unlike resolve_config_path, no canonicalize: repo config is the only
+        // source that can deny a not-yet-created path, and a committed typo
+        // must not brick cplt for everyone who clones.
+        let resolved = resolve_repo_path("not/created/yet", Path::new("/repo"));
+        assert_eq!(resolved, PathBuf::from("/repo/not/created/yet"));
+        assert!(resolved.is_absolute());
     }
 
     #[test]

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -1,6 +1,6 @@
 //! Config file path resolution.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use super::error::ConfigError;
 use super::types::{CONFIG_DIR, CONFIG_FILE};
@@ -324,27 +324,51 @@ pub fn collapse_tilde(path: &str) -> String {
     }
 }
 
-/// Resolve a path from a repo `.cplt.toml`: expand a leading `~/`, then anchor
-/// any still-relative path to the repo root (the directory holding the config).
+/// Resolve a path from a repo `.cplt.toml` into one the sandbox backends can
+/// actually enforce: expand a leading `~/`, normalize lexically, anchor a
+/// still-relative path to `config_dir` (the directory the `.cplt.toml` came
+/// from), then canonicalize if the target exists.
 ///
-/// A relative path must never reach the sandbox backends. Seatbelt accepts
-/// `(deny file-read* (subpath "secrets"))` without a compile error and the rule
-/// then matches nothing — a silent fail-open. Landlock/bwrap drop it. Anchoring
-/// here is also what the global config already promises for its own relative
-/// entries ("Relative paths are resolved from this config file's directory").
+/// Every step closes a fail-open. Seatbelt silently accepts a rule it cannot
+/// match, so an unenforceable path looks enforced in `--print-profile`:
 ///
-/// Deliberately does NOT canonicalize, unlike `resolve_config_path`. Repo config
-/// is the only source that can deny a path that does not exist yet (macOS starts
-/// enforcing once it appears), and hard-failing would let one committed typo
-/// brick cplt for everyone who clones the repo. Joining always succeeds, so no
-/// entry can be dropped.
-pub(super) fn resolve_repo_path(path: &str, project_dir: &Path) -> PathBuf {
+/// | spelling      | emitted verbatim | enforced by Seatbelt |
+/// |---------------|------------------|----------------------|
+/// | `secrets`     | relative         | no                   |
+/// | `./secrets`   | `/repo/./secrets`| no                   |
+/// | `secrets/.`   | `/repo/secrets/.`| no                   |
+/// | `a//b`        | `/repo/a//b`     | no                   |
+/// | a symlink     | the link path    | no (SBPL matches the resolved path) |
+///
+/// Anchoring relative paths is also what the global config already promises for
+/// its own entries ("Relative paths are resolved from this config file's
+/// directory").
+///
+/// Normalization is lexical *before* canonicalization, not instead of it, and
+/// that ordering is the point: `canonicalize` fails on a path that does not
+/// exist yet, and repo config is the only source that can deny a not-yet-created
+/// path (macOS starts enforcing once it appears). Lexical normalization cannot
+/// fail and needs nothing on disk, so `./not-created-yet` is enforceable by
+/// construction; canonicalize then adds symlink resolution wherever the target
+/// is already there. Nothing can be dropped, so nothing can be silently
+/// unenforced.
+///
+/// `..` never reaches here — `repo_config::reject_path_traversal` rejects it at
+/// parse time — so no `ParentDir` handling is needed.
+pub(super) fn resolve_repo_path(path: &str, config_dir: &Path) -> PathBuf {
     let expanded = expand_tilde(path);
-    if expanded.is_relative() {
-        project_dir.join(expanded)
+    // `Path::components` already collapses `a//b` and a trailing `/`, and drops
+    // interior `.`; a *leading* `./` is the one it deliberately preserves.
+    let normalized: PathBuf = expanded
+        .components()
+        .filter(|c| !matches!(c, Component::CurDir))
+        .collect();
+    let full = if normalized.is_relative() {
+        config_dir.join(normalized)
     } else {
-        expanded
-    }
+        normalized
+    };
+    full.canonicalize().unwrap_or(full)
 }
 
 /// Expand tilde, resolve relative paths against config dir, and canonicalize.
@@ -418,36 +442,84 @@ mod tests {
         // verbatim. Seatbelt compiles `(subpath "secrets")` and matches
         // nothing; Landlock/bwrap drop it. Both are silent fail-open.
         assert_eq!(
-            resolve_repo_path("secrets", Path::new("/repo")),
-            PathBuf::from("/repo/secrets")
+            resolve_repo_path("secrets", Path::new("/nonexistent-repo")),
+            PathBuf::from("/nonexistent-repo/secrets")
         );
         assert_eq!(
-            resolve_repo_path("a/b/c.txt", Path::new("/repo")),
-            PathBuf::from("/repo/a/b/c.txt")
+            resolve_repo_path("a/b/c.txt", Path::new("/nonexistent-repo")),
+            PathBuf::from("/nonexistent-repo/a/b/c.txt")
         );
+    }
+
+    #[test]
+    fn resolve_repo_path_normalizes_every_inert_spelling() {
+        // Verified against the kernel: `(subpath "<d>/./x")`, `"<d>/x/."` and
+        // `"<d>//x"` are all accepted by Seatbelt and match nothing, so each
+        // must collapse to the one form that is actually enforced. These use a
+        // non-existent root deliberately — canonicalize cannot run, so this
+        // pins the lexical pass on its own.
+        let root = Path::new("/nonexistent-repo");
+        let want = PathBuf::from("/nonexistent-repo/secrets");
+        for spelling in [
+            "secrets",
+            "./secrets",
+            "secrets/.",
+            "secrets/",
+            "./secrets/",
+        ] {
+            assert_eq!(
+                resolve_repo_path(spelling, root),
+                want,
+                "{spelling:?} must normalize to the enforceable form"
+            );
+        }
+        assert_eq!(
+            resolve_repo_path("a//b", root),
+            PathBuf::from("/nonexistent-repo/a/b")
+        );
+        // A bare `.` means the repo root itself, not a stray relative fragment.
+        assert_eq!(resolve_repo_path("./", root), root);
+    }
+
+    #[test]
+    fn resolve_repo_path_canonicalizes_when_the_target_exists() {
+        // SBPL matches resolved paths, so a deny naming a symlink protects
+        // nothing. Canonicalize closes that wherever the target is already on
+        // disk — the half of the job the lexical pass cannot do.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        std::fs::create_dir(root.join("real")).unwrap();
+        std::os::unix::fs::symlink("real", root.join("link")).unwrap();
+
+        assert_eq!(resolve_repo_path("link", &root), root.join("real"));
+        assert_eq!(resolve_repo_path("./link/", &root), root.join("real"));
     }
 
     #[test]
     fn resolve_repo_path_leaves_absolute_and_tilde_alone() {
         let home = std::env::var("HOME").unwrap();
         assert_eq!(
-            resolve_repo_path("/etc/shadow", Path::new("/repo")),
-            PathBuf::from("/etc/shadow")
+            resolve_repo_path("/nonexistent-abs/shadow", Path::new("/nonexistent-repo")),
+            PathBuf::from("/nonexistent-abs/shadow")
         );
         assert_eq!(
-            resolve_repo_path("~/secrets", Path::new("/repo")),
-            PathBuf::from(format!("{home}/secrets"))
+            resolve_repo_path("~/nonexistent-secrets", Path::new("/nonexistent-repo")),
+            PathBuf::from(format!("{home}/nonexistent-secrets"))
         );
     }
 
     #[test]
     fn resolve_repo_path_keeps_paths_that_do_not_exist_yet() {
-        // Unlike resolve_config_path, no canonicalize: repo config is the only
-        // source that can deny a not-yet-created path, and a committed typo
-        // must not brick cplt for everyone who clones.
-        let resolved = resolve_repo_path("not/created/yet", Path::new("/repo"));
-        assert_eq!(resolved, PathBuf::from("/repo/not/created/yet"));
-        assert!(resolved.is_absolute());
+        // canonicalize FAILS on a path that is not there yet, and repo config is
+        // the only source that can deny one (macOS starts enforcing once it
+        // appears). So the lexical pass runs first and unconditionally: falling
+        // back to the raw join on a canonicalize failure would leave `./x`
+        // inert for exactly the not-yet-created case this supports.
+        for spelling in ["not/created/yet", "./not/created/yet", "not//created/yet/."] {
+            let resolved = resolve_repo_path(spelling, Path::new("/nonexistent-repo"));
+            assert_eq!(resolved, PathBuf::from("/nonexistent-repo/not/created/yet"));
+            assert!(resolved.is_absolute(), "{spelling:?} must be absolute");
+        }
     }
 
     #[test]

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -324,51 +324,90 @@ pub fn collapse_tilde(path: &str) -> String {
     }
 }
 
+/// Drop `CurDir` components and collapse separators. Purely lexical: it cannot
+/// fail and touches nothing on disk.
+///
+/// `..` never reaches here — `repo_config::reject_path_traversal` rejects it at
+/// parse time — so no `ParentDir` handling is needed. `Path::components` already
+/// collapses `a//b` and a trailing `/`, and drops interior `.`; a *leading* `./`
+/// is the one it deliberately preserves, hence the filter.
+pub(crate) fn lexically_normalized(path: &Path) -> PathBuf {
+    path.components()
+        .filter(|c| !matches!(c, Component::CurDir))
+        .collect()
+}
+
+/// Canonicalize as much of `path` as exists, then re-append the rest.
+///
+/// `Path::canonicalize` is all-or-nothing: one absent component and it fails for
+/// the whole path. Falling back to the unresolved path is unsound the moment a
+/// symlink sits *above* the absent part — `link/secret` with `link -> real` and
+/// no `secret` yet emits a rule naming `link/secret`, which Seatbelt matches
+/// against nothing (verified: it blocks reads of neither `link/secret` nor
+/// `real/secret`, while a rule naming `real/secret` blocks both).
+///
+/// Walking up to the deepest existing ancestor resolves that symlink while
+/// keeping the not-yet-created tail, so the rule names where the file will
+/// actually land. This also covers a canonicalize failure that is not ENOENT —
+/// a permission-denied ancestor, or ELOOP — where the unresolved fallback would
+/// likewise name a path the kernel never matches.
+fn canonicalize_deepest(path: &Path) -> PathBuf {
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut cur = path;
+    loop {
+        if let Ok(base) = cur.canonicalize() {
+            return tail.iter().rev().fold(base, |acc, part| acc.join(part));
+        }
+        // Nothing along the whole path resolved (only reachable if even `/`
+        // fails to canonicalize) — keep the lexical form rather than drop it.
+        let (Some(parent), Some(name)) = (cur.parent(), cur.file_name()) else {
+            return path.to_path_buf();
+        };
+        tail.push(name);
+        cur = parent;
+    }
+}
+
 /// Resolve a path from a repo `.cplt.toml` into one the sandbox backends can
 /// actually enforce: expand a leading `~/`, normalize lexically, anchor a
 /// still-relative path to `config_dir` (the directory the `.cplt.toml` came
-/// from), then canonicalize if the target exists.
+/// from), then canonicalize as deep as the path exists.
 ///
 /// Every step closes a fail-open. Seatbelt silently accepts a rule it cannot
 /// match, so an unenforceable path looks enforced in `--print-profile`:
 ///
-/// | spelling      | emitted verbatim | enforced by Seatbelt |
-/// |---------------|------------------|----------------------|
-/// | `secrets`     | relative         | no                   |
-/// | `./secrets`   | `/repo/./secrets`| no                   |
-/// | `secrets/.`   | `/repo/secrets/.`| no                   |
-/// | `a//b`        | `/repo/a//b`     | no                   |
-/// | a symlink     | the link path    | no (SBPL matches the resolved path) |
+/// | spelling        | emitted verbatim   | enforced by Seatbelt |
+/// |-----------------|--------------------|----------------------|
+/// | `secrets`       | relative           | no                   |
+/// | `./secrets`     | `/repo/./secrets`  | no                   |
+/// | `secrets/.`     | `/repo/secrets/.`  | no                   |
+/// | `a//b`          | `/repo/a//b`       | no                   |
+/// | a symlink       | the link path      | no (SBPL matches the resolved path) |
+/// | `link/secret`   | the link path      | no, even though the leaf is absent   |
 ///
 /// Anchoring relative paths is also what the global config already promises for
 /// its own entries ("Relative paths are resolved from this config file's
 /// directory").
 ///
-/// Normalization is lexical *before* canonicalization, not instead of it, and
-/// that ordering is the point: `canonicalize` fails on a path that does not
-/// exist yet, and repo config is the only source that can deny a not-yet-created
-/// path (macOS starts enforcing once it appears). Lexical normalization cannot
-/// fail and needs nothing on disk, so `./not-created-yet` is enforceable by
-/// construction; canonicalize then adds symlink resolution wherever the target
-/// is already there. Nothing can be dropped, so nothing can be silently
+/// Repo config is the only source that can deny a path that does not exist yet
+/// (macOS starts enforcing once it appears), so neither step may fail the entry:
+/// the lexical pass needs nothing on disk, and `canonicalize_deepest` resolves
+/// as much as is there. Nothing can be dropped, so nothing can be silently
 /// unenforced.
 ///
-/// `..` never reaches here — `repo_config::reject_path_traversal` rejects it at
-/// parse time — so no `ParentDir` handling is needed.
+/// The lexical pass is belt-and-braces here — `canonicalize_deepest` walks by
+/// `parent()`/`file_name()`, which are component-based and would drop `.` and
+/// `//` on their own. It is kept so the invariant holds without depending on
+/// that, and it is load-bearing in `repo_config::reject_root_path`, which needs
+/// to spot a root-equal entry before anything touches the disk.
 pub(super) fn resolve_repo_path(path: &str, config_dir: &Path) -> PathBuf {
-    let expanded = expand_tilde(path);
-    // `Path::components` already collapses `a//b` and a trailing `/`, and drops
-    // interior `.`; a *leading* `./` is the one it deliberately preserves.
-    let normalized: PathBuf = expanded
-        .components()
-        .filter(|c| !matches!(c, Component::CurDir))
-        .collect();
+    let normalized = lexically_normalized(&expand_tilde(path));
     let full = if normalized.is_relative() {
         config_dir.join(normalized)
     } else {
         normalized
     };
-    full.canonicalize().unwrap_or(full)
+    canonicalize_deepest(&full)
 }
 
 /// Expand tilde, resolve relative paths against config dir, and canonicalize.
@@ -493,6 +532,38 @@ mod tests {
 
         assert_eq!(resolve_repo_path("link", &root), root.join("real"));
         assert_eq!(resolve_repo_path("./link/", &root), root.join("real"));
+    }
+
+    #[test]
+    fn resolve_repo_path_resolves_a_symlink_above_an_absent_leaf() {
+        // The not-yet-created case is only sound when the lexical location
+        // equals the future resolved location. A symlink ABOVE the absent leaf
+        // breaks that: `canonicalize` fails on the whole path, and naming
+        // `link/secret` gives a rule Seatbelt matches against nothing —
+        // verified: it blocks reads of neither `link/secret` nor `real/secret`,
+        // while naming `real/secret` blocks both. So resolve the deepest
+        // existing ancestor and re-append the tail.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        std::fs::create_dir(root.join("real")).unwrap();
+        std::os::unix::fs::symlink("real", root.join("link")).unwrap();
+
+        // `secret` does not exist yet — the leaf must survive, the link must not.
+        assert_eq!(
+            resolve_repo_path("link/secret", &root),
+            root.join("real/secret")
+        );
+        // Several absent levels below the symlink.
+        assert_eq!(
+            resolve_repo_path("./link/a/b/c", &root),
+            root.join("real/a/b/c")
+        );
+        // And once the leaf exists, the answer does not move.
+        std::fs::create_dir(root.join("real/secret")).unwrap();
+        assert_eq!(
+            resolve_repo_path("link/secret", &root),
+            root.join("real/secret")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1437,7 +1437,8 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 .iter()
                 .map(std::string::String::as_str)
                 .collect();
-            unapproved_proposals = resolved.apply_repo_config(&loaded.config, &approved_refs);
+            unapproved_proposals =
+                resolved.apply_repo_config(&loaded.config, &project_dir, &approved_refs);
         }
         Ok(None) => {} // No .cplt.toml — nothing to do
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1438,7 +1438,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 .map(std::string::String::as_str)
                 .collect();
             unapproved_proposals =
-                resolved.apply_repo_config(&loaded.config, &project_dir, &approved_refs);
+                resolved.apply_repo_config(&loaded.config, &loaded.dir, &approved_refs);
         }
         Ok(None) => {} // No .cplt.toml — nothing to do
         Err(e) => {

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -138,7 +138,7 @@ pub fn load_repo_config(project_dir: &Path) -> Result<Option<LoadedRepoConfig>, 
         return Ok(Some(LoadedRepoConfig {
             config,
             source: RepoConfigSource::GitHead,
-            dir: git_toplevel(project_dir).unwrap_or_else(|| project_dir.to_path_buf()),
+            dir: canonical(git_toplevel(project_dir).unwrap_or_else(|| project_dir.to_path_buf())),
         }));
     }
 
@@ -160,11 +160,23 @@ pub fn load_repo_config(project_dir: &Path) -> Result<Option<LoadedRepoConfig>, 
             source: RepoConfigSource::WorkingTree,
             // The working-tree fallback reads `<project_dir>/.cplt.toml`
             // literally, so here the project dir *is* the config's directory.
-            dir: project_dir.to_path_buf(),
+            dir: canonical(project_dir.to_path_buf()),
         }));
     }
 
     Ok(None)
+}
+
+/// Canonicalize, keeping the input on failure.
+///
+/// `dir` anchors every relative path in the config AND is the containment
+/// boundary for approved allow paths, which are compared against it with
+/// `starts_with`. Both need it to match what `canonicalize` produces for paths
+/// under it, or a repo behind a symlinked checkout would read as "outside the
+/// repo". Callers already pass a canonical path on the enforcing path; this is
+/// belt-and-braces for the ones that may not.
+fn canonical(path: PathBuf) -> PathBuf {
+    path.canonicalize().unwrap_or(path)
 }
 
 /// The git toplevel for `project_dir` — the directory `HEAD:.cplt.toml`
@@ -229,11 +241,36 @@ fn reject_path_traversal(path: &str, context: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Reject a path that names a whole tree root rather than something within it.
+///
+/// `""`, `"."` and `"./"` all normalize to nothing, so they anchor to the repo
+/// root; `"/"` is the filesystem root. As a deny entry, either one blocks read
+/// AND write of the entire checkout (or the entire machine) — a committed
+/// version bricks cplt for everyone who clones. `"."` meaning "the repo" is at
+/// least arguable; an empty string landing in the same place is not, and neither
+/// is worth supporting when `[deny]` exists to carve out parts of a tree.
+fn reject_root_path(path: &str, context: &str) -> Result<(), String> {
+    let normalized = crate::config::lexically_normalized(std::path::Path::new(path));
+    if normalized.as_os_str().is_empty() {
+        return Err(format!(
+            "{context} entry {path:?} resolves to the repository root, which would deny \
+             the entire checkout. Name a path inside the repo instead."
+        ));
+    }
+    if normalized == std::path::Path::new("/") {
+        return Err(format!(
+            "{context} entry {path:?} is the filesystem root, which would deny everything."
+        ));
+    }
+    Ok(())
+}
+
 /// Validate the repo config for safety.
 fn validate_repo_config(config: &RepoConfig) -> Result<(), String> {
     // Validate deny paths don't contain SBPL injection characters or traversal
     for path in &config.deny.paths {
         reject_path_traversal(path, "deny.paths")?;
+        reject_root_path(path, "deny.paths")?;
         crate::sandbox::validate_sbpl_path(&PathBuf::from(path))?;
     }
 
@@ -539,6 +576,27 @@ read = ["~/.gradle/../../.ssh/id_rsa"]
         let result = validate_repo_config(&config);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("'..'"));
+    }
+
+    #[test]
+    fn rejects_deny_paths_naming_a_whole_tree_root() {
+        // A committed `""` or `"."` denies read AND write of the entire
+        // checkout, bricking cplt for everyone who clones. All spellings that
+        // normalize to nothing land on the repo root, so all are rejected.
+        for entry in ["\"\"", "\".\"", "\"./\"", "\"./.\""] {
+            let toml_str = format!("[deny]\npaths = [{entry}]\n");
+            let config = parse_repo_config(&toml_str).unwrap();
+            let err = validate_repo_config(&config)
+                .expect_err("{entry} must be rejected, not silently denied as the repo root");
+            assert!(
+                err.contains("repository root"),
+                "{entry}: unexpected error {err}"
+            );
+        }
+        // The filesystem root gets its own message — it is not the repo root.
+        let config = parse_repo_config("[deny]\npaths = [\"/\"]\n").unwrap();
+        let err = validate_repo_config(&config).expect_err("\"/\" must be rejected");
+        assert!(err.contains("filesystem root"), "unexpected error {err}");
     }
 
     #[test]

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -113,6 +113,14 @@ pub enum RepoConfigSource {
 pub struct LoadedRepoConfig {
     pub config: RepoConfig,
     pub source: RepoConfigSource,
+    /// The directory the `.cplt.toml` was read from — the anchor for its
+    /// relative paths. This is NOT always `project_dir`: `git cat-file blob
+    /// HEAD:.cplt.toml` resolves repo-root-relative regardless of cwd, so a
+    /// `--project-dir <subdir>` run reads the *root's* config and its paths
+    /// must anchor to the root. Anchoring to the subdir instead would emit a
+    /// deny rule for a directory the repo never named — a plausible-looking
+    /// absolute rule protecting the wrong place.
+    pub dir: PathBuf,
 }
 
 /// Read `.cplt.toml` from the project directory.
@@ -130,6 +138,7 @@ pub fn load_repo_config(project_dir: &Path) -> Result<Option<LoadedRepoConfig>, 
         return Ok(Some(LoadedRepoConfig {
             config,
             source: RepoConfigSource::GitHead,
+            dir: git_toplevel(project_dir).unwrap_or_else(|| project_dir.to_path_buf()),
         }));
     }
 
@@ -149,10 +158,32 @@ pub fn load_repo_config(project_dir: &Path) -> Result<Option<LoadedRepoConfig>, 
         return Ok(Some(LoadedRepoConfig {
             config,
             source: RepoConfigSource::WorkingTree,
+            // The working-tree fallback reads `<project_dir>/.cplt.toml`
+            // literally, so here the project dir *is* the config's directory.
+            dir: project_dir.to_path_buf(),
         }));
     }
 
     Ok(None)
+}
+
+/// The git toplevel for `project_dir` — the directory `HEAD:.cplt.toml`
+/// resolves against. `None` when git cannot answer (not a repo, git missing).
+fn git_toplevel(project_dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(project_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let root = String::from_utf8(output.stdout).ok()?;
+    let root = root.trim();
+    if root.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(root))
 }
 
 /// Read `.cplt.toml` from git HEAD (the latest committed version).

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -1181,6 +1181,36 @@ mod tests {
     }
 
     #[test]
+    fn resolved_repo_deny_path_is_masked_not_skipped() {
+        // Issue #179, Linux half: a relative `.cplt.toml` deny path used to
+        // arrive here verbatim and land in `skipped` (see the test below).
+        // apply_repo_config now anchors it to the repo root, so it masks.
+        let base = non_tmp_tempdir();
+        let secret = base.path().join("secrets");
+        std::fs::create_dir(&secret).expect("create secrets");
+
+        let mut resolved = crate::config::Config::default()
+            .merge(crate::config::CliFlags::default())
+            .expect("merge");
+        let repo_config = crate::repo_config::RepoConfig {
+            deny: crate::repo_config::DenySection {
+                paths: vec!["secrets".to_string()],
+                env: vec![],
+            },
+            ..Default::default()
+        };
+        resolved.apply_repo_config(&repo_config, base.path(), &[]);
+
+        let masks = build_deny_masks(&resolved.deny_paths, None);
+        assert!(
+            masks.skipped().is_empty(),
+            "an anchored repo deny path must not be skipped: {:?}",
+            masks.skipped()
+        );
+        assert_eq!(masks.mask_count(), 1);
+    }
+
+    #[test]
     fn deny_mask_skips_relative_missing_and_tmp_paths() {
         // Deliberately under the REAL /tmp — tempfile::tempdir() honors
         // TMPDIR, which may point elsewhere (e.g. a cplt scratch dir).

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -338,12 +338,14 @@ impl DenyMasks {
 
 /// Build mount masks from the user's deny paths.
 ///
-/// CLI and global-config inputs arrive canonicalized (`canonicalize_deny_paths`
-/// and `resolve_config_path` both hard-fail on paths that do not resolve), so
-/// for those the checks here only guard against races (a path deleted since
-/// startup). Repo `.cplt.toml` paths do NOT: they are merely `~`-expanded
-/// (navikt/cplt#179), so relative and unresolvable entries reach this function
-/// and the absolute check and re-canonicalization are real filtering for them.
+/// Every input now arrives absolute: CLI and global-config paths are
+/// canonicalized up front (`canonicalize_deny_paths` and `resolve_config_path`
+/// both hard-fail on paths that do not resolve), and repo `.cplt.toml` paths
+/// are anchored and canonicalize-if-present by `resolve_repo_path`
+/// (navikt/cplt#179). So the absolute check below is a backstop, not routine
+/// filtering, and re-canonicalization mainly guards races (a path deleted since
+/// startup). The one case still expected here is a repo deny path naming a
+/// directory that does not exist yet — enforceable on macOS, unmaskable here.
 /// Entries that cannot be masked are recorded in `skipped` for the caller to
 /// warn about:
 ///
@@ -1060,6 +1062,11 @@ mod tests {
     }
 
     // Deny masks are skipped under /tmp, so their tests need a base outside it.
+    //
+    // Only CARGO_TARGET_DIR is guarded; the CARGO_MANIFEST_DIR fallback is not.
+    // A CI checkout under /tmp would put the fallback base under /tmp too and
+    // silently void every test using this helper (they would assert on paths
+    // the /tmp skip removes). Not worth a guard until a runner does that.
     fn non_tmp_tempdir() -> tempfile::TempDir {
         // A CARGO_TARGET_DIR under /tmp (a common build-speed setup) falls
         // back to the manifest's target/ — a /tmp base would void these tests.

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -1568,6 +1568,41 @@ mod tests {
     }
 
     #[test]
+    fn relative_repo_deny_path_is_emitted_absolute() {
+        // Issue #179, macOS half: a relative `.cplt.toml` deny path used to be
+        // interpolated verbatim as `(deny file-read* (subpath "secrets"))`.
+        // Seatbelt accepts that without a compile error and the rule matches
+        // nothing — a silent fail-open. apply_repo_config now anchors it.
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+
+        let mut resolved = crate::config::Config::default()
+            .merge(crate::config::CliFlags::default())
+            .expect("merge");
+        let repo_config = crate::repo_config::RepoConfig {
+            deny: crate::repo_config::DenySection {
+                paths: vec!["secrets".to_string()],
+                env: vec![],
+            },
+            ..Default::default()
+        };
+        resolved.apply_repo_config(&repo_config, project, &[]);
+
+        let mut opts = test_options(project, home);
+        opts.extra_deny = &resolved.deny_paths;
+        let p = generate_profile(&opts);
+
+        assert!(
+            p.contains(r#"(deny file-read* (subpath "/projects/app/secrets"))"#),
+            "repo deny path must reach SBPL as an absolute subpath"
+        );
+        assert!(
+            !p.contains(r#"(subpath "secrets")"#),
+            "a bare relative subpath compiles but never matches — fail-open"
+        );
+    }
+
+    #[test]
     fn default_path_allows_wildcard_443() {
         // Regression guard: with proxy_forced=false the broad `*:443` allowance
         // must remain exactly as before #53.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -439,7 +439,7 @@ fn effective_snapshot(
     if let Ok(Some(loaded)) = repo_config::load_repo_config(project_dir) {
         let approved = approved_repo_keys(project_dir, &loaded.config);
         let approved_refs: Vec<&str> = approved.iter().map(String::as_str).collect();
-        effective.apply_repo_config(&loaded.config, &approved_refs);
+        effective.apply_repo_config(&loaded.config, project_dir, &approved_refs);
     }
     let _ = effective.reconcile_proxy_forced();
     let effective_values = resolved_values(&effective, global_doc);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -439,7 +439,7 @@ fn effective_snapshot(
     if let Ok(Some(loaded)) = repo_config::load_repo_config(project_dir) {
         let approved = approved_repo_keys(project_dir, &loaded.config);
         let approved_refs: Vec<&str> = approved.iter().map(String::as_str).collect();
-        effective.apply_repo_config(&loaded.config, project_dir, &approved_refs);
+        effective.apply_repo_config(&loaded.config, &loaded.dir, &approved_refs);
     }
     let _ = effective.reconcile_proxy_forced();
     let effective_values = resolved_values(&effective, global_doc);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2292,6 +2292,230 @@ mod e2e_tests {
         dir
     }
 
+    // ============================================================
+    // Repo config (.cplt.toml) path resolution — navikt/cplt#179
+    // ============================================================
+
+    /// Build a git repo with a committed `.cplt.toml`, so `--print-profile`
+    /// exercises the tamper-proof `git cat-file blob HEAD:.cplt.toml` path
+    /// rather than the working-tree fallback.
+    fn repo_with_committed_cplt_toml(label: &str, toml: &str) -> PathBuf {
+        let repo = make_repo_dir(label);
+        std::fs::write(repo.join(".cplt.toml"), toml).unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["add", "-A"]);
+        git(&[
+            "-c",
+            "user.email=t@example.com",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "-m",
+            "init",
+        ]);
+        repo
+    }
+
+    #[test]
+    fn e2e_repo_deny_path_spellings_all_emit_enforcing_rules() {
+        // navikt/cplt#179 follow-up. Seatbelt accepts a rule it cannot match and
+        // says nothing, so an unenforceable spelling looks enforced in the
+        // profile. Verified against the kernel: `(subpath "<dir>/./secrets")`,
+        // `"<dir>/secrets/."` and `"<dir>//secrets"` all read the file fine,
+        // while `"<dir>/secrets"` gives EPERM. Every spelling a user might
+        // reasonably write must therefore normalize to the enforcing form.
+        //
+        // Each spelling is tested twice: against a directory that exists (where
+        // canonicalize does the work) and one that does not (where only the
+        // lexical pass can, and where canonicalize necessarily fails). The
+        // not-yet-created case is the one repo config uniquely supports.
+        let repo = repo_with_committed_cplt_toml(
+            "deny-spellings",
+            r#"
+[deny]
+paths = [
+  "plain", "./dotslash", "dotend/.", "double//slash", "trailing/",
+  "nx-plain", "./nx-dotslash", "nx-dotend/.", "nx-double//slash", "nx-trailing/",
+]
+"#,
+        );
+        for existing in ["plain", "dotslash", "dotend", "double/slash", "trailing"] {
+            std::fs::create_dir_all(repo.join(existing)).unwrap();
+        }
+        let root = std::fs::canonicalize(&repo).unwrap();
+
+        let output = cplt_cmd()
+            .args([
+                "--project-dir",
+                &repo.to_string_lossy(),
+                "--agent",
+                "shell",
+                "--print-profile",
+            ])
+            .output()
+            .expect("binary should run");
+        assert!(output.status.success(), "should succeed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        for name in [
+            "plain",
+            "dotslash",
+            "dotend",
+            "double/slash",
+            "trailing",
+            "nx-plain",
+            "nx-dotslash",
+            "nx-dotend",
+            "nx-double/slash",
+            "nx-trailing",
+        ] {
+            let want = root.join(name);
+            let want = want.to_string_lossy();
+            assert!(
+                stdout.contains(&format!("(deny file-read* (subpath \"{want}\"))")),
+                "{name}: expected an enforcing deny rule for {want}\nstdout: {stdout}"
+            );
+        }
+        // The inert spellings must not survive anywhere in the profile.
+        for inert in ["/./", "//", "/.\"", "\"plain\"", "\"nx-plain\""] {
+            assert!(
+                !stdout.contains(inert),
+                "profile still contains the unenforceable form {inert:?}\nstdout: {stdout}"
+            );
+        }
+    }
+
+    #[test]
+    fn e2e_repo_deny_path_symlink_resolves_to_target() {
+        // SBPL matches the *resolved* path, so a deny naming a symlink protects
+        // nothing — reading through the link is denied, reading the real path is
+        // not. Canonicalizing when the target exists closes that.
+        let repo = repo_with_committed_cplt_toml(
+            "deny-symlink",
+            "[deny]\npaths = [\"link-to-secrets\"]\n",
+        );
+        std::fs::create_dir_all(repo.join("real-secrets")).unwrap();
+        std::os::unix::fs::symlink("real-secrets", repo.join("link-to-secrets")).unwrap();
+        let root = std::fs::canonicalize(&repo).unwrap();
+
+        let output = cplt_cmd()
+            .args([
+                "--project-dir",
+                &repo.to_string_lossy(),
+                "--agent",
+                "shell",
+                "--print-profile",
+            ])
+            .output()
+            .expect("binary should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let target = root.join("real-secrets");
+        let target = target.to_string_lossy();
+        assert!(
+            stdout.contains(&format!("(deny file-read* (subpath \"{target}\"))")),
+            "deny must name the symlink target, which is what SBPL matches\nstdout: {stdout}"
+        );
+        assert!(
+            !stdout.contains("link-to-secrets"),
+            "the symlink path alone would protect nothing\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_repo_deny_path_anchors_to_git_root_under_project_dir_subdir() {
+        // `git cat-file blob HEAD:.cplt.toml` resolves repo-root-relative
+        // regardless of cwd, so `--project-dir <subdir>` still reads the ROOT's
+        // config. Anchoring its relative paths to the subdir would emit
+        // `<root>/sub/secrets` — a confident-looking absolute deny rule
+        // protecting a directory the repo never named, while `<root>/secrets`
+        // stays readable. Worse than the original bug, which was merely inert.
+        let repo =
+            repo_with_committed_cplt_toml("deny-anchor-subdir", "[deny]\npaths = [\"secrets\"]\n");
+        std::fs::create_dir_all(repo.join("secrets")).unwrap();
+        std::fs::create_dir_all(repo.join("sub")).unwrap();
+        let root = std::fs::canonicalize(&repo).unwrap();
+
+        let output = cplt_cmd()
+            .args([
+                "--project-dir",
+                &repo.join("sub").to_string_lossy(),
+                "--agent",
+                "shell",
+                "--print-profile",
+            ])
+            .output()
+            .expect("binary should run");
+        assert!(output.status.success(), "should succeed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let want = root.join("secrets");
+        let want = want.to_string_lossy();
+        assert!(
+            stdout.contains(&format!("(deny file-read* (subpath \"{want}\"))")),
+            "repo-root config must anchor to the git root\nstdout: {stdout}"
+        );
+        let wrong = root.join("sub/secrets");
+        let wrong = wrong.to_string_lossy();
+        assert!(
+            !stdout.contains(wrong.as_ref()),
+            "must not deny {wrong} — the repo never named it\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_repo_deny_relative_path_is_kernel_enforced() {
+        // The property the whole change exists for, checked against the kernel
+        // rather than the profile string: a relative deny path in a committed
+        // `.cplt.toml`, written the way people actually write one, blocks the
+        // read. Pre-fix this printed the file contents.
+        if !sandbox_exec_available() {
+            assert!(
+                !require_sandbox_enforced(),
+                "CPLT_TEST_REQUIRE_SANDBOX=1 but sandbox-exec is unavailable"
+            );
+            return;
+        }
+        let repo =
+            repo_with_committed_cplt_toml("deny-kernel", "[deny]\npaths = [\"./secrets\"]\n");
+        std::fs::create_dir_all(repo.join("secrets")).unwrap();
+        std::fs::write(repo.join("secrets/pw.txt"), "hunter2").unwrap();
+
+        let output = cplt_cmd()
+            .args([
+                "--project-dir",
+                &repo.to_string_lossy(),
+                "--agent",
+                "shell",
+                "--quiet",
+                "--no-proxy",
+                "--yes",
+                "--",
+                "-c",
+                "cat secrets/pw.txt",
+            ])
+            .output()
+            .expect("binary should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("hunter2"),
+            "a committed relative deny path must be enforced\nstdout: {stdout}"
+        );
+    }
+
     #[test]
     fn e2e_config_set_repo_creates_cplt_toml_with_propose() {
         let repo = make_repo_dir("set-repo-create");

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2476,6 +2476,104 @@ paths = [
     }
 
     #[test]
+    fn e2e_repo_deny_path_resolves_symlink_above_an_absent_leaf() {
+        // The not-yet-created case is only sound when the lexical location is
+        // where the file will actually land. `link/secret` with `link -> real`
+        // and no `secret` yet breaks that: canonicalize fails on the whole path,
+        // and the emitted rule names the link. Verified against the kernel —
+        // that rule blocks reads of NEITHER `link/secret` nor `real/secret`,
+        // while a rule naming `real/secret` blocks both.
+        let repo = repo_with_committed_cplt_toml(
+            "deny-mid-symlink",
+            "[deny]\npaths = [\"link/secret\"]\n",
+        );
+        std::fs::create_dir_all(repo.join("real")).unwrap();
+        std::os::unix::fs::symlink("real", repo.join("link")).unwrap();
+        // `secret` deliberately does NOT exist when the profile is generated.
+        let root = std::fs::canonicalize(&repo).unwrap();
+
+        let output = cplt_cmd()
+            .args([
+                "--project-dir",
+                &repo.to_string_lossy(),
+                "--agent",
+                "shell",
+                "--print-profile",
+            ])
+            .output()
+            .expect("binary should run");
+        assert!(output.status.success(), "should succeed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let want = root.join("real/secret");
+        let want = want.to_string_lossy();
+        assert!(
+            stdout.contains(&format!("(deny file-read* (subpath \"{want}\"))")),
+            "the rule must name the resolved path, which is where the file lands\nstdout: {stdout}"
+        );
+        assert!(
+            !stdout.contains("/link/secret"),
+            "a rule naming the symlink matches nothing\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_repo_allow_path_repointed_outside_the_repo_is_refused() {
+        // The trust store pins a hash of the `.cplt.toml` BYTES, so an approval
+        // only vouches for what those bytes name. Here the repo gets
+        // `allow.read = ["data"]` approved while `data -> safe`, then repoints
+        // `data -> /` in a later commit. `.cplt.toml` never changes, so the
+        // pinned hash still matches and the approval stays live — the grant must
+        // be refused on resolution instead, and said out loud.
+        let repo =
+            repo_with_committed_cplt_toml("allow-escape", "[propose.allow]\nread = [\"data\"]\n");
+        std::fs::create_dir_all(repo.join("safe")).unwrap();
+        std::os::unix::fs::symlink("safe", repo.join("data")).unwrap();
+        let root = std::fs::canonicalize(&repo).unwrap();
+
+        let profile = |repo: &Path| {
+            let out = cplt_cmd()
+                .args([
+                    "--project-dir",
+                    &repo.to_string_lossy(),
+                    "--agent",
+                    "shell",
+                    "--accept-repo-config",
+                    "--print-profile",
+                ])
+                .output()
+                .expect("binary should run");
+            (
+                String::from_utf8_lossy(&out.stdout).into_owned(),
+                String::from_utf8_lossy(&out.stderr).into_owned(),
+            )
+        };
+
+        // Baseline: an in-repo symlink target is granted normally.
+        let (stdout, _) = profile(&repo);
+        let safe = root.join("safe");
+        let safe = safe.to_string_lossy();
+        assert!(
+            stdout.contains(&format!("(allow file-read* (subpath \"{safe}\"))")),
+            "an in-repo symlink target should be granted\nstdout: {stdout}"
+        );
+
+        // Repoint outside the repo, leaving `.cplt.toml` untouched.
+        std::fs::remove_file(repo.join("data")).unwrap();
+        std::os::unix::fs::symlink("/", repo.join("data")).unwrap();
+
+        let (stdout, stderr) = profile(&repo);
+        assert!(
+            !stdout.contains("(allow file-read* (subpath \"/\"))"),
+            "a repointed symlink must not grant read of / on a stale approval\nstdout: {stdout}"
+        );
+        assert!(
+            stderr.contains("resolves outside the repository"),
+            "the refusal must be reported, not silent\nstderr: {stderr}"
+        );
+    }
+
+    #[test]
     fn e2e_repo_deny_relative_path_is_kernel_enforced() {
         // The property the whole change exists for, checked against the kernel
         // rather than the profile string: a relative deny path in a committed


### PR DESCRIPTION
## This is a silent fail-open, not just an ergonomics bug

A relative path in a repo `.cplt.toml` was accepted, emitted into the sandbox profile verbatim, and then **not enforced**. The issue title says "silently unenforced"; on macOS that is precisely right, and I verified it against the kernel rather than the code:

```
$ printf '(version 1)\n(allow default)\n(deny file-read* (subpath "secrets"))\n' > p.sb
$ sandbox-exec -f p.sb /bin/cat secrets/pw.txt
hunter2                                        # exit 0 — rule present, inert

$ printf '(version 1)\n(allow default)\n(deny file-read* (subpath "/private/var/.../secrets"))\n' > q.sb
$ sandbox-exec -f q.sb /bin/cat secrets/pw.txt
cat: secrets/pw.txt: Operation not permitted   # exit 1
```

Seatbelt does not reject a relative `subpath`. It compiles the profile, reports success, and matches nothing. So a user who wrote `[deny] paths = ["secrets"]`, committed it, and saw no warning had no denial at all — the worst shape a security tool can fail in.

End to end before the fix:

```
$ cplt --agent shell --print-profile | grep secrets
(deny file-read* (subpath "secrets"))
$ cplt --agent shell --yes -- -c 'cat secrets/pw.txt'
hunter2
```

After:

```
(deny file-read* (subpath "/…/repro/secrets"))
$ cplt … -- -c 'cat secrets/pw.txt'
cat: secrets/pw.txt: Operation not permitted
```

## Scope is wider than the issue states

The drop was at `src/config/loading.rs:1022` in `Resolved::apply_repo_config`: repo paths were tilde-expanded and nothing else.

| Source | Keys | Before |
|---|---|---|
| repo `.cplt.toml` | `deny.paths`, `propose.allow.read`, `.write`, `.socket` | relative accepted, unenforced |
| global `config.toml` | same keys | resolved via `resolve_config_path`; deny hard-fails, allow warns |
| CLI `--deny-path` | — | hard-fails |
| CLI `--allow-read/write` | — | warns and skips |

Repo config was the only source doing neither. It affects **both platforms** and **all four** repo path keys — `propose.allow.socket` was affected too, which the issue does not mention. `..` was already rejected by `validate_repo_config`.

Platform drop points: macOS `sandbox_profile.rs:1134` interpolates verbatim (inert, as shown above); Linux `sandbox_bubblewrap.rs:366` filters on `!path.is_absolute()` into `skipped` — warned-only since #177, so at least visible there.

## Resolve, not reject — and why

Anchored to the directory holding `.cplt.toml`, justified from the codebase's own convention rather than preference:

- `resolve_config_path` already resolves relative *global*-config paths against the config file's directory, and the generated default config says so in prose: "Relative paths are resolved from this config file's directory." Repo config was the outlier.
- Rejecting would turn a committed typo into a hard failure for everyone who clones the repo, and would break the documented `["~/secrets"]` example on machines without that directory.

Deliberately **not** canonicalized, unlike `resolve_config_path`: repo config is the only source that can legitimately deny a path that does not exist yet (macOS enforces once it is created), and `join` cannot fail. So the silence is removed *by construction* — there is no warn-and-skip branch that could go quiet again.

Fixed at the choke point: all four call sites in `apply_repo_config` route through the new `resolve_repo_path`, and both callers already had `project_dir` in scope.

## Tests

Six new, one per layer, so a regression at any layer is caught where it happens:

- `path.rs` ×3 — anchoring, absolute/tilde passthrough, non-existent path preserved
- `loading.rs` ×1 — all four keys anchored, every resolved path asserted `is_absolute()` (that is exactly Linux's drop condition, so it guards that platform by construction)
- `sandbox_profile.rs` ×1 — SBPL contains the absolute subpath and asserts `(subpath "secrets")` is **absent**
- `sandbox_bubblewrap.rs` ×1, Linux-gated — the resolved path masks instead of landing in `skipped`

Mutation-checked: reverting `resolve_repo_path` to plain `expand_tilde` fails 4 tests, one per layer.

`cargo test`: lib 712, unit_tests 266, integration 54, e2e 132 (6 pre-existing ignored), e2e_guards 107, e2e_projects 43 — 1314 passing, 0 failed. fmt and clippy clean.

## Two caveats

The Linux-gated test could not be compile-checked locally (no network for `cargo check --target x86_64-unknown-linux-gnu`); every symbol it uses is public and already used by neighbouring tests in the same module, but CI is the real check here.

On Linux, a resolved-but-nonexistent deny path is still warn-and-skip in `build_deny_masks` — visible, but not enforced. That is a Landlock/bwrap limitation, pre-existing and out of scope.


## Upgrade note — belongs in the release notes

Any repo already shipping a **relative** `deny.paths` entry has been inert on macOS and `skipped`-with-a-warning on Linux. After this it bites:

| Entry | Was | Becomes |
|---|---|---|
| `target` | ignored | denies the real build directory |
| `.git` | ignored | denies the repo's git directory |
| `node_modules` | ignored | denies the real dependency tree |

That is the intent of the fix, but it is a silent behaviour change on upgrade. Pre-upgrade check:

```
cplt --print-profile | grep 'deny file-read'
```

`cliff.toml` renders commit subjects only, so this will not reach the generated notes from the commit body — it needs lifting from here.

## Second pass — what adversarial review caught

The first version of this PR did **not** close its own bug. Verified against the kernel:

| `.cplt.toml` entry | emitted (v1) | emitted (now) | enforced now |
|---|---|---|---|
| `plain` | `/r/plain` | `/r/plain` | yes |
| `./dotslash` | `/r/./dotslash` | `/r/dotslash` | yes — was **inert** |
| `dotend/.` | `/r/dotend/.` | `/r/dotend` | yes — was **inert** |
| `double//slash` | `/r/double//slash` | `/r/double/slash` | yes — was **inert** |
| `mylink` → `link-target` | `/r/mylink` | `/r/link-target` | yes — was **inert** |
| non-existent, all spellings | as above | normalized absolute | enforced once created |

`reject_path_traversal` only rejects `ParentDir`, and `Path::join` does not normalize — so `./secrets`, the most natural way to write a relative path, stayed fail-open on macOS. Linux was unaffected (`build_deny_masks` canonicalizes internally), making it a platform-split fail-open.

Fix: lexical normalization first (`components()` minus `CurDir`, which also collapses `//` and trailing `/`), then `canonicalize().unwrap_or(full)`. Canonicalize-alone is not sufficient — it fails on a path that does not exist yet, which is exactly the case this PR set out to preserve; the test proves it, failing on `nx-dotslash` under a canonicalize-only mutant.

**Anchor bug.** `load_repo_config` reads the blob repo-root-relative, but `main.rs` passed `--project-dir` verbatim, so `--project-dir <root>/sub` produced `(subpath "<root>/sub/secrets")` — pointing at the wrong directory while looking enforced, which is worse than inert. Fixed at the source: `LoadedRepoConfig` now carries `dir`, the directory the config was actually read from (`git rev-parse --show-toplevel` for the HEAD blob, `project_dir` for the macOS working-tree fallback, where the file genuinely is there). Both callers use it, so they cannot diverge. Computing the toplevel inside `apply_repo_config` would have been wrong for the working-tree source.

**Test gap.** A wrong-anchor mutant previously left 712/712 lib tests green, because every test passed `Path::new("/repo")` straight into `apply_repo_config` and `main.rs` is a separate binary target that `--lib` never compiles. Each mutant now fails a distinct e2e test driving a committed `.cplt.toml` through the real binary:

| mutant | failing test |
|---|---|
| wrong anchor at the real call site | `e2e_repo_deny_path_anchors_to_git_root_under_project_dir_subdir` |
| drop the lexical pass | `e2e_repo_deny_path_spellings_all_emit_enforcing_rules` |
| drop canonicalize | `e2e_repo_deny_path_symlink_resolves_to_target` |
| original silent drop | 4 lib tests plus all of the above |

lib 714 · unit_tests 266 · integration 54 · e2e 136 (6 pre-existing ignored) · e2e_guards 107 · e2e_projects 43 — 1320 passing, 0 failed.

## Still unverified

The Linux-gated test could not be compile-checked locally (no network for a cross-target check). CI is the real check.

`e2e_projects` failed two tests on one run and passed on two reruns, including on a clean stashed tree — environmental (that suite spawns real toolchains in parallel), not caused by this change. Flagging rather than hiding it.

Out of scope: on Linux, `propose.allow.read` via a committed symlink is a trust-pin gap — Landlock follows symlinks while `trust::proposal_content_hash` hashes the raw string, so retargeting the symlink changes the grant without invalidating approval. Pre-existing; macOS is fail-closed here.


## Third pass — second adversarial review (Fable)

A second reviewer found two more defects after the first rework. Both are fixed.

**A symlink above an absent leaf was still inert** — the same fail-open, in a shape the previous round did not test. With `deny.paths = ["link/secret"]`, `link -> real`, and `secret` absent at launch, `canonicalize` failed on the leaf and the fallback kept the whole path with the symlink unresolved:

```
rule link/secret (emitted)   via real -> hunter2   via link -> hunter2
rule real/secret (resolved)  via real -> EPERM     via link -> EPERM
```

Fixed with `canonicalize_deepest`: walk up by `parent()`/`file_name()` until `canonicalize` succeeds, then fold the tail back on. The not-yet-created case is preserved, and any non-ENOENT failure (permission-denied ancestor, `ELOOP`) now resolves as far up as it can rather than naming an unresolved path.

**An approved allow-path could be repointed outside the repo without re-approval.** `trust::proposal_content_hash` pins the raw strings, but this PR resolves and canonicalizes them — so a repo could commit `allow.read = ["data"]` with `data` a symlink to somewhere safe, get it approved, and repoint `data` to `/` in a later commit with `.cplt.toml` untouched. The hash is unchanged, so the stale approval keeps applying. Pre-PR these entries were inert, so this PR is what would have enabled it.

Fixed by **rejecting**, not by hashing the resolved target. Hashing would make the trust pin machine-specific and self-invalidating: `~/cache` hashes differently on every machine, and any path absent at approval time changes the hash the moment it is created — re-prompting for a change the repo never made, which trains users to click through re-approvals. Rejecting is fail-closed, needs no change to `proposal_content_hash`, and leaves an actionable out: name the target directly, which puts it back under the pinned bytes.

The invariant: **an approval only vouches for what the pinned bytes name.** Absolute and `~/` entries are exempt for exactly that reason. `[deny]` is deliberately unconfined — it needs no approval and can only tighten, so a repointed deny symlink cannot escalate.

Verified end to end: approve with `data -> safe`, repoint to `/`, and the grant is refused with `matching rules: 0`.

**Also:** `""`, `"."` and `"./"` in `deny.paths` all resolved to the repo root, denying the entire checkout — a committed empty entry would brick the repo for everyone who clones it. Now rejected at parse time alongside `..`. `LoadedRepoConfig::dir` is canonicalized, since it is now both the anchor and the containment boundary and a symlinked checkout would otherwise read as "outside the repo".

Six mutants, each caught by a distinct test — including the ancestor walk, the containment check, and the root rejection.

**Honest correction to the previous description:** the lexical pass is no longer load-bearing inside `resolve_repo_path`. `canonicalize_deepest` walks by `parent()`/`file_name()`, which drop `.` and `//` on their own. It is still load-bearing in `reject_root_path`, which must spot a root-equal entry before touching the disk. Kept in both places so the invariant does not silently depend on that stdlib detail.

## Second behaviour change, beyond the bug

The containment rule rejects a legitimate `allow.read = ["vendor"]` where `vendor` is a symlink to a shared store outside the repo — a pnpm-style layout. It is fail-closed with a message telling the user to name the target directly. Deliberate, but it is a restriction that did not exist before, so it belongs next to the upgrade note above.

lib 718 · unit_tests 266 · integration 54 · e2e 138 (6 pre-existing ignored) · e2e_guards 107 · e2e_projects 43 — 1326 passing, 0 failed.

Closes #179.

