### PR TITLE
docs(gradle): back the SBPL claim with the kernel result, add a workaround

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -376,6 +376,24 @@ forkOptions {
 
 Known affected: `ktlint-gradle` ([JLLeitschuh/ktlint-gradle#1110](https://github.com/JLLeitschuh/ktlint-gradle/issues/1110)). SBPL itself cannot be fixed — macOS sandbox profiles have no primitive for IPv4-mapped addresses, which is why cplt uses the `preferIPv4Stack` workaround at all.
 
+That last claim is not a guess. SBPL accepts only `*` or `localhost` as the host in a `remote ip` rule; a literal address is a parse error, and the `localhost` token does not match an IPv4-mapped connect:
+
+```
+(remote ip "*:*")                  connect succeeds
+(remote ip "localhost:*")          PermissionError [Errno 1] Operation not permitted
+(remote ip "::ffff:127.0.0.1:*")   sandbox-exec: host must be * or localhost in network address
+(remote ip "127.0.0.1:*")          sandbox-exec: host must be * or localhost in network address
+```
+
+So the only rule that would match these workers is `*:*`, which allows every outbound address rather than loopback. `--allow-localhost-any` will not be widened to mean that.
+
+**Workaround until the plugin propagates the environment:** run the affected tasks outside cplt, and keep the rest of the build inside.
+
+```bash
+./gradlew ktlintFormat
+./gradlew ktlintCheck detektMain detektTest build
+```
+
 ## Gradle toolchain JDKs
 
 `~/.gradle` is a dependency store: the sandbox grants read, write, and `file-map-executable` (for JNI libs) but **not** `process-exec`, so a rogue agent cannot drop a binary into the dependency cache and run it. Gradle's toolchain support auto-provisions JDKs into `~/.gradle/jdks`, which lands inside that non-executable tree — forking a toolchain `javac` or test JVM failed with `Operation not permitted`, and no config key could grant exec.


### PR DESCRIPTION
Follow-up to #222.

The WorkerExecutor section of `known-impacts.md` already said SBPL cannot be fixed because macOS sandbox profiles have no primitive for IPv4-mapped addresses. That was asserted rather than shown, which is why the "just match `::ffff:127.0.0.1`" suggestion keeps coming back.

Tested against `sandbox-exec` with a dual-stack listener and a client connecting to `::ffff:127.0.0.1`:

```
(remote ip "*:*")                  connect succeeds
(remote ip "localhost:*")          PermissionError [Errno 1] Operation not permitted
(remote ip "::ffff:127.0.0.1:*")   sandbox-exec: host must be * or localhost in network address
(remote ip "127.0.0.1:*")          sandbox-exec: host must be * or localhost in network address
```

SBPL accepts only `*` or `localhost` as the host. There is no literal-address form to narrow to, so the only rule that would match these workers is `*:*`, which is every outbound address rather than loopback. That is a real widening of `--allow-localhost-any` and this PR records why we are not doing it.

Also adds the practical workaround, which the section was missing: run the affected tasks outside cplt.

Docs only, no behaviour change.
