### PR TITLE
fix(sandbox): grant read+exec on the Homebrew-on-Linux prefix

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -258,10 +258,14 @@ pub fn discover_tools(home_dir: &Path) -> ToolDiscovery {
         })
         .collect();
 
-    let homebrew_prefix = ["/opt/homebrew", "/usr/local/Homebrew"]
-        .iter()
-        .map(PathBuf::from)
-        .find(|p| p.exists());
+    let homebrew_prefix = [
+        "/opt/homebrew",
+        "/usr/local/Homebrew",
+        "/home/linuxbrew/.linuxbrew",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .find(|p| p.exists());
 
     let existing_home_tool_dirs: Vec<String> = home_tool_dirs()
         .iter()

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -208,8 +208,9 @@ const LINUX_TOOL_DIRS: &[&str] = &[
     "/usr/share",
     "/lib",
     "/lib64",
-    "/snap",               // Ubuntu Snap packages
-    "/run/current-system", // NixOS
+    "/snap",                      // Ubuntu Snap packages
+    "/run/current-system",        // NixOS
+    "/home/linuxbrew/.linuxbrew", // Homebrew on Linux; /opt/homebrew counterpart in TOOL_READ_DIRS
 ];
 
 /// Individual home config files (and select config directories) that tools
@@ -1844,6 +1845,27 @@ mod tests {
             assert!(!rule.access.write, "{p} should NOT have write");
             assert!(rule.access.execute, "{p} should have execute");
         }
+    }
+
+    /// #202: Homebrew on Linux installs into /home/linuxbrew/.linuxbrew, and the whole
+    /// prefix needs read + execute. `bin/*` are symlinks into `Cellar/`, and Landlock
+    /// checks the resolved inode, so a bin-only grant never covers the binary at all;
+    /// the binaries then carry PT_INTERP=/home/linuxbrew/.linuxbrew/lib/ld.so, which
+    /// needs read + execute in its own right.
+    #[test]
+    fn linuxbrew_prefix_is_readable_and_executable() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let policy = generate_policy(&test_config(&project, &home));
+
+        let rule = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == Path::new("/home/linuxbrew/.linuxbrew"))
+            .expect("linuxbrew prefix should be a tool dir");
+        assert!(rule.access.read);
+        assert!(rule.access.execute);
+        assert!(!rule.access.write, "linuxbrew prefix must not be writable");
     }
 
     #[test]


### PR DESCRIPTION
## The report

Under `cplt --agent shell`, a `git` that resolves to `/home/linuxbrew/.linuxbrew/bin/git`
fails (#202):

```
exec: Failed to execute process '/home/linuxbrew/.linuxbrew/bin/git':
The file exists and is executable. Check the interpreter or linker?
```

Nothing is wrong with the interpreter. `/home/linuxbrew/.linuxbrew` was missing from
`LINUX_TOOL_DIRS`, so Landlock returned `EACCES` on `execve`. Landlock does not hook
`access(2)`, so the `access(cmd, X_OK)` probe fish runs after a failed exec returns 0 —
and fish, having folded `EACCES` and `ENOENT` into one branch, prints the message above.

## Why the whole prefix

`bin/git` is a symlink into `Cellar/git/<version>/bin/git` and Landlock checks the
resolved inode, so a `bin`-only grant does not cover the binary at all. Past that, the
binaries carry `PT_INTERP=/home/linuxbrew/.linuxbrew/lib/ld.so`, which needs read and
execute in its own right, plus RPATH `lib/`, `opt/`, `libexec/git-core` and
`share/git-core`. `bin`+`lib` and `bin`+`Cellar` both still fail. The prefix is the only
grant that is not fragile.

Read and execute, no write — the same posture as `/opt/homebrew` on macOS and as the
other package-manager roots already in the list. Landlock is grant-only and the rule is
subtree-scoped, so nothing else widens: no policy rule grants write anywhere under the
prefix, and with `HOME=/home/linuxbrew` the `HOME_TOOL_DIRS` entries land beside
`.linuxbrew`, not inside it.

`cplt doctor` now probes this prefix too, alongside `/opt/homebrew` and
`/usr/local/Homebrew`.

## What this does not do

The issue is titled "Add allow-exec configuration option". This is the parity fix for the
documented default prefix only. A source-built Homebrew under `~/.linuxbrew` is still
broken and has no workaround, because `allow.read` grants no exec on either backend. The
general exec knob is a separate piece of work, so this refs the issue rather than closing
it.

Refs #202
