### PR TITLE
fix(sandbox): resolve parent-side helper binaries from trusted directories

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -102,6 +102,22 @@ jobs:
           # and rust/log-injection has already earned its keep here (a real
           # ESC-injection sink in `log_connection`). Test-code alerts are
           # dismissed as "used in tests" in the security tab instead.
+          #
+          # Same treatment for the three `rust/cleartext-logging` alerts on
+          # `git::trusted_git()` / `git::trusted_binary()` (#236). The values
+          # are `TRUSTED_BIN_DIRS` entries joined with a literal binary name —
+          # `/usr/bin/git`, `/usr/bin/bwrap` — with no env var, config value or
+          # user input anywhere in the flow, and `find_in` refuses any `name`
+          # that is not a bare path component. What trips the query is the
+          # *name*: CodeQL's shared sensitive-data heuristic classifies anything
+          # matching `(?<!un|un_|is|is_)trusted(?!_iter)` as
+          # `SensitiveDataClassification::secret()` — its own docs call that
+          # "generic secret or trusted data". `trusted_git`, `trusted_binary`
+          # and `TRUSTED_BIN_DIRS` all match, so every path they produce is
+          # treated as secret material at any log sink. The lookbehind exempts
+          # only `untrusted`/`is_trusted`; there is no spelling of "resolved
+          # from a trusted directory" that keeps the meaning and dodges the
+          # regex. Dismiss as "false positive".
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # ratchet:github/codeql-action/analyze@v4.37.9

--- a/README.md
+++ b/README.md
@@ -729,7 +729,9 @@ What cplt protects against:
 
 - Secret exfiltration (SSH keys, cloud credentials, `.env` files): kernel-blocked
 - Unauthorized code execution from temp dirs: kernel-blocked
-- Persistence via git hooks or cache-dir binaries: kernel-blocked
+- Persistence via cache-dir binaries: kernel-blocked, since those dirs are denied exec
+- Persistence via git hooks in the project: cplt's own parent-side `git` runs with `core.hooksPath=/dev/null`, so it never executes them. A `git` you run yourself still will
+- Persistence via package-manager tool dirs that are both writable and executable (mise shims, `PNPM_HOME`, `~/.deno/bin`, `~/.bun/bin`): write is granted there so `pnpm add -g` and friends work in-sandbox, so an agent can leave a binary behind that a *later* shell picks up off your `PATH`. cplt resolves its own parent-side `git` and `sandbox-exec` from fixed system directories, so a planted binary cannot hijack cplt itself
 - Data exfiltration to unauthorized domains: proxy-blocked
 - Accidental pushes to main and PR merges without review: guard-blocked
 

--- a/README.md
+++ b/README.md
@@ -730,8 +730,9 @@ What cplt protects against:
 - Secret exfiltration (SSH keys, cloud credentials, `.env` files): kernel-blocked
 - Unauthorized code execution from temp dirs: kernel-blocked
 - Persistence via cache-dir binaries: kernel-blocked, since those dirs are denied exec
-- Persistence via git hooks in the project: cplt's own parent-side `git` runs with `core.hooksPath=/dev/null`, so it never executes them. A `git` you run yourself still will
-- Persistence via package-manager tool dirs that are both writable and executable (mise shims, `PNPM_HOME`, `~/.deno/bin`, `~/.bun/bin`): write is granted there so `pnpm add -g` and friends work in-sandbox, so an agent can leave a binary behind that a *later* shell picks up off your `PATH`. cplt resolves its own parent-side `git` and `sandbox-exec` from fixed system directories, so a planted binary cannot hijack cplt itself
+- Persistence via git hooks in the project: `.git/hooks` is write-denied at the kernel on macOS. On Linux, with Landlock and no Bubblewrap, it stays writable, and cplt's own parent-side `git` then runs with `core.hooksPath=/dev/null` so it never executes a planted hook, though a `git` you run yourself still will
+- Persistence via package-manager tool dirs that are both writable and executable (mise shims, `PNPM_HOME`, `~/.deno/bin`, `~/.bun/bin`): write is granted there so `pnpm add -g` and friends work in-sandbox, so an agent can leave a binary behind that a *later* shell picks up off your `PATH`
+- A planted binary hijacking the **agent** cplt launches: cplt resolves its own helpers (`git`, `gh`, `bwrap`, `sandbox-exec`, `mise`) from fixed system directories rather than `PATH`, but the agent binary itself runs from wherever it was found, which for an npm-global install is commonly under a writable mise or node tree
 - Data exfiltration to unauthorized domains: proxy-blocked
 - Accidental pushes to main and PR merges without review: guard-blocked
 

--- a/README.md
+++ b/README.md
@@ -732,7 +732,8 @@ What cplt protects against:
 - Persistence via cache-dir binaries: kernel-blocked, since those dirs are denied exec
 - Persistence via git hooks in the project: `.git/hooks` is write-denied at the kernel on macOS. On Linux, with Landlock and no Bubblewrap, it stays writable, and cplt's own parent-side `git` then runs with `core.hooksPath=/dev/null` so it never executes a planted hook, though a `git` you run yourself still will
 - Persistence via package-manager tool dirs that are both writable and executable (mise shims, `PNPM_HOME`, `~/.deno/bin`, `~/.bun/bin`): write is granted there so `pnpm add -g` and friends work in-sandbox, so an agent can leave a binary behind that a *later* shell picks up off your `PATH`
-- A planted binary hijacking the **agent** cplt launches: cplt resolves its own helpers (`git`, `gh`, `bwrap`, `sandbox-exec`, `mise`) from fixed system directories rather than `PATH`, but the agent binary itself runs from wherever it was found, which for an npm-global install is commonly under a writable mise or node tree
+- A planted binary hijacking the **agent** cplt launches: at launch and audit, cplt resolves the helpers it runs itself (`git`, `bwrap`, `sandbox-exec`, `mise`, and the `gh` it reads a token from) from fixed system directories rather than `PATH`, but the agent binary itself runs from wherever it was discovered, which for an npm-global install is commonly under a writable mise or node tree
+- `cplt doctor`: its version probes (`gh`, `copilot`, `uname`, and each agent it finds) are plain `PATH` lookups run in the parent, so a planted binary executes there. The launch and audit paths do not use them
 - Data exfiltration to unauthorized domains: proxy-blocked
 - Accidental pushes to main and PR merges without review: guard-blocked
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1086,19 +1086,23 @@ fn resolve_mise_shim(candidate: &Path, binary_name: &str) -> Option<PathBuf> {
     let home = std::env::var("HOME").ok();
     let cwd = home.as_deref().unwrap_or("/");
 
-    let output = std::process::Command::new("mise")
-        .arg("which")
-        .arg(binary_name)
-        .current_dir(cwd)
-        .output()
-        .or_else(|_| {
-            std::process::Command::new("asdf")
+    // Trusted paths, not PATH: this runs in the unsandboxed parent before the
+    // agent starts, and mise's own shims directory is one of the write+exec
+    // grants an agent can plant into. When neither is found in a trusted
+    // directory the installs-dir scan below covers the same case, so nothing is
+    // lost beyond mise's own version resolution.
+    let output = ["mise", "asdf"]
+        .iter()
+        .filter_map(|tool| crate::git::trusted_binary(tool))
+        .filter_map(|tool| {
+            std::process::Command::new(&tool)
                 .arg("which")
                 .arg(binary_name)
                 .current_dir(cwd)
                 .output()
+                .ok()
         })
-        .ok();
+        .find(|out| out.status.success());
 
     if let Some(ref out) = output
         && out.status.success()

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -696,19 +696,31 @@ impl Resolved {
     /// Both directions of `starts_with` count. A grant *inside* a trusted dir
     /// is the direct hole; a grant on an ancestor (`/usr`, or `/`) is the same
     /// hole one level up.
+    ///
+    /// [`crate::git::TRUSTED_BIN_ROOTS`] counts too, not just the bin dirs.
+    /// `trusted_binary` follows a symlink and accepts any final target under a
+    /// root, which is what makes Homebrew's `bin/git -> ../Cellar/git/*/bin/git`
+    /// work — so a grant on `/opt/homebrew/Cellar` never touches a *bin* dir yet
+    /// still lets the agent rewrite the file the trusted `git` resolves to.
+    /// Checking only the bin dirs missed exactly the layout the roots exist for.
     #[must_use]
     pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, Vec<&'static str>)> {
         self.allow_write
             .iter()
             .filter_map(|granted| {
-                let hit: Vec<&'static str> = crate::git::TRUSTED_BIN_DIRS
+                let mut hit: Vec<&'static str> = crate::git::TRUSTED_BIN_DIRS
                     .iter()
+                    .chain(crate::git::TRUSTED_BIN_ROOTS.iter())
                     .filter(|d| {
                         let dir = Path::new(*d);
                         dir.starts_with(granted) || granted.starts_with(dir)
                     })
                     .copied()
                     .collect();
+                // A bin dir usually sits under a root, so one grant can match
+                // both spellings of the same place; report each path once.
+                hit.sort_unstable();
+                hit.dedup();
                 (!hit.is_empty()).then(|| (granted.clone(), hit))
             })
             .collect()
@@ -1826,7 +1838,9 @@ validate = false
             found
                 .iter()
                 .any(|(g, dirs)| g == Path::new("/opt/homebrew/bin")
-                    && dirs == &["/opt/homebrew/bin"]),
+                    && dirs.contains(&"/opt/homebrew/bin")
+                    // The bin dir sits under the root, so both are named.
+                    && dirs.contains(&"/opt/homebrew")),
             "the exact-match grant must be reported: {found:?}"
         );
         assert!(
@@ -1853,10 +1867,37 @@ validate = false
         resolved.allow_write = vec![PathBuf::from("/")];
         let found = resolved.write_grants_over_trusted_bins();
         assert_eq!(found.len(), 1, "one logical overlap, one row: {found:?}");
+        for expected in crate::git::TRUSTED_BIN_DIRS
+            .iter()
+            .chain(crate::git::TRUSTED_BIN_ROOTS.iter())
+        {
+            assert!(
+                found[0].1.contains(expected),
+                "the row must name every trusted path it swallows, missing {expected}: {found:?}"
+            );
+        }
+        let mut deduped = found[0].1.clone();
+        deduped.dedup();
+        assert_eq!(deduped, found[0].1, "each path named once: {found:?}");
+    }
+
+    /// The F3 case: `trusted_binary` follows `/opt/homebrew/bin/git` to its
+    /// target under `Cellar`, so a grant there lets the agent rewrite the file
+    /// the parent executes — without ever naming a *bin* directory. Checking
+    /// only `TRUSTED_BIN_DIRS` waved this through.
+    #[test]
+    fn a_write_grant_over_a_symlink_target_root_is_reported() {
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        resolved.allow_write = vec![PathBuf::from("/opt/homebrew/Cellar")];
+        let found = resolved.write_grants_over_trusted_bins();
         assert_eq!(
-            found[0].1.len(),
-            crate::git::TRUSTED_BIN_DIRS.len(),
-            "the row must name every trusted dir it swallows: {found:?}"
+            found.len(),
+            1,
+            "a grant under a trusted root must be reported: {found:?}"
+        );
+        assert!(
+            found[0].1.contains(&"/opt/homebrew"),
+            "the row must name the root it sits under: {found:?}"
         );
     }
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -673,6 +673,38 @@ impl Resolved {
         false
     }
 
+    /// Write grants that overlap a [`crate::git::TRUSTED_BIN_DIRS`] entry, as
+    /// `(granted path, trusted dir)` pairs. Empty is the normal case.
+    ///
+    /// `allow.write` accepts an absolute path as-is — `resolve_config_path`
+    /// only expands `~` and canonicalizes — so nothing stops a grant on
+    /// `/opt/homebrew/bin`, which is exactly what a user reaches for to make
+    /// `brew install` work from inside the sandbox. cplt resolves its own
+    /// `git`, `bwrap` and `sandbox-exec` from those directories and runs them
+    /// in the **unsandboxed parent**, so such a grant hands the agent
+    /// unsandboxed execution on the next launch and undoes the whole point of
+    /// [`crate::git::trusted_binary`].
+    ///
+    /// A warning, not a refusal: erroring would break configs that work today.
+    /// Call after `apply_repo_config`, so the repo-proposed grants are in too.
+    ///
+    /// Both directions of `starts_with` count. A grant *inside* a trusted dir
+    /// is the direct hole; a grant on an ancestor (`/usr`, or `/`) is the same
+    /// hole one level up.
+    #[must_use]
+    pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, &'static str)> {
+        self.allow_write
+            .iter()
+            .flat_map(|granted| {
+                crate::git::TRUSTED_BIN_DIRS.iter().filter_map(move |d| {
+                    let dir = Path::new(d);
+                    (dir.starts_with(granted) || granted.starts_with(dir))
+                        .then(|| (granted.clone(), *d))
+                })
+            })
+            .collect()
+    }
+
     /// Print comprehensive sandbox configuration summary to stderr.
     ///
     /// Shows ALL effective settings including defaults so the user can make
@@ -1766,6 +1798,55 @@ validate = false
     fn config_parse_invalid() {
         let result = Config::parse("[broken");
         assert!(result.is_err());
+    }
+
+    /// The grant that reopens #236: `trusted_binary` refuses `PATH` so the
+    /// parent's `git` can only come from a root-owned directory, and a write
+    /// grant on that directory hands it straight back. Warned about, not
+    /// blocked, so this asserts on the pairs the warning is built from.
+    #[test]
+    fn write_grant_over_a_trusted_bin_dir_is_reported() {
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        resolved.allow_write = vec![
+            PathBuf::from("/opt/homebrew/bin"),
+            PathBuf::from("/usr"), // ancestor: same hole, one level up
+            PathBuf::from("/usr/bin/subdir"), // inside: the direct hole
+        ];
+        let found = resolved.write_grants_over_trusted_bins();
+        assert!(
+            found
+                .iter()
+                .any(|(g, d)| g == Path::new("/opt/homebrew/bin") && *d == "/opt/homebrew/bin"),
+            "the exact-match grant must be reported: {found:?}"
+        );
+        assert!(
+            found.iter().any(|(g, _)| g == Path::new("/usr")),
+            "a grant on an ancestor of a trusted dir must be reported: {found:?}"
+        );
+        assert!(
+            found.iter().any(|(g, _)| g == Path::new("/usr/bin/subdir")),
+            "a grant inside a trusted dir must be reported: {found:?}"
+        );
+    }
+
+    /// The other direction, so the warning stays rare enough to be read: an
+    /// ordinary build-output or cache grant must produce nothing.
+    #[test]
+    fn ordinary_write_grants_are_not_reported() {
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        resolved.allow_write = vec![
+            PathBuf::from("/home/u/project/build"),
+            PathBuf::from("/tmp/sandbox-out"),
+            PathBuf::from("/home/u/.cache/go-build"),
+            // Neither a prefix of a trusted dir nor prefixed by one: `starts_with`
+            // is component-wise, so this must not match `/usr/bin`.
+            PathBuf::from("/usr/binaries"),
+        ];
+        assert_eq!(
+            resolved.write_grants_over_trusted_bins(),
+            vec![],
+            "an ordinary write grant must not warn"
+        );
     }
 
     #[test]

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -751,7 +751,13 @@ impl Resolved {
     pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, Vec<String>)> {
         // Resolution is filesystem-only (no spawn), so this is safe to do while
         // building the warning. `None` for a binary that is not installed.
-        let resolved: Vec<String> = ["git", "gh", "bwrap"]
+        // Every helper the unsandboxed parent resolves this way and then
+        // spawns. `mise`/`asdf` matter as much as git: `resolve_mise_shim`
+        // runs them in the parent, and the warning text names mise explicitly,
+        // so leaving them out promises coverage the check does not deliver.
+        // `sandbox-exec` is absent deliberately — it is the fixed
+        // /usr/bin/sandbox-exec, never resolved.
+        let resolved: Vec<String> = ["git", "gh", "bwrap", "mise", "asdf"]
             .iter()
             .filter_map(|n| crate::git::trusted_binary(n))
             .map(|p| {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -673,8 +673,13 @@ impl Resolved {
         false
     }
 
-    /// Write grants that overlap a [`crate::git::TRUSTED_BIN_DIRS`] entry, as
-    /// `(granted path, trusted dir)` pairs. Empty is the normal case.
+    /// Write grants that overlap [`crate::git::TRUSTED_BIN_DIRS`], as
+    /// `(granted path, every trusted dir it overlaps)`. Empty is the normal case.
+    ///
+    /// Grouped by grant, not one row per pair: a grant on `/usr` or `/` overlaps
+    /// several trusted directories at once, and that is still **one** thing the
+    /// user has to go edit. Emitting a warning per pair would print the same
+    /// advice six times for one line of config.
     ///
     /// `allow.write` accepts an absolute path as-is — `resolve_config_path`
     /// only expands `~` and canonicalizes — so nothing stops a grant on
@@ -692,15 +697,19 @@ impl Resolved {
     /// is the direct hole; a grant on an ancestor (`/usr`, or `/`) is the same
     /// hole one level up.
     #[must_use]
-    pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, &'static str)> {
+    pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, Vec<&'static str>)> {
         self.allow_write
             .iter()
-            .flat_map(|granted| {
-                crate::git::TRUSTED_BIN_DIRS.iter().filter_map(move |d| {
-                    let dir = Path::new(d);
-                    (dir.starts_with(granted) || granted.starts_with(dir))
-                        .then(|| (granted.clone(), *d))
-                })
+            .filter_map(|granted| {
+                let hit: Vec<&'static str> = crate::git::TRUSTED_BIN_DIRS
+                    .iter()
+                    .filter(|d| {
+                        let dir = Path::new(*d);
+                        dir.starts_with(granted) || granted.starts_with(dir)
+                    })
+                    .copied()
+                    .collect();
+                (!hit.is_empty()).then(|| (granted.clone(), hit))
             })
             .collect()
     }
@@ -1816,7 +1825,8 @@ validate = false
         assert!(
             found
                 .iter()
-                .any(|(g, d)| g == Path::new("/opt/homebrew/bin") && *d == "/opt/homebrew/bin"),
+                .any(|(g, dirs)| g == Path::new("/opt/homebrew/bin")
+                    && dirs == &["/opt/homebrew/bin"]),
             "the exact-match grant must be reported: {found:?}"
         );
         assert!(
@@ -1826,6 +1836,27 @@ validate = false
         assert!(
             found.iter().any(|(g, _)| g == Path::new("/usr/bin/subdir")),
             "a grant inside a trusted dir must be reported: {found:?}"
+        );
+        assert_eq!(
+            found.len(),
+            3,
+            "one row per grant, not per (grant, trusted dir) pair: {found:?}"
+        );
+    }
+
+    /// One grant, many overlaps, one warning: `/` contains every trusted
+    /// directory, and six copies of the same advice is how a real warning gets
+    /// scrolled past.
+    #[test]
+    fn a_grant_over_many_trusted_dirs_is_reported_once() {
+        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
+        resolved.allow_write = vec![PathBuf::from("/")];
+        let found = resolved.write_grants_over_trusted_bins();
+        assert_eq!(found.len(), 1, "one logical overlap, one row: {found:?}");
+        assert_eq!(
+            found[0].1.len(),
+            crate::git::TRUSTED_BIN_DIRS.len(),
+            "the row must name every trusted dir it swallows: {found:?}"
         );
     }
 

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -621,6 +621,42 @@ impl Config {
     }
 }
 
+/// Which `allow.write` grants overlap a path the unsandboxed parent executes.
+///
+/// Split out from [`Resolved::write_grants_over_trusted_bins`] so the predicate
+/// can be tested against an injected list. Resolving the real binaries makes the
+/// caller machine-dependent; the rule itself is not, and the rule is the part
+/// worth pinning.
+///
+/// `extra` holds already-resolved binary paths (a Homebrew `bin/git` symlink
+/// followed into `Cellar`, say) — matching those, rather than whole trusted
+/// roots, is what keeps the warning off ordinary `/opt/homebrew/var` grants.
+fn grants_over_trusted_paths(
+    allow_write: &[PathBuf],
+    extra: &[String],
+) -> Vec<(PathBuf, Vec<String>)> {
+    allow_write
+        .iter()
+        .filter_map(|granted| {
+            let mut hit: Vec<String> = crate::git::TRUSTED_BIN_DIRS
+                .iter()
+                .map(|d| (*d).to_string())
+                .chain(extra.iter().cloned())
+                .filter(|d| {
+                    let dir = Path::new(d);
+                    dir.starts_with(granted) || granted.starts_with(dir)
+                })
+                .collect();
+            // A resolved binary usually lives under a bin dir, so one grant can
+            // match both; report each path once. Sorted first because `dedup`
+            // only collapses adjacent duplicates.
+            hit.sort_unstable();
+            hit.dedup();
+            (!hit.is_empty()).then(|| (granted.clone(), hit))
+        })
+        .collect()
+}
+
 /// Read the ambient `NO_PROXY`/`no_proxy` environment value, if any. Kept as a
 /// tiny standalone fn so there is a single place cplt reaches into the process
 /// environment for upstream-proxy-bypass configuration. cplt runs OUTSIDE the
@@ -697,33 +733,35 @@ impl Resolved {
     /// is the direct hole; a grant on an ancestor (`/usr`, or `/`) is the same
     /// hole one level up.
     ///
-    /// [`crate::git::TRUSTED_BIN_ROOTS`] counts too, not just the bin dirs.
-    /// `trusted_binary` follows a symlink and accepts any final target under a
-    /// root, which is what makes Homebrew's `bin/git -> ../Cellar/git/*/bin/git`
-    /// work — so a grant on `/opt/homebrew/Cellar` never touches a *bin* dir yet
-    /// still lets the agent rewrite the file the trusted `git` resolves to.
-    /// Checking only the bin dirs missed exactly the layout the roots exist for.
+    /// The *resolved* helper binaries count too, not just the bin dirs.
+    /// `trusted_binary` follows a symlink and accepts any final target under
+    /// [`crate::git::TRUSTED_BIN_ROOTS`], which is what makes Homebrew's
+    /// `bin/git -> ../Cellar/git/*/bin/git` work — so a grant on the Cellar path
+    /// that binary actually resolves to never touches a *bin* dir yet still lets
+    /// the agent rewrite the file the parent executes.
+    ///
+    /// Matched against those resolved paths rather than the roots wholesale.
+    /// The roots are an acceptance filter for symlink targets, and reusing them
+    /// as a warning predicate fires on every ordinary grant under
+    /// `/opt/homebrew` or `/usr/local` — `var/` for a brew-managed database,
+    /// `lib/node_modules` for `npm -g` — none of which can reach the parent's
+    /// git unless the bin symlink already points there. A warning nobody can
+    /// act on is a warning everybody learns to skip.
     #[must_use]
-    pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, Vec<&'static str>)> {
-        self.allow_write
+    pub fn write_grants_over_trusted_bins(&self) -> Vec<(PathBuf, Vec<String>)> {
+        // Resolution is filesystem-only (no spawn), so this is safe to do while
+        // building the warning. `None` for a binary that is not installed.
+        let resolved: Vec<String> = ["git", "gh", "bwrap"]
             .iter()
-            .filter_map(|granted| {
-                let mut hit: Vec<&'static str> = crate::git::TRUSTED_BIN_DIRS
-                    .iter()
-                    .chain(crate::git::TRUSTED_BIN_ROOTS.iter())
-                    .filter(|d| {
-                        let dir = Path::new(*d);
-                        dir.starts_with(granted) || granted.starts_with(dir)
-                    })
-                    .copied()
-                    .collect();
-                // A bin dir usually sits under a root, so one grant can match
-                // both spellings of the same place; report each path once.
-                hit.sort_unstable();
-                hit.dedup();
-                (!hit.is_empty()).then(|| (granted.clone(), hit))
+            .filter_map(|n| crate::git::trusted_binary(n))
+            .map(|p| {
+                std::fs::canonicalize(&p)
+                    .unwrap_or(p)
+                    .to_string_lossy()
+                    .into_owned()
             })
-            .collect()
+            .collect();
+        grants_over_trusted_paths(&self.allow_write, &resolved)
     }
 
     /// Print comprehensive sandbox configuration summary to stderr.
@@ -1825,22 +1863,23 @@ validate = false
     /// parent's `git` can only come from a root-owned directory, and a write
     /// grant on that directory hands it straight back. Warned about, not
     /// blocked, so this asserts on the pairs the warning is built from.
+    ///
+    /// Driven through `grants_over_trusted_paths` with an injected resolved
+    /// binary: resolving the real one would make the expectations depend on
+    /// whether this machine has Homebrew.
     #[test]
     fn write_grant_over_a_trusted_bin_dir_is_reported() {
-        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
-        resolved.allow_write = vec![
+        let grants = vec![
             PathBuf::from("/opt/homebrew/bin"),
             PathBuf::from("/usr"), // ancestor: same hole, one level up
             PathBuf::from("/usr/bin/subdir"), // inside: the direct hole
         ];
-        let found = resolved.write_grants_over_trusted_bins();
+        let found = grants_over_trusted_paths(&grants, &[]);
         assert!(
             found
                 .iter()
                 .any(|(g, dirs)| g == Path::new("/opt/homebrew/bin")
-                    && dirs.contains(&"/opt/homebrew/bin")
-                    // The bin dir sits under the root, so both are named.
-                    && dirs.contains(&"/opt/homebrew")),
+                    && dirs == &["/opt/homebrew/bin".to_string()]),
             "the exact-match grant must be reported: {found:?}"
         );
         assert!(
@@ -1863,42 +1902,77 @@ validate = false
     /// scrolled past.
     #[test]
     fn a_grant_over_many_trusted_dirs_is_reported_once() {
-        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
-        resolved.allow_write = vec![PathBuf::from("/")];
-        let found = resolved.write_grants_over_trusted_bins();
+        let found = grants_over_trusted_paths(&[PathBuf::from("/")], &[]);
         assert_eq!(found.len(), 1, "one logical overlap, one row: {found:?}");
-        for expected in crate::git::TRUSTED_BIN_DIRS
-            .iter()
-            .chain(crate::git::TRUSTED_BIN_ROOTS.iter())
-        {
+        for expected in crate::git::TRUSTED_BIN_DIRS {
             assert!(
-                found[0].1.contains(expected),
-                "the row must name every trusted path it swallows, missing {expected}: {found:?}"
+                found[0].1.iter().any(|h| h == expected),
+                "the row must name every trusted dir it swallows, missing {expected}: {found:?}"
             );
         }
-        let mut deduped = found[0].1.clone();
-        deduped.dedup();
-        assert_eq!(deduped, found[0].1, "each path named once: {found:?}");
+        // Set-based, not `dedup`-based: `dedup` only collapses ADJACENT
+        // duplicates, so asserting on it would pass if the sort were dropped.
+        let unique: std::collections::BTreeSet<&String> = found[0].1.iter().collect();
+        assert_eq!(
+            unique.len(),
+            found[0].1.len(),
+            "each path named once: {found:?}"
+        );
     }
 
     /// The F3 case: `trusted_binary` follows `/opt/homebrew/bin/git` to its
     /// target under `Cellar`, so a grant there lets the agent rewrite the file
-    /// the parent executes — without ever naming a *bin* directory. Checking
-    /// only `TRUSTED_BIN_DIRS` waved this through.
+    /// the parent executes — without ever naming a *bin* directory.
+    ///
+    /// Matched against the resolved binary, not the whole `/opt/homebrew` root:
+    /// warning on the root would also fire on `/opt/homebrew/var`, which cannot
+    /// reach the parent's git at all.
     #[test]
-    fn a_write_grant_over_a_symlink_target_root_is_reported() {
-        let mut resolved = Config::default().merge(CliFlags::default()).unwrap();
-        resolved.allow_write = vec![PathBuf::from("/opt/homebrew/Cellar")];
-        let found = resolved.write_grants_over_trusted_bins();
+    fn a_write_grant_over_a_resolved_binary_is_reported() {
+        let resolved = vec!["/opt/homebrew/Cellar/git/2.51.0/bin/git".to_string()];
+        let found = grants_over_trusted_paths(&[PathBuf::from("/opt/homebrew/Cellar")], &resolved);
         assert_eq!(
             found.len(),
             1,
-            "a grant under a trusted root must be reported: {found:?}"
+            "a grant containing the resolved binary must be reported: {found:?}"
         );
         assert!(
-            found[0].1.contains(&"/opt/homebrew"),
-            "the row must name the root it sits under: {found:?}"
+            found[0].1.iter().any(|h| h.contains("Cellar")),
+            "the row must name the resolved binary it covers: {found:?}"
         );
+    }
+
+    /// A resolved binary that IS a trusted bin dir entry (a `git` living
+    /// directly in `/usr/bin`, no symlink) puts the same string in the chain
+    /// twice, non-adjacently. `dedup` alone only collapses adjacent duplicates,
+    /// so this fails if the sort before it is ever dropped.
+    #[test]
+    fn a_path_reachable_two_ways_is_named_once() {
+        let resolved = vec!["/usr/bin".to_string()];
+        let found = grants_over_trusted_paths(&[PathBuf::from("/")], &resolved);
+        assert_eq!(found.len(), 1);
+        let hits = &found[0].1;
+        assert_eq!(
+            hits.iter().filter(|h| *h == "/usr/bin").count(),
+            1,
+            "/usr/bin arrives from both the dir list and the resolved binary, \
+             and must still be named once: {hits:?}"
+        );
+    }
+
+    /// The counterpart, and the reason this is matched on resolved binaries
+    /// rather than on `TRUSTED_BIN_ROOTS`: a brew-managed database directory is
+    /// an ordinary grant that cannot reach the parent's git.
+    #[test]
+    fn an_ordinary_grant_under_a_trusted_root_is_not_reported() {
+        let resolved = vec!["/opt/homebrew/Cellar/git/2.51.0/bin/git".to_string()];
+        for ordinary in ["/opt/homebrew/var", "/usr/local/lib/node_modules"] {
+            let found = grants_over_trusted_paths(&[PathBuf::from(ordinary)], &resolved);
+            assert!(
+                found.is_empty(),
+                "{ordinary} cannot reach the parent's binaries and must not warn: {found:?}"
+            );
+        }
     }
 
     /// The other direction, so the warning stays rare enough to be read: an

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1187,17 +1187,23 @@ fn find_app_contents(path: &Path) -> Option<PathBuf> {
 }
 
 /// Resolve a command name to its real path (following symlinks).
+///
+/// Reads `PATH` in-process rather than spawning `which`. `discover_tools` runs
+/// on every launch, in the unsandboxed parent, before the agent starts — and it
+/// called this once per tool plus once per app dir. Spawning a bare `which`
+/// there means a `which` planted in one of the write+exec grants a previous
+/// session had (mise shims, `PNPM_HOME`, `~/.bun/bin`) executes as the user.
+/// A pure-Rust lookup has nothing to hijack. Same reasoning as
+/// `git::TRUSTED_BIN_DIRS`, one rung better: no spawn beats a trusted spawn.
+///
+/// Not a trusted-directory lookup, deliberately: the point of discovery is to
+/// report what is on the user's `PATH`, wherever it lives. The returned path is
+/// only ever *reported* or turned into a sandbox grant, never executed — except
+/// by `discover_agents`/`discover_copilot`, which run version probes for
+/// `cplt doctor` only.
 fn which_resolved(name: &str) -> Option<PathBuf> {
-    let output = std::process::Command::new("which")
-        .arg(name)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let path = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
-    // Follow symlinks to get the real path
-    std::fs::canonicalize(&path).ok().or(Some(path))
+    let path = crate::sandbox::which_binary(name)?;
+    Some(std::fs::canonicalize(&path).unwrap_or(path))
 }
 
 /// Find native `.node` modules matching a name in `~/.copilot/pkg/`.

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -978,9 +978,24 @@ pub fn git_hooks_path(home_dir: &Path) -> Option<PathBuf> {
 /// hostile `filter.*.clean` in a granted repo would make the hardened invoker
 /// refuse, and that repo's `.git/hooks` would lose its deny.
 pub fn git_dir_of(dir: &Path) -> Option<PathBuf> {
-    let output = crate::git::command(dir, &["rev-parse", "--git-common-dir"])?
-        .output()
-        .ok()?;
+    let Some(mut cmd) = crate::git::command(dir, &["rev-parse", "--git-common-dir"]) else {
+        // No trusted git on this machine. Before this fallback existed, that
+        // returned `None` and every gitdir-derived deny for a worktree or a
+        // separate-gitdir repo silently vanished — the fail-open the doc
+        // comment above warns about, now reachable on an ordinary machine
+        // whose git simply lives outside the trusted directories.
+        //
+        // `<dir>/.git` is enough to recover the common cases without running
+        // anything: a plain repo has it as a directory, and a worktree or
+        // submodule has it as a file holding `gitdir: <path>`. Reading a file
+        // is not a PATH-hijack surface, which is the whole reason git is
+        // resolved from trusted directories in the first place.
+        //
+        // Still `None` for a bare repo (no `.git` entry at all); that case has
+        // no working tree for an agent to be sandboxed into.
+        return gitdir_without_git(dir);
+    };
+    let output = cmd.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -1001,6 +1016,42 @@ pub fn git_dir_of(dir: &Path) -> Option<PathBuf> {
     } else {
         None
     }
+}
+
+/// Resolve `<dir>`'s git directory by reading `<dir>/.git`, without running git.
+///
+/// Used only when no trusted git binary exists. Handles the two layouts that
+/// matter for the persistence denies:
+/// - directory → an ordinary repo, the gitdir is `<dir>/.git`
+/// - file      → a worktree or submodule, holding `gitdir: <path>`
+///
+/// The pointer is resolved relative to `<dir>` when relative, canonicalized,
+/// and accepted only if it is a directory — matching what the git-backed path
+/// returns. Deliberately no validation beyond that: the result is turned into
+/// write denies by the caller, so a wrong answer can only over-deny, never
+/// grant. (`git_common_dir` applies its own $HOME and steering checks before
+/// using this for anything that *grants*.)
+fn gitdir_without_git(dir: &Path) -> Option<PathBuf> {
+    let dot_git = dir.join(".git");
+    let meta = std::fs::symlink_metadata(&dot_git).ok()?;
+    if meta.is_dir() {
+        return std::fs::canonicalize(&dot_git).ok().or(Some(dot_git));
+    }
+    let contents = std::fs::read_to_string(&dot_git).ok()?;
+    let pointer = contents
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("gitdir:"))?
+        .trim();
+    if pointer.is_empty() {
+        return None;
+    }
+    let path = if Path::new(pointer).is_absolute() {
+        PathBuf::from(pointer)
+    } else {
+        dir.join(pointer)
+    };
+    let resolved = std::fs::canonicalize(&path).unwrap_or(path);
+    resolved.is_dir().then_some(resolved)
 }
 
 /// Detect if the project is a git worktree and return the shared `.git` directory.
@@ -1377,6 +1428,68 @@ mod tests {
             "an unquotable common dir must be skipped, not returned for \
              prepare() to hard-error on"
         );
+    }
+
+    /// Without a trusted git, a worktree's gitdir must still resolve — it is
+    /// where the real hooks live, and losing it means losing their write deny.
+    /// The `.git` file is read directly; nothing is spawned.
+    #[test]
+    fn gitdir_without_git_follows_a_worktree_pointer() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let real = root.join("main/.git/worktrees/wt");
+        std::fs::create_dir_all(&real).expect("mkdir");
+        let wt = root.join("wt");
+        std::fs::create_dir_all(&wt).expect("mkdir");
+        std::fs::write(wt.join(".git"), format!("gitdir: {}\n", real.display())).expect("write");
+
+        assert_eq!(gitdir_without_git(&wt).as_deref(), Some(real.as_path()));
+    }
+
+    /// A relative pointer is the form git actually writes for a submodule.
+    #[test]
+    fn gitdir_without_git_resolves_a_relative_pointer() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let real = root.join(".git/modules/sub");
+        std::fs::create_dir_all(&real).expect("mkdir");
+        let sub = root.join("sub");
+        std::fs::create_dir_all(&sub).expect("mkdir");
+        std::fs::write(sub.join(".git"), "gitdir: ../.git/modules/sub\n").expect("write");
+
+        assert_eq!(gitdir_without_git(&sub).as_deref(), Some(real.as_path()));
+    }
+
+    #[test]
+    fn gitdir_without_git_handles_a_plain_repo_and_a_non_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+
+        let plain = root.join("plain");
+        std::fs::create_dir_all(plain.join(".git")).expect("mkdir");
+        assert_eq!(
+            gitdir_without_git(&plain).as_deref(),
+            Some(plain.join(".git").as_path())
+        );
+
+        let bare = root.join("nothing");
+        std::fs::create_dir_all(&bare).expect("mkdir");
+        assert_eq!(gitdir_without_git(&bare), None, "no .git entry at all");
+    }
+
+    /// A pointer that does not resolve to a directory is refused rather than
+    /// returned — the git-backed path applies the same `is_dir` check.
+    #[test]
+    fn gitdir_without_git_refuses_a_dangling_pointer() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let dir = root.join("proj");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(dir.join(".git"), "gitdir: /nonexistent/elsewhere\n").expect("write");
+        assert_eq!(gitdir_without_git(&dir), None);
+
+        std::fs::write(dir.join(".git"), "not a pointer at all\n").expect("write");
+        assert_eq!(gitdir_without_git(&dir), None);
     }
 
     /// `git_dir_of` is the resolver behind the #212 sibling-repo protections;

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -978,7 +978,19 @@ pub fn git_hooks_path(home_dir: &Path) -> Option<PathBuf> {
 /// hostile `filter.*.clean` in a granted repo would make the hardened invoker
 /// refuse, and that repo's `.git/hooks` would lose its deny.
 pub fn git_dir_of(dir: &Path) -> Option<PathBuf> {
-    let Some(mut cmd) = crate::git::command(dir, &["rev-parse", "--git-common-dir"]) else {
+    git_dir_of_with(
+        crate::git::command(dir, &["rev-parse", "--git-common-dir"]),
+        dir,
+    )
+}
+
+/// [`git_dir_of`] with the hardened invoker's result injected.
+///
+/// Exists so the no-trusted-git arm is reachable in a test: `trusted_git()`
+/// caches in a `OnceLock`, so on a host that has git the fallback branch is
+/// otherwise unreachable and a revert of the wiring goes unnoticed.
+fn git_dir_of_with(cmd: Option<std::process::Command>, dir: &Path) -> Option<PathBuf> {
+    let Some(mut cmd) = cmd else {
         // No trusted git on this machine. Before this fallback existed, that
         // returned `None` and every gitdir-derived deny for a worktree or a
         // separate-gitdir repo silently vanished — the fail-open the doc
@@ -1029,11 +1041,22 @@ pub fn git_dir_of(dir: &Path) -> Option<PathBuf> {
 /// and accepted only if it is a directory — matching what the git-backed path
 /// returns. Deliberately no validation beyond that: the result is turned into
 /// write denies by the caller, so a wrong answer can only over-deny, never
-/// grant. (`git_common_dir` applies its own $HOME and steering checks before
-/// using this for anything that *grants*.)
+/// grant. (`git_common_dir` returns before granting whenever there is no
+/// trusted git, because its commondir-steering check runs the invoker too.)
+///
+/// The residual that buys: an agent that can write `<root>/.git` can point this
+/// at any existing directory and get that directory's `hooks`/`config`/`modules`
+/// write-denied next session. Real git refuses a pointer to a non-gitdir; this
+/// does not. It is self-denial-of-service only — it can subtract access, never
+/// add it — and the alternative is validating a gitdir's shape without git,
+/// which is more code for a worse failure mode.
 fn gitdir_without_git(dir: &Path) -> Option<PathBuf> {
     let dot_git = dir.join(".git");
-    let meta = std::fs::symlink_metadata(&dot_git).ok()?;
+    // `metadata`, not `symlink_metadata`: git follows a `.git` symlink to a
+    // directory, and the git-backed path canonicalizes to the target. Not
+    // following it here would drop straight to the `read_to_string` branch,
+    // fail with EISDIR, and lose the target's denies.
+    let meta = std::fs::metadata(&dot_git).ok()?;
     if meta.is_dir() {
         return std::fs::canonicalize(&dot_git).ok().or(Some(dot_git));
     }
@@ -1051,7 +1074,33 @@ fn gitdir_without_git(dir: &Path) -> Option<PathBuf> {
         dir.join(pointer)
     };
     let resolved = std::fs::canonicalize(&path).unwrap_or(path);
-    resolved.is_dir().then_some(resolved)
+    if !resolved.is_dir() {
+        return None;
+    }
+    // A worktree's pointer names `<main>/.git/worktrees/<name>`, which is NOT
+    // the directory that holds `hooks/` and `config` — those live in the shared
+    // dir, which `git rev-parse --git-common-dir` returns and which the
+    // per-worktree dir names in its own `commondir` file (git writes literally
+    // `../..`). Returning the per-worktree dir would satisfy nothing: the denies
+    // would land on paths that do not exist while the real hooks stayed open.
+    //
+    // Submodules and `--separate-git-dir` repos have no `commondir`; their
+    // pointer already names the common dir, so they fall through unchanged.
+    if let Ok(raw) = std::fs::read_to_string(resolved.join("commondir")) {
+        let raw = raw.trim();
+        if !raw.is_empty() {
+            let common = if Path::new(raw).is_absolute() {
+                PathBuf::from(raw)
+            } else {
+                resolved.join(raw)
+            };
+            let common = std::fs::canonicalize(&common).unwrap_or(common);
+            if common.is_dir() {
+                return Some(common);
+            }
+        }
+    }
+    Some(resolved)
 }
 
 /// Detect if the project is a git worktree and return the shared `.git` directory.
@@ -1434,16 +1483,60 @@ mod tests {
     /// where the real hooks live, and losing it means losing their write deny.
     /// The `.git` file is read directly; nothing is spawned.
     #[test]
-    fn gitdir_without_git_follows_a_worktree_pointer() {
+    fn gitdir_without_git_follows_a_worktree_to_the_shared_dir() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
-        let real = root.join("main/.git/worktrees/wt");
-        std::fs::create_dir_all(&real).expect("mkdir");
+        let main_git = root.join("main/.git");
+        let per_worktree = main_git.join("worktrees/wt");
+        std::fs::create_dir_all(&per_worktree).expect("mkdir");
+        // What `git worktree add` writes: the pointer names the per-worktree
+        // dir, which names the shared dir in its own `commondir`.
+        std::fs::write(per_worktree.join("commondir"), "../..\n").expect("write commondir");
         let wt = root.join("wt");
         std::fs::create_dir_all(&wt).expect("mkdir");
-        std::fs::write(wt.join(".git"), format!("gitdir: {}\n", real.display())).expect("write");
+        std::fs::write(
+            wt.join(".git"),
+            format!("gitdir: {}\n", per_worktree.display()),
+        )
+        .expect("write");
 
-        assert_eq!(gitdir_without_git(&wt).as_deref(), Some(real.as_path()));
+        // The SHARED dir, not the per-worktree one: `hooks/` and `config` live
+        // there, and it is what `git rev-parse --git-common-dir` returns.
+        assert_eq!(gitdir_without_git(&wt).as_deref(), Some(main_git.as_path()));
+    }
+
+    /// The wiring, not just the helper: with no trusted git, `git_dir_of` must
+    /// fall back rather than return `None`. Untestable through `git_dir_of`
+    /// itself on a host that has git — `trusted_git()` caches — so the invoker
+    /// result is injected.
+    #[test]
+    fn git_dir_of_falls_back_when_there_is_no_trusted_git() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let proj = root.join("proj");
+        std::fs::create_dir_all(proj.join(".git")).expect("mkdir");
+
+        assert_eq!(
+            git_dir_of_with(None, &proj).as_deref(),
+            Some(proj.join(".git").as_path()),
+            "no trusted git must fall back to reading .git, not fail open"
+        );
+    }
+
+    /// A `.git` symlink to a real gitdir is a supported layout, and git follows
+    /// it. Reading link metadata instead would take the pointer-file branch and
+    /// fail with EISDIR, losing the target's denies.
+    #[test]
+    fn gitdir_without_git_follows_a_dot_git_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let real = root.join("elsewhere.git");
+        std::fs::create_dir_all(&real).expect("mkdir");
+        let proj = root.join("proj");
+        std::fs::create_dir_all(&proj).expect("mkdir");
+        std::os::unix::fs::symlink(&real, proj.join(".git")).expect("symlink");
+
+        assert_eq!(gitdir_without_git(&proj).as_deref(), Some(real.as_path()));
     }
 
     /// A relative pointer is the form git actually writes for a submodule.

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1060,6 +1060,13 @@ fn gitdir_without_git(dir: &Path) -> Option<PathBuf> {
     if meta.is_dir() {
         return std::fs::canonicalize(&dot_git).ok().or(Some(dot_git));
     }
+    // Regular file only. `read_to_string` opens O_RDONLY, which blocks forever
+    // on a FIFO with no writer — an agent that can write `<root>/.git` could
+    // otherwise `mkfifo` it and hang the next launch before the sandbox exists.
+    // Real git checks the same thing and exits rather than blocking.
+    if !meta.is_file() {
+        return None;
+    }
     let contents = std::fs::read_to_string(&dot_git).ok()?;
     let pointer = contents
         .lines()
@@ -1520,6 +1527,31 @@ mod tests {
             git_dir_of_with(None, &proj).as_deref(),
             Some(proj.join(".git").as_path()),
             "no trusted git must fall back to reading .git, not fail open"
+        );
+    }
+
+    /// `read_to_string` on a FIFO blocks forever with no writer. An agent that
+    /// can write `<root>/.git` could `mkfifo` it and hang the next launch
+    /// before the sandbox exists. Real git exits rather than blocking.
+    #[test]
+    fn gitdir_without_git_refuses_a_non_regular_dot_git() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+        let proj = root.join("proj");
+        std::fs::create_dir_all(&proj).expect("mkdir");
+        let fifo = proj.join(".git");
+
+        let made = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .is_ok_and(|s| s.success());
+        if !made {
+            return; // no mkfifo on this machine — nothing to assert
+        }
+        assert_eq!(
+            gitdir_without_git(&proj),
+            None,
+            "a FIFO .git must be refused, not read"
         );
     }
 

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1311,9 +1311,10 @@ fn extract_repo_from_api_path(endpoint: &str) -> Option<String> {
 /// variables are ignored because they could retarget the guard's scope.
 ///
 /// Deliberately does **not** route through [`crate::git::command`] (#210).
-/// That builder resolves `git` through `PATH`; this one must use the
-/// caller-validated `real_git` binary, and it needs `--local --no-includes`,
-/// which is stricter than the shared path. `git config` executes nothing, so
+/// It needs `--local --no-includes`, which is stricter than the shared path.
+/// `real_git` must be a [`crate::git::trusted_git`] path — this runs in the
+/// unsandboxed parent at launch, so a `PATH`-resolved binary here is a previous
+/// session's planted `git` executing as the user. `git config` executes nothing, so
 /// the shared `-c` overrides would add no security here. If this ever grows a
 /// subcommand that reads working-tree content, move it onto the shared path.
 pub fn detect_current_repo(real_git: &Path, project_dir: &Path) -> Result<String, String> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -22,6 +22,12 @@
 //! That is a straight sandbox escape, and for [`crate::repo_config`] it is
 //! worse still: those invocations are the input to the trust decision.
 //!
+//! The repository's config is not the only thing an agent can aim at these
+//! invocations. The *binary* is the other one: `git` looked up by name is
+//! resolved from the parent's `PATH` at spawn time, after the agent has
+//! finished writing to directories that are on it. See [`TRUSTED_BIN_DIRS`],
+//! which also spells out the part of that this module does not fix.
+//!
 //! # What is actually reachable
 //!
 //! Measured against git 2.55 for exactly the subcommands cplt runs
@@ -90,8 +96,65 @@
 //! is a loud "could not verify", never a forged clean session, so denial of the
 //! *report* is the correct trade against execution of the *payload*.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+
+/// Absolute directories a parent-side `git` may be resolved from.
+///
+/// `Command::new("git")` resolves through `execvp` **at spawn time**, using the
+/// *parent's* `PATH` — and the parent spawns git after the agent has exited
+/// (`audit::Baseline::finish`). The sandbox grants write **and** exec to several
+/// directories that are on a developer's `PATH` (mise shims, `PNPM_HOME`,
+/// `~/.deno/bin`, `~/.bun/bin` — see `sandbox_policy::HOME_TOOL_DIRS` and
+/// `APP_DIRS`), so an agent can drop a file named `git` into one of them and
+/// have the parent execute it unsandboxed moments later.
+///
+/// These four directories are the ones the sandbox exposes read-only
+/// (`sandbox_policy::TOOL_READ_DIRS`), so nothing inside the sandbox can write
+/// to them. `/usr/bin` first: it is the only one that is SIP-protected on macOS
+/// and root-owned on Linux.
+///
+/// # What this does not fix
+///
+/// This closes the "attacker prepends a directory that wins `PATH` resolution"
+/// half of the problem, and nothing more. If the user's own `git` lives in an
+/// agent-writable tree that also happens to be one of these directories — a
+/// Homebrew prefix owned by the user, say, that a `sandbox.allow.write` grant
+/// opened up — then resolving to a fixed absolute path still finds the
+/// trojaned file. Making the whole class safe means not granting write to
+/// directories that also carry exec, which is a separate decision.
+const TRUSTED_BIN_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/local/bin", "/opt/homebrew/bin"];
+
+/// The `git` binary, resolved once from [`TRUSTED_BIN_DIRS`].
+///
+/// Resolved once per process so a directory that appears *during* a session
+/// cannot change the answer between two calls, and so the warning below is
+/// emitted at most once.
+///
+/// `None` when no trusted `git` exists. Callers then degrade exactly as they do
+/// when git is missing (the audit reports `Incomplete`), which is the honest
+/// outcome — falling back to the bare name would restore the very `PATH` lookup
+/// this exists to remove.
+fn trusted_git() -> Option<&'static Path> {
+    static GIT: OnceLock<Option<PathBuf>> = OnceLock::new();
+    GIT.get_or_init(|| {
+        let found = TRUSTED_BIN_DIRS
+            .iter()
+            .map(|dir| Path::new(dir).join("git"))
+            .find(|p| p.is_file());
+        if found.is_none() {
+            crate::ui::warn(&format!(
+                "no git found in {} — parent-side git queries (audit, repo config \
+                 trust) are skipped rather than resolved through PATH, which a \
+                 sandboxed agent can write to",
+                TRUSTED_BIN_DIRS.join(", ")
+            ));
+        }
+        found
+    })
+    .as_deref()
+}
 
 /// `-c key=value` overrides prepended to every parent-side git invocation.
 ///
@@ -360,7 +423,7 @@ pub fn command(project_dir: &Path, args: &[&str]) -> Option<Command> {
         warn_refused_once();
         return None;
     }
-    let mut cmd = Command::new("git");
+    let mut cmd = Command::new(trusted_git()?);
     harden(&mut cmd);
     for arg in insert_diff_flags(args) {
         cmd.arg(arg);
@@ -384,7 +447,10 @@ pub fn command(project_dir: &Path, args: &[&str]) -> Option<Command> {
 /// on its own terms.
 #[must_use]
 pub fn repo_defines_content_filter(project_dir: &Path) -> bool {
-    let mut cmd = Command::new("git");
+    let Some(git) = trusted_git() else {
+        return false;
+    };
+    let mut cmd = Command::new(git);
     harden(&mut cmd);
     let Ok(out) = cmd
         .args(["config", "--list", "--show-scope", "--includes", "-z"])
@@ -473,6 +539,45 @@ mod tests {
             actual, expected,
             "CONFIG_OVERRIDES changed. Removing an entry weakens #210 hardening; \
              adding one needs a reviewed cost note. Update this list deliberately."
+        );
+    }
+
+    /// Fails if [`command`] goes back to `Command::new("git")`. The bare name
+    /// is resolved by `execvp` at spawn time from the *parent's* `PATH`, and the
+    /// parent spawns git after the agent has exited — so any agent-writable
+    /// directory on `PATH` (mise shims, `PNPM_HOME`, `~/.bun/bin`) is an
+    /// unsandboxed exec.
+    #[test]
+    fn git_is_resolved_from_a_trusted_absolute_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let Some(cmd) = command(dir.path(), &["rev-parse", "HEAD"]) else {
+            // No trusted git on this machine: the call must be refused, never
+            // degraded to the bare name. That is the other half of the contract.
+            assert!(trusted_git().is_none(), "refused despite a resolved git");
+            return;
+        };
+        let program = PathBuf::from(cmd.get_program());
+        assert_eq!(program.file_name().and_then(|n| n.to_str()), Some("git"));
+        assert!(
+            program.is_absolute(),
+            "git must not be resolved through PATH: {program:?}"
+        );
+        assert!(
+            TRUSTED_BIN_DIRS.iter().any(|d| program.starts_with(d)),
+            "{program:?} is outside TRUSTED_BIN_DIRS"
+        );
+    }
+
+    /// Spelled out independently of the const, like the override table above: a
+    /// test that only iterates it cannot notice a writable directory being added
+    /// or `/usr/bin` being dropped.
+    #[test]
+    fn the_trusted_bin_dirs_are_exactly_this() {
+        assert_eq!(
+            TRUSTED_BIN_DIRS,
+            &["/usr/bin", "/bin", "/usr/local/bin", "/opt/homebrew/bin"],
+            "TRUSTED_BIN_DIRS changed. Every entry must be read-only to the \
+             sandbox (sandbox_policy::TOOL_READ_DIRS) and absolute."
         );
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -135,7 +135,7 @@ use std::sync::OnceLock;
 /// install, i.e. a writable+exec tree). Making the whole class safe means not
 /// granting write to directories that also carry exec, which is a separate
 /// decision.
-pub(crate) const TRUSTED_BIN_DIRS: &[&str] = &[
+pub const TRUSTED_BIN_DIRS: &[&str] = &[
     "/usr/bin",
     "/bin",
     "/usr/local/bin",
@@ -186,24 +186,84 @@ pub(crate) fn is_executable_file(path: &Path) -> bool {
     }
 }
 
-/// First executable `name` found in `dirs`. Split out of [`trusted_binary`] so
-/// the not-found path is testable without depending on the host's `/usr/bin`.
+/// Read-only prefixes a trusted binary is allowed to **resolve into**.
+///
+/// [`TRUSTED_BIN_DIRS`] constrains the *path*, which is not the same thing as
+/// the file. `/usr/local/bin/git` and `/opt/homebrew/bin/git` are symlinks on
+/// every Homebrew install, and on Homebrew-for-Intel `/usr/local` is owned by
+/// the invoking user — so the link can point anywhere, including into a
+/// directory the sandbox grants **write** to. Checking only the path would call
+/// that trusted and hand the agent the unsandboxed exec this module exists to
+/// prevent.
+///
+/// Rejecting symlinks outright is not the answer: the legitimate targets are
+/// real (`/opt/homebrew/bin/git` → `/opt/homebrew/Cellar/git/*/bin/git`,
+/// `/run/current-system/sw/bin/git` → `/nix/store/*/bin/git`, `/bin` → `/usr/bin`
+/// on a usrmerge distro, Debian's `/etc/alternatives` hop landing back in
+/// `/usr/bin`), and refusing them would leave most installs with no trusted git
+/// at all. So the target is checked against the *containing* read-only prefixes
+/// rather than [`TRUSTED_BIN_DIRS`] itself.
+///
+/// Every entry is a prefix the sandbox never grants write to: the macOS
+/// `sandbox_policy::TOOL_READ_DIRS` and Linux `sandbox_landlock::LINUX_TOOL_DIRS`
+/// read-only tool grants, plus the Nix store (root-owned and mounted read-only,
+/// and never named by any cplt write grant).
+///
+/// Only the *final* target is checked, not every hop. A chain whose middle link
+/// sits in an agent-writable directory would still pass — but arranging that
+/// means the user's own `git` already routes through an agent-writable path,
+/// which no supported install does.
+pub(crate) const TRUSTED_BIN_ROOTS: &[&str] = &[
+    "/usr/bin",
+    "/bin",
+    "/usr/local",
+    "/opt/homebrew",
+    "/run/current-system",
+    "/nix/store",
+    "/snap",
+    "/home/linuxbrew/.linuxbrew",
+];
+
+/// Does `path` resolve to a file under one of `roots`?
+///
+/// Both sides are canonicalized: the roots because several are themselves
+/// symlinks (`/run/current-system` into the Nix store, `/var` into `/private/var`
+/// on macOS), and a textual prefix test against an unresolved root answers the
+/// wrong question.
+fn resolves_into(path: &Path, roots: &[&str]) -> bool {
+    let Ok(target) = std::fs::canonicalize(path) else {
+        return false;
+    };
+    roots
+        .iter()
+        .filter_map(|r| std::fs::canonicalize(r).ok())
+        .any(|root| target.starts_with(root))
+}
+
+/// First executable `name` found in `dirs` that resolves into `roots`. Split out
+/// of [`trusted_binary`] so the not-found path is testable without depending on
+/// the host's `/usr/bin`.
 ///
 /// `name` must be a single normal path component. `Path::join` drops the base
 /// entirely for an absolute `name` and happily walks out of it for `../x`, so
 /// without this check `trusted_binary` could return a path outside
 /// [`TRUSTED_BIN_DIRS`] — the one guarantee it exists to make.
-fn find_in(dirs: &[&str], name: &str) -> Option<PathBuf> {
+///
+/// A candidate whose target escapes `roots` is skipped like a non-executable
+/// shadow, not fatal: the search goes on to the next directory, so a repointed
+/// `/usr/local/bin/git` still lets a genuine `/opt/homebrew/bin/git` win.
+fn find_in(dirs: &[&str], roots: &[&str], name: &str) -> Option<PathBuf> {
     let mut parts = Path::new(name).components();
     if !matches!(parts.next(), Some(std::path::Component::Normal(_))) || parts.next().is_some() {
         return None;
     }
     dirs.iter()
         .map(|dir| Path::new(dir).join(name))
-        .find(|p| is_executable_file(p))
+        .find(|p| is_executable_file(p) && resolves_into(p, roots))
 }
 
-/// Resolve `name` from [`TRUSTED_BIN_DIRS`], never from `PATH`.
+/// Resolve `name` from [`TRUSTED_BIN_DIRS`], never from `PATH`, and only when
+/// it resolves into [`TRUSTED_BIN_ROOTS`].
 ///
 /// For every parent-side spawn. `None` means "not installed anywhere the agent
 /// cannot reach"; callers degrade as they already do when the tool is missing.
@@ -211,7 +271,7 @@ fn find_in(dirs: &[&str], name: &str) -> Option<PathBuf> {
 /// this exists to remove, and would do so precisely on the machines where the
 /// attacker's directory is the only match.
 pub(crate) fn trusted_binary(name: &str) -> Option<PathBuf> {
-    find_in(TRUSTED_BIN_DIRS, name)
+    find_in(TRUSTED_BIN_DIRS, TRUSTED_BIN_ROOTS, name)
 }
 
 /// The `git` binary, resolved once from [`TRUSTED_BIN_DIRS`].
@@ -684,13 +744,13 @@ mod tests {
         let planted = populated.path().join("git");
         plant_executable(&planted);
         let dirs = [empty.path().to_str().expect("utf8")];
-        assert_eq!(find_in(&dirs, "git"), None);
+        assert_eq!(find_in(&dirs, &dirs, "git"), None);
         let dirs = [
             empty.path().to_str().expect("utf8"),
             populated.path().to_str().expect("utf8"),
         ];
         // First match wins, and the earlier directory is searched first.
-        assert_eq!(find_in(&dirs, "git"), Some(planted));
+        assert_eq!(find_in(&dirs, &dirs, "git"), Some(planted));
     }
 
     fn plant_executable(path: &Path) {
@@ -711,12 +771,12 @@ mod tests {
         plant_executable(&planted);
 
         let dirs = [shadow.path().to_str().expect("utf8")];
-        assert_eq!(find_in(&dirs, "git"), None);
+        assert_eq!(find_in(&dirs, &dirs, "git"), None);
         let dirs = [
             shadow.path().to_str().expect("utf8"),
             real.path().to_str().expect("utf8"),
         ];
-        assert_eq!(find_in(&dirs, "git"), Some(planted));
+        assert_eq!(find_in(&dirs, &dirs, "git"), Some(planted));
     }
 
     /// A file with an execute bit that does **not** apply to us is still a
@@ -748,7 +808,100 @@ mod tests {
             shadow.path().to_str().expect("utf8"),
             real.path().to_str().expect("utf8"),
         ];
-        assert_eq!(find_in(&dirs, "git"), Some(planted));
+        assert_eq!(find_in(&dirs, &dirs, "git"), Some(planted));
+    }
+
+    /// The Homebrew shape, which must keep working: `bin/git` is a symlink and
+    /// its target lives elsewhere under the same read-only prefix
+    /// (`/opt/homebrew/bin/git` → `/opt/homebrew/Cellar/git/*/bin/git`).
+    /// Rejecting symlinks outright would leave those installs with no trusted
+    /// git at all.
+    #[test]
+    fn find_in_accepts_a_symlink_that_stays_inside_a_trusted_root() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let bin = root.path().join("bin");
+        let cellar = root.path().join("Cellar/git/2.55/bin");
+        std::fs::create_dir_all(&bin).expect("mkdir");
+        std::fs::create_dir_all(&cellar).expect("mkdir");
+        let real = cellar.join("git");
+        plant_executable(&real);
+        let link = bin.join("git");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let dirs = [bin.to_str().expect("utf8")];
+        let roots = [root.path().to_str().expect("utf8")];
+        assert_eq!(find_in(&dirs, &roots, "git"), Some(link));
+    }
+
+    /// The hole this closes: the *path* is in a trusted directory but the file
+    /// is not. `/usr/local/bin` is user-owned on a Homebrew-for-Intel install,
+    /// so its `git` symlink can be repointed into an agent-writable tree — and a
+    /// path-only check would call that trusted and execute it unsandboxed.
+    ///
+    /// The escape is skipped like a non-executable shadow, not fatal: a genuine
+    /// binary in a later trusted directory still wins.
+    #[test]
+    fn find_in_rejects_a_symlink_that_escapes_the_trusted_roots() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("tempdir");
+        let bin = root.path().join("bin");
+        std::fs::create_dir_all(&bin).expect("mkdir");
+        let payload = outside.path().join("git");
+        plant_executable(&payload);
+        std::os::unix::fs::symlink(&payload, bin.join("git")).expect("symlink");
+
+        let roots = [root.path().to_str().expect("utf8")];
+        let dirs = [bin.to_str().expect("utf8")];
+        assert_eq!(
+            find_in(&dirs, &roots, "git"),
+            None,
+            "a symlink out of the trusted roots must not resolve"
+        );
+
+        let real_dir = root.path().join("sbin");
+        std::fs::create_dir_all(&real_dir).expect("mkdir");
+        let real = real_dir.join("git");
+        plant_executable(&real);
+        let dirs = [
+            bin.to_str().expect("utf8"),
+            real_dir.to_str().expect("utf8"),
+        ];
+        assert_eq!(
+            find_in(&dirs, &roots, "git"),
+            Some(real),
+            "the search must continue past an escaping symlink"
+        );
+    }
+
+    /// Spelled out independently of the const, like [`TRUSTED_BIN_DIRS`]: every
+    /// root must be a prefix the sandbox never grants write to, and a widened
+    /// entry (`/`, `/home`, `$HOME`) would silently re-admit the symlink escape.
+    #[test]
+    fn the_trusted_bin_roots_are_exactly_this() {
+        assert_eq!(
+            TRUSTED_BIN_ROOTS,
+            &[
+                "/usr/bin",
+                "/bin",
+                "/usr/local",
+                "/opt/homebrew",
+                "/run/current-system",
+                "/nix/store",
+                "/snap",
+                "/home/linuxbrew/.linuxbrew",
+            ],
+            "TRUSTED_BIN_ROOTS changed. Every entry must be an absolute prefix the \
+             sandbox exposes read-only — see `sandbox_policy::TOOL_READ_DIRS` and \
+             `sandbox_landlock::LINUX_TOOL_DIRS`."
+        );
+        for dir in TRUSTED_BIN_DIRS {
+            assert!(
+                TRUSTED_BIN_ROOTS
+                    .iter()
+                    .any(|r| Path::new(dir).starts_with(r)),
+                "{dir} has no containing root, so nothing in it can ever resolve"
+            );
+        }
     }
 
     /// A directory named `git` is searchable, so `X_OK` alone would accept it.
@@ -772,10 +925,10 @@ mod tests {
         std::fs::create_dir(&sub).expect("mkdir");
         let dirs = [sub.to_str().expect("utf8")];
 
-        assert_eq!(find_in(&dirs, outside.to_str().expect("utf8")), None);
-        assert_eq!(find_in(&dirs, "../git"), None);
-        assert_eq!(find_in(&dirs, "./git"), None);
-        assert_eq!(find_in(&dirs, ""), None);
+        assert_eq!(find_in(&dirs, &dirs, outside.to_str().expect("utf8")), None);
+        assert_eq!(find_in(&dirs, &dirs, "../git"), None);
+        assert_eq!(find_in(&dirs, &dirs, "./git"), None);
+        assert_eq!(find_in(&dirs, &dirs, ""), None);
         assert_eq!(trusted_binary("/bin/sh"), None);
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -118,7 +118,9 @@ use std::sync::OnceLock;
 /// Every entry is a directory the sandbox exposes **read-only**
 /// (`sandbox_policy::TOOL_READ_DIRS` on macOS,
 /// `sandbox_landlock::LINUX_TOOL_DIRS` on Linux), so nothing inside the sandbox
-/// can write to it — an invariant the test below enforces. `/usr/bin` first: it
+/// can write to it — an invariant `sandbox.rs`'s
+/// `every_trusted_dir_is_covered_by_a_tool_read_grant` enforces. `/usr/bin`
+/// first: it
 /// is the only one that is SIP-protected on macOS and root-owned on Linux.
 ///
 /// # What this does not fix
@@ -622,36 +624,9 @@ mod tests {
                 "/home/linuxbrew/.linuxbrew/bin",
             ],
             "TRUSTED_BIN_DIRS changed. Every entry must be absolute and read-only \
-             to the sandbox — see the coverage test below."
+             to the sandbox — see `every_trusted_dir_is_covered_by_a_tool_read_grant` \
+             in sandbox.rs."
         );
-    }
-
-    /// The invariant behind the list, not just its contents: a trusted
-    /// directory must be one the sandbox grants **read-only**. An entry the
-    /// sandbox also grants write to would be planted into exactly as easily as
-    /// a PATH directory, and the whole fix would be theatre.
-    ///
-    /// Checked against both platform lists because the resolver is shared; each
-    /// entry only has to be covered by one of them (`/opt/homebrew/bin` is
-    /// macOS, `/run/current-system/sw/bin` is NixOS).
-    #[test]
-    fn every_trusted_dir_is_a_read_only_tool_dir() {
-        let granted: Vec<&str> = crate::sandbox::policy::TOOL_READ_DIRS
-            .iter()
-            .chain(crate::sandbox::landlock_mod::LINUX_TOOL_DIRS)
-            .copied()
-            .collect();
-        for dir in TRUSTED_BIN_DIRS {
-            assert!(
-                Path::new(dir).is_absolute(),
-                "{dir} must be an absolute path"
-            );
-            assert!(
-                granted.iter().any(|g| Path::new(dir).starts_with(g)),
-                "{dir} is not covered by a read-only tool dir grant — either it is \
-                 unreachable from the sandbox's own view or, worse, it is writable"
-            );
-        }
     }
 
     /// The not-found path, which the host's real `/usr/bin/git` would otherwise

--- a/src/git.rs
+++ b/src/git.rs
@@ -293,7 +293,9 @@ pub(crate) fn trusted_git() -> Option<&'static Path> {
             crate::ui::warn(&format!(
                 "no git found in {} — parent-side git queries (audit, repo config \
                  trust, gh guard scope) are skipped rather than resolved through \
-                 PATH, which a sandboxed agent can write to",
+                 PATH, which a sandboxed agent can write to. The git-persistence \
+                 denies still cover <root>/.git for every writable root; a bare \
+                 repository's gitdir cannot be resolved without git and loses them",
                 TRUSTED_BIN_DIRS.join(", ")
             ));
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -149,12 +149,31 @@ pub(crate) const TRUSTED_BIN_DIRS: &[&str] = &[
     "/home/linuxbrew/.linuxbrew/bin",
 ];
 
-/// First `name` found in `dirs`. Split out of [`trusted_binary`] so the
-/// not-found path is testable without depending on the host's `/usr/bin`.
+/// An existing regular file with at least one execute bit.
+///
+/// `which` and `execvp` both require `X_OK`, so a non-executable file of the
+/// right name is not a match — it is a shadow that would turn every spawn into
+/// `EACCES` instead of falling through to the next directory.
+pub(crate) fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+/// First executable `name` found in `dirs`. Split out of [`trusted_binary`] so
+/// the not-found path is testable without depending on the host's `/usr/bin`.
+///
+/// `name` must be a single normal path component. `Path::join` drops the base
+/// entirely for an absolute `name` and happily walks out of it for `../x`, so
+/// without this check `trusted_binary` could return a path outside
+/// [`TRUSTED_BIN_DIRS`] — the one guarantee it exists to make.
 fn find_in(dirs: &[&str], name: &str) -> Option<PathBuf> {
+    let mut parts = Path::new(name).components();
+    if !matches!(parts.next(), Some(std::path::Component::Normal(_))) || parts.next().is_some() {
+        return None;
+    }
     dirs.iter()
         .map(|dir| Path::new(dir).join(name))
-        .find(|p| p.is_file())
+        .find(|p| is_executable_file(p))
 }
 
 /// Resolve `name` from [`TRUSTED_BIN_DIRS`], never from `PATH`.
@@ -636,7 +655,7 @@ mod tests {
         let empty = tempfile::tempdir().expect("tempdir");
         let populated = tempfile::tempdir().expect("tempdir");
         let planted = populated.path().join("git");
-        std::fs::write(&planted, "#!/bin/sh\n").expect("write");
+        plant_executable(&planted);
         let dirs = [empty.path().to_str().expect("utf8")];
         assert_eq!(find_in(&dirs, "git"), None);
         let dirs = [
@@ -645,6 +664,51 @@ mod tests {
         ];
         // First match wins, and the earlier directory is searched first.
         assert_eq!(find_in(&dirs, "git"), Some(planted));
+    }
+
+    fn plant_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::write(path, "#!/bin/sh\n").expect("write");
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    }
+
+    /// A non-executable file named `git` in an earlier trusted directory must
+    /// not shadow the real one: `execvp` needs `X_OK`, so matching it would turn
+    /// every parent-side spawn into `EACCES` instead of searching on.
+    #[test]
+    fn find_in_skips_a_non_executable_shadow() {
+        let shadow = tempfile::tempdir().expect("tempdir");
+        let real = tempfile::tempdir().expect("tempdir");
+        std::fs::write(shadow.path().join("git"), "not executable").expect("write");
+        let planted = real.path().join("git");
+        plant_executable(&planted);
+
+        let dirs = [shadow.path().to_str().expect("utf8")];
+        assert_eq!(find_in(&dirs, "git"), None);
+        let dirs = [
+            shadow.path().to_str().expect("utf8"),
+            real.path().to_str().expect("utf8"),
+        ];
+        assert_eq!(find_in(&dirs, "git"), Some(planted));
+    }
+
+    /// `Path::join` drops the base for an absolute `name` and walks out of it
+    /// for `../x`, either of which would return a path outside
+    /// [`TRUSTED_BIN_DIRS`] — the guarantee `trusted_binary` exists to make.
+    #[test]
+    fn find_in_refuses_anything_but_a_bare_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outside = dir.path().join("git");
+        plant_executable(&outside);
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).expect("mkdir");
+        let dirs = [sub.to_str().expect("utf8")];
+
+        assert_eq!(find_in(&dirs, outside.to_str().expect("utf8")), None);
+        assert_eq!(find_in(&dirs, "../git"), None);
+        assert_eq!(find_in(&dirs, "./git"), None);
+        assert_eq!(find_in(&dirs, ""), None);
+        assert_eq!(trusted_binary("/bin/sh"), None);
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -149,14 +149,41 @@ pub(crate) const TRUSTED_BIN_DIRS: &[&str] = &[
     "/home/linuxbrew/.linuxbrew/bin",
 ];
 
-/// An existing regular file with at least one execute bit.
+/// An existing regular file that **this process** may execute.
 ///
-/// `which` and `execvp` both require `X_OK`, so a non-executable file of the
-/// right name is not a match — it is a shadow that would turn every spawn into
-/// `EACCES` instead of falling through to the next directory.
+/// `which` and `execvp` both require `X_OK` for the calling user, so mode bits
+/// alone are the wrong question: a root-owned `0700` `git` has an execute bit
+/// set, yet every spawn of it fails with `EACCES` — and accepting it here would
+/// shadow a genuinely executable `git` later in [`TRUSTED_BIN_DIRS`], which is
+/// the failure mode this predicate exists to prevent. `faccessat` with
+/// `AT_EACCESS` asks the kernel the same question the spawn will, owner, group,
+/// supplementary groups, other and any ACL included.
+///
+/// This is a shadowing filter, not a security guarantee. The answer describes
+/// the file as it was at this instant; it can be replaced, chmod'ed or
+/// unmounted before the spawn (TOCTOU), and nothing here proves the file is
+/// the binary it claims to be. Trust comes from the directory being read-only
+/// to the sandbox — see [`TRUSTED_BIN_DIRS`] — never from this call.
 pub(crate) fn is_executable_file(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+    use std::os::unix::ffi::OsStrExt;
+
+    // `X_OK` on its own would also accept a *searchable directory*, so the
+    // regular-file check stays. It runs first: it is the cheap rejection.
+    if !std::fs::metadata(path).is_ok_and(|m| m.is_file()) {
+        return false;
+    }
+    let Ok(c_path) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
+        return false; // An interior NUL cannot name a real file.
+    };
+    // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the call.
+    unsafe {
+        libc::faccessat(
+            libc::AT_FDCWD,
+            c_path.as_ptr(),
+            libc::X_OK,
+            libc::AT_EACCESS,
+        ) == 0
+    }
 }
 
 /// First executable `name` found in `dirs`. Split out of [`trusted_binary`] so
@@ -690,6 +717,47 @@ mod tests {
             real.path().to_str().expect("utf8"),
         ];
         assert_eq!(find_in(&dirs, "git"), Some(planted));
+    }
+
+    /// A file with an execute bit that does **not** apply to us is still a
+    /// shadow. Mode `0o011` (exec for group and other, not owner) on a file we
+    /// own is the reproducible stand-in for the real case — a root-owned `0700`
+    /// `git` — which needs a second uid to create. `mode & 0o111 != 0` accepts
+    /// both; `faccessat(X_OK)` rejects both.
+    #[test]
+    fn find_in_skips_a_binary_we_may_not_execute() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // SAFETY: a plain getuid(), no preconditions.
+        if unsafe { libc::geteuid() } == 0 {
+            // root bypasses the permission check whenever *any* execute bit is
+            // set, so there is no shadow to observe. The root-owned-0700 case
+            // this stands in for is likewise unreachable while we are root.
+            return;
+        }
+        let shadow = tempfile::tempdir().expect("tempdir");
+        let real = tempfile::tempdir().expect("tempdir");
+        let denied = shadow.path().join("git");
+        std::fs::write(&denied, "#!/bin/sh\n").expect("write");
+        std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o011)).expect("chmod");
+        assert!(!is_executable_file(&denied), "execute bit is not our bit");
+
+        let planted = real.path().join("git");
+        plant_executable(&planted);
+        let dirs = [
+            shadow.path().to_str().expect("utf8"),
+            real.path().to_str().expect("utf8"),
+        ];
+        assert_eq!(find_in(&dirs, "git"), Some(planted));
+    }
+
+    /// A directory named `git` is searchable, so `X_OK` alone would accept it.
+    #[test]
+    fn is_executable_file_rejects_a_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sub = dir.path().join("git");
+        std::fs::create_dir(&sub).expect("mkdir");
+        assert!(!is_executable_file(&sub));
     }
 
     /// `Path::join` drops the base for an absolute `name` and walks out of it

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,10 +23,12 @@
 //! worse still: those invocations are the input to the trust decision.
 //!
 //! The repository's config is not the only thing an agent can aim at these
-//! invocations. The *binary* is the other one: `git` looked up by name is
+//! invocations. The *binary* is the other one: any program looked up by name is
 //! resolved from the parent's `PATH` at spawn time, after the agent has
-//! finished writing to directories that are on it. See [`TRUSTED_BIN_DIRS`],
-//! which also spells out the part of that this module does not fix.
+//! finished writing to directories that are on it. [`TRUSTED_BIN_DIRS`] and
+//! [`trusted_binary`] are the answer, and are used for every parent-side spawn
+//! in cplt, not only git's — this module is where the reasoning lives, so it is
+//! where they live. [`TRUSTED_BIN_DIRS`] also spells out what that does not fix.
 //!
 //! # What is actually reachable
 //!
@@ -100,20 +102,24 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
-/// Absolute directories a parent-side `git` may be resolved from.
+/// Absolute directories a parent-side binary may be resolved from.
 ///
 /// `Command::new("git")` resolves through `execvp` **at spawn time**, using the
-/// *parent's* `PATH` — and the parent spawns git after the agent has exited
-/// (`audit::Baseline::finish`). The sandbox grants write **and** exec to several
-/// directories that are on a developer's `PATH` (mise shims, `PNPM_HOME`,
-/// `~/.deno/bin`, `~/.bun/bin` — see `sandbox_policy::HOME_TOOL_DIRS` and
-/// `APP_DIRS`), so an agent can drop a file named `git` into one of them and
-/// have the parent execute it unsandboxed moments later.
+/// *parent's* `PATH`. cplt spawns binaries in the parent both after the agent
+/// has exited (`audit::Baseline::finish`) and before the next one starts (the
+/// gh-guard scope check, the bwrap probe). The sandbox grants write **and**
+/// exec to several directories that are on a developer's `PATH` (mise shims,
+/// `PNPM_HOME`, `~/.deno/bin`, `~/.bun/bin` — see
+/// `sandbox_policy::HOME_TOOL_DIRS` and `APP_DIRS`), so an agent can drop a file
+/// named `git` (or `bwrap`, or `mise`) into one of them and have the parent
+/// execute it unsandboxed — at the end of this session, or at the start of the
+/// next one.
 ///
-/// These four directories are the ones the sandbox exposes read-only
-/// (`sandbox_policy::TOOL_READ_DIRS`), so nothing inside the sandbox can write
-/// to them. `/usr/bin` first: it is the only one that is SIP-protected on macOS
-/// and root-owned on Linux.
+/// Every entry is a directory the sandbox exposes **read-only**
+/// (`sandbox_policy::TOOL_READ_DIRS` on macOS,
+/// `sandbox_landlock::LINUX_TOOL_DIRS` on Linux), so nothing inside the sandbox
+/// can write to it — an invariant the test below enforces. `/usr/bin` first: it
+/// is the only one that is SIP-protected on macOS and root-owned on Linux.
 ///
 /// # What this does not fix
 ///
@@ -122,9 +128,43 @@ use std::sync::OnceLock;
 /// agent-writable tree that also happens to be one of these directories — a
 /// Homebrew prefix owned by the user, say, that a `sandbox.allow.write` grant
 /// opened up — then resolving to a fixed absolute path still finds the
-/// trojaned file. Making the whole class safe means not granting write to
-/// directories that also carry exec, which is a separate decision.
-const TRUSTED_BIN_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/local/bin", "/opt/homebrew/bin"];
+/// trojaned file. Nor does it cover the agent binary itself, which cplt spawns
+/// from wherever it was discovered (commonly an npm global under a mise node
+/// install, i.e. a writable+exec tree). Making the whole class safe means not
+/// granting write to directories that also carry exec, which is a separate
+/// decision.
+pub(crate) const TRUSTED_BIN_DIRS: &[&str] = &[
+    "/usr/bin",
+    "/bin",
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    // NixOS: the activated system profile, root-owned and read-only granted.
+    // Without it a NixOS user has no trusted git at all, which costs more than
+    // the audit — `repo_config::load_repo_config` reads `.cplt.toml` with
+    // `git cat-file` and reports "no repo config" when git cannot run.
+    "/run/current-system/sw/bin",
+    // Homebrew on Linux; same trust level as /opt/homebrew/bin.
+    "/home/linuxbrew/.linuxbrew/bin",
+];
+
+/// First `name` found in `dirs`. Split out of [`trusted_binary`] so the
+/// not-found path is testable without depending on the host's `/usr/bin`.
+fn find_in(dirs: &[&str], name: &str) -> Option<PathBuf> {
+    dirs.iter()
+        .map(|dir| Path::new(dir).join(name))
+        .find(|p| p.is_file())
+}
+
+/// Resolve `name` from [`TRUSTED_BIN_DIRS`], never from `PATH`.
+///
+/// For every parent-side spawn. `None` means "not installed anywhere the agent
+/// cannot reach"; callers degrade as they already do when the tool is missing.
+/// Deliberately no `PATH` fallback: a fallback would restore the exact lookup
+/// this exists to remove, and would do so precisely on the machines where the
+/// attacker's directory is the only match.
+pub(crate) fn trusted_binary(name: &str) -> Option<PathBuf> {
+    find_in(TRUSTED_BIN_DIRS, name)
+}
 
 /// The `git` binary, resolved once from [`TRUSTED_BIN_DIRS`].
 ///
@@ -133,21 +173,19 @@ const TRUSTED_BIN_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/local/bin", "/opt/
 /// emitted at most once.
 ///
 /// `None` when no trusted `git` exists. Callers then degrade exactly as they do
-/// when git is missing (the audit reports `Incomplete`), which is the honest
-/// outcome — falling back to the bare name would restore the very `PATH` lookup
-/// this exists to remove.
-fn trusted_git() -> Option<&'static Path> {
+/// when git is missing: `Baseline::capture` records no baseline and no
+/// untracked set, and the report is `AuditReport::Unavailable` ("change audit
+/// unavailable"). Never a clean bill of health — but note it is `Unavailable`,
+/// not `Incomplete`, because both capture queries fail together.
+pub(crate) fn trusted_git() -> Option<&'static Path> {
     static GIT: OnceLock<Option<PathBuf>> = OnceLock::new();
     GIT.get_or_init(|| {
-        let found = TRUSTED_BIN_DIRS
-            .iter()
-            .map(|dir| Path::new(dir).join("git"))
-            .find(|p| p.is_file());
+        let found = trusted_binary("git");
         if found.is_none() {
             crate::ui::warn(&format!(
                 "no git found in {} — parent-side git queries (audit, repo config \
-                 trust) are skipped rather than resolved through PATH, which a \
-                 sandboxed agent can write to",
+                 trust, gh guard scope) are skipped rather than resolved through \
+                 PATH, which a sandboxed agent can write to",
                 TRUSTED_BIN_DIRS.join(", ")
             ));
         }
@@ -575,10 +613,63 @@ mod tests {
     fn the_trusted_bin_dirs_are_exactly_this() {
         assert_eq!(
             TRUSTED_BIN_DIRS,
-            &["/usr/bin", "/bin", "/usr/local/bin", "/opt/homebrew/bin"],
-            "TRUSTED_BIN_DIRS changed. Every entry must be read-only to the \
-             sandbox (sandbox_policy::TOOL_READ_DIRS) and absolute."
+            &[
+                "/usr/bin",
+                "/bin",
+                "/usr/local/bin",
+                "/opt/homebrew/bin",
+                "/run/current-system/sw/bin",
+                "/home/linuxbrew/.linuxbrew/bin",
+            ],
+            "TRUSTED_BIN_DIRS changed. Every entry must be absolute and read-only \
+             to the sandbox — see the coverage test below."
         );
+    }
+
+    /// The invariant behind the list, not just its contents: a trusted
+    /// directory must be one the sandbox grants **read-only**. An entry the
+    /// sandbox also grants write to would be planted into exactly as easily as
+    /// a PATH directory, and the whole fix would be theatre.
+    ///
+    /// Checked against both platform lists because the resolver is shared; each
+    /// entry only has to be covered by one of them (`/opt/homebrew/bin` is
+    /// macOS, `/run/current-system/sw/bin` is NixOS).
+    #[test]
+    fn every_trusted_dir_is_a_read_only_tool_dir() {
+        let granted: Vec<&str> = crate::sandbox::policy::TOOL_READ_DIRS
+            .iter()
+            .chain(crate::sandbox::landlock_mod::LINUX_TOOL_DIRS)
+            .copied()
+            .collect();
+        for dir in TRUSTED_BIN_DIRS {
+            assert!(
+                Path::new(dir).is_absolute(),
+                "{dir} must be an absolute path"
+            );
+            assert!(
+                granted.iter().any(|g| Path::new(dir).starts_with(g)),
+                "{dir} is not covered by a read-only tool dir grant — either it is \
+                 unreachable from the sandbox's own view or, worse, it is writable"
+            );
+        }
+    }
+
+    /// The not-found path, which the host's real `/usr/bin/git` would otherwise
+    /// hide: no `git` in the searched dirs must yield `None`, never a bare name.
+    #[test]
+    fn find_in_returns_none_when_the_binary_is_absent() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let populated = tempfile::tempdir().expect("tempdir");
+        let planted = populated.path().join("git");
+        std::fs::write(&planted, "#!/bin/sh\n").expect("write");
+        let dirs = [empty.path().to_str().expect("utf8")];
+        assert_eq!(find_in(&dirs, "git"), None);
+        let dirs = [
+            empty.path().to_str().expect("utf8"),
+            populated.path().to_str().expect("utf8"),
+        ];
+        // First match wins, and the earlier directory is searched first.
+        assert_eq!(find_in(&dirs, "git"), Some(planted));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1472,15 +1472,17 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         // a grant *in* a trusted dir is the direct hole, a grant on an
         // ancestor (`/usr` over `/usr/bin`) hands out the same hole by
         // containment. Same danger, different thing to go edit.
+        // "path", not "directory": a hit can be a bin directory OR the resolved
+        // binary itself, which is where a Homebrew-style symlink target lands.
         let overlap = if trusted.iter().any(|t| granted.starts_with(t)) {
             format!(
-                "allow.write grants {} — inside the trusted binary directory {dirs}.",
+                "allow.write grants {} — inside the trusted binary path {dirs}.",
                 granted.display()
             )
         } else {
-            let plural = if trusted.len() == 1 { "y" } else { "ies" };
+            let plural = if trusted.len() == 1 { "" } else { "s" };
             format!(
-                "allow.write grants {}, which contains the trusted binary director{plural} {dirs}.",
+                "allow.write grants {}, which contains the trusted binary path{plural} {dirs}.",
                 granted.display()
             )
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -5453,7 +5453,10 @@ fn start_denial_stream() -> Option<std::process::Child> {
     #[cfg(target_os = "macos")]
     {
         ui::info("Streaming sandbox denial logs (--show-denials)...");
-        match std::process::Command::new("log")
+        // Absolute: a bare name is resolved from the parent's PATH at spawn
+        // time, and the sandbox grants the agent write+exec on directories that
+        // sit on it. /usr/bin/log is the only valid location.
+        match std::process::Command::new("/usr/bin/log")
             .args([
                 "stream",
                 "--predicate",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1459,6 +1459,23 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         );
     }
 
+    // A write grant on a directory the parent executes from cancels the
+    // trusted-binary lookup (#236). Warned, not refused: it would break configs
+    // that work today. Here, after every source is merged, so a repo-proposed
+    // grant is covered too, and not gated on `quiet` — it is a sandbox-boundary
+    // warning, not progress chatter.
+    for (granted, trusted) in resolved.write_grants_over_trusted_bins() {
+        ui::warn(&format!(
+            "allow.write grants {} — inside the trusted binary directory {trusted}.\n  \
+             cplt resolves its own git, bwrap and sandbox-exec from {trusted} and runs them \
+             OUTSIDE the sandbox, as you, around every agent session. An agent that can write \
+             there replaces one of those binaries and gets unsandboxed execution on your next \
+             cplt launch — no approval, no prompt.\n  \
+             Grant a directory cplt never executes from, or drop this grant.",
+            granted.display()
+        ));
+    }
+
     // Show unapproved permissions warning (non-fatal — deny-default keeps us safe)
     if !unapproved_proposals.is_empty() && !resolved.quiet {
         ui::warn(&format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1465,14 +1465,28 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
     // grant is covered too, and not gated on `quiet` — it is a sandbox-boundary
     // warning, not progress chatter.
     for (granted, trusted) in resolved.write_grants_over_trusted_bins() {
+        // Two different overlaps, and the user can only act on the right one:
+        // a grant *in* the trusted dir is the direct hole, a grant on an
+        // ancestor (`/usr` over `/usr/bin`) hands out the same hole by
+        // containment. Same danger, different thing to go edit.
+        let overlap = if granted.starts_with(trusted) {
+            format!(
+                "allow.write grants {} — inside the trusted binary directory {trusted}.",
+                granted.display()
+            )
+        } else {
+            format!(
+                "allow.write grants {}, which contains the trusted binary directory {trusted}.",
+                granted.display()
+            )
+        };
         ui::warn(&format!(
-            "allow.write grants {} — inside the trusted binary directory {trusted}.\n  \
+            "{overlap}\n  \
              cplt resolves its own git, bwrap and sandbox-exec from {trusted} and runs them \
              OUTSIDE the sandbox, as you, around every agent session. An agent that can write \
              there replaces one of those binaries and gets unsandboxed execution on your next \
              cplt launch — no approval, no prompt.\n  \
-             Grant a directory cplt never executes from, or drop this grant.",
-            granted.display()
+             Grant a directory cplt never executes from, or drop this grant."
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1464,29 +1464,43 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
     // that work today. Here, after every source is merged, so a repo-proposed
     // grant is covered too, and not gated on `quiet` — it is a sandbox-boundary
     // warning, not progress chatter.
+    // One warning per grant, however many trusted directories it swallows — the
+    // grant is the single line of config the user has to go change.
     for (granted, trusted) in resolved.write_grants_over_trusted_bins() {
+        let dirs = trusted.join(", ");
         // Two different overlaps, and the user can only act on the right one:
-        // a grant *in* the trusted dir is the direct hole, a grant on an
+        // a grant *in* a trusted dir is the direct hole, a grant on an
         // ancestor (`/usr` over `/usr/bin`) hands out the same hole by
         // containment. Same danger, different thing to go edit.
-        let overlap = if granted.starts_with(trusted) {
+        let overlap = if trusted.iter().any(|t| granted.starts_with(t)) {
             format!(
-                "allow.write grants {} — inside the trusted binary directory {trusted}.",
+                "allow.write grants {} — inside the trusted binary directory {dirs}.",
                 granted.display()
             )
         } else {
+            let plural = if trusted.len() == 1 { "y" } else { "ies" };
             format!(
-                "allow.write grants {}, which contains the trusted binary directory {trusted}.",
+                "allow.write grants {}, which contains the trusted binary director{plural} {dirs}.",
                 granted.display()
             )
         };
+        // Named per platform, and only the helpers actually resolved this way:
+        // `sandbox-exec` is macOS-only and is not resolved at all (it is the
+        // fixed /usr/bin/sandbox-exec), `bwrap` is Linux-only. Naming the wrong
+        // one is how a security warning gets dismissed as not applying.
+        let helpers = if cfg!(target_os = "macos") {
+            "git, gh and mise"
+        } else {
+            "git, gh, mise and bwrap"
+        };
         ui::warn(&format!(
             "{overlap}\n  \
-             cplt resolves its own git, bwrap and sandbox-exec from {trusted} and runs them \
-             OUTSIDE the sandbox, as you, around every agent session. An agent that can write \
-             there replaces one of those binaries and gets unsandboxed execution on your next \
-             cplt launch — no approval, no prompt.\n  \
-             Grant a directory cplt never executes from, or drop this grant."
+             cplt resolves its parent-side helpers ({helpers}) from a fixed set of trusted \
+             directories — {} — and runs them OUTSIDE the sandbox, as you, around every agent \
+             session. An agent that can write to any of them replaces one of those binaries and \
+             gets unsandboxed execution on your next cplt launch — no approval, no prompt.\n  \
+             Grant a directory cplt never executes from, or drop this grant.",
+            cplt::git::TRUSTED_BIN_DIRS.join(", ")
         ));
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -41,7 +41,7 @@ mod exec;
 #[path = "sandbox_landlock.rs"]
 pub(crate) mod landlock_mod;
 #[path = "sandbox_policy.rs"]
-pub(crate) mod policy;
+mod policy;
 #[path = "sandbox_profile.rs"]
 mod profile;
 
@@ -63,6 +63,10 @@ pub use profile::{ProfileOptions, generate_profile};
 
 // Environment construction — already platform-agnostic.
 pub use env::{SandboxEnv, build_sandbox_env, npmrc_explicitly_allowed, npmrc_userconfig_override};
+
+// The in-process PATH lookup. Re-exported (rather than opening the whole `exec`
+// module) for `discover::which_resolved`, which must not spawn `which`.
+pub(crate) use exec::which_binary;
 
 // Landlock policy types — cross-platform for testing.
 pub use landlock_mod::{
@@ -569,6 +573,61 @@ fn validate_config_paths(config: &SandboxConfig) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The invariant behind [`crate::git::TRUSTED_BIN_DIRS`], not just its
+    /// contents: every directory cplt resolves a parent-side binary from must be
+    /// one the sandbox grants **read** access to and nothing more. A directory
+    /// the sandbox also granted write to would be planted into exactly as easily
+    /// as a `PATH` directory, and the whole fix would be theatre.
+    ///
+    /// Lives here rather than in `git.rs` because both grant lists are private
+    /// to this module, and one test reaching in is cheaper than opening them to
+    /// the crate.
+    ///
+    /// Checked against both platform lists because the resolver is shared; each
+    /// entry only has to be covered by one of them (`/opt/homebrew/bin` is
+    /// macOS-only, `/run/current-system/sw/bin` NixOS-only).
+    ///
+    /// Scope, so the name does not promise more than it checks: this asserts
+    /// membership in the read-only tool-dir grants. It does not scan the write
+    /// grants for an overlap, because every write grant is `$HOME`-relative or a
+    /// per-tool config dir and so cannot contain an absolute system bin dir. If
+    /// an absolute write grant is ever added, extend this.
+    #[test]
+    fn every_trusted_dir_is_covered_by_a_tool_read_grant() {
+        let granted: Vec<&str> = policy::TOOL_READ_DIRS
+            .iter()
+            .chain(landlock_mod::LINUX_TOOL_DIRS)
+            .copied()
+            .collect();
+        for dir in crate::git::TRUSTED_BIN_DIRS {
+            assert!(
+                Path::new(dir).is_absolute(),
+                "{dir} must be an absolute path"
+            );
+            assert!(
+                granted.iter().any(|g| Path::new(dir).starts_with(g)),
+                "{dir} is not covered by a read-only tool dir grant — either it is \
+                 unreachable from the sandbox's own view or, worse, it is writable"
+            );
+        }
+    }
+
+    /// Linux only, and it actually runs in CI: `bwrap` is the sandbox driver,
+    /// executed by the unsandboxed parent, so it must never come off `PATH`.
+    /// Passes vacuously on a host without bwrap; on a host with one it fails if
+    /// [`bubblewrap::check_availability`] is reverted to a `PATH` lookup.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bwrap_is_never_resolved_from_path() {
+        let found = bubblewrap::check_availability();
+        assert!(
+            found.as_ref().is_none_or(|p| crate::git::TRUSTED_BIN_DIRS
+                .iter()
+                .any(|d| p.starts_with(d))),
+            "bwrap resolved to {found:?}, outside TRUSTED_BIN_DIRS"
+        );
+    }
 
     /// `extra_git_dirs` is the wiring between `prepare()` and the profile: the
     /// emitter test proves the denies get written, this proves the right

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -589,10 +589,17 @@ mod tests {
     /// macOS-only, `/run/current-system/sw/bin` NixOS-only).
     ///
     /// Scope, so the name does not promise more than it checks: this asserts
-    /// membership in the read-only tool-dir grants. It does not scan the write
-    /// grants for an overlap, because every write grant is `$HOME`-relative or a
-    /// per-tool config dir and so cannot contain an absolute system bin dir. If
-    /// an absolute write grant is ever added, extend this.
+    /// membership in the read-only tool-dir grants, and it only covers the
+    /// **built-in** grant lists. It does not scan those for a write overlap
+    /// because every built-in write grant is `$HOME`-relative or a per-tool
+    /// config dir, so none of them can name an absolute system bin dir; if a
+    /// built-in absolute write grant is ever added, extend this.
+    ///
+    /// User configuration is outside that scope. `allow.write` paths go through
+    /// `resolve_config_path`, which accepts an absolute path as-is, so a user
+    /// can grant write on `/usr/local/bin` and overlap a trusted directory. No
+    /// test can see that from here — it is a property of the running config, not
+    /// of the constants.
     #[test]
     fn every_trusted_dir_is_covered_by_a_tool_read_grant() {
         let granted: Vec<&str> = policy::TOOL_READ_DIRS

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -622,12 +622,35 @@ mod tests {
 
     /// Linux only, and it actually runs in CI: `bwrap` is the sandbox driver,
     /// executed by the unsandboxed parent, so it must never come off `PATH`.
-    /// Passes vacuously on a host without bwrap; on a host with one it fails if
-    /// [`bubblewrap::check_availability`] is reverted to a `PATH` lookup.
+    ///
+    /// Asserting only "the result is inside TRUSTED_BIN_DIRS" does not test
+    /// anything: every distro installs bwrap to `/usr/bin`, which is itself
+    /// trusted, so a `PATH` lookup satisfies it on every ordinary host. This
+    /// plants a decoy `bwrap` first on `PATH` instead — a `PATH` lookup returns
+    /// the decoy, trusted resolution cannot, whether or not a real bwrap exists.
     #[cfg(target_os = "linux")]
     #[test]
     fn bwrap_is_never_resolved_from_path() {
-        let found = bubblewrap::check_availability();
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let decoy = tmp.path().join("bwrap");
+        std::fs::write(&decoy, "#!/bin/sh\nexit 0\n").expect("write decoy");
+        std::fs::set_permissions(&decoy, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod decoy");
+
+        let path = format!(
+            "{}:{}",
+            tmp.path().display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let found = temp_env::with_var("PATH", Some(&path), bubblewrap::check_availability);
+
+        assert_ne!(
+            found.as_deref(),
+            Some(decoy.as_path()),
+            "bwrap was resolved from PATH — a planted binary would drive the sandbox"
+        );
         assert!(
             found.as_ref().is_none_or(|p| crate::git::TRUSTED_BIN_DIRS
                 .iter()

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -41,7 +41,7 @@ mod exec;
 #[path = "sandbox_landlock.rs"]
 pub(crate) mod landlock_mod;
 #[path = "sandbox_policy.rs"]
-mod policy;
+pub(crate) mod policy;
 #[path = "sandbox_profile.rs"]
 mod profile;
 

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -115,10 +115,18 @@ pub(crate) struct BubblewrapWrapper {
 
 /// Check if bubblewrap is available on this system.
 ///
-/// Returns the path to the `bwrap` binary if found in PATH. Reuses the
-/// project's own PATH resolver so no extra crate is needed.
+/// Returns the path to the `bwrap` binary if it exists in one of
+/// [`crate::git::TRUSTED_BIN_DIRS`]. **Not** a `PATH` lookup: `bwrap` is the
+/// sandbox driver, executed by the unsandboxed parent, so a `bwrap` a previous
+/// session planted in a write+exec grant on `PATH` (mise shims, `PNPM_HOME`,
+/// `~/.bun/bin`) would be a complete bypass at the next launch. Resolving at
+/// prepare time does not help — the plant happens a whole session earlier.
+///
+/// Cost: a `bwrap` installed outside those directories is not found, and
+/// auto-detect falls back to Landlock-only with its existing warning. Every
+/// distro package installs it into `/usr/bin`.
 pub(crate) fn check_availability() -> Option<PathBuf> {
-    super::exec::which_binary("bwrap")
+    crate::git::trusted_binary("bwrap")
 }
 
 /// Test that bubblewrap can actually create the namespaces we use.
@@ -577,7 +585,12 @@ fn build_wrapper(
     deny_masks: &DenyMasks,
     strict: bool,
 ) -> Result<BubblewrapWrapper, String> {
-    let bwrap_path = check_availability().ok_or_else(|| "bwrap not found in PATH".to_string())?;
+    let bwrap_path = check_availability().ok_or_else(|| {
+        format!(
+            "bwrap not found in {}",
+            crate::git::TRUSTED_BIN_DIRS.join(", ")
+        )
+    })?;
     test_functionality(&bwrap_path, fs_rules, ro_protect, deny_masks)?;
     let bwrap_args = build_bwrap_args(fs_rules, ro_protect, deny_masks);
     Ok(BubblewrapWrapper {

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -415,16 +415,16 @@ fn install_command_wrappers(
     }
 }
 
-/// Find a binary in PATH by name.
+/// Find an executable in PATH by name.
+///
+/// Executability matters: `which` and `execvp` both skip a non-executable file,
+/// so accepting one here would report a stub as the tool's location (`cplt
+/// doctor`) or hand a caller a path that can only ever fail with `EACCES`.
 pub(crate) fn which_binary(name: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join(name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join(name))
+        .find(|p| crate::git::is_executable_file(p))
 }
 
 /// Ignore SIGTTOU/SIGTTIN — copilot (Node.js) may manipulate terminal

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -424,6 +424,15 @@ fn install_command_wrappers(
     // Install git guard wrapper (only if git_guard enabled)
     // Trusted, not PATH: this path is baked into the wrapper the agent's own
     // shell then runs, so a planted `git` would be handed the guard's identity.
+    if git_guard.enabled && crate::git::trusted_git().is_none() {
+        // Say so. Skipping the wrapper silently leaves the user believing
+        // push/force-push are guarded when they are not — the gh branch above
+        // warns in the equivalent situation, and this one did not.
+        ui::warn(
+            "git guard could not find Git in a trusted directory — the git wrapper \
+             is not installed, so push and force-push are NOT blocked in this session.",
+        );
+    }
     if git_guard.enabled
         && let Some(real_git) = crate::git::trusted_git()
     {

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -500,11 +500,20 @@ fn install_signal_forwarding(child_pid: i32) {
 
 // ── macOS: Seatbelt / sandbox-exec ────────────────────────────
 
+/// The Seatbelt driver. Absolute on purpose: a bare program name is resolved
+/// from the parent's PATH at spawn time, and the sandbox grants the agent
+/// write+exec on directories that sit on it (see `TRUSTED_BIN_DIRS` in git.rs).
+#[cfg(target_os = "macos")]
+const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
+
 /// Verify the SBPL profile works by running `/usr/bin/true` inside sandbox-exec.
 #[cfg(target_os = "macos")]
 pub fn preflight(sandbox: &super::PreparedSandbox) -> Result<(), String> {
     let profile_path = write_temp_profile(&sandbox.profile_text)?;
-    let output = Command::new("sandbox-exec")
+    // Absolute: `sandbox-exec` only ever lives in /usr/bin (SIP-protected), and
+    // resolving it by name would go through the parent's PATH, which contains
+    // directories the sandbox itself grants the agent write+exec on.
+    let output = Command::new(SANDBOX_EXEC)
         .arg("-f")
         .arg(&profile_path)
         .arg("/usr/bin/true")
@@ -549,7 +558,7 @@ pub fn exec(
         }
     };
 
-    let mut cmd = Command::new("sandbox-exec");
+    let mut cmd = Command::new(SANDBOX_EXEC);
     cmd.arg("-f").arg(&profile_path).arg(copilot_bin);
 
     configure_command(

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -216,8 +216,14 @@ fn inject_gh_token_if_needed(cmd: &mut Command, agent: Agent) {
         return;
     }
 
-    // Extract token from gh CLI config (outside sandbox)
-    let Ok(output) = std::process::Command::new("gh")
+    // Extract token from gh CLI config (outside sandbox). Trusted path, not
+    // PATH: this runs in the unsandboxed parent at launch and its stdout is
+    // treated as a GitHub token, so a planted `gh` gets both code execution as
+    // the user and a free channel into the agent's environment.
+    let Some(gh) = crate::git::trusted_binary("gh") else {
+        return;
+    };
+    let Ok(output) = std::process::Command::new(&gh)
         .args(["auth", "token"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -268,8 +274,14 @@ fn cache_gh_token_to_file(scratch_dir: &Path, agent: Agent) {
         return;
     }
 
-    // Extract token from gh CLI config (outside sandbox)
-    let Ok(output) = std::process::Command::new("gh")
+    // Extract token from gh CLI config (outside sandbox). Trusted path, not
+    // PATH: this runs in the unsandboxed parent at launch and its stdout is
+    // treated as a GitHub token, so a planted `gh` gets both code execution as
+    // the user and a free channel into the agent's environment.
+    let Some(gh) = crate::git::trusted_binary("gh") else {
+        return;
+    };
+    let Ok(output) = std::process::Command::new(&gh)
         .args(["auth", "token"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -335,8 +347,12 @@ fn install_command_wrappers(
         && let Some(real_gh) = which_binary("gh")
     {
         let repo_scope = if gh_guard.scope_check {
-            if let Some(real_git) = which_binary("git") {
-                match crate::gh_proxy::detect_current_repo(&real_git, project_dir) {
+            // Trusted, not PATH: this git runs in the UNSANDBOXED parent, at
+            // launch. A `git` the previous session planted in ~/.bun/bin (or any
+            // other write+exec grant on PATH) would otherwise execute as the
+            // user here, one session later.
+            if let Some(real_git) = crate::git::trusted_git() {
+                match crate::gh_proxy::detect_current_repo(real_git, project_dir) {
                     Ok(repo) => Some(repo),
                     Err(reason) => {
                         ui::warn(&format!(
@@ -370,8 +386,10 @@ fn install_command_wrappers(
     }
 
     // Install git guard wrapper (only if git_guard enabled)
+    // Trusted, not PATH: this path is baked into the wrapper the agent's own
+    // shell then runs, so a planted `git` would be handed the guard's identity.
     if git_guard.enabled
-        && let Some(real_git) = which_binary("git")
+        && let Some(real_git) = crate::git::trusted_git()
     {
         let script = crate::gh_proxy::generate_git_wrapper_script(
             &real_git.to_string_lossy(),

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -417,9 +417,12 @@ fn install_command_wrappers(
 
 /// Find an executable in PATH by name.
 ///
-/// Executability matters: `which` and `execvp` both skip a non-executable file,
-/// so accepting one here would report a stub as the tool's location (`cplt
-/// doctor`) or hand a caller a path that can only ever fail with `EACCES`.
+/// Executability matters: `which` and `execvp` both skip a file the caller may
+/// not execute, so accepting one here would report a stub as the tool's
+/// location (`cplt doctor`) or hand a caller a path that can only ever fail
+/// with `EACCES`. Deliberately the same predicate as the trusted-directory
+/// lookup — [`crate::git::is_executable_file`], an `X_OK` check, not a
+/// mode-bit test — so the two resolvers cannot disagree about what counts.
 pub(crate) fn which_binary(name: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
     std::env::split_paths(&path_var)

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -203,6 +203,42 @@ fn configure_command(
 /// the gh proxy to safely block `gh auth token` inside the sandbox
 /// while still giving the agent API access.
 ///
+/// `gh`, resolved from [`crate::git::TRUSTED_BIN_DIRS`], warning once when the
+/// only `gh` on this machine is somewhere else.
+///
+/// Before the trusted-lookup change, `gh` came off `PATH`, so an installation in
+/// `~/.local/bin` or a mise shim worked. It no longer does — correctly, since a
+/// planted `gh` hands the agent both unsandboxed execution and a channel into
+/// the next agent's environment. But the failure is invisible: no token is
+/// injected, and the user sees Copilot's GitHub API calls fail with nothing
+/// pointing at cplt. A `gh` that exists on `PATH` and is not trusted is the one
+/// case worth a line on stderr.
+///
+/// Warned once per process: both token paths call this, and two identical
+/// warnings at launch read like two different problems.
+fn trusted_gh() -> Option<PathBuf> {
+    if let Some(gh) = crate::git::trusted_binary("gh") {
+        return Some(gh);
+    }
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    if let Some(untrusted) = which_binary("gh") {
+        WARNED.call_once(|| {
+            ui::warn(&format!(
+                "gh is installed at {} — outside the directories cplt trusts for \
+                 unsandboxed helpers ({}).\n  \
+                 The GitHub token is NOT injected, so the agent's GitHub API calls \
+                 will fail. cplt runs `gh auth token` as you, outside the sandbox, \
+                 so it will not run a `gh` a previous session could have replaced.\n  \
+                 Install gh into one of those directories (`brew install gh`, or your \
+                 distro's package), or export GH_TOKEN yourself before launching.",
+                untrusted.display(),
+                crate::git::TRUSTED_BIN_DIRS.join(", ")
+            ));
+        });
+    }
+    None
+}
+
 /// Only injects for agents that need GitHub access (Copilot).
 fn inject_gh_token_if_needed(cmd: &mut Command, agent: Agent) {
     // Only inject for Copilot — other agents have their own auth
@@ -220,7 +256,7 @@ fn inject_gh_token_if_needed(cmd: &mut Command, agent: Agent) {
     // PATH: this runs in the unsandboxed parent at launch and its stdout is
     // treated as a GitHub token, so a planted `gh` gets both code execution as
     // the user and a free channel into the agent's environment.
-    let Some(gh) = crate::git::trusted_binary("gh") else {
+    let Some(gh) = trusted_gh() else {
         return;
     };
     let Ok(output) = std::process::Command::new(&gh)
@@ -278,7 +314,7 @@ fn cache_gh_token_to_file(scratch_dir: &Path, agent: Agent) {
     // PATH: this runs in the unsandboxed parent at launch and its stdout is
     // treated as a GitHub token, so a planted `gh` gets both code execution as
     // the user and a free channel into the agent's environment.
-    let Some(gh) = crate::git::trusted_binary("gh") else {
+    let Some(gh) = trusted_gh() else {
         return;
     };
     let Ok(output) = std::process::Command::new(&gh)

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -422,19 +422,24 @@ fn install_command_wrappers(
     }
 
     // Install git guard wrapper (only if git_guard enabled)
-    // Trusted, not PATH: this path is baked into the wrapper the agent's own
-    // shell then runs, so a planted `git` would be handed the guard's identity.
-    if git_guard.enabled && crate::git::trusted_git().is_none() {
-        // Say so. Skipping the wrapper silently leaves the user believing
-        // push/force-push are guarded when they are not — the gh branch above
-        // warns in the equivalent situation, and this one did not.
-        ui::warn(
-            "git guard could not find Git in a trusted directory — the git wrapper \
-             is not installed, so push and force-push are NOT blocked in this session.",
-        );
-    }
+    // Trusted first, then PATH — the same call the gh wrapper above makes, and
+    // for the same reason.
+    //
+    // This path is baked into a wrapper the agent's own shell runs INSIDE the
+    // sandbox; it is never executed by the parent. A planted `git` there gains
+    // the agent nothing it does not already have: it can invoke any git by
+    // absolute path and skip the PATH wrapper entirely, so the guard is a policy
+    // on intent, not a boundary. Requiring a trusted git instead removed the
+    // guard outright on every machine whose git comes from mise, asdf,
+    // nix-profile or snap — the agent's PATH still had that git, so `git push`
+    // simply went unguarded. That is a loss with no matching gain.
+    //
+    // Parent-side git (audit, repo-config trust, gh guard scope) stays on
+    // `trusted_git()`, where a planted binary WOULD run unsandboxed.
     if git_guard.enabled
         && let Some(real_git) = crate::git::trusted_git()
+            .map(std::path::Path::to_path_buf)
+            .or_else(|| which_binary("git"))
     {
         let script = crate::gh_proxy::generate_git_wrapper_script(
             &real_git.to_string_lossy(),

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -196,7 +196,7 @@ const LINUX_SYSTEM_READ_PATHS: &[&str] = &[
 
 /// Tool directories with read + execute access.
 /// Linux equivalent of macOS `TOOL_READ_DIRS` in sandbox_policy.rs.
-const LINUX_TOOL_DIRS: &[&str] = &[
+pub(crate) const LINUX_TOOL_DIRS: &[&str] = &[
     "/bin",
     "/sbin",
     "/usr/bin",

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -196,7 +196,7 @@ const LINUX_SYSTEM_READ_PATHS: &[&str] = &[
 
 /// Tool directories with read + execute access.
 /// Linux equivalent of macOS `TOOL_READ_DIRS` in sandbox_policy.rs.
-pub(crate) const LINUX_TOOL_DIRS: &[&str] = &[
+pub(super) const LINUX_TOOL_DIRS: &[&str] = &[
     "/bin",
     "/sbin",
     "/usr/bin",

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -104,7 +104,7 @@ pub(super) const SYSTEM_READ_FILES: &[&str] = &[
 ];
 
 /// Tool directories commonly needed by developers.
-pub(super) const TOOL_READ_DIRS: &[&str] = &[
+pub(crate) const TOOL_READ_DIRS: &[&str] = &[
     "/bin",
     "/usr/bin",
     "/usr/lib",

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -104,7 +104,7 @@ pub(super) const SYSTEM_READ_FILES: &[&str] = &[
 ];
 
 /// Tool directories commonly needed by developers.
-pub(crate) const TOOL_READ_DIRS: &[&str] = &[
+pub(super) const TOOL_READ_DIRS: &[&str] = &[
     "/bin",
     "/usr/bin",
     "/usr/lib",

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -1713,6 +1713,29 @@ mod tests {
     use super::*;
 
     /// Build a minimal `ProfileOptions` for SBPL-string tests.
+    /// Resolving git from trusted directories means `git_common_dir` is `None`
+    /// on a machine whose git lives elsewhere. The denies for an ordinary repo
+    /// must not depend on it: `<root>/.git` is seeded for every writable root
+    /// unconditionally, so the hooks and config denies stand with no git at all.
+    ///
+    /// Pins the boundary of that guarantee — a worktree's *shared* gitdir does
+    /// still need resolving, which is what `discover::gitdir_without_git`
+    /// recovers without spawning anything.
+    #[test]
+    fn git_persistence_denies_do_not_depend_on_a_resolved_git() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let mut opts = test_options(project, home);
+        opts.git_common_dir = None;
+        let p = generate_profile(&opts);
+        for rule in [
+            r#"(deny file-write* (subpath "/projects/app/.git/hooks"))"#,
+            r#"(deny file-write* (literal "/projects/app/.git/config"))"#,
+        ] {
+            assert!(p.contains(rule), "MISSING without git_common_dir: {rule}");
+        }
+    }
+
     fn test_options<'a>(
         project_dir: &'a std::path::Path,
         home_dir: &'a std::path::Path,

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -1718,9 +1718,10 @@ mod tests {
     /// must not depend on it: `<root>/.git` is seeded for every writable root
     /// unconditionally, so the hooks and config denies stand with no git at all.
     ///
-    /// Pins the boundary of that guarantee — a worktree's *shared* gitdir does
-    /// still need resolving, which is what `discover::gitdir_without_git`
-    /// recovers without spawning anything.
+    /// Pins the boundary of that guarantee — a worktree's *shared* gitdir, and
+    /// any grant whose repo data is not at `<root>/.git`, still need resolving.
+    /// `discover::gitdir_without_git` recovers those by reading the `.git`
+    /// pointer (and its `commondir`) without spawning anything.
     #[test]
     fn git_persistence_denies_do_not_depend_on_a_resolved_git() {
         let project = std::path::Path::new("/projects/app");


### PR DESCRIPTION
## The finding

A sandboxed agent can get code execution in the unsandboxed parent, with no user action.

The write+exec grants make it possible: mise's AppDir (`sandbox_policy.rs:668-675`) covers
`shims/` and `installs/<tool>/<ver>/bin`, both on PATH for mise users; `PNPM_HOME` is the
directory `pnpm setup` prepends to PATH; `~/.deno` and `~/.bun` (`:863-874`) hold the `bin`
directories their installers prepend. The profile emits allow-write and allow-exec for all
of them with no deny — the deny loop at `sandbox_profile.rs:809-822` only fires for
`write && !exec`. Contrast `.cargo/bin`, deliberately read-only "to prevent a rogue agent
from trojaning binaries": the class was understood, it just was not applied here.

The trigger was cplt itself. `Command::new("git")` resolves through execvp at spawn time
using the **parent's** PATH, and the post-session audit — on by default — runs after the
agent has exited. Verified empirically: with a fake `git` earlier on PATH,
`Command::new("git")` ran the fake and `Command::new("/usr/bin/git")` did not.

Three review rounds each found another instance, which is the more useful signal: `git` in
the audit, then `bwrap` and `gh auth token` at launch, then `which` on every launch.

## What this changes

`trusted_git()` / `trusted_binary()` in `src/git.rs` resolve from a fixed list —
`/usr/bin`, `/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `/run/current-system/sw/bin`
(NixOS), `/home/linuxbrew/.linuxbrew/bin` — every one of which the sandbox grants read+exec
and never write. A test asserts that property rather than just pinning the list, so adding
a writable directory later fails.

Moved onto it: the audit's `git` and `repo_config`'s `git cat-file`, the gh-guard scope
check feeding `detect_current_repo`, the path baked into the git wrapper, `gh auth token`,
`mise which` / `asdf which`, `bwrap`, `sandbox-exec`, and `log`. `which_resolved` stopped
spawning anything at all — it is a pure PATH walk now.

Deliberately **not** moved: the wrapper's `real_gh`. That runs inside the sandbox with the
agent's own privileges, so a planted `gh` gains the attacker nothing it does not already
have, while requiring a trusted `gh` would silently disable the gh guard for anyone who
installed `gh` to `~/.local/bin` — GitHub's own tarball instructions. Net security loss.

## What it does not fix

The write+exec grants are untouched. Removing them breaks `bun install -g`, `deno install`,
`pnpm add -g` and `mise install` inside the sandbox, which is a product decision, not a
security fix — it is being handled separately.

If the user's own `git` sits inside one of the trusted directories *and* that tree is
agent-writable through an explicit `allow.write`, the resolved path still finds the
trojaned file. Only the "prepend a directory that wins PATH resolution" half is closed.

The agent binary itself is still run from wherever it was discovered, commonly a writable
mise or npm-global tree. Fixing that needs a trust *check* on a discovered path rather than
a resolution change, because `resolve_mise_shim` deliberately returns such a path for
ordinary users — the same unmade decision as the write grants. `cplt doctor` is likewise
still fully PATH-resolved in the parent, and its fix is a different shape again, since
reporting what is on PATH is what the command is for.

The README says all of this rather than implying the class is closed.

## Note on the trusted list

An unresolvable `git` degrades to an `Unavailable` audit — never a clean bill of health —
and on Linux a committed `.cplt.toml` is silently ignored, because `repo_config` reads it
via `git cat-file`. That is why NixOS and Linuxbrew paths are in the list rather than left
to the fallback.
