### PR TITLE
fix(config): make CPLT_CONFIG visible, and refuse one the repo controls

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1013,6 +1013,15 @@ Trust model: cplt trusts that binaries in your PATH are legitimate, the same tru
 
 On shared systems, give `~/.config/cplt/` restrictive permissions (0700). A user who can write to this directory can weaken the sandbox configuration.
 
+`CPLT_CONFIG` moves that trusted input somewhere else, replacing the whole file — every `[sandbox]` key included. It is read from the ambient environment, so a shell that auto-loads repository-provided environment (direnv's `.envrc`, mise) can set it just by you entering a directory, and the repo-config trust model below (which only ever lets a repository *tighten* the sandbox) never sees it.
+
+Two guards keep that visible rather than silent:
+
+- A `CPLT_CONFIG` outside `~/.config/cplt/` prints a warning naming the resolved file. It is deliberately not suppressed by `--quiet` — a quiet run is when a silent substitution costs the most.
+- A `CPLT_CONFIG` that resolves **inside the project directory** is refused and cplt exits non-zero. Falling back to the real user config would be another invisible substitution, so this fails loudly instead. Symlinks and `..` are resolved before the comparison, so a path outside the repo that links back into it is refused too.
+
+Neither guard covers a repository that writes a config *outside* the project and points `CPLT_CONFIG` at that. The warning is what makes that case visible.
+
 ### Scratch directory session IDs
 
 Session IDs for per-session scratch directories come from `/dev/urandom` (16 random bytes, hex-encoded), falling back to PID plus nanosecond timestamp if `/dev/urandom` is unavailable, which is not expected on standard macOS or Linux. The fallback is predictable, but the failure mode is denial-of-service (directory creation fails if it already exists), not compromise.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,19 @@ Point `CPLT_CONFIG` at another file to use it instead of the default location:
 CPLT_CONFIG=/path/to/custom.toml cplt -- --version
 ```
 
+`CPLT_CONFIG` replaces the whole config file, `[sandbox]` keys included, so it
+can widen the sandbox in ways a repo's `.cplt.toml` never can. Because a shell
+that auto-loads repository environment (direnv, mise) can set it just by you
+entering a directory, cplt keeps the substitution visible:
+
+- Pointing it anywhere other than `~/.config/cplt/` prints a warning naming the
+  file. The warning is not suppressed by `--quiet`.
+- Pointing it **inside the project directory** is refused and cplt exits: that
+  file is repository content, and it would replace your config with none of the
+  review a `.cplt.toml` gets. Symlinks and `..` are resolved first, so a link
+  from outside the repo back into it is refused too. Unset `CPLT_CONFIG` (check
+  `.envrc` and mise config) to run.
+
 Paths in `[allow]` and `[deny]` support `~/` expansion and resolve relative to the config file's directory. `proxy.blocked_domains` supports `~/` expansion only.
 
 ## Quick setup

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,7 +25,10 @@ pub use editing::{
 };
 pub use error::ConfigError;
 pub(crate) use path::lexically_normalized;
-pub use path::{collapse_tilde, config_dir, config_path, default_config_contents, expand_tilde};
+pub use path::{
+    CustomConfigVerdict, classify_custom_config, collapse_tilde, config_dir, config_path,
+    default_config_contents, expand_tilde,
+};
 pub use registry::{ConfigKeyInfo, ConfigValueType, all_config_keys, lookup_key};
 pub use repo::{RepoKeyTarget, repo_key_rejection_reason, repo_key_target, set_repo_value_in_doc};
 pub use types::{

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -428,6 +428,67 @@ pub(super) fn resolve_repo_path(path: &str, config_dir: &Path) -> PathBuf {
     canonicalize_deepest(&full)
 }
 
+/// Where a `CPLT_CONFIG` override points, relative to the two locations that
+/// decide whether it can be trusted.
+///
+/// `CPLT_CONFIG` replaces the *entire* user config, including every `[sandbox]`
+/// key, so it goes around the repo-config trust machinery that only ever lets a
+/// repository tighten the sandbox (issue #261). A shell that auto-loads
+/// repository-provided environment (direnv, mise) makes a checkout enough to
+/// aim cplt at a config the repository controls.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CustomConfigVerdict {
+    /// Under `$HOME/.config/cplt/` — the normal location, nothing to say.
+    UserConfigDir,
+    /// Outside the normal location but outside the project too: allowed, but
+    /// the substitution must be visible.
+    Outside(PathBuf),
+    /// Inside the project directory: the repo controls it. Refused.
+    InsideProject(PathBuf),
+}
+
+/// Resolve a path far enough that containment checks cannot be sidestepped.
+///
+/// `canonicalize` alone is not enough: it fails whole-path on a file that does
+/// not exist yet, and `canonicalize_deepest`'s walk gives up entirely on a `..`
+/// component (`file_name()` is `None` there). So walk the components, resolving
+/// symlinks in what has been built up each time a `..` arrives and stepping up
+/// from the resolved path — POSIX order — and fold `..` lexically only out
+/// beyond where the filesystem still has anything to say.
+///
+/// Without this, `<project>/sub/../cplt.toml` and
+/// `~/.config/cplt/sub/../../../evil.toml` both dodge a plain `starts_with`.
+fn fully_resolved(path: &Path) -> PathBuf {
+    let anchored = if path.is_relative() {
+        std::env::current_dir().unwrap_or_default().join(path)
+    } else {
+        path.to_path_buf()
+    };
+    let mut out = PathBuf::new();
+    for component in lexically_normalized(&anchored).components() {
+        if matches!(component, Component::ParentDir) {
+            out = canonicalize_deepest(&out);
+            out.pop();
+        } else {
+            out.push(component);
+        }
+    }
+    canonicalize_deepest(&out)
+}
+
+/// Classify a `CPLT_CONFIG` value. Pure apart from resolving `path` on disk:
+/// `home` and `project_dir` are passed in, already canonicalized by the caller.
+pub fn classify_custom_config(path: &Path, home: &Path, project_dir: &Path) -> CustomConfigVerdict {
+    let resolved = fully_resolved(path);
+    if resolved.starts_with(fully_resolved(project_dir)) {
+        return CustomConfigVerdict::InsideProject(resolved);
+    }
+    if resolved.starts_with(fully_resolved(&home.join(CONFIG_DIR))) {
+        return CustomConfigVerdict::UserConfigDir;
+    }
+    CustomConfigVerdict::Outside(resolved)
+}
+
 /// Expand tilde, resolve relative paths against config dir, and canonicalize.
 pub(super) fn resolve_config_path(
     path: &str,
@@ -650,5 +711,157 @@ mod tests {
         assert_eq!(expanded, PathBuf::from(format!("{home}/.config/test")));
         let collapsed = collapse_tilde(expanded.to_str().unwrap());
         assert_eq!(collapsed, original);
+    }
+
+    // ── CPLT_CONFIG classification (issue #261) ──────────────────
+    //
+    // These take home and project_dir as arguments rather than reading the
+    // environment, so they are safe to run in parallel with everything else.
+
+    /// tempfile hands out paths under /var on macOS, which is a symlink to
+    /// /private/var. Compare resolved paths against resolved fixtures.
+    fn canon(p: &Path) -> PathBuf {
+        p.canonicalize().unwrap()
+    }
+
+    #[test]
+    fn custom_config_under_user_config_dir_is_normal() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let cfg_dir = home.path().join(CONFIG_DIR);
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let cfg = cfg_dir.join(CONFIG_FILE);
+        std::fs::write(&cfg, "").unwrap();
+
+        assert_eq!(
+            classify_custom_config(&cfg, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::UserConfigDir
+        );
+    }
+
+    #[test]
+    fn custom_config_elsewhere_is_flagged_but_allowed() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let cfg = other.path().join("config.toml");
+        std::fs::write(&cfg, "").unwrap();
+
+        assert_eq!(
+            classify_custom_config(&cfg, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::Outside(canon(&cfg))
+        );
+    }
+
+    #[test]
+    fn custom_config_inside_project_is_refused() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let cfg = project.path().join("cplt.toml");
+        std::fs::write(&cfg, "").unwrap();
+
+        assert_eq!(
+            classify_custom_config(&cfg, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::InsideProject(canon(&cfg))
+        );
+    }
+
+    #[test]
+    fn custom_config_inside_project_nested_is_refused() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let dir = project.path().join(".config/nested");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = dir.join("cplt.toml");
+        std::fs::write(&cfg, "").unwrap();
+
+        assert_eq!(
+            classify_custom_config(&cfg, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::InsideProject(canon(&cfg))
+        );
+    }
+
+    #[test]
+    fn custom_config_reached_through_a_symlink_is_still_inside_the_project() {
+        // The escape the containment check exists to survive: a symlink outside
+        // the project pointing back into it. Comparing the unresolved path
+        // would call this Outside and let the repo own the sandbox config.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let real = project.path().join("cplt.toml");
+        std::fs::write(&real, "").unwrap();
+        let link = elsewhere.path().join("innocent.toml");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(
+            classify_custom_config(&link, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::InsideProject(canon(&real))
+        );
+    }
+
+    #[test]
+    fn custom_config_symlinked_directory_into_the_project_is_still_inside() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let real = project.path().join("cplt.toml");
+        std::fs::write(&real, "").unwrap();
+        let link_dir = elsewhere.path().join("repo");
+        std::os::unix::fs::symlink(project.path(), &link_dir).unwrap();
+
+        assert_eq!(
+            classify_custom_config(
+                &link_dir.join("cplt.toml"),
+                &canon(home.path()),
+                &canon(project.path())
+            ),
+            CustomConfigVerdict::InsideProject(canon(&real))
+        );
+    }
+
+    #[test]
+    fn custom_config_dot_dot_back_into_the_project_is_still_inside() {
+        // `<project>/sub/../cplt.toml` where neither `sub` nor the file exists,
+        // so canonicalize stops at the project root and `..` survives into the
+        // tail — it has to be folded there, not left in the path.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let spelled = project.path().join("sub/../cplt.toml");
+
+        assert_eq!(
+            classify_custom_config(&spelled, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::InsideProject(canon(project.path()).join("cplt.toml"))
+        );
+    }
+
+    #[test]
+    fn custom_config_dot_dot_out_of_the_user_config_dir_is_not_normal() {
+        // `~/.config/cplt/sub/../../../evil.toml`, with `sub` absent so `..`
+        // reaches the unresolved tail. It starts_with the user config dir until
+        // `..` is folded, and must not be reported as the normal location.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(CONFIG_DIR)).unwrap();
+        let spelled = home.path().join(CONFIG_DIR).join("sub/../../../evil.toml");
+
+        assert_eq!(
+            classify_custom_config(&spelled, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::Outside(canon(home.path()).join("evil.toml"))
+        );
+    }
+
+    #[test]
+    fn custom_config_that_does_not_exist_is_still_classified() {
+        // The file need not exist: cplt falls back to no config, but the
+        // substitution is still worth flagging.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let cfg = project.path().join("does/not/exist.toml");
+
+        assert_eq!(
+            classify_custom_config(&cfg, &canon(home.path()), &canon(project.path())),
+            CustomConfigVerdict::InsideProject(canon(project.path()).join("does/not/exist.toml"))
+        );
     }
 }

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -449,6 +449,8 @@ pub enum CustomConfigVerdict {
 
 /// Resolve a path far enough that containment checks cannot be sidestepped.
 ///
+/// A relative path is anchored to `relative_anchor` first (the cwd, in practice).
+///
 /// `canonicalize` alone is not enough: it fails whole-path on a file that does
 /// not exist yet, and `canonicalize_deepest`'s walk gives up entirely on a `..`
 /// component (`file_name()` is `None` there). So walk the components, resolving
@@ -458,9 +460,9 @@ pub enum CustomConfigVerdict {
 ///
 /// Without this, `<project>/sub/../cplt.toml` and
 /// `~/.config/cplt/sub/../../../evil.toml` both dodge a plain `starts_with`.
-fn fully_resolved(path: &Path) -> PathBuf {
+fn fully_resolved(path: &Path, relative_anchor: &Path) -> PathBuf {
     let anchored = if path.is_relative() {
-        std::env::current_dir().unwrap_or_default().join(path)
+        relative_anchor.join(path)
     } else {
         path.to_path_buf()
     };
@@ -479,11 +481,16 @@ fn fully_resolved(path: &Path) -> PathBuf {
 /// Classify a `CPLT_CONFIG` value. Pure apart from resolving `path` on disk:
 /// `home` and `project_dir` are passed in, already canonicalized by the caller.
 pub fn classify_custom_config(path: &Path, home: &Path, project_dir: &Path) -> CustomConfigVerdict {
-    let resolved = fully_resolved(path);
-    if resolved.starts_with(fully_resolved(project_dir)) {
+    // A relative value resolves against the cwd, as it would for the open()
+    // itself. If the cwd cannot be read at all, fall back to the project
+    // directory: an unanchorable relative path then lands inside the project
+    // and is refused, so the failure mode is a refusal rather than a pass.
+    let anchor = std::env::current_dir().unwrap_or_else(|_| project_dir.to_path_buf());
+    let resolved = fully_resolved(path, &anchor);
+    if resolved.starts_with(fully_resolved(project_dir, &anchor)) {
         return CustomConfigVerdict::InsideProject(resolved);
     }
-    if resolved.starts_with(fully_resolved(&home.join(CONFIG_DIR))) {
+    if resolved.starts_with(fully_resolved(&home.join(CONFIG_DIR), &anchor)) {
         return CustomConfigVerdict::UserConfigDir;
     }
     CustomConfigVerdict::Outside(resolved)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1366,6 +1366,42 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         }
     };
 
+    // ── CPLT_CONFIG sanity check (issue #261) ────────────────────
+    // The env var replaces the whole user config, every [sandbox] key included,
+    // bypassing the repo-config trust machinery that only ever lets a repo
+    // tighten the sandbox. Warn whenever it points somewhere unusual, and
+    // refuse outright when the project directory controls the file.
+    //
+    // Both messages ignore --quiet: a quiet run is exactly when a silent
+    // config swap does the most damage.
+    if let Ok(custom) = std::env::var("CPLT_CONFIG") {
+        let user_dir = home_dir.join(".config/cplt");
+        match config::classify_custom_config(
+            &config::expand_tilde(&custom),
+            &home_dir,
+            &project_dir,
+        ) {
+            config::CustomConfigVerdict::UserConfigDir => {}
+            config::CustomConfigVerdict::Outside(p) => {
+                ui::warn("CPLT_CONFIG replaces your whole cplt config, sandbox settings included:");
+                eprintln!("  {}", p.display());
+                eprintln!("  It is not under {}.", user_dir.display());
+                eprintln!(
+                    "  If you did not set it yourself, your shell did (direnv, mise, .envrc)."
+                );
+            }
+            config::CustomConfigVerdict::InsideProject(p) => bail!(
+                "CPLT_CONFIG points inside the project directory:\n  \
+                 {}\n  \
+                 That file is repository content, and it would replace your whole cplt \
+                 config — sandbox settings included — with none of the review a .cplt.toml \
+                 gets. Refusing.\n  \
+                 Unset CPLT_CONFIG (check .envrc / mise config) and re-run.",
+                p.display()
+            ),
+        }
+    }
+
     // Safety check: reject overly broad project roots
     if is_unsafe_root(&project_dir, &home_dir) {
         bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1263,6 +1263,78 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
     let cli_allow_socket = canonicalize_paths(&cli.allow_socket, "--allow-socket");
     let cli_deny_paths = canonicalize_deny_paths(&cli.deny_paths)?;
 
+    // Resolve home directory
+    let home_dir = match std::env::var("HOME") {
+        Ok(h) => std::fs::canonicalize(&h)
+            .map_err(|e| anyhow::anyhow!("Cannot resolve $HOME ({h}): {e}"))?,
+        Err(_) => bail!("$HOME not set"),
+    };
+
+    // Resolve project directory
+    let project_dir = match &cli.project_dir {
+        Some(p) => std::fs::canonicalize(p)
+            .map_err(|e| anyhow::anyhow!("Cannot resolve project dir: {e}"))?,
+        None => {
+            if let Some(root) = detect_project_root() {
+                match std::fs::canonicalize(&root) {
+                    Ok(p) => p,
+                    Err(_) => root,
+                }
+            } else {
+                ui::warn("No git repo detected, using cwd");
+                std::env::current_dir()
+                    .and_then(std::fs::canonicalize)
+                    .map_err(|e| anyhow::anyhow!("Cannot resolve cwd: {e}"))?
+            }
+        }
+    };
+
+    // ── CPLT_CONFIG sanity check (issue #261) ────────────────────
+    // The env var replaces the whole user config, every [sandbox] key included,
+    // bypassing the repo-config trust machinery that only ever lets a repo
+    // tighten the sandbox. Warn whenever it points somewhere unusual, and
+    // refuse outright when the project directory controls the file.
+    //
+    // Both messages ignore --quiet: a quiet run is exactly when a silent
+    // config swap does the most damage.
+    // An empty value is how a shell unsets the var in practice; it selects no
+    // file, so there is nothing to flag.
+    if let Some(custom) = std::env::var("CPLT_CONFIG").ok().filter(|s| !s.is_empty()) {
+        let user_dir = home_dir.join(".config/cplt");
+        match config::classify_custom_config(
+            &config::expand_tilde(&custom),
+            &home_dir,
+            &project_dir,
+        ) {
+            config::CustomConfigVerdict::UserConfigDir => {}
+            config::CustomConfigVerdict::Outside(p) => {
+                ui::warn("CPLT_CONFIG replaces your whole cplt config, sandbox settings included:");
+                eprintln!("  {}", p.display());
+                eprintln!("  It is not under {}.", user_dir.display());
+                eprintln!(
+                    "  If you did not set it yourself, your shell did (direnv, mise, .envrc)."
+                );
+            }
+            config::CustomConfigVerdict::InsideProject(p) => bail!(
+                "CPLT_CONFIG points inside the project directory:\n  \
+                 {}\n  \
+                 That file is repository content, and it would replace your whole cplt \
+                 config — sandbox settings included — with none of the review a .cplt.toml \
+                 gets. Refusing.\n  \
+                 Unset CPLT_CONFIG (check .envrc / mise config) and re-run.",
+                p.display()
+            ),
+        }
+    }
+
+    // Safety check: reject overly broad project roots
+    if is_unsafe_root(&project_dir, &home_dir) {
+        bail!(
+            "cplt refuses to sandbox '{}', it is too broad. Use a specific project directory.",
+            project_dir.display()
+        );
+    }
+
     let (cfg, config_path) = match config::Config::load_file() {
         Ok(Some(loaded)) => (loaded.config, Some(loaded.path)),
         Ok(None) => (config::Config::default(), None),
@@ -1339,78 +1411,6 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         Ok(r) => r,
         Err(e) => bail!("{e}"),
     };
-
-    // Resolve home directory
-    let home_dir = match std::env::var("HOME") {
-        Ok(h) => std::fs::canonicalize(&h)
-            .map_err(|e| anyhow::anyhow!("Cannot resolve $HOME ({h}): {e}"))?,
-        Err(_) => bail!("$HOME not set"),
-    };
-
-    // Resolve project directory
-    let project_dir = match &cli.project_dir {
-        Some(p) => std::fs::canonicalize(p)
-            .map_err(|e| anyhow::anyhow!("Cannot resolve project dir: {e}"))?,
-        None => {
-            if let Some(root) = detect_project_root() {
-                match std::fs::canonicalize(&root) {
-                    Ok(p) => p,
-                    Err(_) => root,
-                }
-            } else {
-                ui::warn("No git repo detected, using cwd");
-                std::env::current_dir()
-                    .and_then(std::fs::canonicalize)
-                    .map_err(|e| anyhow::anyhow!("Cannot resolve cwd: {e}"))?
-            }
-        }
-    };
-
-    // ── CPLT_CONFIG sanity check (issue #261) ────────────────────
-    // The env var replaces the whole user config, every [sandbox] key included,
-    // bypassing the repo-config trust machinery that only ever lets a repo
-    // tighten the sandbox. Warn whenever it points somewhere unusual, and
-    // refuse outright when the project directory controls the file.
-    //
-    // Both messages ignore --quiet: a quiet run is exactly when a silent
-    // config swap does the most damage.
-    // An empty value is how a shell unsets the var in practice; it selects no
-    // file, so there is nothing to flag.
-    if let Some(custom) = std::env::var("CPLT_CONFIG").ok().filter(|s| !s.is_empty()) {
-        let user_dir = home_dir.join(".config/cplt");
-        match config::classify_custom_config(
-            &config::expand_tilde(&custom),
-            &home_dir,
-            &project_dir,
-        ) {
-            config::CustomConfigVerdict::UserConfigDir => {}
-            config::CustomConfigVerdict::Outside(p) => {
-                ui::warn("CPLT_CONFIG replaces your whole cplt config, sandbox settings included:");
-                eprintln!("  {}", p.display());
-                eprintln!("  It is not under {}.", user_dir.display());
-                eprintln!(
-                    "  If you did not set it yourself, your shell did (direnv, mise, .envrc)."
-                );
-            }
-            config::CustomConfigVerdict::InsideProject(p) => bail!(
-                "CPLT_CONFIG points inside the project directory:\n  \
-                 {}\n  \
-                 That file is repository content, and it would replace your whole cplt \
-                 config — sandbox settings included — with none of the review a .cplt.toml \
-                 gets. Refusing.\n  \
-                 Unset CPLT_CONFIG (check .envrc / mise config) and re-run.",
-                p.display()
-            ),
-        }
-    }
-
-    // Safety check: reject overly broad project roots
-    if is_unsafe_root(&project_dir, &home_dir) {
-        bail!(
-            "cplt refuses to sandbox '{}', it is too broad. Use a specific project directory.",
-            project_dir.display()
-        );
-    }
 
     // ── Load and apply per-repo config (.cplt.toml) ──────────────
     let mut unapproved_proposals: Vec<String> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1374,7 +1374,9 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
     //
     // Both messages ignore --quiet: a quiet run is exactly when a silent
     // config swap does the most damage.
-    if let Ok(custom) = std::env::var("CPLT_CONFIG") {
+    // An empty value is how a shell unsets the var in practice; it selects no
+    // file, so there is nothing to flag.
+    if let Some(custom) = std::env::var("CPLT_CONFIG").ok().filter(|s| !s.is_empty()) {
         let user_dir = home_dir.join(".config/cplt");
         match config::classify_custom_config(
             &config::expand_tilde(&custom),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1307,7 +1307,14 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             &project_dir,
         ) {
             config::CustomConfigVerdict::UserConfigDir => {}
-            config::CustomConfigVerdict::Outside(p) => {
+            // Only warn for a file that is actually there: a CPLT_CONFIG naming
+            // a path that does not exist selects no config, so nothing was
+            // substituted and there is nothing to flag. (`cplt exec` promises a
+            // clean stderr, and tests point the var at a deliberate dead end to
+            // ignore the developer's real config.) The refusal below is not
+            // gated the same way — a path the repo controls is worth refusing
+            // whether or not the file exists yet.
+            config::CustomConfigVerdict::Outside(p) if p.exists() => {
                 ui::warn("CPLT_CONFIG replaces your whole cplt config, sandbox settings included:");
                 eprintln!("  {}", p.display());
                 eprintln!("  It is not under {}.", user_dir.display());
@@ -1315,6 +1322,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                     "  If you did not set it yourself, your shell did (direnv, mise, .envrc)."
                 );
             }
+            config::CustomConfigVerdict::Outside(_) => {}
             config::CustomConfigVerdict::InsideProject(p) => bail!(
                 "CPLT_CONFIG points inside the project directory:\n  \
                  {}\n  \

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3263,8 +3263,10 @@ paths = [
             .output()
             .unwrap();
 
-        // Isolated config dir (no interference from user's real config)
-        let config_dir = repo.join(".cplt-config");
+        // Isolated config dir (no interference from user's real config).
+        // Deliberately NOT inside the repo: cplt refuses a CPLT_CONFIG the
+        // project controls (issue #261).
+        let config_dir = std::env::temp_dir().join(format!(".cplt-e2e-trust-cfg-{label}-{id}"));
         std::fs::create_dir_all(&config_dir).unwrap();
         let config_file = config_dir.join("config.toml");
         std::fs::write(&config_file, "").unwrap();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4998,4 +4998,129 @@ paths = [
             "docker should be allowed with --allow-docker:\n{stdout}"
         );
     }
+
+    // ── CPLT_CONFIG visibility and containment (issue #261) ─────
+    //
+    // CPLT_CONFIG replaces the whole user config, [sandbox] keys included, so
+    // it walks around the repo-config trust machinery. Both messages must
+    // survive --quiet: a quiet run is when a silent swap costs the most.
+
+    /// A git repo with a HOME of its own, so nothing here can see the real
+    /// user's config. Returns (home, project).
+    fn cplt_config_fixture(tag: &str) -> (tempfile::TempDir, tempfile::TempDir) {
+        let home = tempfile::tempdir().expect("home");
+        let project = tempfile::tempdir().expect("project");
+        std::fs::create_dir_all(home.path().join(".config/cplt")).unwrap();
+        let status = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(project.path())
+            .status()
+            .unwrap_or_else(|e| panic!("git init for {tag}: {e}"));
+        assert!(status.success(), "git init should succeed for {tag}");
+        (home, project)
+    }
+
+    #[test]
+    fn e2e_cplt_config_outside_user_dir_warns_even_when_quiet() {
+        let (home, project) = cplt_config_fixture("outside");
+        let elsewhere = tempfile::tempdir().unwrap();
+        let config = elsewhere.path().join("config.toml");
+        std::fs::write(&config, "[sandbox]\n").unwrap();
+
+        let output = Command::new(binary_path())
+            .args(["--quiet", "--print-profile", "--agent", "copilot"])
+            .current_dir(project.path())
+            .env("HOME", home.path())
+            .env("CPLT_CONFIG", &config)
+            .output()
+            .expect("should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "a config outside the project is allowed: {stderr}"
+        );
+        assert!(
+            stderr.contains("CPLT_CONFIG replaces your whole cplt config"),
+            "--quiet must not swallow the warning: {stderr}"
+        );
+    }
+
+    #[test]
+    fn e2e_cplt_config_under_user_dir_is_silent() {
+        let (home, project) = cplt_config_fixture("normal");
+        let config = home.path().join(".config/cplt/config.toml");
+        std::fs::write(&config, "[sandbox]\n").unwrap();
+
+        let output = Command::new(binary_path())
+            .args(["--quiet", "--print-profile", "--agent", "copilot"])
+            .current_dir(project.path())
+            .env("HOME", home.path())
+            .env("CPLT_CONFIG", &config)
+            .output()
+            .expect("should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "normal location works: {stderr}");
+        assert!(
+            !stderr.contains("CPLT_CONFIG"),
+            "the normal location must not be flagged: {stderr}"
+        );
+    }
+
+    #[test]
+    fn e2e_cplt_config_inside_project_is_refused() {
+        let (home, project) = cplt_config_fixture("inside");
+        let config = project.path().join("ci/cplt.toml");
+        std::fs::create_dir_all(config.parent().unwrap()).unwrap();
+        std::fs::write(&config, "[sandbox]\nallow_env_files = true\n").unwrap();
+
+        let output = Command::new(binary_path())
+            .args(["--quiet", "--print-profile", "--agent", "copilot"])
+            .current_dir(project.path())
+            .env("HOME", home.path())
+            .env("CPLT_CONFIG", &config)
+            .output()
+            .expect("should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "repo-controlled config must not launch: {stderr}"
+        );
+        assert!(
+            stderr.contains("points inside the project directory"),
+            "refusal should say why: {stderr}"
+        );
+    }
+
+    #[test]
+    fn e2e_cplt_config_symlinked_into_project_is_refused() {
+        // The sidestep the containment check exists for: an innocent-looking
+        // path outside the repo that is a symlink back into it.
+        let (home, project) = cplt_config_fixture("symlink");
+        let elsewhere = tempfile::tempdir().unwrap();
+        let real = project.path().join("cplt.toml");
+        std::fs::write(&real, "[sandbox]\n").unwrap();
+        let link = elsewhere.path().join("innocent.toml");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let output = Command::new(binary_path())
+            .args(["--quiet", "--print-profile", "--agent", "copilot"])
+            .current_dir(project.path())
+            .env("HOME", home.path())
+            .env("CPLT_CONFIG", &link)
+            .output()
+            .expect("should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "a symlink into the repo must be refused too: {stderr}"
+        );
+        assert!(
+            stderr.contains("points inside the project directory"),
+            "refusal should say why: {stderr}"
+        );
+    }
 }

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -1204,10 +1204,10 @@ fi
         require_sandbox!();
         let project = TempProject::scaffold_node();
 
-        // Create a temporary config file
-        let config_dir = project.path().join(".cplt-config-test");
-        fs::create_dir_all(&config_dir).unwrap();
-        let config_path = config_dir.join("config.toml");
+        // Create a temporary config file OUTSIDE the project: cplt refuses a
+        // CPLT_CONFIG that the repo itself controls (issue #261).
+        let config_home = TempProject::new("cplt-config-test");
+        let config_path = config_home.path().join("config.toml");
         fs::write(
             &config_path,
             r"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2848,7 +2848,10 @@ except Exception as e:
             return; // no git on this machine — nothing to assert
         }
 
-        let config = project.join("cplt-config.toml");
+        // Outside the project: cplt refuses a CPLT_CONFIG the repo controls
+        // (issue #261).
+        let config_home = tempfile::tempdir().unwrap();
+        let config = config_home.path().join("cplt-config.toml");
         fs::write(&config, "[sandbox]\nbrief = true\nagents_md = true\n").unwrap();
 
         let output = Command::new(binary_path())


### PR DESCRIPTION
Closes #261. Options 1 and 2 from the issue, together. Options 3 (trust prompt on change) and 4 (tighten-only keys) are deliberately not built.

## What changes

`CPLT_CONFIG` replaces the *entire* user config, `[sandbox]` keys included, and is read from the ambient environment. A shell that auto-loads repository-provided environment (direnv's `.envrc`, mise) makes checking out a repository enough to point cplt at a config that repository controls — around the machinery that lets a `.cplt.toml` only ever *tighten* the sandbox.

1. **Warn when it points outside `~/.config/cplt/`.** The startup summary already prints `Config: <path>`, but it does not flag it as unusual and `--quiet` drops the line entirely. The new warning names the resolved file and **is not suppressed by `--quiet`** — a quiet run is exactly when a silent config swap does the most damage.

2. **Refuse a `CPLT_CONFIG` that resolves inside the project directory.** cplt prints why and exits non-zero.

## Decision: hard-exit, not fallback

Refusing means **hard-exit**, not falling back to the real user config. A silent fallback is another invisible substitution — the user would get a different sandbox policy than the command line implies, with nothing to act on. Exiting makes the fix obvious: unset `CPLT_CONFIG` (check `.envrc` / mise config) and re-run.

## Containment is resolved, not spelled

`fully_resolved` resolves symlinks *and* `..` before comparing, or the check is trivially sidestepped by a symlink outside the repo pointing back into it.

Neither `canonicalize` alone nor a lexical pass alone is enough: the config file need not exist yet, and `canonicalize_deepest` gives up entirely on a `..` component (`file_name()` is `None` there). So it walks the components, resolving symlinks in what has been built up each time a `..` arrives — POSIX order — and folds `..` lexically only out beyond where the filesystem still has anything to say. Resolving symlinks first and `..` second matters: the reverse order folds `..` across a link and names the wrong file.

Covered cases: a symlinked file into the repo, a symlinked *directory* into the repo, `<project>/sub/../cplt.toml` with `sub` absent, and `~/.config/cplt/sub/../../../evil.toml` (which `starts_with` the user config dir until `..` is folded).

## Tests

- 9 unit tests in `src/config/path.rs` covering the classification, taking `home` and `project_dir` as arguments rather than reading the environment, so they are parallel-safe (no `temp_env`).
- 4 e2e tests in `tests/e2e.rs`: warning survives `--quiet`, the normal location stays silent, a config inside the repo is refused, and a symlink into the repo is refused.

Mutation-verified the containment check by reintroducing each hole separately: dropping the `..` handling fails exactly the two `..` tests, and dropping the symlink resolution fails the symlink tests. Restored, green.

## Scope note

Two existing tests put `CPLT_CONFIG` inside the project under test (`tests/integration.rs`, `tests/e2e_projects.rs`); both now point at a directory outside it. `cplt trust accept`'s test store is unaffected — that path does not go through the startup context.

Diagnostic subcommands (`cplt config path`, `cplt config validate`) still resolve `CPLT_CONFIG` unguarded: printing the path is their whole job, and they apply no sandbox policy.
