### PR TITLE
fix(config): explain the TOML scoping trap when a section name is used as a key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,7 +164,7 @@ cplt config explain proxy.forced
 
 For arrays of objects, multi-line values, and other complex configuration, edit the file directly and run `cplt config validate` afterwards.
 
-**Dotted keys:** `allow.read` is the `cplt config set` spelling. In the file the same setting is `read = [...]` under an `[allow]` header. A dotted line below another section's header (`allow.read = [...]` under `[git_guard]`) is scoped into that section by TOML and ignored.
+**Dotted keys:** `allow.read` is the `cplt config set` spelling. In the file the same setting is `read = [...]` under an `[allow]` header. A dotted line below another section's header (`allow.read = [...]` under `[git_guard]`) is scoped into that section by TOML, so cplt sees it as an unknown key and ignores it — with a warning at launch and an error from `cplt config validate`.
 
 ## Per-repo configuration (`.cplt.toml`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,7 +164,7 @@ cplt config explain proxy.forced
 
 For arrays of objects, multi-line values, and other complex configuration, edit the file directly and run `cplt config validate` afterwards.
 
-**Dotted keys:** `allow.read` is the `cplt config set` spelling. In the file the same setting is `read = [...]` under an `[allow]` header. A dotted line below another section's header (`allow.read = [...]` under `[git_guard]`) is scoped into that section by TOML, so cplt sees it as an unknown key and ignores it — with a warning at launch and an error from `cplt config validate`.
+**Dotted keys:** a dotted key belongs to whatever section header precedes it. `allow.read = [...]` is valid on its own — above every header, or written as `read = [...]` under `[allow]` — but the same line below `[git_guard]` means `git_guard.allow.read`. cplt then sees an unknown key and ignores it, with a warning at launch and an error from `cplt config validate`, so the grant never takes effect.
 
 ## Per-repo configuration (`.cplt.toml`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,8 @@ cplt config explain proxy.forced
 
 For arrays of objects, multi-line values, and other complex configuration, edit the file directly and run `cplt config validate` afterwards.
 
+**Dotted keys:** `allow.read` is the `cplt config set` spelling. In the file the same setting is `read = [...]` under an `[allow]` header. A dotted line below another section's header (`allow.read = [...]` under `[git_guard]`) is scoped into that section by TOML and ignored.
+
 ## Per-repo configuration (`.cplt.toml`)
 
 Commit a `.cplt.toml` to your repository for project-specific sandbox settings, so every developer does not have to configure the same CLI flags or global config. Global config stays the default, so pass `--repo` explicitly for project settings:

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -70,6 +70,18 @@ fn top_level_keys() -> Vec<&'static str> {
 /// automatically cover any option present in the registry.
 pub(super) fn describe_unknown_key(path: &str) -> String {
     if let Some((section, key)) = path.split_once('.') {
+        // A section name showing up as a key inside another section is a dotted
+        // key written below the wrong header: TOML scopes `allow.read = [...]`
+        // under the preceding `[git_guard]` header as `git_guard.allow.read`,
+        // so the grant is silently dropped (#228).
+        if known_sections().contains(&key) {
+            let example = section_keys(key).first().copied().unwrap_or("x");
+            return format!(
+                "unknown key '{key}' in [{section}]: '{key}' is a top-level section; TOML \
+                 scopes '{key}.{example} = ...' written under [{section}] into [{section}] \
+                 — move it under its own [{key}] header"
+            );
+        }
         // Exclude the reported key itself from the suggestion candidates. The
         // candidates come from CONFIG_KEYS (a superset that includes repo-only
         // keys like `deny.env`), so a key that is valid in the registry but not
@@ -635,5 +647,29 @@ some_new_option = true
         // A real typo of a user-struct key still gets a suggestion.
         let msg = describe_unknown_key("sandbox.inherit_evn");
         assert!(msg.contains("did you mean 'inherit_env'"), "got: {msg}");
+    }
+
+    /// #228: a dotted key like `allow.read = [...]` written below another
+    /// section's header is scoped INTO that section by TOML, so the grant is
+    /// silently dropped. The message must explain that, not just "unknown key".
+    #[test]
+    fn section_name_used_as_key_explains_toml_scoping() {
+        let toml =
+            "[git_guard]\nenabled = true\n\nallow.read = [\"~/.gradle/gradle.properties\"]\n";
+        let diagnostics = validate_config(toml);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.message.contains("unknown key 'allow' in [git_guard]"))
+            .unwrap_or_else(|| panic!("should flag allow under git_guard: {diagnostics:?}"));
+        assert!(
+            diagnostic.message.contains("allow.read"),
+            "got: {}",
+            diagnostic.message
+        );
+        assert!(
+            diagnostic.message.contains("[allow]"),
+            "got: {}",
+            diagnostic.message
+        );
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -76,6 +76,16 @@ pub(super) fn describe_unknown_key(path: &str) -> String {
         // so the grant is silently dropped (#228).
         if known_sections().contains(&key) {
             let example = section_keys(key).first().copied().unwrap_or("x");
+            // Repeating the section name under its own header (`[allow]` +
+            // `allow.read = ...`) needs the opposite advice: drop the prefix.
+            if section == key {
+                return format!(
+                    "unknown key '{key}' in [{section}]: the [{section}] header already \
+                     scopes its keys, so '{key}.{example} = ...' reads as \
+                     '{section}.{key}.{example}' — drop the '{key}.' prefix and write \
+                     '{example} = ...'"
+                );
+            }
             return format!(
                 "unknown key '{key}' in [{section}]: '{key}' is a top-level section; TOML \
                  scopes '{key}.{example} = ...' written under [{section}] into [{section}] \
@@ -661,8 +671,10 @@ some_new_option = true
             .iter()
             .find(|d| d.message.contains("unknown key 'allow' in [git_guard]"))
             .unwrap_or_else(|| panic!("should flag allow under git_guard: {diagnostics:?}"));
+        // The example subkey comes from the registry, so assert the shape of the
+        // hint rather than pinning whichever key happens to be listed first.
         assert!(
-            diagnostic.message.contains("allow.read"),
+            diagnostic.message.contains("allow.") && diagnostic.message.contains("= ..."),
             "got: {}",
             diagnostic.message
         );
@@ -671,5 +683,14 @@ some_new_option = true
             "got: {}",
             diagnostic.message
         );
+    }
+
+    /// The same detection must give the opposite advice when the section name is
+    /// repeated under its own header: the prefix is redundant, not misplaced.
+    #[test]
+    fn section_name_repeated_under_its_own_header_says_drop_the_prefix() {
+        let msg = describe_unknown_key("allow.allow");
+        assert!(msg.contains("drop the 'allow.' prefix"), "got: {msg}");
+        assert!(!msg.contains("move it"), "got: {msg}");
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -88,8 +88,8 @@ pub(super) fn describe_unknown_key(path: &str) -> String {
             }
             return format!(
                 "unknown key '{key}' in [{section}]: '{key}' is a top-level section; TOML \
-                 scopes '{key}.{example} = ...' written under [{section}] into [{section}] \
-                 — move it under its own [{key}] header"
+                 scopes '{key}.{example} = ...' written under [{section}] as \
+                 '{section}.{key}.{example}' — move it under its own [{key}] header"
             );
         }
         // Exclude the reported key itself from the suggestion candidates. The
@@ -683,6 +683,28 @@ some_new_option = true
             "got: {}",
             diagnostic.message
         );
+    }
+
+    /// Line-continuation (`\` at end of line) in the scoping messages must not
+    /// leak the source indentation into the rendered warning.
+    #[test]
+    fn scoping_messages_render_without_runs_of_whitespace() {
+        for msg in [
+            describe_unknown_key("git_guard.allow"),
+            describe_unknown_key("allow.allow"),
+        ] {
+            assert!(
+                !msg.contains("  "),
+                "double space in rendered message: {msg}"
+            );
+        }
+    }
+
+    /// The scoping warning names the fully-qualified path TOML actually builds.
+    #[test]
+    fn scoping_message_shows_the_fully_qualified_path() {
+        let msg = describe_unknown_key("git_guard.allow");
+        assert!(msg.contains("'git_guard.allow."), "got: {msg}");
     }
 
     /// The same detection must give the opposite advice when the section name is


### PR DESCRIPTION
## The report

`cplt` warned `unknown key 'allow' in [git_guard]` about a config file that contains no
`allow` key (#228). It does, indirectly:

```toml
[git_guard]
enabled = true

allow.read = ["~/.gradle/gradle.properties"]
```

TOML scopes a dotted key to the enclosing table, so that last line is
`git_guard.allow.read`. The `[allow]` grant is never seen — the reporter's own
`cplt config show` output shows `read = []` — and the only feedback was a message that
named a key they had not written.

The spelling came from us: `docs/configuration.md` shows `cplt config set allow.read
"~/.gradle/gradle.properties"`, the exact value in the report. That is correct as a CLI
argument and wrong as a line in the file.

## Why it is worth fixing rather than answering

The `allow.read` case fails closed — a grant is dropped, so the sandbox is tighter than
the user intended. The same mistake with `deny.paths` under another section's header
drops a *deny*: the user believes a path is blocked and it is not. Same branch, opposite
direction.

## The change

`describe_unknown_key` now recognises one of cplt's own section names appearing as an
unknown key inside another section, and says what happened:

```
unknown key 'allow' in [git_guard]: 'allow' is a top-level section; TOML scopes
'allow.read = ...' written under [git_guard] into [git_guard] — move it under its own
[allow] header
```

It fires only for the seven names in the registry, so it cannot misfire on an ordinary
typo, which keeps its "did you mean" suggestion.

All three surfaces that print this route through the same function: the launch warning,
`cplt config validate` and `cplt config show`.

Runtime behaviour is unchanged. Unknown keys are still ignored at load time, so a config
written for a newer cplt keeps loading on an older one — making this a hard error would
break that contract, and `git_guard` already has a `[[git_guard.allow_push]]` table, so a
real `git_guard.allow` is not far-fetched.

One sentence in `docs/configuration.md` now says what the file spelling is, next to the
paragraph that tells you to edit the file directly.

Closes #228
