### PR TITLE
ci: stop analysing Rust with CodeQL in the merge queue

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -53,19 +53,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # `actions` just parses workflow YAML — nothing to build.
-          - language: actions
-            build-mode: none
-          # `none` is the only build mode the Rust extractor accepts —
-          # `autobuild` is rejected outright ("Rust does not support the
-          # autobuild build mode"). It extracts 35 of 41 files with errors,
-          # which is exactly what the repository's default setup produces
-          # today, so this is not a regression — but treat Rust findings as
-          # best-effort until the extractor improves. Pre-fetching crate
-          # sources (`cargo fetch`) was measured and changed nothing.
-          - language: rust
-            build-mode: none
+        # `actions` just parses workflow YAML — nothing to build.
+        #
+        # `none` is the only build mode the Rust extractor accepts —
+        # `autobuild` is rejected outright ("Rust does not support the
+        # autobuild build mode"). It extracts 35 of 41 files with errors,
+        # which is exactly what the repository's default setup produces
+        # today, so this is not a regression — but treat Rust findings as
+        # best-effort until the extractor improves. Pre-fetching crate
+        # sources (`cargo fetch`) was measured and changed nothing.
+        #
+        # Rust is left out in the merge queue. The ruleset's `code_scanning`
+        # rule only needs *a* CodeQL result on the queue's temporary ref, and
+        # `actions` produces one in ~40s. Rust takes ~4.5 minutes — longer
+        # than the entry survives — so by upload time GitHub has already
+        # merged it and deleted `refs/heads/gh-readonly-queue/main/pr-N-...`,
+        # and the SARIF upload 404s ("ref ... not found in this repository"),
+        # failing the job. Every merge_group run whose Rust analysis ran past
+        # ~4 minutes has died this way since #200. Rust is still analyzed on
+        # every pull_request, on every push to main, and on the weekly
+        # schedule, so nothing goes unscanned.
+        include: >-
+          ${{ github.event_name == 'merge_group'
+          && fromJSON('[{"language":"actions","build-mode":"none"}]')
+          || fromJSON('[{"language":"actions","build-mode":"none"},{"language":"rust","build-mode":"none"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 


### PR DESCRIPTION
`Analyze (rust)` has failed on every merge-queue run since pr-200 on 27 August — fourteen
of them. Not an alert, not a build failure, not the #229 action bump (the pr-229 run failed
identically while still on the previous version).

```
Uploading results
##[error]ref 'refs/heads/gh-readonly-queue/main/pr-227-fad1d53...' not found in this repository
CodeQL job status was configuration error.
```

Database creation and query evaluation both completed — 41 Rust files extracted without
error. The job died on the SARIF upload, against a ref that no longer existed.

## Why

The ruleset's only required status check is `ci-ok`; CodeQL is not required in the queue.
The code-scanning rule needs *a* CodeQL result on the queue ref, and `Analyze (actions)`
supplies one in ~40 seconds. The queue then merges the entry and GitHub deletes
`refs/heads/gh-readonly-queue/main/pr-N-...` while the Rust analysis is still running at
around four and a half minutes.

The evidence is the duration split: every merge-queue run that passed finished in ≤ 2m36s,
every one that failed ran ≥ 4m05s. It is a race the Rust job cannot win.

It never blocked a merge — `ci-ok` was always the gate — so the only cost was a red main
and about five wasted runner-minutes per merge.

## The change

The matrix `include` becomes an expression: `actions` only under `merge_group`, both
languages everywhere else.

The merge queue still gets its CodeQL result, which is why the workflow listens to
`merge_group` at all. Rust is still analysed on every `pull_request`, every push to `main`,
and the weekly schedule, so nothing reaches main unscanned.

`exclude:` would be the more obvious spelling, but it is applied before `include:` and
cannot remove an entry that `include:` added.

## The alternative

Adding `Analyze (rust)` to the ruleset's required checks would make the queue wait for it
instead. That is also correct, and arguably more principled — but it adds roughly five
minutes to every merge, and it is a repository settings change rather than a code one.

## Verification

`actionlint` exits 0; the folded scalar yields one clean expression and both embedded JSON
arrays parse. Both pinned action SHAs exist upstream. Only CI can confirm GitHub evaluates
the dynamic matrix as intended — one job under `merge_group`, two elsewhere.
