### PR TITLE
test(proxy): poll for observed domains instead of sleeping

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -4822,11 +4822,9 @@ mod tests {
             Some(resolver),
         );
 
-        let status = proxy_connect(proxy.port, "intranet.corp.example:443");
-        assert!(
-            status.contains("200"),
-            "allow_private_domains host must be forwarded to upstream; got: {status}"
-        );
+        // Retry transport flakes: `assert_connect_allowed` still fails fast on a
+        // real `403 Forbidden`, so the policy assertion keeps its teeth.
+        assert_connect_allowed(proxy.port, "intranet.corp.example");
 
         std::thread::sleep(Duration::from_millis(100));
         assert!(
@@ -5027,11 +5025,7 @@ mod tests {
         );
 
         // 1. No-proxy host → DIRECT path: 200, direct origin reached, upstream not.
-        let status = proxy_connect(proxy.port, "internal.corp.example:443");
-        assert!(
-            status.contains("200"),
-            "no-proxy host should connect directly; got: {status}"
-        );
+        assert_connect_allowed(proxy.port, "internal.corp.example");
         std::thread::sleep(Duration::from_millis(100));
         assert!(
             direct.contacted.load(std::sync::atomic::Ordering::SeqCst),
@@ -5045,11 +5039,7 @@ mod tests {
         );
 
         // 2. A host NOT in the no-proxy list is still forwarded to the upstream.
-        let status = proxy_connect(proxy.port, "external.example.net:443");
-        assert!(
-            status.contains("200"),
-            "non-no-proxy host should be forwarded via upstream; got: {status}"
-        );
+        assert_connect_allowed(proxy.port, "external.example.net");
         std::thread::sleep(Duration::from_millis(100));
         assert!(
             upstream_srv

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3198,6 +3198,32 @@ mod tests {
         panic!("{host} must complete a 200 tunnel once allowed");
     }
 
+    /// Block until `host` appears in the proxy's observed set, then return it.
+    ///
+    /// The connection thread records the host *after* the client's CONNECT has
+    /// already returned, so snapshotting straight after `proxy_connect` races
+    /// it. A fixed `sleep(50ms)` hid that race until a loaded CI runner ran
+    /// past the window and failed the run for #158. Polling to a deadline is
+    /// both faster in the common case and reliable under load — same reasoning
+    /// as `assert_connect_allowed`'s retry loop above.
+    fn await_observed(proxy: &ProxyHandle, host: &str) -> ObservedDomain {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(rec) = proxy
+                .observed_domains()
+                .into_iter()
+                .find(|o| o.host == host)
+            {
+                return rec;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "{host} was never recorded in the observed set"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
     #[test]
     fn proxy_default_allowlist_blocks_unknown_domain() {
         require_localhost_tcp!();
@@ -3287,9 +3313,7 @@ mod tests {
         let proxy = make_proxy_default_allowlist(Vec::new(), None, upstream);
 
         let status = proxy_connect(proxy.port, "would-be-blocked.example:443");
-        // Let the connection thread finish recording before snapshotting.
-        std::thread::sleep(Duration::from_millis(50));
-        let observed = proxy.observed_domains();
+        let rec = await_observed(&proxy, "would-be-blocked.example");
         proxy.shutdown();
         up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
 
@@ -3297,10 +3321,6 @@ mod tests {
             !status.contains("Forbidden"),
             "allow-all (observe) must NOT block would-be-blocked.example; got {status}"
         );
-        let rec = observed
-            .iter()
-            .find(|o| o.host == "would-be-blocked.example")
-            .expect("contacted host must be recorded even in allow-all mode");
         assert_eq!(
             rec.verdict,
             DomainVerdict::Allowed,
@@ -3318,8 +3338,7 @@ mod tests {
         let proxy = make_proxy_default_allowlist(copilot_defaults(), None, upstream);
 
         let status = proxy_connect(proxy.port, "evil.com:443");
-        std::thread::sleep(Duration::from_millis(50));
-        let observed = proxy.observed_domains();
+        let rec = await_observed(&proxy, "evil.com");
         proxy.shutdown();
         up.shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
 
@@ -3327,10 +3346,6 @@ mod tests {
             status.contains("403"),
             "evil.com must be blocked under the allowlist; got {status}"
         );
-        let rec = observed
-            .iter()
-            .find(|o| o.host == "evil.com")
-            .expect("blocked host must still be recorded");
         assert_eq!(rec.verdict, DomainVerdict::Blocked);
     }
 


### PR DESCRIPTION
Split out of #175, where these two commits were unrelated to that PR's subject and were
holding up an otherwise reviewable change. They are the reason CI is red on PRs that
touch nothing near the proxy.

## The race

`observe_records_blocked_verdict_under_allowlist` and its allow-all counterpart snapshot
`observed_domains()` right after `proxy_connect` returns. The connection thread records
the host *after* the client's CONNECT has already returned, so the snapshot races it. A
fixed `sleep(50ms)` papered over the gap until a loaded runner ran past the window:

```
test proxy::tests::observe_records_blocked_verdict_under_allowlist ... FAILED
thread '...' panicked at src/proxy.rs:3333:14
test result: FAILED. 769 passed; 1 failed
```

That is the current failure on #227, a docs-only branch.

`await_observed` polls to a 5s deadline instead — faster in the common case and reliable
under load, the same shape as the existing `assert_connect_allowed` retry loop. The
second commit gives the three bare CONNECT-expects-200 asserts the same treatment.

## Scope

Tests only; no change to proxy behaviour. This does not claim to fix every flake in
`linux-integration-tests` — that job has also failed recently on
`copilot_extraction_tests::empty_cache_and_a_clean_exit_means_nothing_to_extract` and, per
#220, on `tests/e2e_projects.rs`. Those are separate and still open.
