### PR TITLE
test(extraction): stage the fixture script, then rename it into place

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7090,8 +7090,11 @@ mod copilot_extraction_tests {
         let f = fixture("empty-dir", EXTRACTS_UNLESS_DIR_EXISTS);
         std::fs::create_dir_all(f.pkg.join("1.0.63")).unwrap();
         // Carry the error. A bare `is_ok()` here cost a CI round-trip to
-        // diagnose, because the failure said nothing about why.
-        assert!(f.run().is_ok(), "extraction failed: {:?}", f.run().err());
+        // diagnose, because the failure said nothing about why. Run once and
+        // report that result: a second run would see the state the first left
+        // behind and could well succeed, describing a failure that never was.
+        let result = f.run();
+        assert!(result.is_ok(), "extraction failed: {result:?}");
         assert!(f.pkg.join("1.0.63/.extraction-complete").exists());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6951,8 +6951,16 @@ mod copilot_extraction_tests {
         std::fs::create_dir_all(&bindir).unwrap();
         std::fs::create_dir_all(&pkg).unwrap();
         let bin = bindir.join("copilot");
+        // Staged write, then rename. Writing this script and exec'ing it under
+        // its final name races every other test thread: `Command::spawn` forks,
+        // and a fork that happens while this file is still open for writing
+        // inherits the writable descriptor, so the exec comes back ETXTBSY.
+        // Under `cargo test` that surfaces as an unexplained intermittent
+        // failure on whichever extraction test lost the race. A rename is
+        // atomic, and the descriptor is closed before the name exists.
+        let staging = bindir.join("copilot.staging");
         std::fs::write(
-            &bin,
+            &staging,
             format!(
                 "#!/bin/sh\nPKG=\"{}\"\nCOUNT=\"{}\"\n{script}\n",
                 pkg.to_string_lossy().replace('"', "\\\""),
@@ -6962,7 +6970,8 @@ mod copilot_extraction_tests {
             ),
         )
         .unwrap();
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::rename(&staging, &bin).unwrap();
         Fixture {
             root,
             home,
@@ -7080,7 +7089,9 @@ mod copilot_extraction_tests {
     fn recovers_from_an_empty_current_version_dir() {
         let f = fixture("empty-dir", EXTRACTS_UNLESS_DIR_EXISTS);
         std::fs::create_dir_all(f.pkg.join("1.0.63")).unwrap();
-        assert!(f.run().is_ok());
+        // Carry the error. A bare `is_ok()` here cost a CI round-trip to
+        // diagnose, because the failure said nothing about why.
+        assert!(f.run().is_ok(), "extraction failed: {:?}", f.run().err());
         assert!(f.pkg.join("1.0.63/.extraction-complete").exists());
     }
 


### PR DESCRIPTION
PR #270 and PR #283 both failed `copilot_extraction_tests::recovers_from_an_empty_current_version_dir` on `linux-integration-tests` today, with neither diff touching that code. `main` is green, so this is a race rather than a regression.

## What races

`fixture()` writes the fake `copilot` script with `std::fs::write`, chmods it, and hands the path straight to a test that spawns it. `Command::spawn` forks. A fork landing while the file is still open for writing inherits the writable descriptor, and the exec then fails with `ETXTBSY` — "Text file busy". Under `cargo test` these run in parallel with each other and with the rest of the binary, so whichever test loses the race fails, and a re-run usually passes. Same shape as the one fixed in #173.

## Fix

Write to a staging name, chmod it, then `rename` it onto `copilot`. The rename is atomic and the descriptor is closed before the final name exists, so no fork can see the file half-written under the name it will exec.

Fixed once in `fixture()`, which every test in the module goes through, rather than at a call site.

## Also

`recovers_from_an_empty_current_version_dir` asserted a bare `f.run().is_ok()`. That is what made this cost a CI round-trip to diagnose: the failure output was `assertion failed: f.run().is_ok()` and nothing else — no errno, no path. It now prints the error.

## Verified

Extraction tests run five times in a row with no failure, plus `cargo test --lib` (848) and `cargo test --test unit_tests` (298). The race is timing-dependent, so a clean local run is evidence and not proof. The real check is whether #270 and #283 go green with this in.
