### PR TITLE
fix(git-guard): resolve branch and remotes in the targeted repo

### DIFF
--- a/docs/git-guard.md
+++ b/docs/git-guard.md
@@ -39,6 +39,29 @@ branches = ["renovate/*", "dependabot/*"]
 force = false
 ```
 
+`remote` names a remote of the repository cplt was launched in. The name alone
+is not a repository identity — every checkout on the machine has an `origin` —
+so at launch the guard resolves the name to that remote's URL and matches on
+the URL from then on. A rule for this repository's `origin` therefore does not
+authorize `git -C ../other-repo push origin main`, even though the other
+checkout also calls its remote `origin`.
+
+URLs are compared after normalization, so the spellings of one remote are one
+remote: `git@github.com:navikt/cplt.git`, `ssh://git@github.com/navikt/cplt`,
+`https://github.com/navikt/cplt.git` and `https://github.com/navikt/cplt` all
+match. The host is lowercased, a `.git` suffix and a trailing slash are
+dropped, and userinfo (`https://token@github.com/...`) is ignored. What is
+*not* normalized: the path case (`navikt/cplt` and `navikt/CPLT` are different
+remotes), host aliases (an `ssh_config` `Host` alias is a different host than
+the name it expands to), and local paths — those compare as the literal string
+git reports.
+
+Nothing changes in the config file format, and a rule written against a remote
+name keeps working. The one behavior change is the intended one: such a rule
+now only covers the repository that name pointed at when the session started.
+If the name does not resolve at launch — no remote by that name in the launch
+repository — the rule falls back to matching the bare name, as before.
+
 <details>
 <summary>CLI flag (override for a single run)</summary>
 
@@ -67,7 +90,7 @@ target branch:
 | `git push origin master` | `master` | Blocked |
 | `git push origin HEAD:refs/heads/main` | `main` (from refspec) | Blocked |
 | `git push origin HEAD:main` | `main` (from refspec) | Blocked |
-| `git push` (bare) | resolved from the current branch via the real git | Allowed on a feature branch, blocked on `main`/`master`, blocked if the branch cannot be resolved |
+| `git push` (bare) | resolved from the current branch via the real git, in the repository the command targets | Allowed on a feature branch, blocked on `main`/`master`, blocked if the branch cannot be resolved |
 | `git push origin` | same, no branch in the arguments | Allowed on a feature branch, blocked on `main`/`master`, blocked if the branch cannot be resolved |
 | `git push --force origin feature/x` | `feature/x` | Blocked while `prevent_force_push` is on, which is the default |
 | `git push --force origin main` | `main` | Blocked |
@@ -80,6 +103,11 @@ does not slip through.
 A push with no branch in the arguments is not waved through. The guard shells
 out to the real git to resolve the current branch, and fails closed when it
 cannot: an unresolvable branch counts as protected and the push is blocked.
+
+That resolution follows the command. `-C`, `--git-dir` and `--work-tree` are
+forwarded to the guard's own git call, so `git -C ../other-repo push` is judged
+by *that* repository's branch, not by the branch of the repository the session
+was launched in.
 
 **Security note:** This mode is intentionally permissive about branches. The
 agent can push to any non-default branch, and the human review gate becomes the

--- a/docs/git-guard.md
+++ b/docs/git-guard.md
@@ -46,6 +46,13 @@ the URL from then on. A rule for this repository's `origin` therefore does not
 authorize `git -C ../other-repo push origin main`, even though the other
 checkout also calls its remote `origin`.
 
+Pinning needs a *trusted* git binary (the same one the gh guard uses to capture
+its repo scope), because it runs unsandboxed in the parent at launch. On a
+machine where cplt cannot find one, it says so and the rules fall back to
+matching the bare name — which is where a rule does apply to another
+repository's same-named remote. Fix the git installation cplt is warning about
+rather than relying on the fallback.
+
 URLs are compared after normalization, so the spellings of one remote are one
 remote: `git@github.com:navikt/cplt.git`, `ssh://git@github.com/navikt/cplt`,
 `https://github.com/navikt/cplt.git` and `https://github.com/navikt/cplt` all
@@ -59,8 +66,10 @@ git reports.
 Nothing changes in the config file format, and a rule written against a remote
 name keeps working. The one behavior change is the intended one: such a rule
 now only covers the repository that name pointed at when the session started.
-If the name does not resolve at launch — no remote by that name in the launch
-repository — the rule falls back to matching the bare name, as before.
+
+Two cases keep the old name matching, both of them announced rather than
+silent: the launch repository has no remote by that name, and cplt found no
+trusted git to resolve it with.
 
 <details>
 <summary>CLI flag (override for a single run)</summary>

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -552,6 +552,7 @@ impl Config {
                     remote: r.remote.clone(),
                     branches: r.branches.clone(),
                     force: r.force.unwrap_or(false),
+                    url: None,
                 })
                 .collect(),
         };

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -728,6 +728,17 @@ pub struct ResolvedPushRule {
     pub remote: Option<String>,
     pub branches: Vec<String>,
     pub force: bool,
+    /// Normalized URL of `remote` as it resolved in the launch repository,
+    /// filled in at wrapper-install time by
+    /// [`crate::gh_proxy::resolve_push_rule_urls`]. Not a config key.
+    ///
+    /// A remote *name* is not a repository identity: every repo has an
+    /// `origin`. Pinning the name to the URL it had at launch is what stops a
+    /// rule written for this repo's `origin` from authorizing a push to some
+    /// other repo's `origin` (#215). `None` means the name could not be
+    /// resolved at launch, and matching falls back to the name alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 /// Resolved configuration after merging config file + CLI flags.

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -3842,16 +3842,19 @@ mod tests {
         Some((tmp, repo))
     }
 
+    /// `git` if it runs, probed directly rather than through `which` so the
+    /// tests do not silently skip on a machine that has git but no `which`.
+    /// `Command` resolves the bare name through PATH.
+    /// `git` if it runs, probed directly rather than through `which` so the
+    /// tests do not silently skip on a machine that has git but no `which`.
+    /// `Command` resolves the bare name through PATH.
     fn which_git() -> Option<PathBuf> {
-        let out = std::process::Command::new("/usr/bin/env")
-            .args(["which", "git"])
+        std::process::Command::new("git")
+            .arg("--version")
             .output()
-            .ok()?;
-        if !out.status.success() {
-            return None;
-        }
-        let path = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-        path.is_file().then_some(path)
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|_| PathBuf::from("git"))
     }
 
     #[test]

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2287,22 +2287,11 @@ pub fn gate_git(
     }
 
     // Find the subcommand by skipping global flags.
-    // Git global flags that take a value (must skip the next arg too).
-    const FLAGS_WITH_VALUE: &[&str] = &[
-        "-c",
-        "-C",
-        "--git-dir",
-        "--work-tree",
-        "--namespace",
-        "--super-prefix",
-        "--config-env",
-    ];
-
     let mut i = 0;
     let mut subcommand = None;
     while i < args.len() {
         let arg = args[i];
-        if FLAGS_WITH_VALUE.contains(&arg) {
+        if GIT_GLOBAL_FLAGS_WITH_VALUE.contains(&arg) {
             i += 2; // skip flag and its value
             continue;
         }
@@ -2345,6 +2334,11 @@ pub fn gate_git(
     // Arguments belonging to the subcommand (everything after it).
     let sub_args = &args[i + 1..];
 
+    // The repository this invocation targets. Every git call the guard makes to
+    // refine its verdict must go through these, or it decides from the launch
+    // repository's branch and remotes instead (#215).
+    let repo_args = repo_target_args(&args[..i]);
+
     // Scope integrity: block mutation of remote URLs while the guard is active.
     // The gh-guard reads `origin` to determine the enforced repo scope, so
     // rewriting a remote's URL would let an agent redirect in-scope operations
@@ -2384,7 +2378,8 @@ pub fn gate_git(
             } else {
                 // No explicit branch: `git push` pushes current branch.
                 // Resolve via real git to determine if we're on a protected branch.
-                let current_branch = real_git.and_then(resolve_current_branch);
+                let current_branch =
+                    real_git.and_then(|git| resolve_current_branch(git, &repo_args));
                 match current_branch {
                     Some(ref b) if !is_default_branch(b) => true,
                     Some(_) => false, // On default branch — fall through to block
@@ -2413,10 +2408,18 @@ pub fn gate_git(
         if sub == "push" && !allow_push_rules.is_empty() {
             let push_args = &args[i + 1..];
             let has_force = push_is_force(push_args);
-            let (remote, branch) = extract_push_remote_and_branch(push_args, real_git);
+            let (remote, branch) = extract_push_remote_and_branch(push_args, real_git, &repo_args);
+            // Resolve the destination remote's URL in the repository this
+            // command targets. A bare `git push` with no remote uses the
+            // branch's configured remote, which is `origin` in all but exotic
+            // setups; guessing wrong here only fails closed.
+            let remote_url = real_git.and_then(|git| {
+                resolve_remote_url(git, &repo_args, remote.as_deref().unwrap_or(SCOPE_REMOTE))
+            });
             if matches_allow_push_rule(
                 allow_push_rules,
                 remote.as_deref(),
+                remote_url.as_deref(),
                 branch.as_deref(),
                 has_force,
             ) {
@@ -2518,9 +2521,65 @@ fn extract_push_target_branch<'a>(push_args: &[&'a str]) -> Option<&'a str> {
     }
 }
 
-/// Resolve the current git branch by calling the real git binary.
-fn resolve_current_branch(real_git: &Path) -> Option<String> {
+/// Git global flags that redirect which repository a command operates on.
+///
+/// `-c`, `--namespace` and friends are deliberately absent: they change
+/// configuration, not the target repository, and forwarding attacker-chosen
+/// `-c` values into the guard's own git calls would hand the agent a way to
+/// influence the verdict.
+const REPO_TARGET_FLAGS: &[&str] = &["-C", "--git-dir", "--work-tree"];
+
+/// Git global flags that consume a following space-separated value, so a scan of
+/// the global-flag prefix never mistakes such a value for a flag of its own.
+const GIT_GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
+    "-c",
+    "-C",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--super-prefix",
+    "--config-env",
+];
+
+/// The `-C` / `--git-dir` / `--work-tree` arguments of a git invocation, in
+/// order, so the guard's own git calls resolve against the repository the
+/// command actually targets rather than the launch repository (#215).
+///
+/// Both spellings are collected: the space-separated form (`-C dir`) and the
+/// `=`-attached long form (`--git-dir=dir`). Multiple `-C` are kept in order
+/// because git applies them cumulatively.
+fn repo_target_args<'a>(args: &[&'a str]) -> Vec<&'a str> {
+    let mut out: Vec<&str> = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i];
+        if REPO_TARGET_FLAGS.contains(&arg) {
+            if let Some(value) = args.get(i + 1) {
+                out.push(arg);
+                out.push(value);
+            }
+            i += 2;
+            continue;
+        }
+        if GIT_GLOBAL_FLAGS_WITH_VALUE.contains(&arg) {
+            i += 2; // a value that must not be scanned as a flag
+            continue;
+        }
+        if arg.starts_with("--")
+            && let Some((flag, _)) = arg.split_once('=')
+            && REPO_TARGET_FLAGS.contains(&flag)
+        {
+            out.push(arg);
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Resolve the current git branch of the repository `repo_args` targets.
+fn resolve_current_branch(real_git: &Path, repo_args: &[&str]) -> Option<String> {
     let output = std::process::Command::new(real_git)
+        .args(repo_args)
         .args(["symbolic-ref", "--short", "HEAD"])
         .output()
         .ok()?;
@@ -2536,16 +2595,68 @@ fn resolve_current_branch(real_git: &Path) -> Option<String> {
     }
 }
 
+/// Normalized URL of `remote` in the repository `repo_args` targets.
+///
+/// `None` when the remote does not exist, git fails, or no git binary is
+/// available — every caller treats that as "cannot prove identity" and fails
+/// closed.
+fn resolve_remote_url(real_git: &Path, repo_args: &[&str], remote: &str) -> Option<String> {
+    // `--` guards against a remote name that looks like a flag.
+    let output = std::process::Command::new(real_git)
+        .args(repo_args)
+        .args(["remote", "get-url", "--", remote])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        None
+    } else {
+        Some(crate::trust::normalize_remote_url(&url))
+    }
+}
+
+/// Pin each rule's remote *name* to the URL that name has in the launch
+/// repository, so the rule identifies a repository and not just a name (#215).
+///
+/// Runs once at wrapper-install time, in the unsandboxed parent, so `real_git`
+/// must be a [`crate::git::trusted_git`] path. A name that does not resolve
+/// (no such remote) is left with `url: None` and keeps matching by name.
+#[must_use]
+pub fn resolve_push_rule_urls(
+    real_git: &Path,
+    project_dir: &Path,
+    rules: &[crate::config::ResolvedPushRule],
+) -> Vec<crate::config::ResolvedPushRule> {
+    let dir = project_dir.to_string_lossy().into_owned();
+    let repo_args = ["-C", dir.as_str()];
+    rules
+        .iter()
+        .map(|rule| {
+            let mut rule = rule.clone();
+            if rule.url.is_none()
+                && let Some(name) = rule.remote.as_deref()
+            {
+                rule.url = resolve_remote_url(real_git, &repo_args, name);
+            }
+            rule
+        })
+        .collect()
+}
+
 /// Extract the remote and branch from `git push` arguments.
 /// Returns (remote, branch) — either may be None.
 fn extract_push_remote_and_branch(
     push_args: &[&str],
     real_git: Option<&Path>,
+    repo_args: &[&str],
 ) -> (Option<String>, Option<String>) {
     let target = extract_push_target_branch(push_args);
     let branch = match target {
         Some(b) => Some(b.to_string()),
-        None => real_git.and_then(resolve_current_branch),
+        None => real_git.and_then(|git| resolve_current_branch(git, repo_args)),
     };
 
     // Extract remote (first positional — the remote name).
@@ -2559,6 +2670,7 @@ fn extract_push_remote_and_branch(
 fn matches_allow_push_rule(
     rules: &[crate::config::ResolvedPushRule],
     remote: Option<&str>,
+    remote_url: Option<&str>,
     branch: Option<&str>,
     is_force: bool,
 ) -> bool {
@@ -2567,11 +2679,25 @@ fn matches_allow_push_rule(
         if is_force && !rule.force {
             continue;
         }
-        // Check remote constraint
+        // Check remote constraint.
+        //
+        // When the rule's remote name resolved to a URL at launch, the rule
+        // identifies a *repository*: the push's remote must resolve to the same
+        // URL, so a rule for this repo's `origin` does not authorize a push to
+        // another repo's `origin` (#215). An unresolvable URL on either side
+        // fails closed. Only a rule whose name never resolved falls back to
+        // matching the bare name.
         if let Some(ref rule_remote) = rule.remote {
-            match remote {
-                Some(r) if r == rule_remote => {}
-                _ => continue,
+            if let Some(rule_url) = rule.url.as_deref() {
+                match remote_url {
+                    Some(u) if u == rule_url => {}
+                    _ => continue,
+                }
+            } else {
+                match remote {
+                    Some(r) if r == rule_remote => {}
+                    _ => continue,
+                }
             }
         }
         // Check branch constraints (glob patterns)
@@ -3624,12 +3750,14 @@ mod tests {
             remote: Some("fork".to_string()),
             branches: vec!["agent/*".to_string()],
             force: false,
+            url: None,
         }];
 
         // Matches: correct remote + matching branch
         assert!(matches_allow_push_rule(
             &rules,
             Some("fork"),
+            None,
             Some("agent/fix-123"),
             false
         ));
@@ -3637,6 +3765,7 @@ mod tests {
         assert!(!matches_allow_push_rule(
             &rules,
             Some("origin"),
+            None,
             Some("agent/fix-123"),
             false
         ));
@@ -3644,6 +3773,7 @@ mod tests {
         assert!(!matches_allow_push_rule(
             &rules,
             Some("fork"),
+            None,
             Some("main"),
             false
         ));
@@ -3651,6 +3781,7 @@ mod tests {
         assert!(!matches_allow_push_rule(
             &rules,
             Some("fork"),
+            None,
             Some("agent/fix"),
             true
         ));
@@ -3660,19 +3791,193 @@ mod tests {
             remote: None,
             branches: vec!["agent/*".to_string()],
             force: true,
+            url: None,
         }];
         assert!(matches_allow_push_rule(
             &rules_force,
             Some("origin"),
+            None,
             Some("agent/x"),
             true
         ));
         assert!(matches_allow_push_rule(
             &rules_force,
             Some("origin"),
+            None,
             Some("agent/x"),
             false
         ));
+    }
+
+    use std::path::PathBuf;
+
+    // ── multi-repo targeting (#215) ──
+    //
+    // The guard's conditional refinements must read the branch and the remotes
+    // of the repository the command targets, not of whatever repository the
+    // agent happens to have been launched in.
+
+    /// A scratch git repo on `branch`, with `origin` pointing at `origin_url`.
+    /// `None` when git is unavailable.
+    fn scratch_repo(branch: &str, origin_url: &str) -> Option<(tempfile::TempDir, PathBuf)> {
+        let git = which_git()?;
+        let tmp = tempfile::tempdir().ok()?;
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).ok()?;
+        let run = |args: &[&str]| {
+            std::process::Command::new(&git)
+                .args(args)
+                .current_dir(&repo)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+        };
+        run(&["init"])?;
+        // No commit needed: symbolic-ref and remotes work on an empty repo, and
+        // `git init -b` is not available on every git these tests may meet.
+        run(&["symbolic-ref", "HEAD", &format!("refs/heads/{branch}")])?;
+        run(&["remote", "add", "origin", origin_url])?;
+        Some((tmp, repo))
+    }
+
+    fn which_git() -> Option<PathBuf> {
+        let out = std::process::Command::new("/usr/bin/env")
+            .args(["which", "git"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let path = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+        path.is_file().then_some(path)
+    }
+
+    #[test]
+    fn repo_target_args_forwards_only_repo_flags() {
+        assert_eq!(repo_target_args(&["-C", "/b"]), vec!["-C", "/b"]);
+        assert_eq!(
+            repo_target_args(&["--git-dir=/b/.git", "--work-tree", "/b"]),
+            vec!["--git-dir=/b/.git", "--work-tree", "/b"]
+        );
+        // `-c` and its value are configuration, not a repo target, and the
+        // value must not be scanned as a flag of its own.
+        assert!(repo_target_args(&["-c", "-C", "-c", "user.name=x"]).is_empty());
+    }
+
+    #[test]
+    fn branch_is_resolved_in_the_repo_dash_c_targets() {
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/other/other.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+
+        // `git -C <repo-on-main> push` must be blocked even though the repo the
+        // test process runs in may sit on a feature branch.
+        let blocked = gate_git(&["-C", &dir, "push"], true, true, true, &[], Some(&git));
+        assert!(
+            blocked.is_err(),
+            "push to main of the -C target must be blocked, got {blocked:?}"
+        );
+
+        // And the mirror image: a -C target on a feature branch is allowed even
+        // when the process's own repo cannot be resolved (detached CI checkout).
+        let Some((_tmp2, feature)) =
+            scratch_repo("feature/x", "https://github.com/other/other.git")
+        else {
+            return;
+        };
+        let feature_dir = feature.to_string_lossy().into_owned();
+        assert!(
+            gate_git(
+                &["-C", &feature_dir, "push"],
+                true,
+                false,
+                true,
+                &[],
+                Some(&git)
+            )
+            .is_ok(),
+            "push to a feature branch of the -C target must be allowed"
+        );
+    }
+
+    #[test]
+    fn allow_push_rule_does_not_match_a_same_named_remote_elsewhere() {
+        use crate::config::ResolvedPushRule;
+
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/other/other.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+
+        // A rule written for the launch repo's `origin`, pinned at launch to
+        // that repo's URL.
+        let rule = ResolvedPushRule {
+            remote: Some("origin".to_string()),
+            branches: vec!["main".to_string()],
+            force: false,
+            url: Some(crate::trust::normalize_remote_url(
+                "git@github.com:navikt/cplt.git",
+            )),
+        };
+        let args = ["-C", dir.as_str(), "push", "origin", "main"];
+        assert!(
+            gate_git(&args, true, true, false, &[rule], Some(&git)).is_err(),
+            "a rule for another repository's origin must not authorize this push"
+        );
+
+        // Same rule, and now the target repo really is that repository — spelled
+        // in a different but equivalent URL form.
+        let Some((_tmp2, same)) = scratch_repo("main", "https://github.com/navikt/cplt") else {
+            return;
+        };
+        let same_dir = same.to_string_lossy().into_owned();
+        let rule = ResolvedPushRule {
+            remote: Some("origin".to_string()),
+            branches: vec!["main".to_string()],
+            force: false,
+            url: Some(crate::trust::normalize_remote_url(
+                "git@github.com:navikt/cplt.git",
+            )),
+        };
+        let args = ["-C", same_dir.as_str(), "push", "origin", "main"];
+        assert!(
+            gate_git(&args, true, true, false, &[rule], Some(&git)).is_ok(),
+            "the same repository under an equivalent URL form must still match"
+        );
+    }
+
+    #[test]
+    fn push_rule_urls_are_pinned_from_the_launch_repo() {
+        use crate::config::ResolvedPushRule;
+
+        let Some((_tmp, repo)) = scratch_repo("main", "git@github.com:navikt/cplt.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let rules = vec![
+            ResolvedPushRule {
+                remote: Some("origin".to_string()),
+                branches: vec![],
+                force: false,
+                url: None,
+            },
+            // A name with no such remote stays unresolved and keeps matching by
+            // name — the documented back-compat fallback.
+            ResolvedPushRule {
+                remote: Some("fork".to_string()),
+                branches: vec![],
+                force: false,
+                url: None,
+            },
+        ];
+        let resolved = resolve_push_rule_urls(&git, &repo, &rules);
+        assert_eq!(resolved[0].url.as_deref(), Some("github.com/navikt/cplt"));
+        assert_eq!(resolved[1].url, None);
     }
 
     #[test]
@@ -3683,6 +3988,7 @@ mod tests {
             remote: Some("fork".to_string()),
             branches: vec!["agent/*".to_string()],
             force: false,
+            url: None,
         }];
 
         // Push to fork agent/fix should be allowed despite prevent_push=true
@@ -4232,6 +4538,7 @@ mod tests {
             remote: Some("origin".to_string()),
             branches: vec!["agent/*".to_string()],
             force: true,
+            url: None,
         }];
         // The remote/branch must parse correctly (not be eaten by --force-with-lease).
         assert!(
@@ -4247,11 +4554,11 @@ mod tests {
         );
         // Branch parsing is correct with the flag present.
         let (remote, branch) =
-            extract_push_remote_and_branch(&["--force-with-lease", "origin", "agent/x"], None);
+            extract_push_remote_and_branch(&["--force-with-lease", "origin", "agent/x"], None, &[]);
         assert_eq!(remote.as_deref(), Some("origin"));
         assert_eq!(branch.as_deref(), Some("agent/x"));
         let (remote, branch) =
-            extract_push_remote_and_branch(&["--signed", "origin", "agent/y"], None);
+            extract_push_remote_and_branch(&["--signed", "origin", "agent/y"], None, &[]);
         assert_eq!(remote.as_deref(), Some("origin"));
         assert_eq!(branch.as_deref(), Some("agent/y"));
     }

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -545,10 +545,25 @@ fn install_command_wrappers(
             .map(std::path::Path::to_path_buf)
             .or_else(|| which_binary("git"))
     {
+        // Pin each allow_push rule's remote name to the URL that name has in
+        // the launch repository. Resolved here, in the unsandboxed parent with
+        // the trusted git, and baked into the wrapper — the same shape as the
+        // gh guard's repo scope. Without it a rule for this repo's `origin`
+        // also authorizes a push to an unrelated repo's `origin` (#215).
+        let mut git_guard = git_guard.clone();
+        if !git_guard.allow_push.is_empty()
+            && let Some(trusted) = crate::git::trusted_git()
+        {
+            git_guard.allow_push = crate::gh_proxy::resolve_push_rule_urls(
+                trusted,
+                project_dir,
+                &git_guard.allow_push,
+            );
+        }
         let script = crate::gh_proxy::generate_git_wrapper_script(
             &real_git.to_string_lossy(),
             &cplt_str,
-            git_guard,
+            &git_guard,
         );
         let wrapper_path = bin_dir.join("git");
         if std::fs::write(&wrapper_path, script).is_ok() {

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -546,19 +546,42 @@ fn install_command_wrappers(
             .or_else(|| which_binary("git"))
     {
         // Pin each allow_push rule's remote name to the URL that name has in
-        // the launch repository. Resolved here, in the unsandboxed parent with
-        // the trusted git, and baked into the wrapper — the same shape as the
-        // gh guard's repo scope. Without it a rule for this repo's `origin`
-        // also authorizes a push to an unrelated repo's `origin` (#215).
+        // the launch repository, so the rule identifies a repository and not
+        // just a name — without it a rule for this repo's `origin` also
+        // authorizes a push to an unrelated repo's `origin` (#215). Baked into
+        // the wrapper, the same shape as the gh guard's repo scope.
+        //
+        // Pinning requires `trusted_git`, not the PATH git the wrapper itself
+        // uses: this call runs in the UNSANDBOXED parent, where a planted git
+        // would execute as the user. With no trusted git the rules stay
+        // unpinned and keep matching by name — the pre-#215 behavior — so the
+        // operator is warned rather than left assuming the stronger guarantee.
         let mut git_guard = git_guard.clone();
-        if !git_guard.allow_push.is_empty()
-            && let Some(trusted) = crate::git::trusted_git()
-        {
-            git_guard.allow_push = crate::gh_proxy::resolve_push_rule_urls(
-                trusted,
-                project_dir,
-                &git_guard.allow_push,
-            );
+        if !git_guard.allow_push.is_empty() {
+            if let Some(trusted) = crate::git::trusted_git() {
+                git_guard.allow_push = crate::gh_proxy::resolve_push_rule_urls(
+                    trusted,
+                    project_dir,
+                    &git_guard.allow_push,
+                );
+                for rule in &git_guard.allow_push {
+                    if rule.url.is_none()
+                        && let Some(name) = rule.remote.as_deref()
+                    {
+                        ui::warn(&format!(
+                            "git guard: allow_push remote {name:?} does not exist in this \
+                             repository, so the rule matches by name and also applies to a \
+                             remote called {name:?} in another repository."
+                        ));
+                    }
+                }
+            } else {
+                ui::warn(
+                    "git guard could not find a trusted Git to pin allow_push remotes to \
+                     their URLs. Those rules will match by remote name, so they also apply \
+                     to a same-named remote in another repository.",
+                );
+            }
         }
         let script = crate::gh_proxy::generate_git_wrapper_script(
             &real_git.to_string_lossy(),


### PR DESCRIPTION
Fixes #215.

The git guard's conditional refinements evaluated the **launch** repository's
branch and remotes rather than the repository the command targets, so
`git -C B push` was judged by repo A.

## What changed

**Branch resolution follows the command.** `resolve_current_branch` now
forwards the invocation's `-C`, `--git-dir` and `--work-tree` arguments to its
own git call; with none present it still inherits the invocation's cwd, which
is the previous behavior. `-c` and `--namespace` are deliberately *not*
forwarded: they change configuration, not the target repository, and feeding
agent-chosen `-c` values into the guard's own git calls would be a new way to
influence the verdict.

**allow_push rules match on remote URL, not remote name.** A name is not a
repository identity — every checkout has an `origin`.

The blanket guard is untouched: `gate_git` remains argv-only and repo-agnostic,
so `git -C B push --force` is still blocked when prevention is unconditional.

## URL normalisation

Comparison reuses `trust::normalize_remote_url`, already in the tree for repo
fingerprinting. It treats these as the same remote:

- `git@github.com:navikt/cplt.git`
- `ssh://git@github.com/navikt/cplt`
- `https://github.com/navikt/cplt.git`
- `https://github.com/navikt/cplt`

It lowercases the host, strips a `.git` suffix and a trailing slash, and drops
userinfo (`https://token@github.com/...`).

Deliberately **not** normalised, and stated in the docs:

- **path case** — `navikt/cplt` and `navikt/CPLT` compare as different remotes.
  GitHub treats them as one, other forges do not, and guessing wrong here fails
  *open*.
- **host aliases** — an `ssh_config` `Host gh` alias is a different host than
  the name it expands to. Resolving it would mean parsing the agent's ssh
  config at gate time.
- **local paths and other transports** — compared as the literal string git
  reports.

Each of these fails closed: an unrecognised spelling does not match a rule, so
the push is blocked rather than waved through.

## Existing config written against remote names

No config change is required and no key is added or removed. The name in
`remote = "origin"` is resolved **once, at wrapper-install time, in the
unsandboxed parent** — the same shape as the gh guard's repo scope — and the
resulting URL is pinned into the wrapper. From then on the rule matches by URL.

So a rule written against a name keeps working for the repository it was
written for. The behavior change is the intended one, and it is a tightening:
such a rule no longer covers a same-named remote in a *different* repository.
That is the bug being fixed, and it is documented in `docs/git-guard.md`
rather than left to be discovered.

One deliberate looseness: if the name does not resolve at launch (no remote by
that name in the launch repository) the rule keeps matching the bare name, as
before. Failing closed there would silently disable rules that name a remote
the user creates later, which is the "quietly got stricter" failure mode this
change is trying not to cause.

## Tests

Both halves, in `src/gh_proxy.rs`:

- `branch_is_resolved_in_the_repo_dash_c_targets` — a scratch repo on `main`
  reached via `-C` is blocked under `protect_default_branch_only`, and one on a
  feature branch is allowed, regardless of the branch the test process's own
  repo sits on.
- `allow_push_rule_does_not_match_a_same_named_remote_elsewhere` — a rule
  pinned to `github.com/navikt/cplt` does not match a repo whose `origin` is
  someone else's, and does match the same repo spelled in a different URL form.
- `push_rule_urls_are_pinned_from_the_launch_repo` — pinning, and the
  unresolvable-name fallback.
- `repo_target_args_forwards_only_repo_flags` — `-c` and its value are not
  mistaken for repo targeting.

Both halves mutation-checked: reintroducing the missing `-C` forwarding fails
`branch_is_resolved_in_the_repo_dash_c_targets` only, and reverting to name
matching fails `allow_push_rule_does_not_match_a_same_named_remote_elsewhere`
only. Restored, both green.

`cargo fmt`, `cargo test --lib` (863), `cargo test --test unit_tests` (313),
`cargo test --test e2e_git_hardening` (7), `cargo test --test e2e_guards` (123)
all pass; clippy is clean in every touched file.
