### PR TITLE
fix(gh): resolve gate()'s git from trusted directories, not PATH

### DIFF
--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1698,12 +1698,23 @@ pub fn gate(
     // and scope-checked commands are refused. That matches what the gh wrapper
     // already tells the user in the same situation, and it fails closed: the
     // alternative is answering a scope question with an unverified answer.
-    gate_with_scope_resolver(args, policy, || {
-        let git = crate::git::trusted_git().ok_or_else(|| {
-            "no git in a trusted directory, so the repository scope cannot be verified".to_string()
-        })?;
-        detect_current_repo(git, project_dir)
-    })
+    // Resolved once, and passed to BOTH consumers: the scope resolver below and
+    // `gate_with_scope_resolver`'s own `real_git`, which #230 uses to verify the
+    // invocation repo of an implicit target. Passing `None` there would silently
+    // skip that check.
+    let trusted = crate::git::trusted_git();
+    gate_with_scope_resolver(
+        args,
+        policy,
+        || {
+            let git = trusted.ok_or_else(|| {
+                "no git in a trusted directory, so the repository scope cannot be verified"
+                    .to_string()
+            })?;
+            detect_current_repo(git, project_dir)
+        },
+        trusted,
+    )
 }
 
 /// Evaluate a `gh` command using a pre-resolved Git binary for repository scope.

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1551,8 +1551,13 @@ fn arg_reveals_token(arg: &str) -> bool {
 
 /// Evaluate a full command and return a human-friendly verdict.
 ///
-/// This is the entry point used by the `gh-gate` subcommand.
-/// Returns the verified repository scope when allowed, or an error when blocked.
+/// Used by `cplt check` (`check.rs`), which explains what the guard would do.
+/// The `gh-gate` subcommand does not come through here: it has the startup
+/// scope captured before launch and calls `gate_with_repo_scope` instead.
+///
+/// Returns the repository scope when one could be resolved, or an error when
+/// the command is blocked. An allowed decision does not imply a scope — a
+/// command that needs none is allowed without resolving one.
 pub fn gate(
     args: &[&str],
     project_dir: &Path,

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1558,7 +1558,22 @@ pub fn gate(
     project_dir: &Path,
     policy: &GatePolicy,
 ) -> Result<GateApproval, String> {
-    gate_with_git(args, project_dir, policy, Path::new("git"))
+    // Trusted, not PATH (#250). The only caller is `cplt check`, which runs in
+    // the UNSANDBOXED parent, so a `git` planted in a write+exec directory on
+    // PATH would execute as the user. `gate_with_git` documents its parameter
+    // as a trusted binary; passing `Path::new("git")` kept that promise by
+    // convention rather than by the code.
+    //
+    // No trusted git means the scope cannot be verified, so the resolver errors
+    // and scope-checked commands are refused. That matches what the gh wrapper
+    // already tells the user in the same situation, and it fails closed: the
+    // alternative is answering a scope question with an unverified answer.
+    gate_with_scope_resolver(args, policy, || {
+        let git = crate::git::trusted_git().ok_or_else(|| {
+            "no git in a trusted directory, so the repository scope cannot be verified".to_string()
+        })?;
+        detect_current_repo(git, project_dir)
+    })
 }
 
 /// Evaluate a `gh` command using a pre-resolved Git binary for repository scope.


### PR DESCRIPTION
Closes #250.

`gate()` passed `Path::new("git")` into `gate_with_git`, whose parameter is documented as a trusted binary. Its only caller is `src/check.rs:461`, which runs in the **unsandboxed parent** on `cplt check`, so a `git` planted in a write+exec directory on `PATH` would have executed as the user there. #236 moved every other parent-side spawn onto `crate::git::trusted_git()`; this was the call site it did not reach, because the trust lived in the parameter's doc comment rather than in the code.

## The change

`gate()` now resolves through `crate::git::trusted_git()`. When there is no trusted git the resolver returns an error, so scope-checked commands are refused rather than answered from an unverified lookup — the same outcome the gh wrapper already reports in that situation, and it fails closed.

`gate_with_git` is unchanged and stays as the seam that takes an explicit binary.

## Test coverage

None added, and worth being explicit about why: `trusted_git()` caches in a `OnceLock`, so the `None` arm is unreachable from a test on any host that has git installed. The same limitation applies to the other call sites #236 converted. Making it testable would mean threading the resolver through `gate`, which is a larger change than this fix warrants.

794 + 288 tests pass, clippy clean.