### PR TITLE
fix(agent): name the WSL interop trap instead of failing at extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ Everything below runs **inside the distro** (`wsl`, or the Ubuntu profile in Win
 # 1. Node — Copilot CLI is a Node package
 sudo apt update && sudo apt install -y nodejs npm
 
-# 2. GitHub CLI, and log in
+# 2. GitHub CLI, and log in — if apt has no 'gh', add GitHub's apt repo first:
+#    https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 sudo apt install -y gh
 gh auth login
 
@@ -294,13 +295,13 @@ cplt doctor
 
 If `copilot` complains about the Node version, Ubuntu's packaged Node is older than it wants — install a newer one *inside the distro* (nvm, NodeSource, or mise) and re-run step 3.
 
-**Do not install Copilot CLI on the Windows side.** WSL appends the Windows `PATH` to the distro's, so a Windows-side `npm install -g @github/copilot` turns up inside the distro as `/mnt/c/Users/<user>/AppData/Roaming/npm/copilot`. That is a Windows install reached through interop: it cannot run in the Linux sandbox, and the npm shim execs a `node` the distro does not have. The symptom used to be an unrelated runtime-extraction error; cplt now names the cause when it resolves an agent under `/mnt/<drive>/`, and `cplt doctor` reports it as a failing check instead of passing ([#188](https://github.com/navikt/cplt/issues/188)).
+**Do not install Copilot CLI on the Windows side.** WSL appends the Windows `PATH` to the distro's, so a Windows-side `npm install -g @github/copilot` turns up inside the distro as `/mnt/c/Users/<user>/AppData/Roaming/npm/copilot`. That is a Windows install reached through interop: it cannot run in the Linux sandbox, and the npm shim execs a `node` the distro does not have. The symptom used to be an unrelated runtime-extraction error; cplt now names the cause when it resolves an agent under `/mnt/<drive>/` *and* it detects it is running under WSL (`WSL_DISTRO_NAME`, `WSL_INTEROP`, or a Microsoft kernel in `/proc/version`), and `cplt doctor` reports it as a failing check instead of passing ([#188](https://github.com/navikt/cplt/issues/188)). On a plain Linux box `/mnt/c` is left alone — it is an ordinary mount point there.
 
 **Kernel requirement.** Landlock needs kernel 5.13+, and TCP port filtering needs 6.7+ (see [Honest gaps](#honest-gaps)). `cplt doctor` prints the kernel version and the Landlock ABI it found — that is the check that matters on your machine. If it reports Landlock as unavailable, `wsl --update` in PowerShell and `cat /sys/kernel/security/lsm` inside the distro are the first two things to look at.
 
 **Keep the project in the Linux filesystem.** Work in `~/src/...` inside the distro rather than `/mnt/c/Users/...`. Microsoft's own guidance is that cross-OS file access through `/mnt/c` is markedly slower; and while cplt applies the same sandbox rules wherever the project lives (nothing in cplt special-cases `/mnt`), we have not confirmed that Landlock enforces those rules the same way on the 9p/drvfs mount that backs `/mnt/c` as it does on ext4. Until someone verifies that, treat a project under `/mnt/c` as unproven rather than supported.
 
-> **Not yet verified on a real WSL2 install.** What is verified from this repo: the `/mnt/<drive>/` detection and its error text, that `cplt doctor` fails on such an agent and prints kernel + Landlock ABI, that Landlock requires 5.13+ (6.7+ for port filtering), and that `install.sh` installs the Linux release binary. What is *not* verified by anyone here: that the WSL2 kernel you get has Landlock enabled, the exact `apt` package names and Node versions on your distro release, and Landlock's behaviour on `/mnt/c`. If you run this sequence, please report what actually happened in [#189](https://github.com/navikt/cplt/issues/189).
+> **Not yet verified on a real WSL2 install.** What is verified from this repo: the `/mnt/<drive>/` detection and its error text, that `cplt doctor` fails on such an agent and prints kernel + Landlock ABI, that Landlock requires 5.13+ (6.7+ for port filtering), and that `install.sh` installs the Linux release binary. What is *not* verified by anyone here: that the WSL2 kernel you get has Landlock enabled, that your WSL session really exports `WSL_DISTRO_NAME`/`WSL_INTEROP` or reports a Microsoft kernel (that is what switches the interop check on), the exact `apt` package names and Node versions on your distro release, and Landlock's behaviour on `/mnt/c`. If you run this sequence, please report what actually happened in [#189](https://github.com/navikt/cplt/issues/189).
 
 ### Shell setup (recommended)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - **macOS**: Apple Seatbelt/SBPL via `sandbox-exec`
 - **Linux**: Landlock LSM + seccomp-BPF + optional Bubblewrap namespace isolation (kernel 5.13+; full network filtering on 6.7+)
-- **Windows**: no native support — there is no Windows sandbox backend. Run cplt inside WSL2, where it is an ordinary Linux install: [Windows (WSL2) setup](#windows-wsl2)
+- **Windows**: no native support — there is no Windows sandbox backend. Run cplt inside WSL2, where it is an ordinary Linux install and the Microsoft kernel ships Landlock: [Windows (WSL2) setup](#windows-wsl2)
 
 ![cplt banner](./assets/cplt.png)
 
@@ -262,22 +262,26 @@ Alternatively, run `/usr/local/bin/cplt` explicitly to bypass PATH resolution.
 
 ### Windows (WSL2)
 
-cplt has no Windows sandbox backend — the enforcement is Apple Seatbelt on macOS and Landlock LSM on Linux, so there is nothing to run natively on Windows. The supported route is [WSL2](https://learn.microsoft.com/windows/wsl/install): inside the distro, cplt is a normal Linux install.
+cplt has no Windows sandbox backend — the enforcement is Apple Seatbelt on macOS and Landlock LSM on Linux, so there is nothing to run natively on Windows. The supported route is [WSL2](https://learn.microsoft.com/windows/wsl/install), where cplt is an ordinary Linux install and the sandbox is kernel-enforced: every Microsoft kernel branch builds `CONFIG_SECURITY_LANDLOCK=y` and lists `landlock` first in `CONFIG_LSM` ([`config-wsl`](https://github.com/microsoft/WSL2-Linux-Kernel/blob/master/arch/x86/configs/config-wsl)), shipped since kernel 5.15.57.1, and WSL's default kernel command line sets no `lsm=` override.
 
 In PowerShell, once:
 
 ```powershell
-wsl --install     # installs WSL2 + Ubuntu, then reboot
-wsl --update      # WSL2 ships its own Microsoft-maintained kernel; keep it current
+wsl --install                    # WSL2 + the default distro (now Ubuntu 26.04 LTS), then reboot
+wsl --install -d Ubuntu-24.04    # …or pin an older release
+wsl --update                     # keep the Microsoft kernel current — see the ABI note below
 ```
 
 Everything below runs **inside the distro** (`wsl`, or the Ubuntu profile in Windows Terminal) — not in PowerShell:
 
 ```bash
-# 1. Node — Copilot CLI is a Node package
+# 1. Node — Copilot CLI requires Node 22+
+#    Ubuntu 26.04 ships 22.x, so apt is enough:
 sudo apt update && sudo apt install -y nodejs npm
+#    Ubuntu 24.04 ships Node 18 — too old. Use nvm, fnm, or NodeSource there instead.
 
-# 2. GitHub CLI, and log in — if apt has no 'gh', add GitHub's apt repo first:
+# 2. GitHub CLI, and log in. Ubuntu's universe package works but lags
+#    (2.45 on 24.04); add GitHub's apt repo if you want a current gh:
 #    https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 sudo apt install -y gh
 gh auth login
@@ -293,15 +297,19 @@ curl -fsSL https://raw.githubusercontent.com/navikt/cplt/main/install.sh | bash
 cplt doctor
 ```
 
-If `copilot` complains about the Node version, Ubuntu's packaged Node is older than it wants — install a newer one *inside the distro* (nvm, NodeSource, or mise) and re-run step 3.
+**Do not install Copilot CLI on the Windows side.** With interop on (the default), the Windows `PATH` is appended to the distro's, so a Windows-side `npm install -g @github/copilot` turns up inside the distro as `/mnt/c/Users/<user>/AppData/Roaming/npm/copilot`. That is a Windows install reached through interop: it cannot run in the Linux sandbox, and the npm shim execs a `node` that the distro will not have unless you installed one there too. The symptom used to be an unrelated runtime-extraction error; cplt now names the cause when it resolves an agent under `/mnt/<drive>/` *and* it is running under WSL, and `cplt doctor` reports it as a failing check instead of passing ([#188](https://github.com/navikt/cplt/issues/188)). WSL is detected from kernel-owned state — `/run/WSL`, or the kernel name in `/proc/sys/kernel/osrelease` / `/proc/version` — not from `WSL_DISTRO_NAME`, which is absent under `sudo` and in systemd units and which any process can set. On a plain Linux box `/mnt/c` is left alone: it is an ordinary mount point there.
 
-**Do not install Copilot CLI on the Windows side.** WSL appends the Windows `PATH` to the distro's, so a Windows-side `npm install -g @github/copilot` turns up inside the distro as `/mnt/c/Users/<user>/AppData/Roaming/npm/copilot`. That is a Windows install reached through interop: it cannot run in the Linux sandbox, and the npm shim execs a `node` the distro does not have. The symptom used to be an unrelated runtime-extraction error; cplt now names the cause when it resolves an agent under `/mnt/<drive>/` *and* it detects it is running under WSL (`WSL_DISTRO_NAME`, `WSL_INTEROP`, or a Microsoft kernel in `/proc/version`), and `cplt doctor` reports it as a failing check instead of passing ([#188](https://github.com/navikt/cplt/issues/188)). On a plain Linux box `/mnt/c` is left alone — it is an ordinary mount point there.
+Two limits of that check, both by choice: it keys on the *default* automount root, so if you have relocated it (`[automount] root` in `/etc/wsl.conf`) the Windows-side install is not recognised and you get the old, less helpful failure with the path in it; and turning interop off stops the Windows `PATH` from leaking in but does **not** unmount `/mnt/c`.
 
-**Kernel requirement.** Landlock needs kernel 5.13+, and TCP port filtering needs 6.7+ (see [Honest gaps](#honest-gaps)). `cplt doctor` prints the kernel version and the Landlock ABI it found — that is the check that matters on your machine. If it reports Landlock as unavailable, `wsl --update` in PowerShell and `cat /sys/kernel/security/lsm` inside the distro are the first two things to look at.
+**Kernel and Landlock ABI.** Current WSL (2.7.x and later) ships Linux 6.18, which gives Landlock ABI 7 — everything cplt uses. An install still on the 6.6 kernel line gets ABI 3: filesystem rules are enforced, but TCP port rules (ABI 4), ioctl restriction (ABI 5) and signal/abstract-socket scoping (ABI 6) are not available, and network filtering falls back to the CONNECT proxy. `wsl --update` moves you forward. `cplt doctor` prints the kernel version and the ABI it found — that is the check that matters on your machine.
 
-**Keep the project in the Linux filesystem.** Work in `~/src/...` inside the distro rather than `/mnt/c/Users/...`. Microsoft's own guidance is that cross-OS file access through `/mnt/c` is markedly slower; and while cplt applies the same sandbox rules wherever the project lives (nothing in cplt special-cases `/mnt`), we have not confirmed that Landlock enforces those rules the same way on the 9p/drvfs mount that backs `/mnt/c` as it does on ext4. Until someone verifies that, treat a project under `/mnt/c` as unproven rather than supported.
+> **Do not disable Landlock in `.wslconfig`.** A `[wsl2] kernelCommandLine` with an `lsm=` list that omits `landlock`, or a custom `[wsl2] kernel=` built without `CONFIG_SECURITY_LANDLOCK`, removes the kernel enforcement cplt depends on — `cplt doctor` will report Landlock as unavailable.
 
-> **Not yet verified on a real WSL2 install.** What is verified from this repo: the `/mnt/<drive>/` detection and its error text, that `cplt doctor` fails on such an agent and prints kernel + Landlock ABI, that Landlock requires 5.13+ (6.7+ for port filtering), and that `install.sh` installs the Linux release binary. What is *not* verified by anyone here: that the WSL2 kernel you get has Landlock enabled, that your WSL session really exports `WSL_DISTRO_NAME`/`WSL_INTEROP` or reports a Microsoft kernel (that is what switches the interop check on), the exact `apt` package names and Node versions on your distro release, and Landlock's behaviour on `/mnt/c`. If you run this sequence, please report what actually happened in [#189](https://github.com/navikt/cplt/issues/189).
+**Keep the project in the Linux filesystem.** Work in `~/src/...` inside the distro rather than `/mnt/c/Users/...`. Microsoft's own guidance is that cross-OS file access is markedly slower, and `/mnt/c` is served over 9p by default as of WSL 2.9.x (virtiofs is opt-in via `[wsl2] virtiofs=true`). More to the point: we have not verified how Landlock enforces rules on that mount. The kernel documents no exclusion for network- or FUSE-backed filesystems — only pipes, sockets and nsfs — and Landlock's own test suite exercises 9p and FUSE, so we expect it to work; nobody here has confirmed it. Treat a project under `/mnt/c` as unproven rather than supported.
+
+**Bubblewrap.** Ubuntu 23.10+ blocks unprivileged user namespaces through `kernel.apparmor_restrict_unprivileged_userns`, which breaks `bwrap`. That sysctl comes from an Ubuntu kernel patch that is absent from the Microsoft kernel, so the optional Bubblewrap layer is expected to work on Ubuntu-under-WSL2 — but that is inference from the kernel source, not something we have run. If `bwrap` fails there, please say so in [#189](https://github.com/navikt/cplt/issues/189). (cplt's own seccomp filter is a plain `PR_SET_SECCOMP` BPF program, which stacks on top of the filter WSL installs in every process.)
+
+> **Not yet verified on a real WSL2 install.** Verified from source: Landlock is compiled in and first in `CONFIG_LSM` on the Microsoft kernel; the `/mnt/<drive>/` detection, the WSL signals it uses, and their error text; that `cplt doctor` fails on such an agent and prints kernel + Landlock ABI; the 5.13+/6.7+ requirements; and that `install.sh` installs the Linux release binary. Still unverified by anyone here: how Landlock behaves on `/mnt/c`, whether Bubblewrap works under WSL2, the exact package versions your distro release ships, and the sequence above end to end. If you run it, please report what actually happened in [#189](https://github.com/navikt/cplt/issues/189).
 
 ### Shell setup (recommended)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - **macOS**: Apple Seatbelt/SBPL via `sandbox-exec`
 - **Linux**: Landlock LSM + seccomp-BPF + optional Bubblewrap namespace isolation (kernel 5.13+; full network filtering on 6.7+)
+- **Windows**: no native support — there is no Windows sandbox backend. Run cplt inside WSL2, where it is an ordinary Linux install: [Windows (WSL2) setup](#windows-wsl2)
 
 ![cplt banner](./assets/cplt.png)
 
@@ -258,6 +259,48 @@ export PATH="/usr/local/bin:$PATH"
 ```
 
 Alternatively, run `/usr/local/bin/cplt` explicitly to bypass PATH resolution.
+
+### Windows (WSL2)
+
+cplt has no Windows sandbox backend — the enforcement is Apple Seatbelt on macOS and Landlock LSM on Linux, so there is nothing to run natively on Windows. The supported route is [WSL2](https://learn.microsoft.com/windows/wsl/install): inside the distro, cplt is a normal Linux install.
+
+In PowerShell, once:
+
+```powershell
+wsl --install     # installs WSL2 + Ubuntu, then reboot
+wsl --update      # WSL2 ships its own Microsoft-maintained kernel; keep it current
+```
+
+Everything below runs **inside the distro** (`wsl`, or the Ubuntu profile in Windows Terminal) — not in PowerShell:
+
+```bash
+# 1. Node — Copilot CLI is a Node package
+sudo apt update && sudo apt install -y nodejs npm
+
+# 2. GitHub CLI, and log in
+sudo apt install -y gh
+gh auth login
+
+# 3. The agent — installed in the distro, never on the Windows side
+npm install -g @github/copilot
+
+# 4. cplt
+curl -fsSL https://raw.githubusercontent.com/navikt/cplt/main/install.sh | bash
+# (or: brew install navikt/tap/cplt, if you use Homebrew on Linux)
+
+# 5. Check the result
+cplt doctor
+```
+
+If `copilot` complains about the Node version, Ubuntu's packaged Node is older than it wants — install a newer one *inside the distro* (nvm, NodeSource, or mise) and re-run step 3.
+
+**Do not install Copilot CLI on the Windows side.** WSL appends the Windows `PATH` to the distro's, so a Windows-side `npm install -g @github/copilot` turns up inside the distro as `/mnt/c/Users/<user>/AppData/Roaming/npm/copilot`. That is a Windows install reached through interop: it cannot run in the Linux sandbox, and the npm shim execs a `node` the distro does not have. The symptom used to be an unrelated runtime-extraction error; cplt now names the cause when it resolves an agent under `/mnt/<drive>/`, and `cplt doctor` reports it as a failing check instead of passing ([#188](https://github.com/navikt/cplt/issues/188)).
+
+**Kernel requirement.** Landlock needs kernel 5.13+, and TCP port filtering needs 6.7+ (see [Honest gaps](#honest-gaps)). `cplt doctor` prints the kernel version and the Landlock ABI it found — that is the check that matters on your machine. If it reports Landlock as unavailable, `wsl --update` in PowerShell and `cat /sys/kernel/security/lsm` inside the distro are the first two things to look at.
+
+**Keep the project in the Linux filesystem.** Work in `~/src/...` inside the distro rather than `/mnt/c/Users/...`. Microsoft's own guidance is that cross-OS file access through `/mnt/c` is markedly slower; and while cplt applies the same sandbox rules wherever the project lives (nothing in cplt special-cases `/mnt`), we have not confirmed that Landlock enforces those rules the same way on the 9p/drvfs mount that backs `/mnt/c` as it does on ext4. Until someone verifies that, treat a project under `/mnt/c` as unproven rather than supported.
+
+> **Not yet verified on a real WSL2 install.** What is verified from this repo: the `/mnt/<drive>/` detection and its error text, that `cplt doctor` fails on such an agent and prints kernel + Landlock ABI, that Landlock requires 5.13+ (6.7+ for port filtering), and that `install.sh` installs the Linux release binary. What is *not* verified by anyone here: that the WSL2 kernel you get has Landlock enabled, the exact `apt` package names and Node versions on your distro release, and Landlock's behaviour on `/mnt/c`. If you run this sequence, please report what actually happened in [#189](https://github.com/navikt/cplt/issues/189).
 
 ### Shell setup (recommended)
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,6 +8,7 @@
 use crate::ui;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::OnceLock;
 
 // ── Per-agent default allowlists ─────────────────────────────────────────────
 //
@@ -969,24 +970,40 @@ pub fn canonicalize_agent_dirs(dirs: &mut [AgentDir]) {
     }
 }
 
-/// Are we running inside WSL?
+/// Are we running inside WSL? Cached — it cannot change within a process.
 ///
-/// `WSL_DISTRO_NAME` and `WSL_INTEROP` are set by WSL in every distro session,
-/// and WSL2's `/proc/version` names the Microsoft-built kernel. Either signal
-/// is enough; both are absent on ordinary Linux, where `/mnt/c` is just a
-/// mount point somebody chose and must be left alone.
+/// Two independent signals, both cheap reads of kernel-owned state:
+///
+/// - `/run/WSL` exists. WSL's own init creates it; this is snapd's primary
+///   signal, and it survives a custom `[wsl2] kernel=` whose
+///   `CONFIG_LOCALVERSION` drops the marker below.
+/// - the kernel name in `/proc/sys/kernel/osrelease` (what systemd reads) or
+///   `/proc/version` names WSL. They cover the reverse case: snapd notes that
+///   `/run/WSL` can be missing under undocumented circumstances.
+///
+/// Deliberately *not* used: `WSL_DISTRO_NAME` and `WSL_INTEROP`. Both are
+/// absent under `sudo`, in systemd units and in cron (microsoft/WSL#5914,
+/// #9719) — and any user can export them, which disqualifies them from a
+/// decision that refuses to run an agent.
 pub fn is_wsl() -> bool {
-    std::env::var_os("WSL_DISTRO_NAME").is_some()
-        || std::env::var_os("WSL_INTEROP").is_some()
-        || std::fs::read_to_string("/proc/version").is_ok_and(|v| is_wsl_proc_version(&v))
+    static WSL: OnceLock<bool> = OnceLock::new();
+    *WSL.get_or_init(|| {
+        Path::new("/run/WSL").exists()
+            || ["/proc/sys/kernel/osrelease", "/proc/version"]
+                .iter()
+                .any(|f| std::fs::read_to_string(f).is_ok_and(|s| names_wsl_kernel(&s)))
+    })
 }
 
-/// Does this `/proc/version` string come from a WSL kernel?
+/// Does this kernel release or version string come from a WSL kernel?
 ///
-/// WSL1 and WSL2 both name Microsoft in it ("… Microsoft@Microsoft.com …",
-/// "…-microsoft-standard-WSL2 …"); a stock distro kernel does not.
-fn is_wsl_proc_version(version: &str) -> bool {
-    version.to_ascii_lowercase().contains("microsoft")
+/// Case-insensitive on purpose: WSL2 writes `-microsoft-standard-WSL2` with a
+/// lowercase m, WSL1 wrote `4.4.0-19041-Microsoft` with a capital one, so a
+/// case-sensitive match for either spelling misses the other. `wsl` is matched
+/// too, as systemd does, for kernels that carry only that marker.
+fn names_wsl_kernel(s: &str) -> bool {
+    let s = s.to_ascii_lowercase();
+    s.contains("microsoft") || s.contains("wsl")
 }
 
 /// Must this resolved agent binary be refused as a Windows interop install?
@@ -1008,10 +1025,21 @@ pub fn is_wsl_interop_binary(path: &Path, wsl: bool) -> bool {
 /// the Linux sandbox (#188).
 ///
 /// The single-letter component is what separates a drive mount from an
-/// ordinary `/mnt/data`-style mount point — but `/mnt/c` is also a perfectly
-/// ordinary mount on a non-WSL machine (a NAS, a second disk), so callers must
-/// gate this on [`is_wsl`]. On a Linux box that is not WSL, a real agent under
-/// `/mnt/d` has to keep working.
+/// ordinary `/mnt/data`-style mount point — and, deliberately, from `/mnt/wsl`
+/// and `/mnt/wslg`, which are WSL's own tmpfs and WSLg, not Windows paths.
+/// `/mnt/c` is also a perfectly ordinary mount on a non-WSL machine (a NAS, a
+/// second disk), so callers must gate this on [`is_wsl`]: on a Linux box that
+/// is not WSL, a real agent under `/mnt/d` has to keep working.
+///
+/// Known ceiling: `/mnt` is only the *default* automount root. `[automount]
+/// root` in `/etc/wsl.conf` relocates it (Microsoft's own example is
+/// `/windir/c`), automount can be switched off, and drives can be mounted
+/// anywhere with `mount -t drvfs`. Such a setup is simply not detected — the
+/// agent then fails later with its path in the message, which is the failure
+/// mode we prefer over refusing a working install. The exact answer is the
+/// longest-matching mount for the path in `/proc/self/mountinfo` having fstype
+/// `9p` with `aname=drvfs`, `virtiofs`, `virtio-plan9`, or `drvfs`; worth
+/// parsing if relocated automount roots ever show up in a bug report.
 pub fn is_windows_interop_path(path: &Path) -> bool {
     let mut parts = path.components();
     matches!(parts.next(), Some(std::path::Component::RootDir))
@@ -1171,6 +1199,10 @@ mod tests {
         assert!(!is_windows_interop_path(Path::new(
             "/home/user/.local/bin/copilot"
         )));
+        // WSL's own mounts: /mnt/wsl is its tmpfs, /mnt/wslg is WSLg. Neither
+        // is a Windows path, and both must stay usable.
+        assert!(!is_windows_interop_path(Path::new("/mnt/wsl/bin/copilot")));
+        assert!(!is_windows_interop_path(Path::new("/mnt/wslg/bin/copilot")));
         // A drive root is not a binary, and only absolute paths are mounts.
         assert!(!is_windows_interop_path(Path::new("/mnt/c")));
         assert!(!is_windows_interop_path(Path::new("mnt/c/bin/copilot")));
@@ -1193,27 +1225,36 @@ mod tests {
     }
 
     /// `/mnt/c` is an ordinary mount point on plenty of non-WSL Linux boxes, so
-    /// the interop rule hangs entirely off this signal. Real `/proc/version`
-    /// strings, WSL2 and WSL1 vs a stock distro kernel.
+    /// the interop rule hangs entirely off this signal. Real strings from
+    /// `/proc/sys/kernel/osrelease` and `/proc/version`, WSL2 and WSL1 against
+    /// a stock distro kernel.
     #[test]
-    fn wsl_proc_version_distinguishes_wsl_from_stock_kernels() {
-        assert!(is_wsl_proc_version(
+    fn wsl_kernel_names_distinguish_wsl_from_stock_kernels() {
+        // osrelease, one short line — what systemd reads.
+        assert!(names_wsl_kernel("5.15.167.4-microsoft-standard-WSL2"));
+        assert!(names_wsl_kernel("6.6.87.2-microsoft-standard-WSL2+"));
+        // WSL1 spelled it with a capital M, WSL2 with a lowercase one: a
+        // case-sensitive match for either spelling misses the other.
+        assert!(names_wsl_kernel("4.4.0-19041-Microsoft"));
+        // /proc/version, the long form.
+        assert!(names_wsl_kernel(
             "Linux version 5.15.167.4-microsoft-standard-WSL2 \
              (root@941d701f84f1) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37) #1 SMP"
         ));
-        assert!(is_wsl_proc_version(
-            "Linux version 4.4.0-19041-Microsoft \
-             (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #1237-Microsoft"
-        ));
-        assert!(!is_wsl_proc_version(
+        // A kernel carrying only the WSL marker, which systemd also matches.
+        assert!(names_wsl_kernel("6.18.0-wsl-custom"));
+
+        assert!(!names_wsl_kernel("6.8.0-45-generic"));
+        assert!(!names_wsl_kernel(
             "Linux version 6.8.0-45-generic (buildd@lcy02-amd64-091) \
              (x86_64-linux-gnu-gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0) #45-Ubuntu SMP"
         ));
-        assert!(!is_wsl_proc_version(""));
+        assert!(!names_wsl_kernel(""));
     }
 
-    /// Nothing on macOS may be treated as WSL — `/proc/version` does not exist
-    /// there, and the call sites are `cfg!(target_os = "linux")`-gated anyway.
+    /// Nothing on macOS may be treated as WSL — neither `/run/WSL` nor the
+    /// `/proc` files exist there, and the call sites are
+    /// `cfg!(target_os = "linux")`-gated anyway.
     #[test]
     #[cfg(target_os = "macos")]
     fn is_wsl_is_false_on_macos() {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -719,12 +719,28 @@ impl Agent {
 
         // For Copilot, track editor shims as fallback
         let mut editor_shim: Option<PathBuf> = None;
+        // Windows-side installs reached through WSL interop, tracked only so the
+        // failure can name the cause instead of "not found in PATH".
+        let mut windows_interop: Option<PathBuf> = None;
 
         for binary_name in binary_names {
             for dir in path_var.split(':') {
                 let candidate = PathBuf::from(dir).join(binary_name);
 
                 if !candidate.is_file() {
+                    continue;
+                }
+
+                // WSL inherits the Windows PATH, so an agent installed on the
+                // Windows side shows up here as /mnt/c/.../<binary>. It is a
+                // Windows executable (or an npm shim that execs a Windows-side
+                // `node`), so it cannot run in the Linux sandbox. Skip it and
+                // keep looking — WSL appends the Windows PATH after the Linux
+                // one, so a distro-side install normally wins anyway (#188).
+                if cfg!(target_os = "linux") && is_windows_interop_path(&candidate) {
+                    if windows_interop.is_none() {
+                        windows_interop = Some(candidate);
+                    }
                     continue;
                 }
 
@@ -786,6 +802,19 @@ impl Agent {
             }
             Agent::Shell => unreachable!("Shell is resolved via $SHELL above"),
         };
+
+        if let Some(win) = windows_interop {
+            return Err(format!(
+                "{} resolves to a Windows install reached through WSL interop:\n  \
+                 {}\n  \
+                 Paths under /mnt/<drive>/ are the Windows filesystem: that binary is a Windows \
+                 executable (npm installs it as a shim that execs `node`), so it cannot run in \
+                 the Linux sandbox — and the distro has no `node` for the shim to exec.\n  \
+                 Fix: install Node and the agent inside the WSL distro. {install_hint}",
+                self.display_name(),
+                win.display()
+            ));
+        }
 
         Err(format!(
             "{} not found in PATH. {install_hint}",
@@ -924,6 +953,29 @@ pub fn canonicalize_agent_dirs(dirs: &mut [AgentDir]) {
     }
 }
 
+/// Is this path on a Windows drive exposed to WSL as `/mnt/<drive>/…`?
+///
+/// WSL2 mounts the Windows drives under `/mnt/c`, `/mnt/d`, … and (with
+/// interop enabled, the default) appends the Windows `PATH` to the distro's
+/// `PATH`. A tool installed on the Windows side therefore resolves inside the
+/// distro to `/mnt/c/Users/<user>/AppData/Roaming/npm/<name>` — a Windows
+/// executable, or the npm-generated shim that execs `node`. Neither runs in
+/// the Linux sandbox (#188).
+///
+/// The single-letter component is what separates a drive mount from an
+/// ordinary `/mnt/data`-style mount point. This is a heuristic on the path
+/// alone: it needs no WSL detection, and it is only consulted on Linux.
+pub fn is_windows_interop_path(path: &Path) -> bool {
+    let mut parts = path.components();
+    matches!(parts.next(), Some(std::path::Component::RootDir))
+        && parts.next().is_some_and(|c| c.as_os_str() == "mnt")
+        && parts.next().is_some_and(|c| {
+            let drive = c.as_os_str().as_encoded_bytes();
+            drive.len() == 1 && drive[0].is_ascii_alphabetic()
+        })
+        && parts.next().is_some()
+}
+
 /// Check if a copilot binary is a VS Code/Cursor/editor shim script.
 fn is_editor_shim(path: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
@@ -1041,6 +1093,40 @@ mod tests {
             process_exec: false,
             write_files: vec![],
         }
+    }
+
+    /// The exact path from the #188 report: Copilot CLI installed on the
+    /// Windows side, resolved inside the distro through WSL interop.
+    ///
+    /// Pure path logic, so it runs on every platform (the call site in
+    /// `resolve_binary` is Linux-gated, that part is not covered here).
+    #[test]
+    fn windows_interop_path_detects_npm_shim_on_c_drive() {
+        assert!(is_windows_interop_path(Path::new(
+            "/mnt/c/Users/someone/AppData/Roaming/npm/copilot"
+        )));
+        assert!(is_windows_interop_path(Path::new("/mnt/d/tools/copilot")));
+        // Drive letters are lowercase by default but casing is configurable.
+        assert!(is_windows_interop_path(Path::new("/mnt/C/tools/copilot")));
+    }
+
+    #[test]
+    fn windows_interop_path_ignores_ordinary_mounts_and_linux_paths() {
+        // Multi-character component: an ordinary mount point, not a drive.
+        assert!(!is_windows_interop_path(Path::new("/mnt/data/bin/copilot")));
+        assert!(!is_windows_interop_path(Path::new("/mnt/c1/bin/copilot")));
+        assert!(!is_windows_interop_path(Path::new(
+            "/usr/local/bin/copilot"
+        )));
+        assert!(!is_windows_interop_path(Path::new(
+            "/home/user/.local/bin/copilot"
+        )));
+        // A drive root is not a binary, and only absolute paths are mounts.
+        assert!(!is_windows_interop_path(Path::new("/mnt/c")));
+        assert!(!is_windows_interop_path(Path::new("mnt/c/bin/copilot")));
+        assert!(!is_windows_interop_path(Path::new("sub/mnt/c/copilot")));
+        // "mnt" must be the first component, not any component.
+        assert!(!is_windows_interop_path(Path::new("/opt/mnt/c/copilot")));
     }
 
     /// Dotfile managers routinely symlink `~/.config/<agent>` elsewhere. Both

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,6 +5,7 @@
 //! different binary names, config directories, and runtime requirements, but
 //! shares the same core sandbox infrastructure.
 
+use crate::ui;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -722,25 +723,13 @@ impl Agent {
         // Windows-side installs reached through WSL interop, tracked only so the
         // failure can name the cause instead of "not found in PATH".
         let mut windows_interop: Option<PathBuf> = None;
+        let wsl = cfg!(target_os = "linux") && is_wsl();
 
         for binary_name in binary_names {
             for dir in path_var.split(':') {
                 let candidate = PathBuf::from(dir).join(binary_name);
 
                 if !candidate.is_file() {
-                    continue;
-                }
-
-                // WSL inherits the Windows PATH, so an agent installed on the
-                // Windows side shows up here as /mnt/c/.../<binary>. It is a
-                // Windows executable (or an npm shim that execs a Windows-side
-                // `node`), so it cannot run in the Linux sandbox. Skip it and
-                // keep looking — WSL appends the Windows PATH after the Linux
-                // one, so a distro-side install normally wins anyway (#188).
-                if cfg!(target_os = "linux") && is_windows_interop_path(&candidate) {
-                    if windows_interop.is_none() {
-                        windows_interop = Some(candidate);
-                    }
                     continue;
                 }
 
@@ -763,6 +752,25 @@ impl Agent {
                     std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
                 if self_exe.as_ref() == Some(&resolved) {
                     continue; // skip cplt aliased as this binary
+                }
+
+                // Under WSL the Windows PATH is appended to the distro's, so an
+                // agent installed on the Windows side turns up here as
+                // /mnt/c/.../<binary>: a Windows executable, or the npm shim
+                // that execs `node`. Neither runs in the Linux sandbox. Skip it
+                // and keep looking — a distro-side install normally comes first
+                // in PATH anyway (#188). Checked after canonicalization so a
+                // distro-side symlink into /mnt is caught too, matching what
+                // `cplt doctor` reports.
+                if is_wsl_interop_binary(&resolved, wsl) {
+                    if windows_interop.is_none() {
+                        ui::warn(&format!(
+                            "Ignoring {} — Windows install reached through WSL interop",
+                            resolved.display()
+                        ));
+                        windows_interop = Some(resolved);
+                    }
+                    continue;
                 }
 
                 // Copilot-specific: prefer standalone over editor shims
@@ -807,9 +815,10 @@ impl Agent {
             return Err(format!(
                 "{} resolves to a Windows install reached through WSL interop:\n  \
                  {}\n  \
-                 Paths under /mnt/<drive>/ are the Windows filesystem: that binary is a Windows \
+                 Under WSL, /mnt/<drive>/ is the Windows filesystem: that binary is a Windows \
                  executable (npm installs it as a shim that execs `node`), so it cannot run in \
-                 the Linux sandbox — and the distro has no `node` for the shim to exec.\n  \
+                 the Linux sandbox — and unless you installed Node in the distro too, the shim \
+                 has no `node` to exec.\n  \
                  Fix: install Node and the agent inside the WSL distro. {install_hint}",
                 self.display_name(),
                 win.display()
@@ -834,6 +843,13 @@ impl Agent {
             .ok()
             .and_then(|p| std::fs::canonicalize(&p).ok());
 
+        // Same WSL interop rule as `resolve_binary`: a Windows-side copilot must
+        // not win auto-detection over a working distro-side agent (#188).
+        let wsl = cfg!(target_os = "linux") && is_wsl();
+        let usable = |resolved: &PathBuf| {
+            self_exe.as_ref() != Some(resolved) && !is_wsl_interop_binary(resolved, wsl)
+        };
+
         let mut found_copilot = false;
         let mut found_opencode = false;
         let mut found_gemini = false;
@@ -845,7 +861,7 @@ impl Agent {
                 if candidate.is_file() {
                     let resolved =
                         std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
-                    if self_exe.as_ref() != Some(&resolved) {
+                    if usable(&resolved) {
                         found_copilot = true;
                     }
                 }
@@ -855,7 +871,7 @@ impl Agent {
                 if candidate.is_file() {
                     let resolved =
                         std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
-                    if self_exe.as_ref() != Some(&resolved) {
+                    if usable(&resolved) {
                         found_opencode = true;
                     }
                 }
@@ -865,7 +881,7 @@ impl Agent {
                 if candidate.is_file() {
                     let resolved =
                         std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
-                    if self_exe.as_ref() != Some(&resolved) {
+                    if usable(&resolved) {
                         found_gemini = true;
                     }
                 }
@@ -877,7 +893,7 @@ impl Agent {
                     if candidate.is_file() {
                         let resolved =
                             std::fs::canonicalize(candidate).unwrap_or_else(|_| candidate.clone());
-                        if self_exe.as_ref() != Some(&resolved) {
+                        if usable(&resolved) {
                             found_antigravity = true;
                             break;
                         }
@@ -953,6 +969,35 @@ pub fn canonicalize_agent_dirs(dirs: &mut [AgentDir]) {
     }
 }
 
+/// Are we running inside WSL?
+///
+/// `WSL_DISTRO_NAME` and `WSL_INTEROP` are set by WSL in every distro session,
+/// and WSL2's `/proc/version` names the Microsoft-built kernel. Either signal
+/// is enough; both are absent on ordinary Linux, where `/mnt/c` is just a
+/// mount point somebody chose and must be left alone.
+pub fn is_wsl() -> bool {
+    std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::env::var_os("WSL_INTEROP").is_some()
+        || std::fs::read_to_string("/proc/version").is_ok_and(|v| is_wsl_proc_version(&v))
+}
+
+/// Does this `/proc/version` string come from a WSL kernel?
+///
+/// WSL1 and WSL2 both name Microsoft in it ("… Microsoft@Microsoft.com …",
+/// "…-microsoft-standard-WSL2 …"); a stock distro kernel does not.
+fn is_wsl_proc_version(version: &str) -> bool {
+    version.to_ascii_lowercase().contains("microsoft")
+}
+
+/// Must this resolved agent binary be refused as a Windows interop install?
+///
+/// The path shape alone is not enough — see [`is_windows_interop_path`] — so
+/// callers pass the WSL signal from [`is_wsl`] and this is the only place the
+/// two are combined.
+pub fn is_wsl_interop_binary(path: &Path, wsl: bool) -> bool {
+    wsl && is_windows_interop_path(path)
+}
+
 /// Is this path on a Windows drive exposed to WSL as `/mnt/<drive>/…`?
 ///
 /// WSL2 mounts the Windows drives under `/mnt/c`, `/mnt/d`, … and (with
@@ -963,8 +1008,10 @@ pub fn canonicalize_agent_dirs(dirs: &mut [AgentDir]) {
 /// the Linux sandbox (#188).
 ///
 /// The single-letter component is what separates a drive mount from an
-/// ordinary `/mnt/data`-style mount point. This is a heuristic on the path
-/// alone: it needs no WSL detection, and it is only consulted on Linux.
+/// ordinary `/mnt/data`-style mount point — but `/mnt/c` is also a perfectly
+/// ordinary mount on a non-WSL machine (a NAS, a second disk), so callers must
+/// gate this on [`is_wsl`]. On a Linux box that is not WSL, a real agent under
+/// `/mnt/d` has to keep working.
 pub fn is_windows_interop_path(path: &Path) -> bool {
     let mut parts = path.components();
     matches!(parts.next(), Some(std::path::Component::RootDir))
@@ -1098,8 +1145,9 @@ mod tests {
     /// The exact path from the #188 report: Copilot CLI installed on the
     /// Windows side, resolved inside the distro through WSL interop.
     ///
-    /// Pure path logic, so it runs on every platform (the call site in
-    /// `resolve_binary` is Linux-gated, that part is not covered here).
+    /// Pure path logic, so it runs on every platform. What is *not* covered
+    /// here: the `is_wsl() && …` gating at the three call sites, which needs a
+    /// real WSL environment (or process-wide env mutation) to exercise.
     #[test]
     fn windows_interop_path_detects_npm_shim_on_c_drive() {
         assert!(is_windows_interop_path(Path::new(
@@ -1115,6 +1163,8 @@ mod tests {
         // Multi-character component: an ordinary mount point, not a drive.
         assert!(!is_windows_interop_path(Path::new("/mnt/data/bin/copilot")));
         assert!(!is_windows_interop_path(Path::new("/mnt/c1/bin/copilot")));
+        // A single component that is not a drive letter.
+        assert!(!is_windows_interop_path(Path::new("/mnt/1/bin/copilot")));
         assert!(!is_windows_interop_path(Path::new(
             "/usr/local/bin/copilot"
         )));
@@ -1127,6 +1177,47 @@ mod tests {
         assert!(!is_windows_interop_path(Path::new("sub/mnt/c/copilot")));
         // "mnt" must be the first component, not any component.
         assert!(!is_windows_interop_path(Path::new("/opt/mnt/c/copilot")));
+    }
+
+    /// The gate itself: `/mnt/c` on a plain Linux box is a NAS, a second disk,
+    /// an encrypted volume — an agent there is real and must keep working.
+    #[test]
+    fn wsl_interop_binary_only_fires_under_wsl() {
+        let win = Path::new("/mnt/c/Users/someone/AppData/Roaming/npm/copilot");
+        assert!(is_wsl_interop_binary(win, true));
+        assert!(!is_wsl_interop_binary(win, false));
+        assert!(!is_wsl_interop_binary(
+            Path::new("/usr/local/bin/copilot"),
+            true
+        ));
+    }
+
+    /// `/mnt/c` is an ordinary mount point on plenty of non-WSL Linux boxes, so
+    /// the interop rule hangs entirely off this signal. Real `/proc/version`
+    /// strings, WSL2 and WSL1 vs a stock distro kernel.
+    #[test]
+    fn wsl_proc_version_distinguishes_wsl_from_stock_kernels() {
+        assert!(is_wsl_proc_version(
+            "Linux version 5.15.167.4-microsoft-standard-WSL2 \
+             (root@941d701f84f1) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37) #1 SMP"
+        ));
+        assert!(is_wsl_proc_version(
+            "Linux version 4.4.0-19041-Microsoft \
+             (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #1237-Microsoft"
+        ));
+        assert!(!is_wsl_proc_version(
+            "Linux version 6.8.0-45-generic (buildd@lcy02-amd64-091) \
+             (x86_64-linux-gnu-gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0) #45-Ubuntu SMP"
+        ));
+        assert!(!is_wsl_proc_version(""));
+    }
+
+    /// Nothing on macOS may be treated as WSL — `/proc/version` does not exist
+    /// there, and the call sites are `cfg!(target_os = "linux")`-gated anyway.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn is_wsl_is_false_on_macos() {
+        assert!(!is_wsl());
     }
 
     /// Dotfile managers routinely symlink `~/.config/<agent>` elsewhere. Both

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -443,6 +443,26 @@ impl Discovery {
             critical_ok = false;
         } else {
             for agent in &self.agents {
+                // A Windows-side install reached through WSL interop cannot run
+                // in the Linux sandbox, so reporting it as present is what let
+                // doctor say "all critical checks passed" for a setup that
+                // cannot start (#188). WSL appends the Windows PATH after the
+                // distro's, so `which` only lands here when no Linux-side
+                // install exists.
+                if cfg!(target_os = "linux") && crate::agent::is_windows_interop_path(&agent.path) {
+                    println!(
+                        "  {}✗{} {} ({}): {} — Windows install via WSL interop, cannot run in the \
+                         Linux sandbox. Install Node and {} inside the WSL distro.",
+                        ui::stdout_color(ui::RED),
+                        ui::stdout_color(ui::RESET),
+                        agent.name,
+                        agent.binary_name,
+                        agent.path.display(),
+                        agent.binary_name
+                    );
+                    critical_ok = false;
+                    continue;
+                }
                 if let Some(ref ver) = agent.version {
                     println!(
                         "  {}✓{} {} ({}) v{ver}: {}",

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -442,17 +442,20 @@ impl Discovery {
             );
             critical_ok = false;
         } else {
+            let wsl = cfg!(target_os = "linux") && crate::agent::is_wsl();
             for agent in &self.agents {
                 // A Windows-side install reached through WSL interop cannot run
                 // in the Linux sandbox, so reporting it as present is what let
                 // doctor say "all critical checks passed" for a setup that
-                // cannot start (#188). WSL appends the Windows PATH after the
-                // distro's, so `which` only lands here when no Linux-side
-                // install exists.
-                if cfg!(target_os = "linux") && crate::agent::is_windows_interop_path(&agent.path) {
+                // cannot start (#188). Gated on an actual WSL signal: on a plain
+                // Linux box /mnt/c is an ordinary mount and an agent there is
+                // fine. WSL appends the Windows PATH after the distro's, so
+                // `which` only lands here when no Linux-side install exists.
+                if crate::agent::is_wsl_interop_binary(&agent.path, wsl) {
                     println!(
-                        "  {}✗{} {} ({}): {} — Windows install via WSL interop, cannot run in the \
-                         Linux sandbox. Install Node and {} inside the WSL distro.",
+                        "  {}✗{} {} ({}): {} — Windows install reached through WSL interop, \
+                         cannot run in the Linux sandbox. Install Node and {} inside the WSL \
+                         distro.",
                         ui::stdout_color(ui::RED),
                         ui::stdout_color(ui::RESET),
                         agent.name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5664,12 +5664,16 @@ fn ensure_copilot_extracted(
         }
         Ok(())
     } else {
-        Err(
+        Err(format!(
             "Copilot runtime extraction failed. The sandbox blocks writes to copilot/pkg,\n  \
              so extraction must succeed before entering the sandbox.\n  \
-             Fix: run 'copilot --version' manually, then retry cplt."
-                .to_string(),
-        )
+             Binary: {}\n  \
+             Version reported: {}\n  \
+             Fix: run '{} --version' manually and read its output, then retry cplt.",
+            copilot_bin.display(),
+            reported_version.as_deref().unwrap_or("could not parse"),
+            copilot_bin.display(),
+        ))
     }
 }
 
@@ -5857,12 +5861,16 @@ fn ensure_copilot_extracted_linux(
         }
         Ok(())
     } else {
-        Err(
+        Err(format!(
             "Copilot runtime extraction failed. The sandbox blocks writes to copilot cache,\n  \
              so extraction must succeed before entering the sandbox.\n  \
-             Fix: run 'copilot --version' manually, then retry cplt."
-                .to_string(),
-        )
+             Binary: {}\n  \
+             Version reported: {}\n  \
+             Fix: run '{} --version' manually and read its output, then retry cplt.",
+            copilot_bin.display(),
+            reported_version.as_deref().unwrap_or("could not parse"),
+            copilot_bin.display(),
+        ))
     }
 }
 


### PR DESCRIPTION
Closes #188. Closes #189.

## Second pass — external research changed both halves

Nobody here has a WSL2 machine, so the claims were grounded against primary sources: Microsoft's WSL and WSL2-Linux-Kernel repos, kernel.org, Ubuntu package archives, and the tool vendors' own docs.

### Landlock IS available on WSL2 — the load-bearing unknown, answered

`CONFIG_SECURITY_LANDLOCK=y` and `landlock` is **first** in `CONFIG_LSM` on every Microsoft kernel branch — 5.15, 6.1, 6.6, 6.18, x86 and arm64 (`arch/x86/configs/config-wsl` in microsoft/WSL2-Linux-Kernel). WSL's default kernel command line contains no `lsm=` override (`WslCoreVm.cpp:1612`). Microsoft announced it in kernel 5.15.57.1.

So the docs now assert it with a citation instead of hedging. The risk that replaces it: a user who sets `[wsl2] kernelCommandLine` with an `lsm=` list omitting `landlock`, or a custom `[wsl2] kernel=`, loses enforcement — and `landlock_create_ruleset()` then returns `EOPNOTSUPP` rather than `ENOSYS`.

ABI floor now stated: current WSL (2.7.x) ships 6.18 → ABI 7; installs still on 6.6 get **ABI 3**, losing network rules (ABI 4), ioctl restriction (ABI 5) and signal/abstract-socket scoping (ABI 6). Read from the shipped `security/landlock/syscalls.c` in each branch.

### Two of the three detection signals were the wrong choice

`WSL_DISTRO_NAME` and `WSL_INTEROP` are **removed from the gate**. They are absent under `sudo` (microsoft/WSL#5914, #9719), absent in systemd units and cron, and trivially spoofable by any user — disqualifying for a security-relevant decision. WSL's own interop doc treats `WSL_INTEROP` absence as an expected state.

The gate is now `/run/WSL` (snapd's primary signal, created by WSL's init) OR a case-insensitive `microsoft`/`wsl` match on `/proc/sys/kernel/osrelease` or `/proc/version` (systemd's approach, which tests both markers). Cached in a `OnceLock`.

The case-insensitivity was already right and is now documented with its reason: WSL2 writes `-microsoft-standard-WSL2` with a **lowercase** m, WSL1 wrote `4.4.0-19041-Microsoft` with a capital M — so a case-sensitive check for "Microsoft" is a WSL2 false negative.

### `/mnt/<letter>` is a heuristic, and the ceiling is documented

`[automount] root` in `/etc/wsl.conf` is user-configurable — Microsoft's own docs use `/windir/c` as the example — and drives can be mounted anywhere via `mount -t drvfs` or `/etc/fstab`. The structurally correct source is `/proc/self/mountinfo` (longest-matching mount with fstype `9p`+`aname=drvfs`, `virtiofs`, `virtio-plan9`, or `drvfs`).

Deliberately **not** implemented: with the WSL gate in place the non-WSL false positive is gone, the false-negative cost is now low (an undetected shim fails later with its own path printed), and a relocated automount root is rare. What mountinfo buys is a better message in an unusual configuration, for ~30 lines of parser plus tests. The exact upgrade path is written into the predicate's doc comment.

`/mnt/wsl` and `/mnt/wslg` exclusion is now deliberate rather than incidental — two asserts pin it, and one mutant is killed by exactly that case.

### Docs corrections research forced

- **Node.** `sudo apt install -y nodejs npm` gives Node **18** on Ubuntu 24.04; Copilot CLI documents **Node 22+**. The original one-liner simply would not work for anyone following it. Now named per release (26.04 ships 22.22 and works).
- **`gh`** was over-hedged the other way: it *is* in Ubuntu universe (2.45 on 24.04, 2.46 on 26.04). `apt install gh` works, it is just old.
- **`wsl --install` now defaults to Ubuntu 26.04 LTS** (pinned in `distributions/DistributionInfo.json`). Recently changed. `-d Ubuntu-24.04` pins the older one.
- **`/mnt/c` is still 9p by default** as of WSL 2.9.x; virtiofs is opt-in via `[wsl2] virtiofs=true` and is not in the published `.wslconfig` table.
- PATH ordering hedged, plus: disabling interop does **not** unmount `/mnt/c`.
- All `WSL_DISTRO_NAME`-based troubleshooting advice removed.

### Two findings we had no idea about — cplt is clean on both

Every process on WSL2 already inherits a seccomp filter installed by WSL itself. `SECCOMP_FILTER_FLAG_NEW_LISTENER` fails with `EBUSY` there (microsoft/WSL#9548, open since 2023), and anything reading `/proc/self/status` `Seccomp:` to decide "am I already sandboxed?" gets a false positive on every WSL2 process.

Checked both: `apply_seccomp_filter` is a plain `prctl(PR_SET_SECCOMP, ...)` with no `seccomp(2)` flags, so it stacks; and nothing in `src/` or `tests/` reads `/proc/self/status` — the recursion guard is `__CPLT_WRAPPED`. No code bug either way.

Also: Ubuntu 23.10+ blocks unprivileged user namespaces via `kernel.apparmor_restrict_unprivileged_userns`, which breaks bwrap. That sysctl is an Ubuntu **kernel patch**, absent from the Microsoft kernel (zero occurrences in `security/apparmor/lsm.c` on 6.6 and 6.18), so Ubuntu-on-WSL2 is not expected to hit it. Documented as inference-from-kernel-source with a request to report.

### Final unverified list

Landlock availability comes **off** it. What remains: Landlock enforcement on `/mnt/c` (no primary source either way; the kernel documents no exclusion for network or FUSE-backed filesystems, and Landlock's own test tooling exercises 9p and FUSE, so we expect it to work), bwrap under WSL2, distro package versions, and the install sequence end to end.

10 mutants, all killed. lib 713; 26 / 132 (+6 pre-existing ignored) / 107 / 43 / 54 / 266 — all passing.

Still untested and stated plainly: the `cfg!(target_os = "linux") && is_wsl()` computation at the three call sites, and the `/run/WSL` branch. Both need a real WSL box.


Two angles on the same user's WSL2 experience.

## #188 — the diagnosis, not the platform

Under WSL2, `copilot` on PATH can resolve to the Windows npm shim under `/mnt/c/...`. `node` does not exist inside the distro, so the agent cannot start — but the user saw "runtime extraction failed", and `cplt doctor` still said "All critical checks passed".

Both halves verified in code:

- **The misleading message is reachable for this cause.** `ensure_copilot_extracted_linux` spawns `copilot --no-auto-update --version`. The WSL npm shim exits 127 (`exec: node: not found`), so `child_exit_ok` is false, the "no SEA extraction" escape hatch is skipped, and the generic error fires. stderr was `Stdio::null()`, so the real reason was thrown away.
- **Why doctor passed.** `print_report` prints `✓ <Agent>` for anything `which_resolved` finds, whether or not the version probe succeeded, and `node` lives only in `TOOLS_TO_CHECK`, which never touches `critical_ok`. "All critical checks passed ✓" was structurally guaranteed in this setup.

A doctor that reports green while the agent cannot start is the actual defect here — same class as the silent non-enforcement bugs fixed elsewhere today.

Changes:

- `src/agent.rs`: `is_windows_interop_path` — absolute, first component `mnt`, second a single ASCII letter, plus at least one more component. `resolve_binary` skips such candidates on Linux and keeps searching (WSL appends the Windows PATH last, so a distro-side install already wins). If it was the only match, the error names the cause and points at installing Node and the agent inside the distro.
- `src/discover.rs`: doctor prints `✗` for an agent on such a path and sets `critical_ok = false`.
- `src/main.rs`: both extraction failure messages now carry the binary path and the version copilot reported. That is the small, safe part of #166; the stale-dir deadlock is untouched.

Mutation-checked, and one mutation is worth reporting because it initially **survived**: replacing the `RootDir` anchor with `is_some()` passed both tests until a `!is_windows_interop_path("sub/mnt/c/copilot")` assertion was added. The other two (dropping the single-letter check, dropping the trailing-component requirement) failed immediately.

## #189 — the docs

A Windows bullet next to macOS/Linux, and a `### Windows (WSL2)` install section: PowerShell `wsl --install` / `--update`, then inside the distro node/npm, `gh` + `gh auth login`, `npm i -g @github/copilot`, `install.sh` or brew, `cplt doctor`. Plus the Windows-side-install warning that cross-references #188, the kernel requirement, and project-location guidance.

## What is NOT verified

Neither I nor the agent that wrote this can test WSL2 from a macOS host, and the docs say so in a marked block rather than presenting inference as tested. The claims a real WSL2 user needs to confirm:

1. `wsl --install` yields a kernel with **Landlock enabled** — the load-bearing unknown. If not, cplt refuses to sandbox at all.
2. `sudo apt install -y nodejs npm` gives a Node new enough for current Copilot CLI (hedged in the docs; the hedge itself is untested).
3. `gh` is in the distro's default repos — on some Ubuntu releases it needs the GitHub apt repo.
4. `install.sh` runs cleanly in a fresh distro, and `brew install navikt/tap/cplt` works on Linuxbrew.
5. `cplt doctor` reaches the Landlock probe and prints a sane ABI/kernel line.
6. The new error text fires for a real `/mnt/c/.../npm/copilot` — detection is unit-tested on a fake path only.
7. Whether Landlock enforces normally for a project under `/mnt/c` (9p/drvfs). Documented as unproven, **not** as broken.
8. `wsl --update` as the remedy for an old kernel — Microsoft's documented behaviour, not something this repo can verify.

Landlock 5.13+/6.7+ and the doctor kernel/ABI output are real repo claims (`src/sandbox_landlock.rs:887`, `docs/security.md:48`), not inference.

## Coverage limits

The predicate is pure path logic and runs on macOS too, so its test is not vacuous there. The `cfg!(target_os = "linux")` gating at the two call sites is **not** covered — a `resolve_binary` test would have to mutate `PATH` process-wide, which is racy under parallel tests.

`cargo test`: lib 710, then 26 / 132 (+6 pre-existing ignored) / 107 / 43 / 54 / 266 — all passing. fmt and clippy clean.

One thing flagged rather than hidden: during an intermediate run the lib suite reported 709 passed / 1 failed, not reproducible in 9 subsequent runs and the test name was not captured. Nothing in this diff touches a plausible candidate; the timing-sensitive proxy tests are the likely suspect. Recording it here in case it recurs.

