### PR TITLE
fix(proxy): escape control characters in the proxy log sinks

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -77,6 +77,20 @@ jobs:
           # Matches the `extended` query suite the default setup used, so this
           # swap does not quietly narrow what gets flagged.
           queries: security-extended
+          # Deliberately no `config-file:`. The recurring false positives are
+          # 30 `rust/log-injection` alerts whose source AND sink both sit inside
+          # the `#[cfg(test)] mod tests` at the bottom of src/proxy.rs (a
+          # TcpStream the test opened to a listener it spawned in-process,
+          # reported at an `assert!` message), plus one `rust/cleartext-logging`
+          # for the scratch session id, reported at src/ui.rs:96 — the shared
+          # `ui::info` eprintln. `paths-ignore` filters whole FILES, never a
+          # module inside one, so the only patterns that would silence these are
+          # `src/proxy.rs` and `src/ui.rs` — which would blind CodeQL to the
+          # CONNECT proxy and to every output helper, exactly the code worth
+          # scanning. `query-filters` is no better: it drops a query repo-wide,
+          # and rust/log-injection has already earned its keep here (a real
+          # ESC-injection sink in `log_connection`). Test-code alerts are
+          # dismissed as "used in tests" in the security tab instead.
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # ratchet:github/codeql-action/analyze@v4.37.8

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -83,7 +83,7 @@ jobs:
           # TcpStream the test opened to a listener it spawned in-process,
           # reported at an `assert!` message), plus one `rust/cleartext-logging`
           # for the scratch session id, reported at src/ui.rs:96 — the shared
-          # `ui::info` eprintln. `paths-ignore` filters whole FILES, never a
+          # `ui::ok` eprintln. `paths-ignore` filters whole FILES, never a
           # module inside one, so the only patterns that would silence these are
           # `src/proxy.rs` and `src/ui.rs` — which would blind CodeQL to the
           # CONNECT proxy and to every output helper, exactly the code worth

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1995,6 +1995,32 @@ fn log_connection(state: &ProxyState, method: &str, target: &str, status: &str) 
     let log_file = state.log_file.as_deref();
     let level = state.log_level;
 
+    // SECURITY: `method` and `target` are agent-controlled. Both are sliced
+    // straight out of the CONNECT request line in `handle_connection`, and this
+    // function is the ONE sink they reach: the stderr verdict line below, the
+    // `--proxy-log` audit file, and — via `record_observation` — the observed
+    // host set that `--observe-domains-out` writes as a ready-to-paste
+    // allowlist. Escaping here therefore covers all three.
+    //
+    // `lines()` + `split_whitespace()` upstream already make CR/LF (and every
+    // other whitespace class, incl. VT/FF/NEL/U+2028) unforgeable, so the
+    // space-delimited audit format cannot be forged. ESC (0x1b) is NOT
+    // whitespace and survived untouched: a target of "\x1b[2K\r" let the agent
+    // ERASE or overwrite the very BLOCKED lines the user is watching, and
+    // landed raw in the audit file for `cat` to re-emit.
+    //
+    // Escape rather than strip: the audit log must show that something odd was
+    // attempted, not silently swallow it. `escape_debug` leaves printable
+    // Unicode alone (IDN hostnames, punycode and UTF-8 alike) while covering
+    // C0/C1, DEL, bidi overrides and zero-width formatters — a wider net than
+    // "strip C0 controls" for one stdlib call, and lossless.
+    let (method, target, status) = (
+        method.escape_debug().to_string(),
+        target.escape_debug().to_string(),
+        status.escape_debug().to_string(),
+    );
+    let (method, target, status) = (method.as_str(), target.as_str(), status.as_str());
+
     // Record the observation for every CONNECT verdict, regardless of the stderr
     // log level or whether a --proxy-log file is set. This is the single choke
     // point every verdict flows through, so the collector sees the FULL set of
@@ -3392,6 +3418,111 @@ mod tests {
             }
             Err(e) => format!("ERROR: {e}"),
         }
+    }
+
+    /// A control character in the agent's request line must never reach a log
+    /// sink verbatim.
+    ///
+    /// Drives the REAL path — raw request lines over TCP into a live proxy —
+    /// and inspects both sinks `log_connection` feeds: the `--proxy-log` audit
+    /// file and the observed-host set behind `--observe-domains-out`. The
+    /// stderr verdict line is formatted from the same two escaped locals, so
+    /// the file assertion covers it too.
+    ///
+    /// Without the escaping, `\x1b[2K\r` in a CONNECT target reaches the
+    /// user's terminal intact and erases the BLOCKED lines they are watching —
+    /// including the one this very request produces.
+    #[test]
+    fn proxy_log_sinks_escape_control_characters() {
+        require_localhost_tcp!();
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("proxy.log");
+
+        // Resolution always fails: the verdict is deterministic (still logged
+        // AND recorded) and no lookup for a control-character host leaves the
+        // machine.
+        let resolver: ResolverFn = Arc::new(|_h: &str, _p: u16| None);
+        let proxy = start(ProxyOptions {
+            port: 0,
+            blocked_file: PathBuf::from("/dev/null"),
+            allowed_ports: vec![443, 80],
+            allow_localhost_ports: Vec::new(),
+            allow_localhost_any: false,
+            allowed_domains_file: None,
+            allowed_domains_initial: Vec::new(),
+            default_allowlist: Vec::new(),
+            subscription_blocklist: Vec::new(),
+            cli_private_domains: Vec::new(),
+            config_private_domains: Vec::new(),
+            repo_private_domains: Vec::new(),
+            config_file: None,
+            log_file: Some(log.clone()),
+            log_level: ProxyLogLevel::All,
+            timeout: Duration::from_secs(5),
+            upstream: None,
+            upstream_no_proxy: Vec::new(),
+            resolver: Some(resolver),
+        })
+        .expect("proxy start failed");
+
+        // Raw request lines, exactly as a hostile agent would send them.
+        let attacks = [
+            // ESC and BEL inside the hostname — neither is whitespace, so both
+            // survive `lines()` and `split_whitespace()` into `target`.
+            "CONNECT evil\x1b[2K\x07.example:443 HTTP/1.1",
+            // Line-erase payload: `split_whitespace()` leaves "\x1b[2K" as the
+            // target and drops the rest of the line.
+            "CONNECT \x1b[2K\rEVIL.example:443 HTTP/1.1",
+            // The METHOD is agent-controlled too and is logged (UNSUPPORTED).
+            "GE\x1bT http://evil.example/ HTTP/1.1",
+        ];
+        for line in attacks {
+            let mut conn =
+                std::net::TcpStream::connect(format!("127.0.0.1:{}", proxy.port)).unwrap();
+            let _ = write!(conn, "{line}\r\nHost: x\r\n\r\n");
+            let mut drain = Vec::new();
+            let _ = std::io::Read::read_to_end(&mut conn, &mut drain);
+        }
+
+        let observed = proxy.observed_domains();
+        proxy.shutdown();
+
+        let bytes = std::fs::read(&log).expect("audit log must exist");
+        let text = String::from_utf8(bytes.clone()).expect("audit log must stay UTF-8");
+        assert_eq!(
+            text.lines().count(),
+            attacks.len(),
+            "one audit line per request: {text:?}"
+        );
+        let raw: Vec<u8> = bytes
+            .iter()
+            .copied()
+            .filter(|b| (*b < 0x20 && *b != b'\n') || *b == 0x7f)
+            .collect();
+        assert!(
+            raw.is_empty(),
+            "control characters reached the --proxy-log audit file: {raw:?} in {text:?}"
+        );
+        assert!(
+            text.contains("\\u{1b}"),
+            "the escape attempt must survive in the log as evidence, \
+             not be silently stripped: {text:?}"
+        );
+
+        for o in &observed {
+            assert!(
+                !o.host.chars().any(char::is_control),
+                "control characters reached the observed-domain set that \
+                 --observe-domains-out writes as an allowlist: {:?}",
+                o.host
+            );
+        }
+        assert!(
+            observed.iter().any(|o| o.host.contains("\\u{1b}")),
+            "the hostile targets must still be recorded, escaped: {observed:?}"
+        );
     }
 
     fn make_proxy(allow_localhost_ports: Vec<u16>, allow_localhost_any: bool) -> ProxyHandle {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3478,7 +3478,19 @@ mod tests {
             // The METHOD is agent-controlled too and is logged (UNSUPPORTED).
             "GE\x1bT http://evil.example/ HTTP/1.1",
         ];
-        for line in attacks {
+        // Legitimate targets that must pass through the escaping VERBATIM. The
+        // guard is only acceptable because it is lossless for real hostnames:
+        // swapping `escape_debug` for `escape_default` would mangle the IDN
+        // into "m\u{fc}nchen.de" in the terminal, in the audit file, and in
+        // the --observe-domains-out allowlist, where it silently stops
+        // matching anything. Punycode and the trailing dot are the other two
+        // spellings a user can legitimately see.
+        let legit = [
+            "CONNECT münchen.de:443 HTTP/1.1",
+            "CONNECT xn--mnchen-3ya.de:443 HTTP/1.1",
+            "CONNECT example.com.:443 HTTP/1.1",
+        ];
+        for line in attacks.iter().chain(legit.iter()) {
             let mut conn =
                 std::net::TcpStream::connect(format!("127.0.0.1:{}", proxy.port)).unwrap();
             let _ = write!(conn, "{line}\r\nHost: x\r\n\r\n");
@@ -3493,7 +3505,7 @@ mod tests {
         let text = String::from_utf8(bytes.clone()).expect("audit log must stay UTF-8");
         assert_eq!(
             text.lines().count(),
-            attacks.len(),
+            attacks.len() + legit.len(),
             "one audit line per request: {text:?}"
         );
         let raw: Vec<u8> = bytes
@@ -3523,6 +3535,28 @@ mod tests {
             observed.iter().any(|o| o.host.contains("\\u{1b}")),
             "the hostile targets must still be recorded, escaped: {observed:?}"
         );
+
+        // Lossless for legitimate hostnames: UTF-8 IDN, punycode and the
+        // trailing-dot form all survive both sinks byte-for-byte (the observed
+        // set additionally lowercases and strips the trailing dot, which is
+        // `normalize_hostname`'s long-standing job, not the escaping's).
+        for host in [
+            "münchen.de:443",
+            "xn--mnchen-3ya.de:443",
+            "example.com.:443",
+        ] {
+            assert!(
+                text.contains(host),
+                "escaping must not touch a legitimate hostname: {host:?} missing from {text:?}"
+            );
+        }
+        for host in ["münchen.de", "xn--mnchen-3ya.de", "example.com"] {
+            assert!(
+                observed.iter().any(|o| o.host == host),
+                "escaping must not mangle a legitimate hostname in the \
+                 --observe-domains-out set: {host:?} missing from {observed:?}"
+            );
+        }
     }
 
     fn make_proxy(allow_localhost_ports: Vec<u16>, allow_localhost_any: bool) -> ProxyHandle {


### PR DESCRIPTION
CodeQL flagged 30 `rust/log-injection` alerts in `src/proxy.rs` and one `rust/cleartext-logging`. Triage found all 31 are false positives — **and that the scanner missed the one production sink that does take agent-controlled input.**

## What CodeQL found, and why none of it is real

The 30 log-injection alerts are all inside `#[cfg(test)] mod tests` (which starts at `src/proxy.rs:2085`; every flagged line is 3165–4971). The "source" is a `TcpStream` the test itself opened to a listener the same test spawned in-process; the "sink" is an `assert!` failure message. Nothing is logged, and `cargo test` output is not machine-parsed anywhere in this repo.

The cleartext-logging alert is the scratch directory path — `generate_session_id()` is 16 bytes of hex from `/dev/urandom` used as a directory name, in a base dir that is 0700 and owner-checked, and the path is compiled into the sandbox profile so the agent knows it by construction. CodeQL flagged it on the *name* `session_id`.

## What it missed

`log_connection` (`src/proxy.rs:1994`) is the production sink, and its `target` comes straight out of the CONNECT request line — fully agent-controlled. CodeQL never flagged it because it has no source model for the accept-side read.

Newline forgery is impossible: `lines()` strips `\n`/`\r` and `split_whitespace()` also removes VT, FF, NEL, U+2028 and U+2029, so the space-delimited audit format cannot be forged. That holds by accident rather than by design.

**But `\x1b` is not whitespace and survives all three filters.** Verified directly:

```
CONNECT \x1b[2K\rEVIL.example:443 HTTP/1.1
  parts = ["CONNECT", "\u{1b}[2K", "EVIL.example:443", "HTTP/1.1"]
  target bytes = [27, 91, 50, 75]
```

Those bytes reach the user's terminal verbatim via the `eprintln!` at `:2022` under `--proxy-log-level blocked` or `all`, and are written raw into the `--proxy-log` file, where `cat` re-emits them. **An agent can erase or overwrite the proxy verdict lines the user is watching — including its own BLOCKED lines.** That is directly against the threat model.

`method` is agent-controlled too, from the same `split_whitespace()` line, and logged verbatim at `:1025` — `GE\x1bT http://… HTTP/1.1` was an equally good vector. The original triage missed that one.

## Fix

One guard at the top of `log_connection`, escaping `method`, `target` and `status`. Every consumer traced first:

| Consumer | Reached via |
|---|---|
| stderr `eprintln!` (`:2022`) | agent-controlled, was raw |
| audit-file `writeln!` (`:2036`) | agent-controlled, was raw |
| `record_observation` (`:2010`) → `observed_domains` → `--observe-domains-out` | agent-controlled, was raw |
| `handle_connect` → `normalize_hostname` → policy matching | not a log sink |

`record_observation` has exactly one non-test caller and it is inside `log_connection`, so the single guard genuinely covers all three sinks — confirmed by mutation, not assumed.

**Escape rather than strip**, using `escape_debug()`:

- An audit log exists to record that something odd was attempted. Stripping turns `GE\x1bT` into a clean-looking `GET` and `evil\x1b[2K.example` into `evil[2K.example` — the attack becomes a typo. Mutation 3 below shows exactly that output.
- It is lossless and reversible; "strip C0" destroys evidence.
- **It does not touch IDNs.** Verified: `münchen.de` and `xn--mnchen-3ya.de` pass through unchanged, while `\x1b` and bidi overrides (U+202E) are escaped.
- It covers more than a hand-rolled hostname allowlist would: C0, C1, DEL, bidi overrides, zero-width formatters. A stricter `[a-z0-9.-]` rule was tempting and defensible on the wire, but it would reject UTF-8 IDNs that `normalize_hostname`'s Unicode `to_lowercase()` implies cplt accepts today.

## Mutation check — four, all killed

| mutation | result |
|---|---|
| escaping removed | fails, raw bytes `[27, 7, 27, 27]` in the audit file |
| `target` escaped but `method` not | fails on `[27]` — proves the method sink is covered |
| `escape_debug` → strip controls | fails the evidence assertion, printing the sanitised-into-plausibility log |
| escaping moved *below* `record_observation` | fails on `"\u{1b}[2k"` in the observed-domain set — proves placement, not just existence, is load-bearing |

The test drives the real path: three raw request lines over TCP into a live `start()`ed proxy with an injected always-fail resolver (deterministic, no DNS), asserting on the actual `--proxy-log` file bytes and on `observed_domains()`.

## CodeQL config: deliberately none

`paths-ignore` **cannot** express this. The Rust job runs `build-mode: none`, so path filters do apply — but they are glob filters over whole files with no sub-file granularity. The only pattern that silences the 30 test-module alerts is `src/proxy.rs`, which would remove the CONNECT proxy — including the sink this PR fixes — from analysis entirely.

Alert 9 is worse than first triaged: its reported location is **`src/ui.rs:96`**, the shared `ui::info` eprintln, not `src/scratch.rs` (that is only the source). Ignoring its file would drop every prefixed-output helper in the binary. `query-filters` only excludes a query repo-wide, and `rust/log-injection` has just earned its keep on this exact file.

So: a 14-line comment in `codeql.yaml` recording the reasoning where the next person will look, and no config file that would do nothing.

**Recommended follow-up, not done here:** bulk-dismiss alerts 10–39 as "used in tests" and alert 9 as a false positive, in the security tab. No GitHub state was touched.

## Flagged rather than smoothed over

- **Alert 8** (`actions/cache-poisoning/direct-cache`, `release.yaml:75`) is also open and was not assessed here — it is what PR #176 addresses.
- Escaping happens *before* `record_observation`, so a hostile host lands in `--observe-domains-out` escaped (`\u{1b}[2k`). Judged correct — inert as an allowlist entry, visible as evidence — but "drop non-hostname entries from the out-file entirely" is a defensible alternative.
- `connect_via_upstream` still sends the **un-escaped** host on the upstream CONNECT line (`:1443`). CR/LF remain unforgeable there so there is no request smuggling, and it is not a terminal sink. A reviewer may prefer rejecting a control-character request line outright at the trust boundary in `handle_connection`; that would not remove the need for the sink guard, and no such target can resolve anyway.

1405 passed, 0 failed, 6 ignored. fmt and clippy clean.

## Second pass — adversarial review

**Verdict: SAFE TO MERGE.** The guard placement was verified complete rather than assumed: `record_observation` has exactly one non-test caller, at `src/proxy.rs:2036` inside `log_connection` *after* the escape shadowing, and all 20 `log_connection` call sites pass raw agent strings only as `method`/`target`. Every other proxy-side `eprintln!` (654, 687, 1736) prints config paths or io errors. `relay`/`pump`, the accept loop and `read_upstream_connect_status` log nothing agent-controlled. Raw C1 bytes cannot sneak past either — `from_utf8_lossy` turns them into U+FFFD, and UTF-8-encoded C1 (U+009B, U+0085) is escaped.

`escape_debug` was checked empirically: it escapes ESC, BEL, DEL, C1, NEL, bidi overrides, ZWJ and U+2028/9, and passes through IDNs, punycode, trailing dots, RTL letters, mid-string combining marks, `[::1]:443` and `host:port` untouched. Nothing terminal-dangerous survives it, since every terminal control sequence needs ESC or C1.

Nothing parses `--proxy-log`; the one e2e consumer greps a plain hostname, unaffected by escaping. Length is bounded by `handle_connection`'s single 8192-byte read — at most ~8KB raw, ~48KB escaped per line.

### One gap closed

**The Unicode passthrough property this fix advertises had no test behind it.** Mutating `escape_debug()` → `escape_default()` passed **all 739 lib tests**, while mangling every non-ASCII hostname: `münchen.de` → `m\u{fc}nchen.de` in the terminal, in the audit file, and in `--observe-domains-out`, where the entry becomes a silently inert allowlist line.

The test now sends three legitimate targets alongside the hostile ones — a UTF-8 IDN, its punycode form, and a trailing-dot host — and asserts each appears verbatim in the audit file and exactly in the observed set. The trailing-dot and lowercasing difference between the two sinks is asserted explicitly and attributed to `normalize_hostname` in a comment, so nobody later reads it as escaping damage.

The `escape_default` mutant now fails on the first new assertion. The four earlier mutants still fail as before.

### Recorded, deliberately not fixed here

The gh/git gate BLOCKED messages (`src/main.rs:2635`, `src/gh_proxy.rs:1646,1669,1684,1704,1722`) interpolate agent argv and `eprintln!` it unescaped — the same bug class. But the sink is the sandboxed process's own inherited stderr, which the agent can already write arbitrary ESC bytes to directly, and there is no file sink. No new capability, so it is a consistency follow-up rather than a hole.

A mutant dropping only `status.escape_debug()` survives, and that is fine: every `status` today is a constant or an OS `{e}` string carrying at most a resolved IP. That escape is defence in depth against a future field, not a live path.

The `codeql.yaml` comment named `ui::info` where `src/ui.rs:96` is in fact `ui::ok`; corrected. The same slip is in the body of commit `4135e20`, left alone rather than force-pushing history under an open PR.

1405 passed, 0 failed, 6 ignored.
