### PR TITLE
docs(sandbox): state why goose gets no Keychain substitute

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -403,6 +403,7 @@ flow needs access cplt does not grant by default.
 | Copilot | never (unverified) | — | — |
 | Claude Code | `CLAUDE_CODE_OAUTH_TOKEN` is set | that OAuth token | none — see below |
 | Antigravity | `~/.gemini/antigravity-cli/antigravity-oauth-token` exists and is non-empty | that file | refreshes into that file |
+| goose | never (provider-dependent) | — | some providers refresh through the keyring mid-session |
 
 The trade is not free. Whole-Keychain read+write is exchanged for a full OAuth
 token sitting in the agent's environment, readable by every process it spawns and
@@ -461,6 +462,22 @@ Copilot. Only credentials that are durable for a whole session qualify.
   believes is revoked. Every other way the file goes bad — missing, empty,
   unreadable, corrupt, expired past its refresh token — surfaces as a plain sign-in
   error.
+
+- **goose** — not eligible, and unlike Copilot that is a finding rather than a
+  gap. goose's `Config::get_secret` does read the uppercased environment
+  variable before its keyring, so precedence is not the problem; the session
+  lifetime is. Its GitHub Copilot provider re-reads `GITHUB_COPILOT_TOKEN`
+  through that path whenever its cached API info expires, and its OAuth
+  persistence layer writes *refreshed* credentials back into the keyring with
+  `set_secret` — both mid-session, not at startup. Which of those applies
+  depends on the provider goose is configured for, out of the several hundred it
+  embeds, so a substitute would have to match the configured provider's key
+  rather than any variable from goose's env hints: a developer with
+  `OPENAI_API_KEY` exported and goose pointed at Anthropic would otherwise lose
+  the keyring and the login with it. `GOOSE_DISABLE_KEYRING` does not rescue it
+  either — it sends the same writes to `~/.config/goose/secrets.yaml`, which
+  cplt grants read-only. Determined by reading goose's source
+  (`aaif-goose/goose`), not by inspecting the credential's shape.
 
 **Copilot is deliberately not eligible.** Claude Code's substitute was
 confirmed by running the agent under a profile with the grant dropped; Copilot's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -475,8 +475,9 @@ Copilot. Only credentials that are durable for a whole session qualify.
   rather than any variable from goose's env hints: a developer with
   `OPENAI_API_KEY` exported and goose pointed at Anthropic would otherwise lose
   the keyring and the login with it. `GOOSE_DISABLE_KEYRING` does not rescue it
-  either — it sends the same writes to `~/.config/goose/secrets.yaml`, which
-  cplt grants read-only. Determined by reading goose's source
+  either — it sends the same writes to `secrets.yaml` in goose's config dir
+  (`$XDG_CONFIG_HOME/goose`, `~/.config/goose` by default), which cplt grants
+  read-only. Determined by reading goose's source
   (`aaif-goose/goose`), not by inspecting the credential's shape.
 
 **Copilot is deliberately not eligible.** Claude Code's substitute was

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -437,8 +437,8 @@ impl Agent {
             // exported and goose pointed at Anthropic would otherwise lose the
             // keyring and the login with it. `GOOSE_DISABLE_KEYRING` is not the
             // escape hatch either — it redirects those same writes to
-            // `~/.config/goose/secrets.yaml`, and cplt grants that dir
-            // read-only.
+            // `secrets.yaml` in goose's config dir ($XDG_CONFIG_HOME/goose,
+            // ~/.config/goose by default), which cplt grants read-only.
             Agent::Goose => &[],
             _ => &[],
         }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -415,6 +415,31 @@ impl Agent {
             // billing. Users who want that can pass it explicitly with
             // `--pass-env ANTHROPIC_API_KEY`.
             Agent::Claude => &["CLAUDE_CODE_OAUTH_TOKEN"],
+            // goose gets no substitute either, but this one is not "unprobed" —
+            // it was read in goose's own source (aaif-goose/goose, `main`), and
+            // the answer is that goose reaches its keyring *during* a session,
+            // not only at startup:
+            //
+            // - `Config::get_secret` (crates/goose/src/config/base.rs) does
+            //   check the uppercased env var before the keyring, so the
+            //   precedence half is fine.
+            // - `providers/githubcopilot.rs` re-reads `GITHUB_COPILOT_TOKEN`
+            //   through that path every time its cached API info expires
+            //   (`refresh_in`), which is mid-session, not at startup.
+            // - `oauth/persist.rs::save_persisted` *writes* refreshed
+            //   credentials back through `set_secret`, i.e. into the keyring,
+            //   mid-session — reached by the gateway and declarative providers.
+            //
+            // So the right answer depends on which provider goose is configured
+            // for, and goose embeds several hundred of them. A substitute would
+            // have to match the *configured* provider's key rather than find any
+            // var from `auth_env_hint()`: a developer with OPENAI_API_KEY
+            // exported and goose pointed at Anthropic would otherwise lose the
+            // keyring and the login with it. `GOOSE_DISABLE_KEYRING` is not the
+            // escape hatch either — it redirects those same writes to
+            // `~/.config/goose/secrets.yaml`, and cplt grants that dir
+            // read-only.
+            Agent::Goose => &[],
             _ => &[],
         }
     }
@@ -2196,6 +2221,49 @@ mod tests {
                 assert!(
                     !agent.auth_env_hint().is_empty(),
                     "{agent:?} is not OAuth-first, so it needs an env hint to suggest"
+                );
+            }
+        }
+    }
+
+    /// Every agent that wants the Keychain must state whether it has a
+    /// substitute credential, and an empty answer must be a decision.
+    ///
+    /// Same shape as `every_agent_declares_its_auth_model`, for the same reason:
+    /// the expectation is an EXHAUSTIVE match, so a new agent variant stops
+    /// compiling here until someone says where its credential can be read
+    /// without the login Keychain (#242). The two empty answers are not the
+    /// same kind of empty and the comments say which is which — Copilot's is
+    /// unprobed (#277), goose's is probed and negative.
+    #[test]
+    fn every_keychain_agent_states_its_substitute() {
+        fn expected_substitutes(agent: Agent) -> &'static [&'static str] {
+            match agent {
+                // Unprobed: filling this in needs the run #277 asks for, not an
+                // argument. See the comment in `keychain_substitute_env_vars`.
+                Agent::Copilot => &[],
+                // Probed and negative: goose re-reads and rewrites its keyring
+                // mid-session for some providers, so a one-shot substitute
+                // cannot be safe for all of them.
+                Agent::Goose => &[],
+                // File-based substitute instead, in `credential_outside_keychain`.
+                Agent::Antigravity => &[],
+                Agent::Claude => &["CLAUDE_CODE_OAUTH_TOKEN"],
+                // Agents that never wanted the grant have nothing to trade.
+                Agent::OpenCode | Agent::Pi | Agent::Shell => &[],
+            }
+        }
+        for agent in ALL_AGENTS {
+            assert_eq!(
+                agent.keychain_substitute_env_vars(),
+                expected_substitutes(agent),
+                "{agent:?}'s Keychain substitute changed — update SECURITY.md's \
+                 per-agent table and say what verified it"
+            );
+            if !agent.needs_keychain() {
+                assert!(
+                    agent.keychain_substitute_env_vars().is_empty(),
+                    "{agent:?} offers a substitute for a grant it never gets"
                 );
             }
         }


### PR DESCRIPTION
Part of #242. No behaviour change — this closes an evidence gap, not a grant.

## Where #242 actually stands

Most of it landed in #257: the `sandbox.keychain_substitute` mechanism, the Claude Code substitute (`CLAUDE_CODE_OAUTH_TOKEN`), the Antigravity fallback-file substitute, and the finding that the SBPL file rules are the only lever (there is no keychain operation in SBPL, and blocking securityd's Mach service is neither necessary nor sufficient). Gemini is not a case at all any more — #262 removed the agent. Copilot is blocked on the live probe in #277.

That leaves goose, which is in `needs_keychain()` and appears nowhere in the trade: no arm in `keychain_substitute_env_vars`, no row in SECURITY.md's per-agent table. It reads as an oversight.

## It is not an oversight

Read against goose's own source (`aaif-goose/goose`, `main`), the question #242 says to settle per agent — read once at startup, or re-read and rewritten during a session — has this answer for goose: **it depends on the provider, and for some providers it is mid-session both ways.**

- `crates/goose/src/config/base.rs` — `Config::get_secret` checks the uppercased env var *before* the keyring, so precedence is not the obstacle.
- `crates/goose/src/providers/githubcopilot.rs` — re-reads `GITHUB_COPILOT_TOKEN` through that same path every time its cached API info expires (`refresh_in`). Mid-session, not at startup.
- `crates/goose/src/oauth/persist.rs` — `save_persisted` writes *refreshed* credentials back with `set_secret`, i.e. into the keyring. Also mid-session; reached by the gateway and declarative providers.

goose embeds several hundred providers, so a substitute would have to match the *configured* provider's key rather than find any variable from `auth_env_hint()`. A developer with `OPENAI_API_KEY` exported and goose pointed at Anthropic would otherwise lose the keyring and the login with it. `GOOSE_DISABLE_KEYRING` is not the escape hatch either: it redirects those same writes to `~/.config/goose/secrets.yaml`, and cplt grants that directory read-only.

Evidence is the source, not the credential's shape. goose is not installed on the machine this was written on, so no live run backs it — which is the same standard #277 holds Copilot to, and the reason this PR does not drop a grant.

## What is here

- The `Agent::Goose` arm in `keychain_substitute_env_vars`, with the finding written down where the next person will look.
- A goose row in SECURITY.md's per-agent table and a bullet in "Why each agent lands where it does".
- `every_keychain_agent_states_its_substitute`: an exhaustive match, same shape as `every_agent_declares_its_auth_model`, so a new agent variant stops compiling until someone states where its credential can be read without the login Keychain. The two empty arrays are now distinguishable — Copilot's is unprobed, goose's is probed and negative — and filling either in fails the test until the docs follow.

Mutation-checked: setting goose to `["OPENAI_API_KEY"]` fails `every_keychain_agent_states_its_substitute` with the message pointing at SECURITY.md; restored, it passes.

868 + 313 tests pass. clippy clean for the touched files.
