### PR TITLE
fix(sandbox): allow Chrome for Testing to register Mach services

### DIFF
--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -506,8 +506,12 @@ fn emit_system_access(
     //    user clients during renderer init, even in headless mode (SwiftShader
     //    fallback still queries IOKit before deciding to use software rendering).
     //
-    // 4. mach-register — Chromium registers Mach services under the org.chromium.*
-    //    namespace for IPC between browser, renderer, GPU, and Crashpad processes.
+    // 4. mach-register — Chromium registers Mach services for IPC between
+    //    browser, renderer, GPU, and Crashpad processes. The namespace is the
+    //    build's bundle ID, not a fixed string: an upstream Chromium build uses
+    //    org.chromium.*, while the Chrome for Testing build Playwright actually
+    //    downloads uses com.google.chrome.for.testing.* (#263). Both are
+    //    allowed; anything else still cannot register.
     //    Crashpad's child_port_handshake uses bootstrap_check_in() which requires
     //    this permission; without it, EPERM (1100) cascades into a segfault.
     //    Scoped to ^org\.chromium\..+$ — the trailing \. prevents matching
@@ -522,8 +526,8 @@ fn emit_system_access(
     // iokit-open-user-client is unscoped because IOKit class names vary by GPU
     // hardware and macOS version; scoping would break on different machines.
     // system-socket is scoped to AF_UNIX — only Unix domain sockets, not TCP/UDP.
-    // mach-register is scoped to ^org\.chromium\..+$ to prevent registration
-    // of arbitrary global Mach services.
+    // mach-register is scoped to the two known browser namespaces to prevent
+    // registration of arbitrary global Mach services.
     if allow_chromium_runtime {
         sbpl!(
             sb,
@@ -532,9 +536,19 @@ fn emit_system_access(
         sbpl!(sb, "(allow syscall*)");
         sbpl!(sb, "(allow system-socket (socket-domain AF_UNIX))");
         sbpl!(sb, "(allow iokit-open-user-client)");
+        // Two alternations rather than one loose pattern: each anchors the
+        // literal namespace and requires at least one character after the dot,
+        // so neither "org.chromiumevil" nor "com.google.chrome.for.testingX"
+        // matches. Chromium uses variable-depth subnamespaces (crashpad.*,
+        // Chromium.*) and Chrome for Testing appends a pid to
+        // MachPortRendezvousServer, so the tail stays open.
         sbpl!(
             sb,
             r#"(allow mach-register (global-name-regex #"^org\.chromium\..+$"))"#
+        );
+        sbpl!(
+            sb,
+            r#"(allow mach-register (global-name-regex #"^com\.google\.chrome\.for\.testing\..+$"))"#
         );
         sbpl!(sb);
     }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -7143,6 +7143,16 @@ fn chromium_runtime_rules_emitted_for_ms_playwright() {
         p.contains(r#"(allow mach-register (global-name-regex #"^org\.chromium\..+$"))"#),
         "mach-register must be anchored with ^...$ and scoped to org.chromium.*"
     );
+    // #263: the browser Playwright actually downloads is Chrome for Testing,
+    // which registers under its own bundle ID. Without this the launch dies on
+    // `bootstrap_check_in ... MachPortRendezvousServer: Permission denied (1100)`
+    // even with --allow-cache-exec ms-playwright.
+    assert!(
+        p.contains(
+            r#"(allow mach-register (global-name-regex #"^com\.google\.chrome\.for\.testing\..+$"))"#
+        ),
+        "Chrome for Testing registers under com.google.chrome.for.testing.*, not org.chromium.*"
+    );
     assert!(
         p.contains(r#"(regex #"^/private/var/folders/[^/]+/[^/]+/T/com\.google\.chrome\.for\.testing\.[^/]+/SingletonSocket$")"#),
         "SingletonSocket regex must use [^/]+/[^/]+ for var/folders segments and be fully anchored"
@@ -7247,6 +7257,12 @@ fn chromium_runtime_rules_absent_by_default() {
     assert!(
         !p.contains("SingletonSocket"),
         "SingletonSocket rules must not be emitted by default"
+    );
+    // The Chrome for Testing namespace is behind the same opt-in as the rest of
+    // the browser runtime — widening it for #263 must not widen the default.
+    assert!(
+        !p.contains("mach-register"),
+        "no mach-register namespace may be granted by default"
     );
 }
 


### PR DESCRIPTION
Fixes the Mach-registration half of #263.

## What was wrong

`--allow-cache-exec ms-playwright` opens cache *execution*. Mach service registration is a separate gate, scoped to Chromium's upstream namespace only:

```scheme
(allow mach-register (global-name-regex #"^org\.chromium\..+$"))
```

Playwright downloads Chrome for Testing, which registers under its own bundle ID. The launch failed at:

```text
bootstrap_check_in com.google.chrome.for.testing.MachPortRendezvousServer.<pid>: Permission denied (1100)
```

@AudunSorheim's diagnosis in the issue was correct on both counts: the failure and that it is a runtime-policy gap, not a cache-execution problem.

## The change

A second anchored alternation:

```scheme
(allow mach-register (global-name-regex #"^com\.google\.chrome\.for\.testing\..+$"))
```

Two patterns instead of one loose one. Each anchors its literal namespace and requires at least one character after the trailing dot, so `org.chromiumevil` and `com.google.chrome.for.testingX` still cannot register. The tail is open because Chromium uses variable-depth subnamespaces and Chrome for Testing appends a pid.

Still behind the same opt-in (`allow_cache_exec` containing `ms-playwright`). A new assertion pins that no `mach-register` namespace is granted by default.

## Verification

Unit tests cover the emitted rule and the opt-in gate. The new assertion fails if the alternation is removed (mutation-checked).

**Not verified end to end.** The issue asks for a macOS integration test that launches the real browser through `sandbox-exec`. I could not run one: this environment is a background launchd session (`launchctl managername` returns `Background`), and Chrome for Testing hangs there even *outside* cplt, so there is no baseline to compare against. Someone on a normal terminal should confirm the reproduction from the issue now succeeds before this is considered closed.

The other half of #263, whether anything else in the browser launch path is still denied, is untested for the same reason.
