### PR TITLE
ci(release): stop caching, closing the cache-poisoning alert

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,16 +72,6 @@ jobs:
           toolchain: "1.94"
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # ratchet:actions/cache@v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: release-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: release-${{ matrix.target }}-
-
       - name: Build release binary
         run: |
           CPLT_LONG_VERSION="${{ needs.version.outputs.version }}" cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
Closes CodeQL alert 8 (`actions/cache-poisoning/direct-cache`, **high** — the only high-severity alert open on main).

## The vector

`release.yaml` triggers on `workflow_dispatch` as well as `workflow_run`, checks out `github.event.workflow_run.head_sha || github.sha`, builds it, and then writes a cargo cache keyed `release-<target>-<Cargo.lock hash>`. A dispatch on a ref whose code has not been reviewed populates a cache that later privileged runs restore, which is what CodeQL flags.

## The change

The cache step is removed rather than narrowed. A scoped-key workaround still writes attacker-influenced bytes into a cache the default branch can read; deleting it removes the vector instead of making it harder to reach.

The cost is a cold build on release. Releases are infrequent, so that is a few minutes on a job that already cross-compiles four targets.

`ci.yaml` keeps its cache and is untouched: it runs on `pull_request`, where the cache scope is the PR's own branch rather than the default branch.

Alerts 40 and 41 (`rust/log-injection`, medium) are fixed separately in #270.