### PR TITLE
fix(sandbox): keep per-subdir posture for relocated CARGO_HOME

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -759,6 +759,7 @@ mod tests {
             restrict_net_connect: true,
             proxy_forced: false,
             home_dir: PathBuf::from("/home/u"),
+            precreate_dirs: vec![],
         }
     }
 

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -69,8 +69,9 @@ pub struct ToolDiscovery {
     pub tools: Vec<ToolInfo>,
     /// Homebrew prefix (e.g. `/opt/homebrew` or `/usr/local`).
     pub homebrew_prefix: Option<PathBuf>,
-    /// Which HOME_TOOL_DIRS actually exist on disk.
-    pub existing_home_tool_dirs: Vec<String>,
+    /// Which HOME_TOOL_DIRS actually exist on disk, at their effective paths
+    /// (relocated tool homes such as `CARGO_HOME` already applied).
+    pub existing_home_tool_dirs: Vec<ResolvedToolDir>,
     /// Writable APP_DIRS considered during discovery, including paths that may not yet exist.
     pub existing_app_dirs: Vec<String>,
 }
@@ -244,8 +245,11 @@ const TOOLS_TO_CHECK: &[&str] = &[
 
 use crate::sandbox::app_dirs;
 use crate::sandbox::home_tool_dirs;
+use crate::sandbox::{ResolvedToolDir, ToolRoot};
 
-pub fn discover_tools(home_dir: &Path) -> ToolDiscovery {
+/// `tool_roots` relocates HOME_TOOL_DIRS trees named by env vars
+/// (`CARGO_HOME`, `GOPATH`, ...); see `ToolRoot`.
+pub fn discover_tools(home_dir: &Path, tool_roots: &[ToolRoot]) -> ToolDiscovery {
     let tools: Vec<ToolInfo> = TOOLS_TO_CHECK
         .iter()
         .chain(app_dirs().iter().map(|app_dir| &app_dir.application))
@@ -266,13 +270,13 @@ pub fn discover_tools(home_dir: &Path) -> ToolDiscovery {
     .map(PathBuf::from)
     .find(|p| p.exists());
 
-    let existing_home_tool_dirs: Vec<String> = home_tool_dirs()
+    let existing_home_tool_dirs: Vec<ResolvedToolDir> = home_tool_dirs()
         .iter()
+        .map(|d| d.resolve(home_dir, tool_roots))
         // Writable cache dirs are always included: tools create them on first use,
         // and the profile must permit the write that creates the directory.
         // Non-writable dirs (tool runtimes) are pruned to existing only.
-        .filter(|d| d.write || home_dir.join(d.path).exists())
-        .map(|d| d.path.to_string())
+        .filter(|d| d.dir.write || d.path.exists())
         .collect();
 
     // Writable app dirs are always included in this list because they potentially could be created on first use.
@@ -350,7 +354,7 @@ pub fn discover_all(home_dir: &Path, project_dir: &Path) -> Discovery {
         auth: discover_auth(home_dir),
         copilot: discover_copilot(home_dir),
         agents: discover_agents(),
-        tools: discover_tools(home_dir),
+        tools: discover_tools(home_dir, &[]),
         paths: discover_paths(home_dir, project_dir),
     }
 }
@@ -545,17 +549,29 @@ impl Discovery {
             );
         }
         if !self.tools.existing_home_tool_dirs.is_empty() {
+            let joined: Vec<String> = self
+                .tools
+                .existing_home_tool_dirs
+                .iter()
+                .map(|d| d.path.display().to_string())
+                .collect();
             println!(
-                "  {}✓{} Tool dirs: ~/{}",
+                "  {}✓{} Tool dirs: {}",
                 ui::stdout_color(ui::GREEN),
                 ui::stdout_color(ui::RESET),
-                self.tools.existing_home_tool_dirs.join(", ~/")
+                joined.join(", ")
             );
         }
         let missing_dirs: Vec<&str> = home_tool_dirs()
             .iter()
             .map(|d| d.path)
-            .filter(|p| !self.tools.existing_home_tool_dirs.iter().any(|e| e == p))
+            .filter(|p| {
+                !self
+                    .tools
+                    .existing_home_tool_dirs
+                    .iter()
+                    .any(|e| e.dir.path == *p)
+            })
             .collect();
         if !missing_dirs.is_empty() {
             let joined: Vec<String> = missing_dirs.iter().map(|d| format!("~/{d}")).collect();
@@ -1765,7 +1781,7 @@ mod tests {
     #[test]
     fn tool_discovery_finds_git() {
         let home = PathBuf::from(std::env::var("HOME").unwrap());
-        let tools = discover_tools(&home);
+        let tools = discover_tools(&home, &[]);
         assert!(
             tools.tools.iter().any(|t| t.name == "git"),
             "git should be found on any dev machine"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1102,6 +1102,7 @@ fn detect_project_root() -> Option<PathBuf> {
 
 // Use library's is_unsafe_root
 use cplt::is_unsafe_root;
+use cplt::sandbox::ToolRoot;
 use cplt::ui;
 
 /// Prompt the user to confirm the sandbox configuration.
@@ -1201,7 +1202,13 @@ fn canonicalize_deny_paths(paths: &[PathBuf]) -> anyhow::Result<Vec<PathBuf>> {
 /// path to open, and macOS SBPL rules for missing paths are inert. Paths are
 /// merged into `allow_read`/`allow_write`, which the backends already handle;
 /// this only ever *adds* access.
-fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) {
+///
+/// Vars whose default location is split into `HOME_TOOL_DIRS` entries with
+/// different postures (`CARGO_HOME` → `.cargo/{bin,registry,git}`) are not
+/// granted as one tree: they come back as `ToolRoot`s that relocate those
+/// entries, so `$CARGO_HOME/bin` stays exec-only and never writable (#152).
+fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) -> Vec<ToolRoot> {
+    let mut roots = Vec::new();
     // Read only the handful of recognized tool-path vars rather than snapshotting
     // the entire parent environment — no need to copy unrelated secrets (tokens,
     // credentials) into a Vec just to inspect a fixed, small set of names.
@@ -1233,6 +1240,17 @@ fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) {
             ));
             continue;
         }
+        // One root per default tree: a second segment of a list var
+        // (`GOPATH=/a:/b`) keeps the plain whole-tree grant below.
+        if let Some(default) = cplt::sandbox::relocatable_tool_prefix(ovr.name)
+            && roots.iter().all(|r: &ToolRoot| r.default != default)
+        {
+            roots.push(ToolRoot {
+                default,
+                root: path,
+            });
+            continue;
+        }
         let target = if ovr.write {
             &mut resolved.allow_write
         } else {
@@ -1242,6 +1260,7 @@ fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) {
             target.push(path);
         }
     }
+    roots
 }
 
 /// Resolved configuration, paths, and agent info needed by the sandbox.
@@ -2458,8 +2477,11 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         unapproved_proposals: _,
     } = resolve_context(&cli, false)?;
 
+    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
+    let tool_roots = merge_tool_path_env_overrides(&mut resolved, &home_dir);
+
     // Run auto-discovery to tighten the sandbox profile
-    let tool_discovery = discover::discover_tools(&home_dir);
+    let tool_discovery = discover::discover_tools(&home_dir, &tool_roots);
     let existing_home_tool_dirs = tool_discovery.existing_home_tool_dirs;
     let existing_app_dirs = tool_discovery.existing_app_dirs;
 
@@ -2582,9 +2604,6 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     // Start proxy (handle returned for RAII ownership)
     let proxy_handle =
         start_proxy_if_enabled(&mut resolved, &cli, config_path.as_ref(), active_agent)?;
-
-    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
-    merge_tool_path_env_overrides(&mut resolved, &home_dir);
 
     // Prepare the sandbox — validates paths, generates platform-specific profile.
     // Path validation (SBPL injection checks on macOS) is handled internally
@@ -3108,7 +3127,10 @@ fn prepare_shell_sandbox(
 ) -> anyhow::Result<ShellSandbox> {
     let active_agent = agent::Agent::Shell;
 
-    let tool_discovery = discover::discover_tools(home_dir);
+    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
+    let tool_roots = merge_tool_path_env_overrides(resolved, home_dir);
+
+    let tool_discovery = discover::discover_tools(home_dir, &tool_roots);
     let existing_home_tool_dirs = tool_discovery.existing_home_tool_dirs;
     let existing_app_dirs = tool_discovery.existing_app_dirs;
 
@@ -3177,9 +3199,6 @@ fn prepare_shell_sandbox(
 
     let proxy_handle = start_proxy_if_enabled(resolved, cli, config_path, active_agent)?;
     let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
-
-    // Grant access to tool paths relocated via env vars (GOPATH, CARGO_HOME, ...).
-    merge_tool_path_env_overrides(resolved, home_dir);
 
     // See the #242 note at the other `SandboxConfig` construction.
     let keychain_substitute = active_agent.credential_outside_keychain(

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -54,8 +54,9 @@ pub use policy::{
     ENV_PREFIX_ALLOWLIST, HARDENING_ENV_VARS, HOME_TOOL_DIRS, HardeningCategory, HardeningEnvVar,
     HomeToolDir, PLAYWRIGHT_SOCKET_BASE_MAX_BYTES, PLAYWRIGHT_SOCKET_DIR_PREFIX,
     PLAYWRIGHT_SOCKET_PATH_LIMIT, PLAYWRIGHT_SOCKET_ROOT, PLAYWRIGHT_SOCKET_WORST_CASE_SUFFIX,
-    TOOL_PATH_ENV_VARS, ToolPathEnvVar, ToolPathOverride, app_dirs, current_uid, home_tool_dirs,
-    linux_docker_socket_paths, playwright_runtime_intent, socket_mask_paths,
+    ResolvedToolDir, TOOL_PATH_ENV_VARS, ToolPathEnvVar, ToolPathOverride, ToolRoot,
+    active_tool_dirs, app_dirs, current_uid, home_tool_dirs, linux_docker_socket_paths,
+    playwright_runtime_intent, relocatable_tool_prefix, socket_mask_paths,
     tool_override_path_is_safe, tool_path_env_overrides, validate_playwright_socket_dir,
     validate_sbpl_path,
 };
@@ -105,9 +106,10 @@ pub struct SandboxConfig<'a> {
     pub extra_write: &'a [PathBuf],
     pub extra_socket: &'a [PathBuf],
     pub extra_deny: &'a [PathBuf],
-    /// If `Some`, only include these home tool dirs (tighter profile via discovery).
-    /// If `None`, all known home tool dirs are included.
-    pub existing_home_tool_dirs: Option<&'a [String]>,
+    /// If `Some`, only include these home tool dirs (tighter profile via discovery,
+    /// with relocated tool homes such as `CARGO_HOME` already resolved).
+    /// If `None`, all known home tool dirs are included at their defaults.
+    pub existing_home_tool_dirs: Option<&'a [ResolvedToolDir]>,
     /// If `Some`, only include these app dirs (tighter profile via discovery).
     /// If `None`, all known app dirs are included.
     pub existing_app_dirs: Option<&'a [String]>,
@@ -661,6 +663,9 @@ fn validate_config_paths(config: &SandboxConfig) -> Result<(), String> {
     }
     if let Some(dir) = config.dotnet_root {
         policy::validate_sbpl_path(dir).map_err(|e| format!("DOTNET_ROOT: {e}"))?;
+    }
+    for d in config.existing_home_tool_dirs.unwrap_or(&[]) {
+        policy::validate_sbpl_path(&d.path).map_err(|e| format!("Tool dir: {e}"))?;
     }
     if let Some(p) = config.git_hooks_path {
         policy::validate_sbpl_path(p).map_err(|e| format!("Git hooks path: {e}"))?;

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -32,7 +32,7 @@
 //! cannot. Use `--with-proxy` on Linux for localhost SSRF protection.
 //! The proxy handles domain-level filtering on both platforms.
 
-use super::policy::{self, HomeToolDir};
+use super::policy;
 #[cfg(target_os = "linux")]
 use crate::ui;
 use std::fmt::Write as _;
@@ -102,9 +102,12 @@ pub struct LandlockPolicy {
     /// (Landlock ABI < v4): warn-and-continue would launch the agent with open
     /// direct networking behind the very flag meant to prevent it.
     pub proxy_forced: bool,
-    /// Home directory — used to pre-create writable cache directories that
+    /// Home directory — used to pre-create cache-exec directories that
     /// Landlock needs to open(O_PATH) before the sandbox is applied.
     pub home_dir: PathBuf,
+    /// Writable home tool dirs (build caches such as `$CARGO_HOME/registry`)
+    /// pre-created before the sandbox is applied, for the same reason.
+    pub precreate_dirs: Vec<PathBuf>,
 }
 
 /// Pre-computed data for sandbox application in the child process.
@@ -362,19 +365,18 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
         }
     }
 
-    // ── Home tool directories (filtered by discovery) ──
-    for dir in policy::home_tool_dirs() {
-        if should_include_tool_dir(dir, config) {
-            fs_rules.push(FsRule {
-                path: home.join(dir.path),
-                access: FsAccess {
-                    read: true,
-                    write: dir.write,
-                    execute: dir.process_exec || dir.map_exec,
-                    ioctl: false,
-                },
-            });
-        }
+    // ── Home tool directories (filtered by discovery, relocated homes resolved) ──
+    let tool_dirs = policy::active_tool_dirs(home, config.existing_home_tool_dirs);
+    for policy::ResolvedToolDir { path, dir } in &tool_dirs {
+        fs_rules.push(FsRule {
+            path: path.clone(),
+            access: FsAccess {
+                read: true,
+                write: dir.write,
+                execute: dir.process_exec || dir.map_exec,
+                ioctl: false,
+            },
+        });
     }
 
     // ── Cache exec carve-out (opt-in; Linux equivalent of macOS allow_cache_exec) ──
@@ -760,20 +762,19 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
     // provides domain filtering and port enforcement for remote connections).
     let restrict_net_connect = !config.allow_localhost_any;
 
+    let precreate_dirs = tool_dirs
+        .into_iter()
+        .filter(|d| d.dir.write)
+        .map(|d| d.path)
+        .collect();
+
     LandlockPolicy {
         fs_rules,
         net_rules,
         restrict_net_connect,
         proxy_forced: config.proxy_forced,
         home_dir: home.to_path_buf(),
-    }
-}
-
-/// Check if a home tool directory should be included based on discovery data.
-fn should_include_tool_dir(dir: &HomeToolDir, config: &super::SandboxConfig) -> bool {
-    match &config.existing_home_tool_dirs {
-        Some(existing) => existing.iter().any(|e| e == dir.path),
-        None => true,
+        precreate_dirs,
     }
 }
 
@@ -1165,12 +1166,9 @@ pub fn precompute(policy: LandlockPolicy) -> Result<PrecomputedSandbox, String> 
     // Scope: only HOME_TOOL_DIRS with write=true (build caches). We do NOT
     // pre-create user --allow-write paths, socket paths, or arbitrary writable
     // rules — those require the user to set up the filesystem themselves.
-    for dir in policy::home_tool_dirs() {
-        if dir.write {
-            let path = policy.home_dir.join(dir.path);
-            if !path.exists() {
-                let _ = std::fs::create_dir_all(&path);
-            }
+    for path in &policy.precreate_dirs {
+        if !path.exists() {
+            let _ = std::fs::create_dir_all(path);
         }
     }
 
@@ -2642,12 +2640,11 @@ mod tests {
     fn discovery_filtering_limits_home_tool_dirs() {
         let project = PathBuf::from("/home/user/project");
         let home = PathBuf::from("/home/user");
-        let existing = vec![
-            ".cargo/bin".to_string(),
-            ".cargo/registry".to_string(),
-            ".cargo/git".to_string(),
-            ".nvm".to_string(),
-        ];
+        let existing: Vec<policy::ResolvedToolDir> = policy::home_tool_dirs()
+            .iter()
+            .filter(|d| [".cargo/bin", ".cargo/registry", ".cargo/git", ".nvm"].contains(&d.path))
+            .map(|d| d.resolve(&home, &[]))
+            .collect();
         let mut config = test_config(&project, &home);
         config.existing_home_tool_dirs = Some(&existing);
         let policy = generate_policy(&config);
@@ -3255,6 +3252,7 @@ mod tests {
             restrict_net_connect: false,
             proxy_forced: false,
             home_dir: PathBuf::from("/tmp/test-home"),
+            precreate_dirs: vec![],
         };
 
         let precomputed = precompute(policy).expect("precompute should succeed");

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -926,6 +926,7 @@ pub fn app_dirs() -> &'static [AppDir] {
 /// Security principle: every writable+executable directory is a potential
 /// binary-drop staging path (see SECURITY.md axios case study). Grant exec
 /// only where tools genuinely install executables.
+#[derive(Debug, PartialEq, Eq)]
 pub struct HomeToolDir {
     pub path: &'static str,
     pub process_exec: bool,
@@ -1173,6 +1174,80 @@ pub fn home_tool_dirs() -> &'static [HomeToolDir] {
     HOME_TOOL_DIRS
 }
 
+/// A tool home relocated by an env var (`CARGO_HOME=~/.local/share/cargo`).
+///
+/// [`HOME_TOOL_DIRS`] entries under `default` (home-relative, e.g. `.cargo`)
+/// are re-rooted under `root` (absolute, canonicalized, existence-checked by
+/// the caller) and keep their own permission flags, so `$CARGO_HOME/bin` gets
+/// the exec-only posture of `~/.cargo/bin` rather than one write grant over
+/// the whole tree (#152).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolRoot {
+    pub default: &'static str,
+    pub root: PathBuf,
+}
+
+/// A [`HOME_TOOL_DIRS`] entry at its effective absolute path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedToolDir {
+    pub path: PathBuf,
+    pub dir: &'static HomeToolDir,
+}
+
+impl HomeToolDir {
+    /// Absolute path of this entry: under the matching [`ToolRoot`] if one
+    /// relocates its tree, else under `home`.
+    pub fn resolve(&'static self, home: &Path, roots: &[ToolRoot]) -> ResolvedToolDir {
+        let rel = Path::new(self.path);
+        let path = roots
+            .iter()
+            .find_map(|r| {
+                let rest = rel.strip_prefix(r.default).ok()?;
+                // `join("")` would append a trailing separator, and Seatbelt
+                // matches the literal string.
+                Some(if rest.as_os_str().is_empty() {
+                    r.root.clone()
+                } else {
+                    r.root.join(rest)
+                })
+            })
+            .unwrap_or_else(|| home.join(rel));
+        ResolvedToolDir { path, dir: self }
+    }
+}
+
+/// The default subpath of tool-path env var `name` that has [`HOME_TOOL_DIRS`]
+/// entries under it, if any. Such a var relocates those entries (see
+/// [`ToolRoot`]) instead of granting its whole tree.
+pub fn relocatable_tool_prefix(name: &str) -> Option<&'static str> {
+    TOOL_PATH_ENV_VARS
+        .iter()
+        .find(|tv| tv.name == name)?
+        .default_subpaths
+        .iter()
+        .copied()
+        .find(|d| {
+            HOME_TOOL_DIRS
+                .iter()
+                .any(|h| Path::new(h.path).starts_with(d))
+        })
+}
+
+/// Home tool dirs to grant: the discovered subset when available, else every
+/// entry at its default location under `home`.
+pub fn active_tool_dirs(
+    home: &Path,
+    discovered: Option<&[ResolvedToolDir]>,
+) -> Vec<ResolvedToolDir> {
+    match discovered {
+        Some(dirs) => dirs.to_vec(),
+        None => HOME_TOOL_DIRS
+            .iter()
+            .map(|d| d.resolve(home, &[]))
+            .collect(),
+    }
+}
+
 // ── Tool-path environment variable overrides ───────────────────────────────
 
 /// A development tool environment variable that relocates where the tool reads
@@ -1251,6 +1326,14 @@ pub const TOOL_PATH_ENV_VARS: &[ToolPathEnvVar] = &[
         name: "CARGO_HOME",
         write: true,
         default_subpaths: &[".cargo"],
+        list: false,
+    },
+    // RUSTUP_HOME holds the toolchains that the `$CARGO_HOME/bin` proxies
+    // exec into. Read-only, like the default `.rustup` entry.
+    ToolPathEnvVar {
+        name: "RUSTUP_HOME",
+        write: false,
+        default_subpaths: &[".rustup"],
         list: false,
     },
     // ── Node / npm / yarn / pnpm ─────────────────────────────────────────────

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -21,8 +21,8 @@ macro_rules! sbpl {
 
 use super::policy::{
     DENIED_CACHE_PREFIXES, DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS,
-    GPG_SIGNING_ALLOW_FILES, HOME_TOOL_DIRS, HomeToolDir, SENSITIVE_PROJECT_PATTERNS,
-    SYSTEM_READ_FILES, TOOL_READ_DIRS, app_dirs, playwright_runtime_intent,
+    GPG_SIGNING_ALLOW_FILES, ResolvedToolDir, SENSITIVE_PROJECT_PATTERNS, SYSTEM_READ_FILES,
+    TOOL_READ_DIRS, active_tool_dirs, app_dirs, playwright_runtime_intent,
     validate_playwright_socket_dir, validate_sbpl_path,
 };
 
@@ -36,9 +36,10 @@ pub struct ProfileOptions<'a> {
     pub extra_write: &'a [PathBuf],
     pub allow_socket: &'a [PathBuf],
     pub extra_deny: &'a [PathBuf],
-    /// If `Some`, only include these home tool dirs (tighter profile via discovery).
-    /// If `None`, all known home tool dirs are included.
-    pub existing_home_tool_dirs: Option<&'a [String]>,
+    /// If `Some`, only include these home tool dirs (tighter profile via discovery,
+    /// relocated tool homes already resolved). If `None`, all known home tool
+    /// dirs are included at their defaults.
+    pub existing_home_tool_dirs: Option<&'a [ResolvedToolDir]>,
     /// If `Some`, only include these app dirs (tighter profile via discovery).
     /// If `None`, all known app dirs are included.
     pub existing_app_dirs: Option<&'a [String]>,
@@ -941,7 +942,7 @@ fn emit_nested_gitdir_denies(sb: &mut String, root: &str) {
 fn emit_tool_dirs(
     sb: &mut String,
     home_dir: &std::path::Path,
-    existing_home_tool_dirs: Option<&[String]>,
+    existing_home_tool_dirs: Option<&[ResolvedToolDir]>,
     existing_app_dirs: Option<&[String]>,
     agent: Agent,
     allow_cache_exec: &[String],
@@ -954,38 +955,32 @@ fn emit_tool_dirs(
         sbpl!(sb, "(allow file-map-executable (subpath \"{dir}\"))");
     }
     // Home tool dirs: use discovered existing dirs if available, else include all
-    let active_dirs: Vec<&HomeToolDir> = match existing_home_tool_dirs {
-        Some(dirs) => HOME_TOOL_DIRS
-            .iter()
-            .filter(|d| dirs.iter().any(|s| s == d.path))
-            .collect(),
-        None => HOME_TOOL_DIRS.iter().collect(),
-    };
+    let active_dirs = active_tool_dirs(home_dir, existing_home_tool_dirs);
 
-    for dir in &active_dirs {
-        let p = dir.path;
-        sbpl!(sb, "(allow file-read* (subpath \"{home}/{p}\"))");
+    for ResolvedToolDir { path, dir } in &active_dirs {
+        let p = path.to_string_lossy();
+        sbpl!(sb, "(allow file-read* (subpath \"{p}\"))");
         if dir.process_exec {
-            sbpl!(sb, "(allow process-exec (subpath \"{home}/{p}\"))");
+            sbpl!(sb, "(allow process-exec (subpath \"{p}\"))");
         }
         if dir.map_exec {
-            sbpl!(sb, "(allow file-map-executable (subpath \"{home}/{p}\"))");
+            sbpl!(sb, "(allow file-map-executable (subpath \"{p}\"))");
         }
         if dir.write {
-            sbpl!(sb, "(allow file-write* (subpath \"{home}/{p}\"))");
+            sbpl!(sb, "(allow file-write* (subpath \"{p}\"))");
         }
     }
     // Deny exec from writable dirs that should not have it.
     // Must come AFTER allows (last-match-wins in Seatbelt).
     // The blanket (allow process-exec) means we need explicit denies,
     // not just absence of a per-dir allow.
-    for dir in &active_dirs {
-        let p = dir.path;
+    for ResolvedToolDir { path, dir } in &active_dirs {
+        let p = path.to_string_lossy();
         if dir.write && !dir.process_exec {
-            sbpl!(sb, "(deny process-exec (subpath \"{home}/{p}\"))");
+            sbpl!(sb, "(deny process-exec (subpath \"{p}\"))");
         }
         if dir.write && !dir.map_exec {
-            sbpl!(sb, "(deny file-map-executable (subpath \"{home}/{p}\"))");
+            sbpl!(sb, "(deny file-map-executable (subpath \"{p}\"))");
         }
     }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8962,7 +8962,7 @@ fn landlock_relocated_cargo_bin_is_exec_only_and_registry_is_precreated() {
     let rule = |p: &str| {
         ll.fs_rules
             .iter()
-            .find(|r| r.path == PathBuf::from(p))
+            .find(|r| r.path == std::path::Path::new(p))
             .unwrap_or_else(|| panic!("{p} should have a rule"))
     };
     let bin = rule("/home/tester/.local/share/cargo/bin");
@@ -8980,7 +8980,7 @@ fn landlock_relocated_cargo_bin_is_exec_only_and_registry_is_precreated() {
     assert!(
         !ll.fs_rules
             .iter()
-            .any(|r| r.path == PathBuf::from("/home/tester/.cargo/bin"))
+            .any(|r| r.path == std::path::Path::new("/home/tester/.cargo/bin"))
     );
 }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -14,6 +14,8 @@ use cplt::sandbox::{
     playwright_runtime_intent, playwright_sockets_dir_override, tool_override_path_is_safe,
     tool_path_env_overrides, validate_playwright_socket_dir, validate_sbpl_path,
 };
+use cplt::sandbox::{ResolvedToolDir, ToolRoot, home_tool_dirs, relocatable_tool_prefix};
+use std::path::PathBuf;
 
 // ============================================================
 // Unsafe root detection
@@ -8769,6 +8771,216 @@ fn tool_path_list_per_segment_safety_guard_drops_unsafe_segment() {
     assert!(
         !tool_override_path_is_safe(std::path::Path::new("/"), home),
         "the `/` segment must be dropped by the guard"
+    );
+}
+
+// --- Relocated tool homes keep per-subdir HOME_TOOL_DIRS posture (#152) ------
+// CARGO_HOME=~/.local/share/cargo must yield the same split as ~/.cargo:
+// bin exec-only, registry/git writable without process-exec. One write grant
+// over the whole tree made $CARGO_HOME/bin non-executable.
+
+fn tool_dir(path: &str) -> &'static cplt::sandbox::HomeToolDir {
+    home_tool_dirs()
+        .iter()
+        .find(|d| d.path == path)
+        .unwrap_or_else(|| panic!("{path} missing from HOME_TOOL_DIRS"))
+}
+
+fn cargo_root() -> Vec<ToolRoot> {
+    vec![ToolRoot {
+        default: ".cargo",
+        root: PathBuf::from("/home/tester/.local/share/cargo"),
+    }]
+}
+
+#[test]
+fn relocatable_prefix_covers_split_trees_only() {
+    assert_eq!(relocatable_tool_prefix("CARGO_HOME"), Some(".cargo"));
+    assert_eq!(relocatable_tool_prefix("RUSTUP_HOME"), Some(".rustup"));
+    assert_eq!(relocatable_tool_prefix("GOPATH"), Some("go"));
+    // No HOME_TOOL_DIRS entry lives under go/pkg/mod → plain whole-tree grant.
+    assert_eq!(relocatable_tool_prefix("GOMODCACHE"), None);
+    assert_eq!(relocatable_tool_prefix("NODE_PATH"), None);
+    assert_eq!(relocatable_tool_prefix("NOT_A_TOOL_VAR"), None);
+}
+
+#[test]
+fn resolve_reroots_entries_under_relocated_home() {
+    let home = std::path::Path::new("/home/tester");
+    let roots = cargo_root();
+    let bin = tool_dir(".cargo/bin").resolve(home, &roots);
+    assert_eq!(
+        bin.path,
+        PathBuf::from("/home/tester/.local/share/cargo/bin")
+    );
+    assert!(bin.dir.process_exec && !bin.dir.write);
+    let registry = tool_dir(".cargo/registry").resolve(home, &roots);
+    assert_eq!(
+        registry.path,
+        PathBuf::from("/home/tester/.local/share/cargo/registry")
+    );
+    assert!(registry.dir.write && !registry.dir.process_exec);
+    // Unrelated entries stay under HOME.
+    assert_eq!(
+        tool_dir(".nvm").resolve(home, &roots).path,
+        PathBuf::from("/home/tester/.nvm")
+    );
+    // No roots → default location.
+    assert_eq!(
+        tool_dir(".cargo/bin").resolve(home, &[]).path,
+        PathBuf::from("/home/tester/.cargo/bin")
+    );
+}
+
+#[test]
+fn resolve_entry_equal_to_root_has_no_trailing_separator() {
+    let home = std::path::Path::new("/home/tester");
+    let roots = vec![ToolRoot {
+        default: ".rustup",
+        root: PathBuf::from("/home/tester/.local/share/rustup"),
+    }];
+    let r = tool_dir(".rustup").resolve(home, &roots);
+    assert_eq!(r.path, PathBuf::from("/home/tester/.local/share/rustup"));
+    assert!(!r.path.to_string_lossy().ends_with('/'));
+}
+
+#[test]
+fn tool_path_rustup_home_custom_yields_read_only_rule() {
+    let home = std::path::Path::new("/home/tester");
+    let env = env_pairs(&[("RUSTUP_HOME", "/home/tester/.local/share/rustup")]);
+    let overrides = tool_path_env_overrides(&env, home);
+    assert_eq!(overrides.len(), 1);
+    assert!(
+        !overrides[0].write,
+        "toolchains are read-only, like ~/.rustup"
+    );
+    let env = env_pairs(&[("RUSTUP_HOME", "~/.rustup")]);
+    assert!(
+        tool_path_env_overrides(&env, home).is_empty(),
+        "default location is already covered by HOME_TOOL_DIRS"
+    );
+}
+
+fn relocated_cargo_dirs() -> Vec<ResolvedToolDir> {
+    let home = std::path::Path::new("/home/tester");
+    let roots = cargo_root();
+    [".cargo/bin", ".cargo/registry", ".cargo/git"]
+        .iter()
+        .map(|p| tool_dir(p).resolve(home, &roots))
+        .collect()
+}
+
+#[test]
+fn profile_relocated_cargo_bin_is_exec_only_and_registry_is_write_only() {
+    let dirs = relocated_cargo_dirs();
+    let p = generate_profile(&ProfileOptions {
+        project_dir: std::path::Path::new("/projects/app"),
+        home_dir: std::path::Path::new("/home/tester"),
+        extra_read: &[],
+        extra_write: &[],
+        allow_socket: &[],
+        extra_deny: &[],
+        existing_home_tool_dirs: Some(&dirs),
+        existing_app_dirs: None,
+        extra_ports: &[],
+        localhost_ports: &[],
+        proxy_port: None,
+        proxy_forced: false,
+        allow_env_files: false,
+        allow_localhost_any: false,
+        scratch_dir: None,
+        allow_tmp_exec: false,
+        copilot_install_dir: None,
+        java_home: None,
+        dotnet_root: None,
+        git_hooks_path: None,
+        git_common_dir: None,
+        extra_git_dirs: &[],
+        allow_gpg_signing: false,
+        deny_clipboard: false,
+        allow_jvm_attach: false,
+        allow_msbuild: false,
+        allow_docker: false,
+        electron_app_dir: None,
+        agent: cplt::agent::Agent::Copilot,
+        agent_dirs: &[],
+        allow_cache_exec: &[],
+        allow_cache_exec_any: false,
+        allow_browser: false,
+        credential_outside_keychain: false,
+    });
+    let bin = "/home/tester/.local/share/cargo/bin";
+    let registry = "/home/tester/.local/share/cargo/registry";
+    assert!(p.contains(&format!("(allow process-exec (subpath \"{bin}\"))")));
+    assert!(!p.contains(&format!("(allow file-write* (subpath \"{bin}\"))")));
+    assert!(p.contains(&format!("(allow file-write* (subpath \"{registry}\"))")));
+    assert!(p.contains(&format!("(deny process-exec (subpath \"{registry}\"))")));
+    // The default location is not granted when discovery relocated it.
+    assert!(!p.contains("/home/tester/.cargo/bin"));
+}
+
+#[test]
+fn landlock_relocated_cargo_bin_is_exec_only_and_registry_is_precreated() {
+    let dirs = relocated_cargo_dirs();
+    let ll = generate_policy(&SandboxConfig {
+        project_dir: std::path::Path::new("/projects/app"),
+        home_dir: std::path::Path::new("/home/tester"),
+        extra_read: &[],
+        extra_write: &[],
+        extra_socket: &[],
+        extra_deny: &[],
+        existing_home_tool_dirs: Some(&dirs),
+        existing_app_dirs: None,
+        extra_ports: &[],
+        localhost_ports: &[],
+        proxy_port: None,
+        proxy_forced: false,
+        allow_env_files: false,
+        allow_localhost_any: false,
+        scratch_dir: None,
+        playwright_socket_dir: None,
+        allow_tmp_exec: false,
+        copilot_install_dir: None,
+        java_home: None,
+        dotnet_root: None,
+        git_hooks_path: None,
+        git_common_dir: None,
+        allow_gpg_signing: false,
+        deny_clipboard: false,
+        allow_jvm_attach: false,
+        allow_msbuild: false,
+        allow_docker: false,
+        electron_app_dir: None,
+        agent: cplt::agent::Agent::Copilot,
+        agent_dirs: &[],
+        allow_cache_exec: &[],
+        allow_cache_exec_any: false,
+        allow_browser: false,
+        use_bubblewrap: None,
+        keychain_substitute: None,
+    });
+    let rule = |p: &str| {
+        ll.fs_rules
+            .iter()
+            .find(|r| r.path == PathBuf::from(p))
+            .unwrap_or_else(|| panic!("{p} should have a rule"))
+    };
+    let bin = rule("/home/tester/.local/share/cargo/bin");
+    assert!(bin.access.execute && !bin.access.write);
+    let registry = rule("/home/tester/.local/share/cargo/registry");
+    assert!(registry.access.write);
+    assert!(
+        ll.precreate_dirs
+            .contains(&PathBuf::from("/home/tester/.local/share/cargo/registry"))
+    );
+    assert!(
+        !ll.precreate_dirs
+            .contains(&PathBuf::from("/home/tester/.local/share/cargo/bin"))
+    );
+    assert!(
+        !ll.fs_rules
+            .iter()
+            .any(|r| r.path == PathBuf::from("/home/tester/.cargo/bin"))
     );
 }
 


### PR DESCRIPTION
Closes #152.

## What was wrong

`CARGO_HOME` is in `TOOL_PATH_ENV_VARS` with `write: true`, so a relocated cargo home (`CARGO_HOME=~/.local/share/cargo`) landed in `allow_write` as one tree. The default `~/.cargo` is three `HOME_TOOL_DIRS` entries with different postures (`bin` exec-only, `registry` and `git` writable without process-exec). The relocated tree got write everywhere and exec nowhere on Linux (Landlock `extra_write` rules carry `execute: false`), which is the "mounted noexec" the reporter saw. On macOS the same grant was write plus exec through the blanket `(allow process-exec)`, the write-then-exec shape the sandbox is meant to rule out.

## What changed

- `HomeToolDir::resolve(home, roots)` and `ToolRoot` in `sandbox_policy.rs`: a tool-path env var whose default location has `HOME_TOOL_DIRS` entries under it (`relocatable_tool_prefix`) re-roots those entries under the relocated path, flags intact, instead of adding a whole-tree grant. `HOME_TOOL_DIRS` stays the single list for both backends.
- `discover_tools` takes the roots and returns `existing_home_tool_dirs` as `Vec<ResolvedToolDir>` (absolute path plus the entry). `SandboxConfig` / `ProfileOptions` carry that type; SBPL and Landlock emit from it via `active_tool_dirs`. `None` still means "every entry at its default", so the existing test fixtures did not change.
- `merge_tool_path_env_overrides` runs before discovery (it only appends to the allow lists) and returns the roots. Canonicalization and the `tool_override_path_is_safe` guard apply before a root is accepted, so an unset, empty, missing, or unsafe value produces no grant. A second segment of a list var (`GOPATH=/a:/b`) keeps the plain whole-tree grant it had.
- Landlock pre-creates writable relocated caches (`$CARGO_HOME/registry`) through a new `LandlockPolicy.precreate_dirs`, replacing the loop that only knew the default location.
- `RUSTUP_HOME` added to `TOOL_PATH_ENV_VARS` as read-only. Without it the cargo proxies in `$CARGO_HOME/bin` can exec but the toolchain they hand off to under an XDG `RUSTUP_HOME` is not readable on Linux.

Result with `CARGO_HOME=~/.local/share/cargo`: `bin` read+exec, `registry` and `git` read+write+map-exec with an explicit process-exec deny on macOS, nothing on the tree root (so a `credentials.toml` there is no longer readable either, matching the default).

## Behavior changes beyond cargo

The rule is data-driven, so the other vars that map onto `HOME_TOOL_DIRS` trees change too:

- `GOPATH`: `$GOPATH/bin` becomes exec-only and `$GOPATH/pkg` writable, matching `~/go`. A relocated `GOPATH` previously had write on the whole tree, so `go install` into it worked there and now does not, the same as at the default location. If that trade is wrong I can special-case it.
- `NPM_CONFIG_CACHE` / `npm_config_cache`: same posture as before (write, no exec) plus the explicit macOS process-exec deny `.npm` already gets.
- `PNPM_HOME`: takes the `Library/pnpm` posture (exec+write) instead of write-only.

## Verified

- `cargo fmt`, `cargo test --lib` (840), `cargo test --test unit_tests` (304, six new), `cargo clippy --all-targets -- -D warnings` clean on touched files (the remaining clippy hits are in untouched files from a newer local rustc).
- Reverted the re-rooting in `resolve` and confirmed the four new profile/policy/resolve tests fail, then restored it.
- `cplt --print-profile` on macOS with `CARGO_HOME` and `RUSTUP_HOME` pointed at fresh dirs under `~/.local/share`: the cargo rules move to the relocated paths with the split posture above, the rustup rules follow with no trailing separator, and the default `~/.cargo` rules are gone.

## Not verified

- No Linux machine here. The Landlock path is covered by `generate_policy` unit tests (rules and `precreate_dirs`), but I did not run a real `cargo build` under bubblewrap with a relocated `CARGO_HOME`.
- `cplt check` calls `discover_all`, which passes no roots, so its "Tool dirs" line still reports default locations. It now prints absolute paths instead of `~/`-prefixed ones.
- Pre-existing and unchanged: a user `allow.write` covering an exec-only tool dir (default or relocated) still reopens write+exec there, since `HOME_TOOL_DIRS` exec-only entries carry no write-deny of their own.
