### PR TITLE
fix(env): point NPM_CONFIG_USERCONFIG at a nonexistent scratch path

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -486,7 +486,7 @@ Or for a single run: `cplt --allow-read ~/.m2/settings.xml`
 
 > **Note:** these are the *overridable* credential denials (`DENIED_HOME_SUBPATHS`). A second list, `~/.netrc`, `~/.pypirc`, `~/.gem/credentials` and `~/.vault-token`, is meant to be hard-denied, and **on macOS it is**: the generic `allow.read` grants are emitted before the literal deny rules, and only `DENIED_HOME_SUBPATHS` and `DENIED_DOTFILES` get a post-deny re-allow, so no `allow.read` can reach them. **On Linux that guarantee does not currently hold.** Landlock is grant-only, so those files are withheld by omission rather than by a deny rule, and `allow.read` paths are added to the ruleset without being checked against the list. `cplt config set allow.read "~/.netrc"` therefore produces a working read grant. This is a known gap, tracked in #207. Do not rely on the hard-deny list to stop a deliberate `allow.read` on Linux.
 
-If you would rather not hand `~/.npmrc` to the agent at all, see [`NPM_CONFIG_USERCONFIG`](#yarn-1-and-unreadable-home-rc-files) below, or use a project-level `.npmrc`, which is readable as part of the project directory and can take its token from an environment variable.
+You do not need to allow `~/.npmrc` just to stop yarn 1 crashing on it — cplt redirects `NPM_CONFIG_USERCONFIG` for that, see [yarn 1 and unreadable home rc files](#yarn-1-and-unreadable-home-rc-files) below. If you would rather not hand `~/.npmrc` to the agent at all but do need a private registry, use a project-level `.npmrc`, which is readable as part of the project directory and can take its token from an environment variable.
 
 > **Linux limitation:** the denials for files *inside an allowed tool dir* are only enforced on macOS, via SBPL literal deny rules. On Linux, Landlock cannot deny individual files within an allowed directory, so the parent dirs (`.m2`, `.gradle`, `.cargo`) stay fully readable for dependency resolution. `~/.npmrc` is the exception: it sits at the top of `$HOME`, which is never granted, so it is withheld on both platforms.
 
@@ -513,7 +513,15 @@ One consequence is worth knowing: an agent can deliberately force the audit to `
 
 ## yarn 1 and unreadable home rc files
 
-`yarn install` fails outright under the default policy when an `~/.npmrc` exists on the host. Nothing is resolved and no `node_modules` is written:
+**The `~/.npmrc` half of this is handled automatically since [#180](https://github.com/navikt/cplt/issues/180).** cplt sets `NPM_CONFIG_USERCONFIG` to a path inside the session scratch dir that deliberately does not exist, so the user-level npmrc read fails with `ENOENT`, which yarn 1 tolerates, instead of the denial errno, which it does not. Nothing is granted: `~/.npmrc` stays unreadable either way. `~/.yarnrc` is a separate loader and still needs `allow.read`; see below.
+
+The injection is skipped in three cases, where the failure below can still appear:
+
+- you allowed `~/.npmrc` yourself (`allow.read`), so you asked for the real file and cplt does not redirect around it;
+- you set `NPM_CONFIG_USERCONFIG` yourself, and your value wins;
+- the scratch dir is off (`--no-scratch-dir`), so there is nowhere to point that would not silently swallow `npm config set` writes.
+
+Without it, `yarn install` fails outright under the default policy when an `~/.npmrc` exists on the host. Nothing is resolved and no `node_modules` is written:
 
 ```
 yarn install v1.22.22
@@ -522,7 +530,7 @@ error Error: EACCES: permission denied, open '/home/you/.npmrc'
 
 macOS reports the same failure as `EPERM: operation not permitted`. The errno differs by backend; the outcome does not.
 
-**Fix.** If you only install from the public registry, point yarn at a different npmrc. The token stays outside the sandbox:
+**Fix, in the skipped cases.** If you only install from the public registry, point yarn at a different npmrc. The token stays outside the sandbox:
 
 ```bash
 : > .npmrc.sandbox
@@ -535,7 +543,7 @@ If you do need the registry auth in `~/.npmrc`, allow it instead:
 cplt config set allow.read "~/.npmrc"
 ```
 
-Or for a single run: `cplt --allow-read ~/.npmrc`. Deleting an `~/.npmrc` you do not use works just as well. If you also keep a `~/.yarnrc`, neither fix covers it on its own. See below.
+Or for a single run: `cplt --allow-read ~/.npmrc`. Deleting an `~/.npmrc` you do not use works just as well. Neither fix covers a `~/.yarnrc`. See below.
 
 **Why only yarn 1.** `~/.npmrc` is denied by default because it commonly holds a registry token. Every package manager reads it; only yarn 1 treats an *unreadable* one as fatal. Both of its config loaders, `NpmRegistry.getPossibleConfigLocations` (which is what reaches `~/.npmrc`) and `parseRcPaths` (which reads the `.yarnrc` family), tolerate a *missing* file and rethrow everything else:
 
@@ -551,7 +559,7 @@ Or for a single run: `cplt --allow-read ~/.npmrc`. Deleting an `~/.npmrc` you do
 
 npm, pnpm and bun all carry on past a denied `~/.npmrc` and install normally from the public registry ([navikt/cplt#180](https://github.com/navikt/cplt/issues/180) measured npm 10.9.8, pnpm 11.22.0 and bun 1.4.0). The trigger is therefore the file's *existence*, not its contents. An `~/.npmrc` holding nothing but `save-exact=true` breaks yarn 1 exactly as a token-bearing one does.
 
-**It is not only `~/.npmrc`.** `parseRcPaths` fails the same way on `~/.yarnrc` when it exists, including when `~/.npmrc` has already been allowed. Allowing `~/.npmrc` alone is not enough if you keep a `~/.yarnrc`:
+**It is not only `~/.npmrc`, and the automatic fix does not cover the rest.** `parseRcPaths` fails the same way on `~/.yarnrc` when it exists. `NPM_CONFIG_USERCONFIG` does not reach that loader, so the redirect above leaves this crash in place, as does allowing `~/.npmrc`:
 
 ```
 error Error: EPERM: operation not permitted, open '/Users/you/.yarnrc'
@@ -559,13 +567,13 @@ error Error: EPERM: operation not permitted, open '/Users/you/.yarnrc'
 
 `~/.yarnrc` is not in any deny list. Like most home dotfiles it is simply never granted, since the sandbox enumerates the specific `$HOME` config files tools need rather than granting `$HOME` wholesale. Allow it the same way (`cplt config set allow.read "~/.yarnrc"`) if you keep one.
 
-**Why `NPM_CONFIG_USERCONFIG` works.** It is on cplt's environment allowlist because it names a path rather than carrying a secret, and yarn 1's npmrc loader honours it (`this.config.userconfig || join(home, '.npmrc')`), so pointing it at a readable file makes yarn skip `~/.npmrc` without the sandbox ever granting it. That is why it is the better default. `allow.read` fixes the crash by handing the credential over, this fixes it by removing the need. It redirects only the npmrc loader, so a `~/.yarnrc` still needs the treatment above.
+**Why `NPM_CONFIG_USERCONFIG` works.** It is on cplt's environment allowlist because it names a path rather than carrying a secret, and yarn 1's npmrc loader honours it: `mergeEnv('npm_config_')` lowercases the variable into `config.userconfig`, which replaces the `~/.npmrc` entry in `getPossibleConfigLocations`. That list is gated on an existence check before the read, so a path that does not exist is skipped rather than read. This is why cplt injects the variable rather than granting the file. `allow.read` fixes the crash by handing the credential over, the redirect fixes it by removing the need. npm and pnpm honour the same variable and could not read `~/.npmrc` in the sandbox anyway, so nothing changes for them. It redirects only the npmrc loader, so a `~/.yarnrc` still needs the treatment above.
 
 The XDG variables, by contrast, do not help. yarn 1's `.yarnrc` scan builds its own path list with hardcoded `~/.yarnrc` entries and runs before the XDG-aware `getConfigDir()` is consulted, so neither `XDG_CONFIG_HOME` nor `XDG_DATA_HOME` removes those paths from the list. yarn 2+ (berry) uses a different config loader and is unaffected.
 
 One footgun with `allow.read`: the path must **exist** when cplt starts. A missing path is warned about and dropped, so `allow.read "~/.npmrc"` on a machine without one is silently inert. That is fine here, since yarn only fails when the file exists in the first place.
 
-**Why cplt does not make the denial look like ENOENT.** The tempting accommodation is to report these files as *absent* rather than *denied*, which every package manager tolerates. macOS can express that. SBPL accepts `(deny file-read* (literal …) (with errno 2))`, so the read fails with `No such file or directory`. Linux cannot. Landlock is grant-only with no control over the errno a denied `open` returns, and on Linux `~/.npmrc` is not denied by a rule at all. It is simply never granted. Shipping the macOS half would fix macOS, leave Linux (where this was reported) untouched, and split the two backends' denial semantics for every tool, not just yarn. One line of config is the better trade. Bubblewrap could mask the file with an empty `/dev/null` bind, but it is opt-in, applies only where the wrapper is active, and inverts the existing deny-path masks, which deliberately use an unreadable placeholder so a masked read fails loudly instead of reading as empty.
+**Why cplt does not make the *denial itself* look like ENOENT.** The redirect above sidesteps the errno for the one file that has an env-var escape hatch. It does not change what a denied `open` reports, so `~/.yarnrc` and every other withheld dotfile still fail with the platform's denial errno. The tempting general accommodation is to report these files as *absent* rather than *denied*, which every package manager tolerates. macOS can express that. SBPL accepts `(deny file-read* (literal …) (with errno 2))`, so the read fails with `No such file or directory`. Linux cannot. Landlock is grant-only with no control over the errno a denied `open` returns, and on Linux `~/.npmrc` is not denied by a rule at all. It is simply never granted. Shipping the macOS half would fix macOS, leave Linux (where this was reported) untouched, and split the two backends' denial semantics for every tool, not just yarn. One line of config is the better trade. Bubblewrap could mask the file with an empty `/dev/null` bind, but it is opt-in, applies only where the wrapper is active, and inverts the existing deny-path masks, which deliberately use an unreadable placeholder so a masked read fails loudly instead of reading as empty.
 
 Adding `~/.npmrc` to the default read grant is not an option either. That hands the npm token to the sandboxed agent, which is the one thing the denial exists to prevent.
 

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -519,7 +519,7 @@ The injection is skipped in three cases, where the failure below can still appea
 
 - you allowed `~/.npmrc` yourself (`allow.read`), so you asked for the real file and cplt does not redirect around it;
 - you set `NPM_CONFIG_USERCONFIG` yourself, and your value wins;
-- the scratch dir is off (`--no-scratch-dir`), so there is nowhere to point that would not silently swallow `npm config set` writes.
+- the scratch dir is off (`--no-scratch-dir`), so there is no session-scoped writable location to point at.
 
 Without it, `yarn install` fails outright under the default policy when an `~/.npmrc` exists on the host. Nothing is resolved and no `node_modules` is written:
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -62,7 +62,7 @@ pub use policy::{
 pub use profile::{ProfileOptions, generate_profile};
 
 // Environment construction — already platform-agnostic.
-pub use env::{SandboxEnv, build_sandbox_env};
+pub use env::{SandboxEnv, build_sandbox_env, npmrc_userconfig_override};
 
 // Landlock policy types — cross-platform for testing.
 pub use landlock_mod::{
@@ -168,6 +168,9 @@ pub struct PreparedSandbox {
     allow_localhost: Vec<u16>,
     /// Whether all localhost ports are open (`--allow-localhost-any`).
     allow_localhost_any: bool,
+    /// Whether the user explicitly re-allowed `$HOME/.npmrc` via `allow.read`.
+    /// Suppresses the `NPM_CONFIG_USERCONFIG` redirect (see #180).
+    npmrc_allowed: bool,
     /// Landlock + seccomp pre-computed sandbox data (Linux only).
     /// Built in the parent process; applied in pre_exec.
     #[cfg(target_os = "linux")]
@@ -341,6 +344,10 @@ fn prepare_impl(
         agent: config.agent,
         allow_localhost: config.localhost_ports.to_vec(),
         allow_localhost_any: config.allow_localhost_any,
+        npmrc_allowed: config
+            .extra_read
+            .iter()
+            .any(|p| p == &config.home_dir.join(".npmrc")),
     })
 }
 
@@ -476,6 +483,10 @@ fn prepare_impl(
         agent: config.agent,
         allow_localhost: config.localhost_ports.to_vec(),
         allow_localhost_any: config.allow_localhost_any,
+        npmrc_allowed: config
+            .extra_read
+            .iter()
+            .any(|p| p == &config.home_dir.join(".npmrc")),
         precomputed,
         bwrap_wrapper,
     })

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -62,7 +62,7 @@ pub use policy::{
 pub use profile::{ProfileOptions, generate_profile};
 
 // Environment construction — already platform-agnostic.
-pub use env::{SandboxEnv, build_sandbox_env, npmrc_userconfig_override};
+pub use env::{SandboxEnv, build_sandbox_env, npmrc_explicitly_allowed, npmrc_userconfig_override};
 
 // Landlock policy types — cross-platform for testing.
 pub use landlock_mod::{
@@ -344,10 +344,7 @@ fn prepare_impl(
         agent: config.agent,
         allow_localhost: config.localhost_ports.to_vec(),
         allow_localhost_any: config.allow_localhost_any,
-        npmrc_allowed: config
-            .extra_read
-            .iter()
-            .any(|p| p == &config.home_dir.join(".npmrc")),
+        npmrc_allowed: env::npmrc_explicitly_allowed(config.home_dir, config.extra_read),
     })
 }
 
@@ -483,10 +480,7 @@ fn prepare_impl(
         agent: config.agent,
         allow_localhost: config.localhost_ports.to_vec(),
         allow_localhost_any: config.allow_localhost_any,
-        npmrc_allowed: config
-            .extra_read
-            .iter()
-            .any(|p| p == &config.home_dir.join(".npmrc")),
+        npmrc_allowed: env::npmrc_explicitly_allowed(config.home_dir, config.extra_read),
         precomputed,
         bwrap_wrapper,
     })

--- a/src/sandbox_env.rs
+++ b/src/sandbox_env.rs
@@ -257,6 +257,19 @@ pub fn build_sandbox_env(
     env
 }
 
+/// Whether the user explicitly re-allowed `$HOME/.npmrc` via `--allow-read` / `allow.read`.
+///
+/// Both entry points canonicalize before the path reaches `extra_read`
+/// (`canonicalize_paths` in main.rs, `resolve_config_path` in config/path.rs), so a
+/// stow/chezmoi `~/.npmrc -> ~/dotfiles/npmrc` is stored as the link *target*. Compare
+/// canonicalized, or the flag reads false for exactly the users who opted in and the
+/// `NPM_CONFIG_USERCONFIG` redirect silently ignores the token they asked for.
+pub fn npmrc_explicitly_allowed(home_dir: &Path, extra_read: &[std::path::PathBuf]) -> bool {
+    let npmrc = home_dir.join(".npmrc");
+    let resolved = std::fs::canonicalize(&npmrc).unwrap_or(npmrc);
+    extra_read.iter().any(|p| p == &resolved)
+}
+
 /// Where to point `NPM_CONFIG_USERCONFIG`, or `None` when the injection must be skipped.
 ///
 /// The sandbox denies `~/.npmrc` (it holds registry auth tokens). npm, pnpm and bun
@@ -270,8 +283,8 @@ pub fn build_sandbox_env(
 /// - the user opted back into `~/.npmrc` via `allow.read` (`npmrc_allowed`) — they
 ///   want the token, and redirecting would silently break private-registry auth;
 /// - the user set `NPM_CONFIG_USERCONFIG` themselves (it is on `ENV_ALLOWLIST`);
-/// - there is no scratch dir — `/dev/null` would make `npm config set` writes vanish
-///   silently, so leaving the EACCES in place is the honest failure.
+/// - there is no scratch dir — without one there is no session-scoped writable location
+///   to point at, and leaving the denial in place is better than inventing a target.
 pub fn npmrc_userconfig_override(
     parent_env: &[(String, String)],
     scratch_dir: Option<&Path>,
@@ -280,9 +293,12 @@ pub fn npmrc_userconfig_override(
     if npmrc_allowed {
         return None;
     }
+    // Case-insensitive: npm and yarn both lowercase `npm_config_*` env keys, so a user's
+    // `npm_config_userconfig` (which `--inherit-env` passes through) is the same setting.
+    // Injecting the uppercase form alongside it makes which one wins depend on env order.
     if parent_env
         .iter()
-        .any(|(k, v)| k == "NPM_CONFIG_USERCONFIG" && !v.is_empty())
+        .any(|(k, v)| k.eq_ignore_ascii_case("NPM_CONFIG_USERCONFIG") && !v.is_empty())
     {
         return None;
     }

--- a/src/sandbox_env.rs
+++ b/src/sandbox_env.rs
@@ -257,6 +257,39 @@ pub fn build_sandbox_env(
     env
 }
 
+/// Where to point `NPM_CONFIG_USERCONFIG`, or `None` when the injection must be skipped.
+///
+/// The sandbox denies `~/.npmrc` (it holds registry auth tokens). npm, pnpm and bun
+/// treat the resulting EACCES/EPERM as "no user config"; yarn 1 only tolerates
+/// ENOENT/EISDIR and aborts the whole install (#180). Pointing the user-config path
+/// at a file that does not exist inside the scratch dir turns the denial into ENOENT,
+/// which every one of them handles. Semantically a no-op: the real `~/.npmrc` was
+/// unreadable in the sandbox either way.
+///
+/// Skipped when:
+/// - the user opted back into `~/.npmrc` via `allow.read` (`npmrc_allowed`) — they
+///   want the token, and redirecting would silently break private-registry auth;
+/// - the user set `NPM_CONFIG_USERCONFIG` themselves (it is on `ENV_ALLOWLIST`);
+/// - there is no scratch dir — `/dev/null` would make `npm config set` writes vanish
+///   silently, so leaving the EACCES in place is the honest failure.
+pub fn npmrc_userconfig_override(
+    parent_env: &[(String, String)],
+    scratch_dir: Option<&Path>,
+    npmrc_allowed: bool,
+) -> Option<std::path::PathBuf> {
+    if npmrc_allowed {
+        return None;
+    }
+    if parent_env
+        .iter()
+        .any(|(k, v)| k == "NPM_CONFIG_USERCONFIG" && !v.is_empty())
+    {
+        return None;
+    }
+    // "npmrc" (no dot) so it cannot collide with a real dotfile the agent creates.
+    Some(scratch_dir?.join("npmrc"))
+}
+
 /// Dangerous NODE_OPTIONS flags that allow code preloading or module interception.
 const NODE_OPTIONS_DANGEROUS: &[&str] = &[
     "--require",

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -65,6 +65,7 @@ fn configure_command(
     agent: Agent,
     gh_guard: &crate::config::GhGuardPolicy,
     git_guard: &crate::config::GitGuardPolicy,
+    npmrc_allowed: bool,
 ) {
     for arg in copilot_args {
         cmd.arg(arg);
@@ -112,6 +113,16 @@ fn configure_command(
         .any(|(k, v)| k == "DOTNET_CLI_HOME" && !v.is_empty());
     if !user_dotnet_cli_home {
         cmd.env("DOTNET_CLI_HOME", home_dir);
+    }
+
+    // Point npm-family tools at a nonexistent user config inside the scratch dir so
+    // the denied ~/.npmrc reads as ENOENT instead of EACCES/EPERM — yarn 1 aborts the
+    // whole install on the latter (#180). See `npmrc_userconfig_override` for the cases
+    // where this must not fire.
+    if let Some(path) =
+        super::env::npmrc_userconfig_override(&parent_env, scratch_dir, npmrc_allowed)
+    {
+        cmd.env("NPM_CONFIG_USERCONFIG", path);
     }
 
     // Tell mise to ignore config files in ancestor directories that the sandbox blocks.
@@ -556,6 +567,7 @@ pub fn exec(
         sandbox.agent,
         gh_guard,
         git_guard,
+        sandbox.npmrc_allowed,
     );
 
     // Strip repo-config denied env vars
@@ -694,6 +706,7 @@ pub fn exec(
         sandbox.agent,
         gh_guard,
         git_guard,
+        sandbox.npmrc_allowed,
     );
 
     // Strip repo-config denied env vars
@@ -831,6 +844,7 @@ fn exec_bwrap(
         sandbox.agent,
         gh_guard,
         git_guard,
+        sandbox.npmrc_allowed,
     );
     for var in deny_env {
         cmd.env_remove(var);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4309,6 +4309,70 @@ paths = [
         );
     }
 
+    /// Pull `KEY=value` out of `env` output.
+    fn env_value<'a>(stdout: &'a str, key: &str) -> Option<&'a str> {
+        stdout
+            .lines()
+            .find_map(|l| l.strip_prefix(&format!("{key}=")))
+    }
+
+    /// #180: the sandbox denies `~/.npmrc`, and yarn 1 aborts on the denial errno where
+    /// it tolerates ENOENT. cplt redirects `NPM_CONFIG_USERCONFIG` at a nonexistent path
+    /// in the scratch dir so the read misses instead of being refused.
+    #[test]
+    fn e2e_exec_npmrc_userconfig_redirected_to_scratch() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args(["--no-validate", "exec", "--", "/usr/bin/env"])
+            .current_dir(project_dir())
+            // A developer's own value legitimately suppresses the injection.
+            .env_remove("NPM_CONFIG_USERCONFIG")
+            .env_remove("npm_config_userconfig")
+            .output()
+            .expect("cplt exec should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let tmpdir = env_value(&stdout, "TMPDIR").expect("scratch dir is on by default");
+        let userconfig = env_value(&stdout, "NPM_CONFIG_USERCONFIG").unwrap_or_else(|| {
+            panic!("NPM_CONFIG_USERCONFIG must be injected by default.\nstdout: {stdout}")
+        });
+
+        assert_eq!(
+            userconfig,
+            format!("{tmpdir}/npmrc"),
+            "NPM_CONFIG_USERCONFIG must point inside the session scratch dir.\nstdout: {stdout}"
+        );
+        assert!(
+            !std::path::Path::new(userconfig).exists(),
+            "the redirect target must not exist, or the read is not ENOENT"
+        );
+    }
+
+    #[test]
+    fn e2e_exec_npmrc_userconfig_absent_without_scratch_dir() {
+        require_sandbox!();
+        let output = cplt_cmd()
+            .args([
+                "--no-validate",
+                "--no-scratch-dir",
+                "exec",
+                "--",
+                "/usr/bin/env",
+            ])
+            .current_dir(project_dir())
+            .env_remove("NPM_CONFIG_USERCONFIG")
+            .env_remove("npm_config_userconfig")
+            .output()
+            .expect("cplt exec should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            env_value(&stdout, "NPM_CONFIG_USERCONFIG").is_none(),
+            "without a scratch dir there is nowhere to point, so nothing is injected.\n\
+             stdout: {stdout}"
+        );
+    }
+
     #[test]
     fn e2e_exec_no_command_errors() {
         let output = cplt_cmd()

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8,7 +8,8 @@ use cplt::is_unsafe_root;
 use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, is_private_ip};
 use cplt::sandbox::{
     HardeningCategory, ProfileOptions, SandboxConfig, build_sandbox_env, generate_policy,
-    generate_profile, tool_override_path_is_safe, tool_path_env_overrides, validate_sbpl_path,
+    generate_profile, npmrc_userconfig_override, tool_override_path_is_safe,
+    tool_path_env_overrides, validate_sbpl_path,
 };
 
 // ============================================================
@@ -5439,6 +5440,64 @@ fn profile_gpg_signing_allows_socket_file_read() {
 // ============================================================
 // build_sandbox_env — scratch dir env injection
 // ============================================================
+
+// #180: the sandbox denies ~/.npmrc, and yarn 1 aborts on EACCES/EPERM where it
+// tolerates ENOENT. Redirecting NPM_CONFIG_USERCONFIG at a nonexistent scratch
+// path turns the denial into ENOENT — unless the user opted back in.
+
+#[test]
+fn npmrc_userconfig_redirected_by_default() {
+    let parent = make_env(&[("HOME", "/Users/test")]);
+    let scratch = std::path::Path::new("/scratch/session123");
+    assert_eq!(
+        npmrc_userconfig_override(&parent, Some(scratch), false),
+        Some(scratch.join("npmrc")),
+        "NPM_CONFIG_USERCONFIG should point at a nonexistent scratch path by default"
+    );
+    assert!(
+        !scratch.join("npmrc").exists(),
+        "the redirect target must not exist, or the read is not ENOENT"
+    );
+}
+
+#[test]
+fn npmrc_userconfig_not_redirected_when_user_allows_npmrc() {
+    let parent = make_env(&[("HOME", "/Users/test")]);
+    let scratch = std::path::Path::new("/scratch/session123");
+    assert_eq!(
+        npmrc_userconfig_override(&parent, Some(scratch), true),
+        None,
+        "allow.read ~/.npmrc means the user wants the real file — do not redirect"
+    );
+}
+
+#[test]
+fn npmrc_userconfig_not_redirected_when_user_set_it() {
+    let parent = make_env(&[
+        ("HOME", "/Users/test"),
+        ("NPM_CONFIG_USERCONFIG", "/Users/test/custom-npmrc"),
+    ]);
+    let scratch = std::path::Path::new("/scratch/session123");
+    assert_eq!(
+        npmrc_userconfig_override(&parent, Some(scratch), false),
+        None,
+        "a user-set NPM_CONFIG_USERCONFIG must not be clobbered"
+    );
+    // An empty value is treated as unset.
+    let empty = make_env(&[("NPM_CONFIG_USERCONFIG", "")]);
+    assert!(npmrc_userconfig_override(&empty, Some(scratch), false).is_some());
+}
+
+#[test]
+fn npmrc_userconfig_not_redirected_without_scratch_dir() {
+    let parent = make_env(&[("HOME", "/Users/test")]);
+    assert_eq!(
+        npmrc_userconfig_override(&parent, None, false),
+        None,
+        "without a scratch dir there is nowhere safe to point: `npm config set` writes \
+         would vanish silently"
+    );
+}
 
 #[test]
 fn env_scratch_dir_sets_tmpdir_vars() {

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -5448,7 +5448,8 @@ fn profile_gpg_signing_allows_socket_file_read() {
 #[test]
 fn npmrc_userconfig_redirected_by_default() {
     let parent = make_env(&[("HOME", "/Users/test")]);
-    let scratch = std::path::Path::new("/scratch/session123");
+    let scratch_dir = tempfile::tempdir().expect("tempdir");
+    let scratch = scratch_dir.path();
     assert_eq!(
         npmrc_userconfig_override(&parent, Some(scratch), false),
         Some(scratch.join("npmrc")),
@@ -5463,7 +5464,8 @@ fn npmrc_userconfig_redirected_by_default() {
 #[test]
 fn npmrc_userconfig_not_redirected_when_user_allows_npmrc() {
     let parent = make_env(&[("HOME", "/Users/test")]);
-    let scratch = std::path::Path::new("/scratch/session123");
+    let scratch_dir = tempfile::tempdir().expect("tempdir");
+    let scratch = scratch_dir.path();
     assert_eq!(
         npmrc_userconfig_override(&parent, Some(scratch), true),
         None,
@@ -5477,7 +5479,8 @@ fn npmrc_userconfig_not_redirected_when_user_set_it() {
         ("HOME", "/Users/test"),
         ("NPM_CONFIG_USERCONFIG", "/Users/test/custom-npmrc"),
     ]);
-    let scratch = std::path::Path::new("/scratch/session123");
+    let scratch_dir = tempfile::tempdir().expect("tempdir");
+    let scratch = scratch_dir.path();
     assert_eq!(
         npmrc_userconfig_override(&parent, Some(scratch), false),
         None,

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8,8 +8,8 @@ use cplt::is_unsafe_root;
 use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, is_private_ip};
 use cplt::sandbox::{
     HardeningCategory, ProfileOptions, SandboxConfig, build_sandbox_env, generate_policy,
-    generate_profile, npmrc_userconfig_override, tool_override_path_is_safe,
-    tool_path_env_overrides, validate_sbpl_path,
+    generate_profile, npmrc_explicitly_allowed, npmrc_userconfig_override,
+    tool_override_path_is_safe, tool_path_env_overrides, validate_sbpl_path,
 };
 
 // ============================================================
@@ -5494,9 +5494,58 @@ fn npmrc_userconfig_not_redirected_without_scratch_dir() {
     assert_eq!(
         npmrc_userconfig_override(&parent, None, false),
         None,
-        "without a scratch dir there is nowhere safe to point: `npm config set` writes \
-         would vanish silently"
+        "without a scratch dir there is no session-scoped writable location to point at"
     );
+}
+
+#[test]
+fn npmrc_allowed_matches_a_plain_file() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let npmrc = home.path().join(".npmrc");
+    std::fs::write(&npmrc, "//registry/:_authToken=t\n").expect("write npmrc");
+
+    assert!(
+        !npmrc_explicitly_allowed(home.path(), &[]),
+        "no allow.read entry means no opt-in"
+    );
+    assert!(
+        npmrc_explicitly_allowed(
+            home.path(),
+            &[std::fs::canonicalize(&npmrc).expect("canonicalize")]
+        ),
+        "an allow.read of ~/.npmrc must register as an opt-in"
+    );
+}
+
+#[test]
+fn npmrc_allowed_matches_a_symlinked_npmrc() {
+    // stow/chezmoi: ~/.npmrc -> ~/dotfiles/npmrc. Both --allow-read (canonicalize_paths)
+    // and config allow.read (resolve_config_path) canonicalize, so extra_read holds the
+    // link *target*. Comparing against the unresolved $HOME/.npmrc misses it, the flag
+    // reads false, and the redirect silently ignores the token the user allowed.
+    let home = tempfile::tempdir().expect("tempdir");
+    let target = home.path().join("dotfiles-npmrc");
+    std::fs::write(&target, "//registry/:_authToken=t\n").expect("write target");
+    std::os::unix::fs::symlink(&target, home.path().join(".npmrc")).expect("symlink");
+
+    let extra_read = vec![std::fs::canonicalize(&target).expect("canonicalize")];
+    assert!(
+        npmrc_explicitly_allowed(home.path(), &extra_read),
+        "a symlinked ~/.npmrc allowed via its canonical target must still count as opt-in"
+    );
+}
+
+#[test]
+fn npmrc_allowed_tolerates_a_missing_npmrc() {
+    // canonicalize fails when the file does not exist; the fallback must degrade to a
+    // literal compare rather than panic. (allow.read of a missing path is dropped
+    // upstream anyway, so this only has to be safe.)
+    let home = tempfile::tempdir().expect("tempdir");
+    assert!(!npmrc_explicitly_allowed(home.path(), &[]));
+    assert!(npmrc_explicitly_allowed(
+        home.path(),
+        &[home.path().join(".npmrc")]
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## The report

`cplt exec -- yarn install` fails on Linux under the default policy (#180). npm, pnpm and
bun survive the same conditions; yarn 1 does not:

```
error Error: EACCES: permission denied, open '/home/chris/.npmrc'
```

The reporter traced 120 installs and showed `~/.npmrc` is opened `O_RDONLY` 120 times and
written 0 times, so denying it costs nothing for public-registry installs. The policy is
right; the errno is the problem.

## Why yarn and not the others

Landlock's hook is `file_open`, which runs after path lookup succeeds. A file that is
*missing* gives `ENOENT`; one that is *present but denied* gives `EACCES`. yarn 1
tolerates the first and dies on the second.

One correction to the report: the crash is not in `parseRcPaths`, which only reads the
`.yarnrc` family. `~/.npmrc` dies in `NpmRegistry.loadConfig` → `getPossibleConfigLocations`,
which gates on `fs.exists` — a stat, which Landlock does not restrict — and then `readFile`s
with no try/catch at all. That matters, because it means `~/.yarnrc` is a second,
independent crash that this fix does not cover.

## The fix

Point `NPM_CONFIG_USERCONFIG` at a path inside the scratch dir that does not exist, so the
read is `ENOENT` instead of `EACCES`. yarn's `mergeEnv('npm_config_')` lowercases env keys,
so the variable lands in `config.userconfig` and replaces the `~/.npmrc` entry; the
nonexistent path then fails the `exists` gate and is skipped. npm and pnpm honour the same
variable and could not read `~/.npmrc` anyway.

This is the same shape as the `MISE_IGNORED_CONFIG_PATHS` and `DOTNET_CLI_HOME` injections
already in `configure_command`: tell the tool to skip a path the sandbox withholds.

Three cases skip the redirect: the user allowed `~/.npmrc` through `allow.read` (they want
the token), they set `NPM_CONFIG_USERCONFIG` themselves, or there is no scratch dir — with
one there is nowhere session-scoped and writable to point at, and `npm config set` writes
would have nowhere to land.

The `allow.read` check resolves symlinks. `--allow-read` and config `allow.read` both
canonicalize, so a stow- or chezmoi-managed `~/.npmrc -> ~/dotfiles/npmrc` would otherwise
have been redirected despite the user asking for their token — which works today on Linux,
so it would have been a regression.

## Scope

`~/.npmrc` only. `~/.yarnrc` still needs `allow.read`, and `docs/known-impacts.md` says so.
Nothing else changes: the file stays unreadable, no grant is added, and the agent gains
nothing it did not already have — it can write a project-local `.npmrc` today, which takes
precedence over the user config anyway.

Closes #180
