### PR TITLE
fix(env): remove stale npm_config_userconfig case variants before injecting

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -543,7 +543,7 @@ One consequence is worth knowing: an agent can deliberately force the audit to `
 The injection is skipped in three cases, where the failure below can still appear:
 
 - you allowed `~/.npmrc` yourself (`allow.read`), so you asked for the real file and cplt does not redirect around it;
-- you set `NPM_CONFIG_USERCONFIG` yourself, and your value wins;
+- you set `NPM_CONFIG_USERCONFIG` yourself — in any capitalisation, since npm and yarn lowercase the key — and your value wins;
 - the scratch dir is off (`--no-scratch-dir`), so there is no session-scoped writable location to point at.
 
 Without it, `yarn install` fails outright under the default policy when an `~/.npmrc` exists on the host. Nothing is resolved and no `node_modules` is written:
@@ -592,7 +592,7 @@ error Error: EPERM: operation not permitted, open '/Users/you/.yarnrc'
 
 `~/.yarnrc` is not in any deny list. Like most home dotfiles it is simply never granted, since the sandbox enumerates the specific `$HOME` config files tools need rather than granting `$HOME` wholesale. Allow it the same way (`cplt config set allow.read "~/.yarnrc"`) if you keep one.
 
-**Why `NPM_CONFIG_USERCONFIG` works.** It is on cplt's environment allowlist because it names a path rather than carrying a secret, and yarn 1's npmrc loader honours it: `mergeEnv('npm_config_')` lowercases the variable into `config.userconfig`, which replaces the `~/.npmrc` entry in `getPossibleConfigLocations`. That list is gated on an existence check before the read, so a path that does not exist is skipped rather than read. This is why cplt injects the variable rather than granting the file. `allow.read` fixes the crash by handing the credential over, the redirect fixes it by removing the need. npm and pnpm honour the same variable and could not read `~/.npmrc` in the sandbox anyway, so nothing changes for them. It redirects only the npmrc loader, so a `~/.yarnrc` still needs the treatment above.
+**Why `NPM_CONFIG_USERCONFIG` works.** It is on cplt's environment allowlist because it names a path rather than carrying a secret, and yarn 1's npmrc loader honours it: `mergeEnv('npm_config_')` lowercases the variable into `config.userconfig`, which replaces the `~/.npmrc` entry in `getPossibleConfigLocations`. That list is gated on an existence check before the read, so a path that does not exist is skipped rather than read. Because that lowercasing collapses every spelling into one entry, and an *empty* value is falsy enough to fall back to `~/.npmrc`, cplt also removes any other-cased `npm_config_userconfig` from the child environment when it injects — otherwise a stray empty one could win the merge and undo the redirect. This is why cplt injects the variable rather than granting the file. `allow.read` fixes the crash by handing the credential over, the redirect fixes it by removing the need. npm and pnpm honour the same variable and could not read `~/.npmrc` in the sandbox anyway, so nothing changes for them. It redirects only the npmrc loader, so a `~/.yarnrc` still needs the treatment above.
 
 The XDG variables, by contrast, do not help. yarn 1's `.yarnrc` scan builds its own path list with hardcoded `~/.yarnrc` entries and runs before the XDG-aware `getConfigDir()` is consulted, so neither `XDG_CONFIG_HOME` nor `XDG_DATA_HOME` removes those paths from the list. yarn 2+ (berry) uses a different config loader and is unaffected.
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -62,7 +62,10 @@ pub use policy::{
 pub use profile::{ProfileOptions, generate_profile};
 
 // Environment construction — already platform-agnostic.
-pub use env::{SandboxEnv, build_sandbox_env, npmrc_explicitly_allowed, npmrc_userconfig_override};
+pub use env::{
+    SandboxEnv, build_sandbox_env, npmrc_explicitly_allowed, npmrc_userconfig_override,
+    npmrc_userconfig_stale_variants,
+};
 
 // Landlock policy types — cross-platform for testing.
 pub use landlock_mod::{

--- a/src/sandbox_env.rs
+++ b/src/sandbox_env.rs
@@ -306,6 +306,28 @@ pub fn npmrc_userconfig_override(
     Some(scratch_dir?.join("npmrc"))
 }
 
+/// Keys in `parent_env` that name the same npm setting as `NPM_CONFIG_USERCONFIG`
+/// but are spelled differently, and so must be dropped when the override is injected.
+///
+/// npm and yarn both build their config by lowercasing every `npm_config_*` key
+/// (yarn 1's `NpmRegistry.getConfigFromEnv`, npm's own `npm-conf`), so
+/// `npm_config_userconfig` and `NPM_CONFIG_USERCONFIG` collapse to one entry and
+/// the last one the environ happens to yield wins. `npmrc_userconfig_override`
+/// deliberately treats an *empty* value as unset, so it can inject alongside an
+/// empty lowercase variant — and if that variant survives, the merge may pick the
+/// empty string, drop the redirect, and put `~/.npmrc` (and yarn 1's abort) back.
+/// Removing the variants leaves exactly one value in play instead of relying on
+/// iteration order.
+pub fn npmrc_userconfig_stale_variants(parent_env: &[(String, String)]) -> Vec<&str> {
+    parent_env
+        .iter()
+        .map(|(k, _)| k.as_str())
+        .filter(|k| {
+            k.eq_ignore_ascii_case("NPM_CONFIG_USERCONFIG") && *k != "NPM_CONFIG_USERCONFIG"
+        })
+        .collect()
+}
+
 /// Dangerous NODE_OPTIONS flags that allow code preloading or module interception.
 const NODE_OPTIONS_DANGEROUS: &[&str] = &[
     "--require",

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -122,6 +122,12 @@ fn configure_command(
     if let Some(path) =
         super::env::npmrc_userconfig_override(&parent_env, scratch_dir, npmrc_allowed)
     {
+        // Drop the other spellings first: npm and yarn lowercase every
+        // `npm_config_*` key, so a leftover (necessarily empty) lowercase
+        // variant would collide with the injection and could win the merge.
+        for key in super::env::npmrc_userconfig_stale_variants(&parent_env) {
+            cmd.env_remove(key);
+        }
         cmd.env("NPM_CONFIG_USERCONFIG", path);
     }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -9,7 +9,8 @@ use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, i
 use cplt::sandbox::{
     HardeningCategory, ProfileOptions, SandboxConfig, build_sandbox_env, generate_policy,
     generate_profile, npmrc_explicitly_allowed, npmrc_userconfig_override,
-    tool_override_path_is_safe, tool_path_env_overrides, validate_sbpl_path,
+    npmrc_userconfig_stale_variants, tool_override_path_is_safe, tool_path_env_overrides,
+    validate_sbpl_path,
 };
 
 // ============================================================
@@ -5489,6 +5490,40 @@ fn npmrc_userconfig_not_redirected_when_user_set_it() {
     // An empty value is treated as unset.
     let empty = make_env(&[("NPM_CONFIG_USERCONFIG", "")]);
     assert!(npmrc_userconfig_override(&empty, Some(scratch), false).is_some());
+    // Including in the lowercase spelling npm and yarn also accept.
+    let empty_lower = make_env(&[("npm_config_userconfig", "")]);
+    assert!(npmrc_userconfig_override(&empty_lower, Some(scratch), false).is_some());
+    // A non-empty lowercase one is still the user's own setting.
+    let lower = make_env(&[("npm_config_userconfig", "/Users/test/custom-npmrc")]);
+    assert_eq!(
+        npmrc_userconfig_override(&lower, Some(scratch), false),
+        None
+    );
+}
+
+/// #234 follow-up: injecting only the uppercase key leaves an empty lowercase
+/// one in the child env, and npm/yarn lowercase every `npm_config_*` key before
+/// merging — so the empty string could win and put the `~/.npmrc` read back.
+#[test]
+fn npmrc_userconfig_lowercase_variants_are_removed() {
+    let parent = make_env(&[
+        ("HOME", "/Users/test"),
+        ("npm_config_userconfig", ""),
+        ("NPM_CONFIG_USERCONFIG", ""),
+        ("Npm_Config_UserConfig", ""),
+        ("NPM_CONFIG_CACHE", "/tmp/cache"),
+    ]);
+    let mut stale = npmrc_userconfig_stale_variants(&parent);
+    stale.sort_unstable();
+    assert_eq!(
+        stale,
+        ["Npm_Config_UserConfig", "npm_config_userconfig"],
+        "every spelling but the one we inject must be removed, and nothing else"
+    );
+    assert!(
+        npmrc_userconfig_stale_variants(&make_env(&[("HOME", "/Users/test")])).is_empty(),
+        "no variants means nothing to remove"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #234, which merged with this Copilot finding open.

`configure_command` injects `NPM_CONFIG_USERCONFIG`, and `npmrc_userconfig_override`
deliberately treats an empty value as unset. That leaves a hole when the parent environment
holds an *empty lowercase* `npm_config_userconfig`.

yarn 1's `mergeEnv('npm_config_')` lowercases every key into a single `userconfig` entry,
last-wins over the environ, and npm's own env parsing does the same. So the injected
uppercase value and a pre-existing empty lowercase one collapse into one key. If the empty
one wins, `config.userconfig` is `""` — and `getPossibleConfigLocations` uses
`userconfig || path.join(userHome, '.npmrc')`. A falsy empty string does not merely tie:
it **deterministically restores the `~/.npmrc` read**, and with it the EACCES abort #180
was about.

`npmrc_userconfig_stale_variants` now returns every case variant that is not the exact key
we inject, and `configure_command` removes them before setting ours, so exactly one value
is ever in play.

Tests cover an empty lowercase variant, a non-empty lowercase variant, a mixed-case
variant, and assert an unrelated `NPM_CONFIG_CACHE` is left alone.

The documentation in `docs/known-impacts.md` is updated against the text as it stands after
#235, not as it was when #234 was written.
