### PR TITLE
test: isolate suites from developer config, PATH and git config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ set.
 - `src/main.rs` CLI entry point, orchestration
 - `src/lib.rs` library crate root (re-exports modules for test access)
 - `src/proxy.rs` CONNECT proxy, domain blocking, audit log
+- `tests/common/mod.rs` test isolation helpers, shared by every suite
 - `tests/unit_tests.rs` cross-platform unit tests
 - `tests/integration.rs` macOS sandbox-exec kernel-level tests
 - `tests/integration_linux.rs` Linux Landlock+seccomp kernel-level tests
@@ -104,6 +105,26 @@ The four tiers each prove something the others cannot, so all four are needed.
 4. **E2E project tests** verify that realistic developer workflows (git, node,
    python, rust file ops, config files) work inside the sandbox. Catches
    real-world breakage that synthetic tests miss.
+
+### Isolation
+
+A test must not inherit the machine it runs on. Build every subprocess with the
+helpers in `tests/common/mod.rs`, never `Command::new` directly:
+
+- `cplt_cmd()` — the binary with `CPLT_CONFIG` pointed at a dead end, so config
+  resolution (CLI flag > config > preset > default) sees the defaults rather
+  than the developer's `~/.config/cplt/config.toml`.
+- `cplt_cmd_with_ambient_config()` — the explicit opt-out, for a test that is
+  itself about config discovery.
+- `git_cmd(dir)` — git with `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_NOSYSTEM` cleared,
+  so `commit.gpgsign`, `core.hooksPath` and `init.defaultBranch` cannot decide
+  whether fixture setup succeeds.
+- `temp_repo(remote)` — a throwaway repo with a known `origin`. Anything that
+  resolves a repository from the cwd belongs here, not in the checkout, whose
+  `origin` is `navikt/cplt` only for people who cloned it directly.
+
+Two failures came from skipping this (issue #245), and both reported success
+while exercising nothing.
 
 Which tier to use:
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,117 @@
+//! Shared test isolation helpers.
+//!
+//! Tests must not inherit the machine they run on. Two failures traced to the
+//! same root (issue #245): one test asserted a property of one developer's
+//! `~/.config/cplt/config.toml` while exercising nothing, and six e2e tests
+//! only passed when the checkout's `origin` happened to be `navikt/cplt`.
+//!
+//! The cure is structural. Every `Command` a test spawns is built here with
+//! the ambient state already neutralised, so a test has to opt *out* of
+//! isolation (`cplt_cmd_with_ambient_config`) rather than remember to opt in.
+//! Do not reach for `Command::new` directly in a test — a convention that
+//! depends on memory has already failed twice.
+
+#![allow(dead_code)] // not every test binary uses every helper
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// A `CPLT_CONFIG` value that can never name a real file: `/dev/null` is a
+/// character device, so nothing can exist beneath it. Config resolution falls
+/// through to the built-in defaults instead of the developer's dotfiles.
+pub const NO_CONFIG: &str = "/dev/null/nonexistent";
+
+/// Path to the `cplt` binary built for this test run.
+#[must_use]
+pub fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
+}
+
+/// A `cplt` `Command` isolated from the developer's config file.
+///
+/// `gh_guard.enabled`, `sandbox.preset`, `allow_localhost_any` and every other
+/// key resolve as CLI flag > config > default. Without this the "default"
+/// under test is whatever the machine happens to have configured.
+#[must_use]
+pub fn cplt_cmd() -> Command {
+    let mut cmd = Command::new(binary_path());
+    cmd.env("CPLT_CONFIG", NO_CONFIG);
+    cmd
+}
+
+/// A `cplt` `Command` that reads the ambient `~/.config/cplt/config.toml`.
+///
+/// Deliberately verbose: a test using this asserts something about config
+/// *discovery*, and its assertions must hold for any config the reader's
+/// machine might have. If that is not what you meant, use [`cplt_cmd`].
+#[must_use]
+pub fn cplt_cmd_with_ambient_config() -> Command {
+    Command::new(binary_path())
+}
+
+/// Resolve a binary by name, preferring `/usr/bin` so the developer's PATH
+/// cannot substitute a different implementation.
+///
+/// # Panics
+/// If the binary is not found in `/usr/bin` or on `PATH`.
+#[must_use]
+pub fn binary_in_path(name: &str) -> PathBuf {
+    let system = PathBuf::from("/usr/bin").join(name);
+    if system.is_file() {
+        return system;
+    }
+    std::env::split_paths(&std::env::var_os("PATH").expect("PATH should be set"))
+        .map(|dir| dir.join(name))
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| panic!("{name} should be available in PATH"))
+}
+
+/// A `git` `Command` in `dir`, isolated from the developer's global and system
+/// git config.
+///
+/// Global config reaches a fixture repo as `commit.gpgsign` (no signing key on
+/// CI, or none on the developer's machine), `core.hooksPath` (arbitrary hooks
+/// running inside the fixture), `init.defaultBranch` and aliases. All of it
+/// turns fixture setup into a property of the machine.
+#[must_use]
+pub fn git_cmd(dir: &Path) -> Command {
+    let mut cmd = Command::new(binary_in_path("git"));
+    cmd.current_dir(dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_NOSYSTEM", "1");
+    cmd
+}
+
+/// Run an isolated `git` command in `dir` and return whether it succeeded.
+pub fn git_ok(dir: &Path, args: &[&str]) -> bool {
+    git_cmd(dir)
+        .args(args)
+        .output()
+        .expect("git should run")
+        .status
+        .success()
+}
+
+/// A throwaway git repository whose `origin` is `remote` ("owner/name").
+///
+/// Anything that resolves a repository from the cwd — the gh-guard's scope
+/// check above all — must run here rather than in the checkout, whose `origin`
+/// is `navikt/cplt` only for people who cloned it directly.
+///
+/// # Panics
+/// If `git init` or `git remote add` fails.
+#[must_use]
+pub fn temp_repo(remote: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(git_ok(dir.path(), &["init", "--quiet"]));
+    assert!(git_ok(
+        dir.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            &format!("https://github.com/{remote}.git"),
+        ]
+    ));
+    dir
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -9,17 +9,17 @@
 //! Run live tests that hit the Copilot API:
 //!   cargo test --test e2e -- --ignored
 
+mod common;
+
 #[cfg(target_os = "macos")]
 mod e2e_tests {
     use std::path::{Path, PathBuf};
     use std::process::Command;
+
+    use crate::common::{binary_path, cplt_cmd, cplt_cmd_with_ambient_config, git_cmd};
     use std::sync::atomic::{AtomicU32, Ordering};
 
     static FAKE_COPILOT_COUNTER: AtomicU32 = AtomicU32::new(0);
-
-    fn binary_path() -> PathBuf {
-        PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
-    }
 
     fn project_dir() -> PathBuf {
         std::fs::canonicalize(".").unwrap()
@@ -96,20 +96,6 @@ mod e2e_tests {
         };
     }
 
-    /// Configure a Command to ignore the user's config file.
-    /// Prevents user settings (e.g., allow_localhost_any) from affecting test assertions.
-    fn no_user_config(cmd: &mut Command) -> &mut Command {
-        cmd.env("CPLT_CONFIG", "/dev/null/nonexistent")
-    }
-
-    /// Create a cplt Command pre-configured to ignore the user's config.
-    /// Use for tests that assert on profile/output content that config could affect.
-    fn cplt_cmd() -> Command {
-        let mut cmd = Command::new(binary_path());
-        no_user_config(&mut cmd);
-        cmd
-    }
-
     // ============================================================
     // Full pipeline tests (sandbox-exec → copilot child process)
     // ============================================================
@@ -118,7 +104,7 @@ mod e2e_tests {
     fn e2e_copilot_version_inside_sandbox() {
         require_copilot!();
         require_sandbox!();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate", "--", "--version"])
             .current_dir(project_dir())
             .output()
@@ -466,7 +452,7 @@ mod e2e_tests {
     #[test]
     fn e2e_doctor_exits_successfully() {
         require_copilot!();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--doctor"])
             .current_dir(project_dir())
             .output()
@@ -484,7 +470,7 @@ mod e2e_tests {
     fn e2e_doctor_reports_auth_section() {
         // No require_copilot!: doctor always prints the Auth section header
         // regardless of whether Copilot is installed, so this runs in CI.
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--doctor"])
             .current_dir(project_dir())
             .output()
@@ -501,7 +487,7 @@ mod e2e_tests {
     #[test]
     fn e2e_doctor_reports_copilot_section() {
         require_copilot!();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--doctor"])
             .current_dir(project_dir())
             .output()
@@ -519,7 +505,7 @@ mod e2e_tests {
     fn e2e_doctor_reports_tools_section() {
         // No require_copilot!: doctor always prints the Tools section (git is
         // present on the runner) regardless of Copilot, so this runs in CI.
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--doctor"])
             .current_dir(project_dir())
             .output()
@@ -536,7 +522,7 @@ mod e2e_tests {
     #[test]
     fn e2e_doctor_reports_sandbox_paths() {
         require_copilot!();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--doctor"])
             .current_dir(project_dir())
             .output()
@@ -553,7 +539,7 @@ mod e2e_tests {
     #[test]
     fn e2e_doctor_subcommand_works() {
         require_copilot!();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["doctor"])
             .current_dir(project_dir())
             .output()
@@ -580,7 +566,7 @@ mod e2e_tests {
     #[test]
     fn e2e_doctor_flag_shows_deprecation() {
         require_copilot!();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--doctor"])
             .current_dir(project_dir())
             .output()
@@ -608,7 +594,7 @@ mod e2e_tests {
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["doctor"])
             .current_dir(dir.path())
             .output()
@@ -637,7 +623,7 @@ mod e2e_tests {
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["doctor"])
             .current_dir(dir.path())
             .env("NO_COLOR", "1")
@@ -661,7 +647,7 @@ mod e2e_tests {
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["doctor"])
             .current_dir(dir.path())
             .env("TERM", "dumb")
@@ -687,7 +673,7 @@ mod e2e_tests {
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["doctor"])
             .current_dir(dir.path())
             .env("NO_COLOR", "1")
@@ -959,7 +945,7 @@ mod e2e_tests {
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
 
-        let mut cmd = Command::new(binary_path());
+        let mut cmd = cplt_cmd();
         cmd.args(["--yes", "--no-validate"])
             .args(extra_args)
             .args(["--", "--version"]) // fake copilot ignores args, prints env
@@ -987,7 +973,7 @@ mod e2e_tests {
         let fake_dir = create_fake_copilot();
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
-        let mut cmd = Command::new(binary_path());
+        let mut cmd = cplt_cmd();
         cmd.current_dir(project_dir()).env("PATH", &new_path);
         (cmd, fake_dir)
     }
@@ -1126,7 +1112,7 @@ mod e2e_tests {
     ) -> (String, String, bool) {
         use std::process::Stdio;
 
-        let mut cmd = Command::new(binary_path());
+        let mut cmd = cplt_cmd();
         cmd.args(["--yes", "--no-validate"])
             .args(extra_cplt_args)
             .arg("--");
@@ -1167,9 +1153,8 @@ mod e2e_tests {
 
         // Initialize git so Copilot doesn't complain
         let run_git = |args: &[&str]| {
-            Command::new("git")
+            git_cmd(dir.path())
                 .args(args)
-                .current_dir(dir.path())
                 .env("GIT_AUTHOR_NAME", "Test")
                 .env("GIT_AUTHOR_EMAIL", "test@test.com")
                 .env("GIT_COMMITTER_NAME", "Test")
@@ -1202,18 +1187,16 @@ mod e2e_tests {
         std::fs::write(dir.join("canary.txt"), &token).unwrap();
 
         // Commit the file so git doesn't show it as untracked noise
-        Command::new("git")
+        git_cmd(&dir)
             .args(["add", "."])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "test@test.com")
             .output()
             .ok();
-        Command::new("git")
+        git_cmd(&dir)
             .args(["commit", "-m", "add canary"])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
@@ -1290,18 +1273,16 @@ mod e2e_tests {
         }
 
         // Commit so it's visible
-        Command::new("git")
+        git_cmd(&dir)
             .args(["add", "."])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "test@test.com")
             .output()
             .ok();
-        Command::new("git")
+        git_cmd(&dir)
             .args(["commit", "-m", "add script"])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
@@ -1338,18 +1319,16 @@ mod e2e_tests {
         std::fs::write(dir.join(".env"), format!("SECRET_TOKEN={token}\n")).unwrap();
 
         // Commit so it's in the repo
-        Command::new("git")
+        git_cmd(&dir)
             .args(["add", "-f", ".env"])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "test@test.com")
             .output()
             .ok();
-        Command::new("git")
+        git_cmd(&dir)
             .args(["commit", "-m", "add env"])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
@@ -1449,18 +1428,16 @@ mod e2e_tests {
             .unwrap();
         }
 
-        Command::new("git")
+        git_cmd(&dir)
             .args(["add", "."])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
             .env("GIT_COMMITTER_EMAIL", "test@test.com")
             .output()
             .ok();
-        Command::new("git")
+        git_cmd(&dir)
             .args(["commit", "-m", "add script"])
-            .current_dir(&dir)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
             .env("GIT_COMMITTER_NAME", "Test")
@@ -1499,7 +1476,7 @@ mod e2e_tests {
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate", "--", "--version"])
             .current_dir(project_dir())
             .env("PATH", &new_path)
@@ -1558,7 +1535,7 @@ mod e2e_tests {
         std::os::unix::fs::symlink(binary_path(), dir.path().join("copilot")).unwrap();
 
         // PATH contains ONLY the symlink dir — no real copilot anywhere
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate", "--", "--version"])
             .current_dir(project_dir())
             .env("PATH", dir.path().display().to_string())
@@ -1579,7 +1556,7 @@ mod e2e_tests {
 
     #[test]
     fn e2e_shell_setup_prints_alias() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--shell-setup")
             .output()
             .expect("binary should run");
@@ -1596,7 +1573,7 @@ mod e2e_tests {
         let zshrc = fake_home.join(".zshrc");
 
         // First install — should create the file with the eval line
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--shell-install")
             .env("HOME", &fake_home)
             .env("SHELL", "/bin/zsh")
@@ -1615,7 +1592,7 @@ mod e2e_tests {
         );
 
         // Second install — should be idempotent
-        let output2 = Command::new(binary_path())
+        let output2 = cplt_cmd()
             .arg("--shell-install")
             .env("HOME", &fake_home)
             .env("SHELL", "/bin/zsh")
@@ -1641,15 +1618,24 @@ mod e2e_tests {
 
     #[test]
     fn e2e_config_path_prints_path() {
-        let output = Command::new(binary_path())
+        // Asserts config *discovery*, so CPLT_CONFIG must stay unset — but the
+        // fallback is $HOME-derived, so point HOME at a temp dir and assert the
+        // exact path instead of the substring the reader's machine happens to
+        // produce.
+        let home = tempfile::tempdir().unwrap();
+        let output = cplt_cmd_with_ambient_config()
             .args(["config", "path"])
+            .env("HOME", home.path())
+            .env_remove("CPLT_CONFIG")
             .output()
             .expect("should run");
         assert!(output.status.success(), "config path should succeed");
         let stdout = String::from_utf8_lossy(&output.stdout);
+        let expected = home.path().join(".config/cplt/config.toml");
         assert!(
-            stdout.contains("config.toml"),
-            "should print config path: {stdout}"
+            stdout.contains(&*expected.to_string_lossy()),
+            "should print the HOME-derived config path {}: {stdout}",
+            expected.display()
         );
     }
 
@@ -1662,7 +1648,7 @@ mod e2e_tests {
         let _ = std::fs::remove_dir_all(&fake_home);
         std::fs::create_dir_all(&fake_home).unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "validate"])
             .env("HOME", &fake_home)
             .env(
@@ -1698,7 +1684,7 @@ mod e2e_tests {
         let config_file = fake_home.join("config.toml");
         std::fs::write(&config_file, "[sandbox]\nquiet = true\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "validate"])
             .env("CPLT_CONFIG", config_file.to_str().unwrap())
             .output()
@@ -1726,7 +1712,7 @@ mod e2e_tests {
         let config_file = fake_home.join("config.toml");
         std::fs::write(&config_file, "[sandbox]\ninherit_evn = true\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "validate"])
             .env("CPLT_CONFIG", config_file.to_str().unwrap())
             .output()
@@ -1761,7 +1747,7 @@ mod e2e_tests {
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "show"])
             .env("CPLT_CONFIG", config_file.to_str().unwrap())
             .output()
@@ -1794,7 +1780,7 @@ mod e2e_tests {
         let _ = std::fs::remove_dir_all(&fake_home);
         std::fs::create_dir_all(&fake_home).unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "show"])
             .env(
                 "CPLT_CONFIG",
@@ -1827,7 +1813,7 @@ mod e2e_tests {
 
         let config_file = fake_home.join(".config/cplt/config.toml");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "init"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -1856,7 +1842,7 @@ mod e2e_tests {
         std::fs::create_dir_all(&config_dir).unwrap();
         std::fs::write(config_dir.join("config.toml"), "# existing\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "init"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -1881,7 +1867,7 @@ mod e2e_tests {
         let _ = std::fs::remove_dir_all(&fake_home);
         std::fs::create_dir_all(&fake_home).unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--init-config")
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -1911,7 +1897,7 @@ mod e2e_tests {
 
     #[test]
     fn e2e_settings_requires_interactive_terminal() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("settings")
             .env_remove("__CPLT_TRUST_LOCKED")
             .output()
@@ -1934,7 +1920,7 @@ mod e2e_tests {
         let config_path = fake_home.join(".config/cplt/config.toml");
         assert!(!config_path.exists());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "sandbox.quiet", "true"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -1961,7 +1947,7 @@ mod e2e_tests {
     fn e2e_config_get_returns_default() {
         let fake_home = make_config_home("get-default");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "get", "sandbox.quiet"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -1985,7 +1971,7 @@ mod e2e_tests {
         let fake_home = make_config_home("set-get");
 
         // Set a value
-        let set_out = Command::new(binary_path())
+        let set_out = cplt_cmd()
             .args(["config", "set", "proxy.port", "9090"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -1998,7 +1984,7 @@ mod e2e_tests {
         );
 
         // Get it back
-        let get_out = Command::new(binary_path())
+        let get_out = cplt_cmd()
             .args(["config", "get", "proxy.port"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2016,7 +2002,7 @@ mod e2e_tests {
         let fake_home = make_config_home("set-unset");
 
         // Set a value
-        Command::new(binary_path())
+        cplt_cmd()
             .args(["config", "set", "sandbox.quiet", "true"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2024,7 +2010,7 @@ mod e2e_tests {
             .expect("should run");
 
         // Unset it
-        let unset_out = Command::new(binary_path())
+        let unset_out = cplt_cmd()
             .args(["config", "set", "sandbox.quiet", "--unset"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2037,7 +2023,7 @@ mod e2e_tests {
         );
 
         // Get should return default
-        let get_out = Command::new(binary_path())
+        let get_out = cplt_cmd()
             .args(["config", "get", "sandbox.quiet"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2054,7 +2040,7 @@ mod e2e_tests {
         let fake_home = make_config_home("set-dangerous");
 
         // Without --force should fail
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "sandbox.inherit_env", "true"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2068,7 +2054,7 @@ mod e2e_tests {
         );
 
         // With --force should succeed
-        let output2 = Command::new(binary_path())
+        let output2 = cplt_cmd()
             .args(["config", "set", "sandbox.inherit_env", "true", "--force"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2087,7 +2073,7 @@ mod e2e_tests {
     fn e2e_config_set_dangerous_false_no_force_needed() {
         let fake_home = make_config_home("set-dangerous-false");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "sandbox.inherit_env", "false"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2111,7 +2097,7 @@ mod e2e_tests {
             let fake_home = make_config_home(&format!("set-preset-{preset}"));
 
             // Without --force should fail and name what it enables.
-            let output = Command::new(binary_path())
+            let output = cplt_cmd()
                 .args(["config", "set", "sandbox.preset", preset])
                 .env("HOME", fake_home.to_str().unwrap())
                 .env_remove("CPLT_CONFIG")
@@ -2128,7 +2114,7 @@ mod e2e_tests {
             );
 
             // With --force should succeed.
-            let output2 = Command::new(binary_path())
+            let output2 = cplt_cmd()
                 .args(["config", "set", "sandbox.preset", preset, "--force"])
                 .env("HOME", fake_home.to_str().unwrap())
                 .env_remove("CPLT_CONFIG")
@@ -2150,7 +2136,7 @@ mod e2e_tests {
         for preset in ["strict", "standard"] {
             let fake_home = make_config_home(&format!("set-safe-preset-{preset}"));
 
-            let output = Command::new(binary_path())
+            let output = cplt_cmd()
                 .args(["config", "set", "sandbox.preset", preset])
                 .env("HOME", fake_home.to_str().unwrap())
                 .env_remove("CPLT_CONFIG")
@@ -2170,7 +2156,7 @@ mod e2e_tests {
     fn e2e_config_set_invalid_key_fails() {
         let fake_home = make_config_home("set-badkey");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "sandbox.queit", "true"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2187,7 +2173,7 @@ mod e2e_tests {
     fn e2e_config_get_invalid_key_fails() {
         let fake_home = make_config_home("get-badkey");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "get", "nope"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2203,7 +2189,7 @@ mod e2e_tests {
         let fake_home = make_config_home("set-comments");
 
         // Create a config with comments via init
-        Command::new(binary_path())
+        cplt_cmd()
             .args(["config", "init"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2215,7 +2201,7 @@ mod e2e_tests {
         assert!(before.contains('#'), "init template should have comments");
 
         // Set a value
-        Command::new(binary_path())
+        cplt_cmd()
             .args(["config", "set", "sandbox.quiet", "true"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2240,7 +2226,7 @@ mod e2e_tests {
         let fake_home = make_config_home("set-append");
 
         // Set initial array
-        Command::new(binary_path())
+        cplt_cmd()
             .args(["config", "set", "allow.ports", "8080"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2248,7 +2234,7 @@ mod e2e_tests {
             .expect("should run");
 
         // Append another value
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "allow.ports", "--append", "9090"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2261,7 +2247,7 @@ mod e2e_tests {
         );
 
         // Get should show both
-        let get_out = Command::new(binary_path())
+        let get_out = cplt_cmd()
             .args(["config", "get", "allow.ports"])
             .env("HOME", fake_home.to_str().unwrap())
             .env_remove("CPLT_CONFIG")
@@ -2284,11 +2270,7 @@ mod e2e_tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         // Initialize git repo (required for repo detection)
-        std::process::Command::new("git")
-            .args(["init", "--quiet"])
-            .current_dir(&dir)
-            .output()
-            .unwrap();
+        git_cmd(&dir).args(["init", "--quiet"]).output().unwrap();
         dir
     }
 
@@ -2303,11 +2285,7 @@ mod e2e_tests {
         let repo = make_repo_dir(label);
         std::fs::write(repo.join(".cplt.toml"), toml).unwrap();
         let git = |args: &[&str]| {
-            let out = std::process::Command::new("git")
-                .args(args)
-                .current_dir(&repo)
-                .output()
-                .unwrap();
+            let out = git_cmd(&repo).args(args).output().unwrap();
             assert!(
                 out.status.success(),
                 "git {args:?} failed: {}",
@@ -2620,7 +2598,7 @@ paths = [
         let cplt_toml = repo.join(".cplt.toml");
         assert!(!cplt_toml.exists());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2656,7 +2634,7 @@ paths = [
     fn e2e_config_set_repo_deny_paths() {
         let repo = make_repo_dir("set-repo-deny");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "--repo", "deny.paths", "~/secrets"])
             .current_dir(&repo)
             .output()
@@ -2686,7 +2664,7 @@ paths = [
         let repo = make_repo_dir("set-repo-allow-arr");
 
         // Set first read path
-        Command::new(binary_path())
+        cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2699,7 +2677,7 @@ paths = [
             .expect("should run");
 
         // Append second
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2738,7 +2716,7 @@ paths = [
     fn e2e_config_set_repo_rejects_invalid_key() {
         let repo = make_repo_dir("set-repo-invalid");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "--repo", "sandbox.quiet", "true"])
             .current_dir(&repo)
             .output()
@@ -2762,7 +2740,7 @@ paths = [
     fn e2e_config_set_repo_rejects_false_proposal() {
         let repo = make_repo_dir("set-repo-false");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2789,7 +2767,7 @@ paths = [
         let repo = make_repo_dir("set-repo-danger");
 
         // Without --force
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "--repo", "sandbox.allow_docker", "true"])
             .current_dir(&repo)
             .output()
@@ -2803,7 +2781,7 @@ paths = [
         );
 
         // With --force
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2836,7 +2814,7 @@ paths = [
         let repo = make_repo_dir("set-repo-unset");
 
         // Set a value first
-        Command::new(binary_path())
+        cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2849,7 +2827,7 @@ paths = [
             .expect("should run");
 
         // Unset it
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2880,7 +2858,7 @@ paths = [
     fn e2e_config_set_repo_port_array() {
         let repo = make_repo_dir("set-repo-ports");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "--repo", "allow.ports", "8080"])
             .current_dir(&repo)
             .output()
@@ -2904,7 +2882,7 @@ paths = [
 
         // Set same value twice
         for _ in 0..2 {
-            Command::new(binary_path())
+            cplt_cmd()
                 .args(["config", "set", "--repo", "allow.read", "~/.gradle"])
                 .current_dir(&repo)
                 .output()
@@ -2922,7 +2900,7 @@ paths = [
     fn e2e_config_set_repo_proxy_private_domains() {
         let repo = make_repo_dir("set-repo-proxy");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "config",
                 "set",
@@ -2957,7 +2935,7 @@ paths = [
     fn e2e_config_set_repo_deny_env() {
         let repo = make_repo_dir("set-repo-deny-env");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "set", "--repo", "deny.env", "VAULT_TOKEN"])
             .current_dir(&repo)
             .output()
@@ -2981,7 +2959,7 @@ paths = [
 
     #[test]
     fn e2e_config_explain_all_lists_keys() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "explain"])
             .output()
             .expect("should run");
@@ -3001,7 +2979,7 @@ paths = [
 
     #[test]
     fn e2e_config_explain_single_key() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "explain", "sandbox.quiet"])
             .output()
             .expect("should run");
@@ -3018,7 +2996,7 @@ paths = [
 
     #[test]
     fn e2e_config_explain_invalid_key() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["config", "explain", "sandbox.queit"])
             .output()
             .expect("should run");
@@ -3032,7 +3010,7 @@ paths = [
 
     #[test]
     fn e2e_update_help() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["update", "--help"])
             .output()
             .expect("should run");
@@ -3048,7 +3026,7 @@ paths = [
     /// since --check is read-only and fast.
     #[test]
     fn e2e_update_check_runs() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["update", "--check"])
             .output()
             .expect("should run");
@@ -3107,7 +3085,7 @@ paths = [
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate"])
             .args(cplt_args)
             .current_dir(project_dir())
@@ -3228,29 +3206,19 @@ paths = [
         std::fs::create_dir_all(&repo).unwrap();
 
         // Init git repo and commit .cplt.toml
-        Command::new("git")
-            .args(["init", "--quiet"])
-            .current_dir(&repo)
-            .output()
-            .unwrap();
-        Command::new("git")
+        git_cmd(&repo).args(["init", "--quiet"]).output().unwrap();
+        git_cmd(&repo)
             .args(["config", "user.email", "test@test.com"])
-            .current_dir(&repo)
             .output()
             .unwrap();
-        Command::new("git")
+        git_cmd(&repo)
             .args(["config", "user.name", "Test"])
-            .current_dir(&repo)
             .output()
             .unwrap();
 
         std::fs::write(repo.join(".cplt.toml"), cplt_toml_content).unwrap();
-        Command::new("git")
-            .args(["add", ".cplt.toml"])
-            .current_dir(&repo)
-            .output()
-            .unwrap();
-        Command::new("git")
+        git_cmd(&repo).args(["add", ".cplt.toml"]).output().unwrap();
+        git_cmd(&repo)
             .args([
                 "-c",
                 "commit.gpgSign=false",
@@ -3259,14 +3227,21 @@ paths = [
                 "init",
                 "--quiet",
             ])
-            .current_dir(&repo)
             .output()
             .unwrap();
 
         // Isolated config dir (no interference from user's real config).
         // Deliberately NOT inside the repo: cplt refuses a CPLT_CONFIG the
         // project controls (issue #261).
+        //
+        // Wiped first: the path is deterministic, and it holds the trust store
+        // (`<parent of CPLT_CONFIG>/trust/`) keyed on the equally deterministic
+        // repo path. A store left behind by an earlier run made this repo start
+        // out *approved*, so "before accept, should be pending" failed
+        // intermittently — intermittently because `id` depends on how many
+        // other tests ran first.
         let config_dir = std::env::temp_dir().join(format!(".cplt-e2e-trust-cfg-{label}-{id}"));
+        let _ = std::fs::remove_dir_all(&config_dir);
         std::fs::create_dir_all(&config_dir).unwrap();
         let config_file = config_dir.join("config.toml");
         std::fs::write(&config_file, "").unwrap();
@@ -3277,7 +3252,7 @@ paths = [
     /// Build a Command for the cplt binary with trust-related env vars cleared.
     /// Trust tests must not inherit __CPLT_TRUST_LOCKED from a parent sandbox.
     fn trust_cmd(repo: &Path, config_file: &Path) -> Command {
-        let mut cmd = Command::new(binary_path());
+        let mut cmd = cplt_cmd();
         cmd.current_dir(repo)
             .env("CPLT_CONFIG", config_file.to_str().unwrap())
             .env_remove("__CPLT_TRUST_LOCKED");
@@ -3453,12 +3428,8 @@ paths = [
             "[propose]\nallow_localhost_any = true\nallow_docker = true\n",
         )
         .unwrap();
-        Command::new("git")
-            .args(["add", ".cplt.toml"])
-            .current_dir(&repo)
-            .output()
-            .unwrap();
-        Command::new("git")
+        git_cmd(&repo).args(["add", ".cplt.toml"]).output().unwrap();
+        git_cmd(&repo)
             .args([
                 "-c",
                 "commit.gpgSign=false",
@@ -3467,7 +3438,6 @@ paths = [
                 "change proposals",
                 "--quiet",
             ])
-            .current_dir(&repo)
             .output()
             .unwrap();
 
@@ -3549,7 +3519,7 @@ paths = [
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate", "--", "--version"])
             .current_dir(&repo)
             .env("PATH", &new_path)
@@ -3590,7 +3560,7 @@ paths = [
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
 
         // Run with flag — should succeed
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -3687,7 +3657,7 @@ paths = [
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.path().display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -3736,7 +3706,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -3761,7 +3731,7 @@ paths = [
         std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname=\"x\"").unwrap();
         std::fs::write(dir.path().join("Dockerfile"), "FROM rust:1.80").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -3781,7 +3751,7 @@ paths = [
     fn e2e_init_empty_project_succeeds() {
         let dir = tempfile::tempdir().unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -3803,7 +3773,7 @@ paths = [
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("Dockerfile"), "FROM node:20").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--write"])
             .current_dir(dir.path())
             .output()
@@ -3825,7 +3795,7 @@ paths = [
         std::fs::write(dir.path().join("Dockerfile"), "FROM node:20").unwrap();
         std::fs::write(dir.path().join(".cplt.toml"), "# existing").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--write"])
             .current_dir(dir.path())
             .output()
@@ -3845,7 +3815,7 @@ paths = [
         std::fs::write(dir.path().join("Dockerfile"), "FROM node:20").unwrap();
         std::fs::write(dir.path().join(".cplt.toml"), "# old content").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--write", "--force"])
             .current_dir(dir.path())
             .output()
@@ -3864,7 +3834,7 @@ paths = [
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("Dockerfile"), "FROM node:20").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--quiet"])
             .current_dir(dir.path())
             .output()
@@ -3897,7 +3867,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -3922,7 +3892,7 @@ paths = [
         std::fs::create_dir_all(home.path().join("Library/Caches/ms-playwright")).unwrap();
         std::fs::create_dir_all(home.path().join(".cache/ms-playwright")).unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--global"])
             .env("HOME", home.path())
             .env("CPLT_CONFIG", home.path().join("config.toml"))
@@ -3949,7 +3919,7 @@ paths = [
         std::fs::create_dir_all(home.path().join(".cache/ms-playwright")).unwrap();
         let config_path = home.path().join("cplt/config.toml");
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--global", "--write"])
             .env("HOME", home.path())
             .env("CPLT_CONFIG", &config_path)
@@ -3971,10 +3941,13 @@ paths = [
     #[test]
     fn e2e_init_global_empty_home() {
         let home = tempfile::tempdir().unwrap();
-
-        let output = Command::new(binary_path())
+        // `init --global` detects machine-level config from PATH as well as
+        // HOME: an agent binary the developer happens to have installed makes
+        // "nothing detected" false. Empty PATH means empty detection.
+        let output = cplt_cmd()
             .args(["init", "--global"])
             .env("HOME", home.path())
+            .env("PATH", "")
             .env("CPLT_CONFIG", home.path().join("config.toml"))
             .output()
             .expect("should run");
@@ -4011,7 +3984,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -4050,7 +4023,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -4093,7 +4066,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -4128,7 +4101,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init"])
             .current_dir(dir.path())
             .output()
@@ -4158,7 +4131,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["init", "--quiet"])
             .current_dir(dir.path())
             .output()
@@ -4189,7 +4162,7 @@ paths = [
         )
         .unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["doctor"])
             .current_dir(dir.path())
             .output()
@@ -4647,7 +4620,7 @@ paths = [
             "playwright-deny-env",
             "[deny]\nenv = [\"PWTEST_SOCKETS_DIR\"]\n",
         );
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--no-validate",
                 "--allow-cache-exec",
@@ -5013,9 +4986,8 @@ paths = [
         let home = tempfile::tempdir().expect("home");
         let project = tempfile::tempdir().expect("project");
         std::fs::create_dir_all(home.path().join(".config/cplt")).unwrap();
-        let status = Command::new("git")
+        let status = git_cmd(project.path())
             .args(["init", "-q"])
-            .current_dir(project.path())
             .status()
             .unwrap_or_else(|e| panic!("git init for {tag}: {e}"));
         assert!(status.success(), "git init should succeed for {tag}");
@@ -5029,7 +5001,7 @@ paths = [
         let config = elsewhere.path().join("config.toml");
         std::fs::write(&config, "[sandbox]\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--quiet", "--print-profile", "--agent", "copilot"])
             .current_dir(project.path())
             .env("HOME", home.path())
@@ -5054,7 +5026,7 @@ paths = [
         let config = home.path().join(".config/cplt/config.toml");
         std::fs::write(&config, "[sandbox]\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--quiet", "--print-profile", "--agent", "copilot"])
             .current_dir(project.path())
             .env("HOME", home.path())
@@ -5077,7 +5049,7 @@ paths = [
         std::fs::create_dir_all(config.parent().unwrap()).unwrap();
         std::fs::write(&config, "[sandbox]\nallow_env_files = true\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--quiet", "--print-profile", "--agent", "copilot"])
             .current_dir(project.path())
             .env("HOME", home.path())
@@ -5107,7 +5079,7 @@ paths = [
         let link = elsewhere.path().join("innocent.toml");
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--quiet", "--print-profile", "--agent", "copilot"])
             .current_dir(project.path())
             .env("HOME", home.path())

--- a/tests/e2e_git_hardening.rs
+++ b/tests/e2e_git_hardening.rs
@@ -9,7 +9,10 @@
 //! Run: cargo test --test e2e_git_hardening
 
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
+
+mod common;
+use common::git_cmd;
 
 /// A scratch repo plus the marker path its payload would create.
 struct Fixture {
@@ -20,17 +23,13 @@ struct Fixture {
 }
 
 fn git(repo: &Path, args: &[&str]) -> bool {
-    Command::new("git")
+    // `git_cmd` keeps the developer's (and CI's) own git config out of FIXTURE
+    // SETUP: a global `core.hooksPath` pre-commit hook or `commit.gpgsign`
+    // would otherwise make `git commit` fail here for reasons unrelated to the
+    // property under test. This affects only these setup commands — the cplt
+    // code paths under test spawn their own git and see the real environment.
+    git_cmd(repo)
         .args(args)
-        .current_dir(repo)
-        // Keep the developer's (and CI's) own git config out of FIXTURE SETUP:
-        // a global `core.hooksPath` pre-commit hook or `commit.gpgsign` would
-        // otherwise make `git commit` fail here for reasons unrelated to the
-        // property under test. This affects only these setup commands — the
-        // cplt code paths under test spawn their own git and see the real
-        // environment.
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_AUTHOR_NAME", "t")
         .env("GIT_AUTHOR_EMAIL", "t@example.invalid")
         .env("GIT_COMMITTER_NAME", "t")

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -1747,20 +1747,16 @@ fi
 // config can be approved. Asserting only on the state enum is how the
 // not-a-git-repo case slipped through review.
 mod trust_accept_guard {
-    use crate::common::cplt_cmd;
+    use crate::common::{cplt_cmd, git_cmd};
     use std::path::Path;
-    use std::process::Command;
 
     fn git(dir: &Path, args: &[&str]) {
-        let out = Command::new("git")
+        let out = git_cmd(dir)
             .args(args)
-            .current_dir(dir)
             .env("GIT_AUTHOR_NAME", "t")
             .env("GIT_AUTHOR_EMAIL", "t@e.x")
             .env("GIT_COMMITTER_NAME", "t")
             .env("GIT_COMMITTER_EMAIL", "t@e.x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_NOSYSTEM", "1")
             .output()
             .expect("git should run");
         assert!(out.status.success(), "git {args:?} failed");

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -20,23 +20,10 @@
 //! These tests do NOT require sandbox-exec or macOS — they test the gate
 //! subcommands directly and work on macOS and Linux.
 
-use std::path::PathBuf;
 use std::process::Command;
 
-fn binary_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
-}
-
-fn binary_in_path(name: &str) -> PathBuf {
-    let system = PathBuf::from("/usr/bin").join(name);
-    if system.is_file() {
-        return system;
-    }
-    std::env::split_paths(&std::env::var_os("PATH").expect("PATH should be set"))
-        .map(|dir| dir.join(name))
-        .find(|path| path.is_file())
-        .unwrap_or_else(|| panic!("{name} should be available in PATH"))
-}
+mod common;
+use common::{binary_in_path, binary_path, cplt_cmd, git_cmd, temp_repo};
 
 /// Run `cplt gh-gate` with default block policy.
 /// Returns (stdout, stderr, exit_success).
@@ -44,39 +31,11 @@ fn gh_gate(args: &[&str]) -> (String, String, bool) {
     gh_gate_with_opts(args, &[])
 }
 
-/// Create a throwaway Git repository with `origin` pointing at `remote`
-/// ("owner/name"), so the gate's cwd checks do not depend on the developer's
-/// own checkout origin.
-fn temp_repo(remote: &str) -> tempfile::TempDir {
-    let dir = tempfile::tempdir().unwrap();
-    let git = binary_in_path("git");
-    let run_git = |args: &[&str]| {
-        Command::new(&git)
-            .args(args)
-            .current_dir(dir.path())
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .status()
-            .expect("git should run")
-    };
-    assert!(run_git(&["init", "--quiet"]).success());
-    assert!(
-        run_git(&[
-            "remote",
-            "add",
-            "origin",
-            &format!("https://github.com/{remote}.git"),
-        ])
-        .success()
-    );
-    dir
-}
-
 /// Run `cplt gh-gate` with extra policy flags, from a temp checkout of the
 /// scoped repo.
 fn gh_gate_with_opts(args: &[&str], opts: &[&str]) -> (String, String, bool) {
     let repo = temp_repo("navikt/cplt");
-    let mut cmd = Command::new(binary_path());
+    let mut cmd = cplt_cmd();
     cmd.arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true") // if allowed, exec this harmless binary
@@ -104,7 +63,10 @@ fn git_gate(args: &[&str], prevent_push: bool, prevent_force_push: bool) -> (Str
 
 /// Run `cplt git-gate` with protect-default-branch-only mode.
 fn git_gate_protect_default(args: &[&str]) -> (String, String, bool) {
-    let mut cmd = Command::new(binary_path());
+    // The gate resolves the target repo from the cwd; a temp repo keeps that
+    // independent of whatever origin the checkout running the tests has.
+    let repo = temp_repo("navikt/cplt");
+    let mut cmd = cplt_cmd();
     cmd.arg("git-gate")
         .arg("--real-git")
         .arg("/usr/bin/true")
@@ -114,7 +76,7 @@ fn git_gate_protect_default(args: &[&str]) -> (String, String, bool) {
         .arg("--protect-default-branch-only=true")
         .arg("--")
         .args(args)
-        .current_dir(env!("CARGO_MANIFEST_DIR"));
+        .current_dir(repo.path());
 
     let output = cmd.output().expect("cplt git-gate should run");
     (
@@ -131,7 +93,10 @@ fn git_gate_with_mode(
     prevent_force_push: bool,
     mode: &str,
 ) -> (String, String, bool) {
-    let mut cmd = Command::new(binary_path());
+    // The gate resolves the target repo from the cwd; a temp repo keeps that
+    // independent of whatever origin the checkout running the tests has.
+    let repo = temp_repo("navikt/cplt");
+    let mut cmd = cplt_cmd();
     cmd.arg("git-gate")
         .arg("--real-git")
         .arg("/usr/bin/true")
@@ -140,7 +105,7 @@ fn git_gate_with_mode(
         .arg(format!("--prevent-force-push={prevent_force_push}"))
         .arg("--")
         .args(args)
-        .current_dir(env!("CARGO_MANIFEST_DIR"));
+        .current_dir(repo.path());
 
     let output = cmd.output().expect("cplt git-gate should run");
     (
@@ -346,31 +311,9 @@ fn gh_gate_allows_same_repo_pr_close() {
 
 #[test]
 fn gh_gate_rejects_nested_repo_retargeting() {
-    let temp = tempfile::tempdir().unwrap();
-    let git = binary_in_path("git");
-    assert!(
-        Command::new(&git)
-            .args(["init", "--quiet"])
-            .current_dir(temp.path())
-            .status()
-            .unwrap()
-            .success()
-    );
-    assert!(
-        Command::new(&git)
-            .args([
-                "remote",
-                "add",
-                "origin",
-                "https://github.com/evil-org/other.git"
-            ])
-            .current_dir(temp.path())
-            .status()
-            .unwrap()
-            .success()
-    );
+    let temp = temp_repo("evil-org/other");
 
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -397,7 +340,7 @@ fn gh_gate_blocks_implicit_repo_scope_from_sibling_repo() {
     let sibling_repo = temp_repo("evil-org/other-repo");
     let git = binary_in_path("git");
 
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -435,7 +378,7 @@ fn gh_gate_blocks_implicit_read_from_sibling_repo() {
     // #213 also covers reads: `gh pr list` in a sibling repo must not silently
     // answer from the startup repo.
     let sibling = temp_repo("evil-org/other-repo");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -463,7 +406,7 @@ fn gh_gate_blocks_implicit_read_from_sibling_repo() {
 #[test]
 fn gh_gate_warns_but_allows_implicit_read_from_sibling_in_warn_mode() {
     let sibling = temp_repo("evil-org/other-repo");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -487,7 +430,7 @@ fn gh_gate_warns_but_allows_implicit_read_from_sibling_in_warn_mode() {
 fn gh_gate_blocks_implicit_repo_view_from_sibling_repo() {
     // `gh repo view` with no argument shows the repository of the cwd.
     let sibling = temp_repo("evil-org/other-repo");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -516,7 +459,7 @@ fn gh_gate_blocks_implicit_repo_view_from_sibling_repo() {
 fn gh_gate_allows_owner_scoped_repo_list_from_sibling_repo() {
     // `gh repo list <owner>` takes an owner, not the cwd repository.
     let sibling = temp_repo("evil-org/other-repo");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -547,7 +490,7 @@ fn cplt_check_matches_the_gate_when_cwd_differs_from_project_dir() {
     // depends on whether the machine running the tests happens to enable it.
     let startup = temp_repo("navikt/cplt");
     let sibling = temp_repo("evil-org/other-repo");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("--project-dir")
         .arg(startup.path())
         .arg("--gh-guard")
@@ -572,7 +515,7 @@ fn cplt_check_matches_the_gate_when_cwd_differs_from_project_dir() {
 fn gh_gate_allows_global_read_from_sibling_repo() {
     // Commands that do not resolve a repository from the cwd stay usable.
     let sibling = temp_repo("evil-org/other-repo");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -597,7 +540,7 @@ fn gh_gate_allows_global_read_from_sibling_repo() {
 fn gh_gate_fails_closed_when_implicit_repo_scope_is_unverifiable() {
     let temp = tempfile::tempdir().unwrap();
     let git = binary_in_path("git");
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -667,7 +610,7 @@ fn gh_gate_ignores_runtime_git_config_for_scope() {
         .success()
     );
 
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -689,7 +632,7 @@ fn gh_gate_ignores_runtime_git_config_for_scope() {
 #[test]
 fn gh_gate_fails_closed_when_repo_scope_is_unavailable() {
     let temp = tempfile::tempdir().unwrap();
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -724,7 +667,7 @@ fn gh_gate_pins_verified_repo_in_gh_repo() {
     std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
     let repo = temp_repo("navikt/cplt");
 
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg(&fake_gh)
@@ -760,7 +703,7 @@ fn gh_gate_pins_verified_repo_for_allow_command() {
     .unwrap();
     std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg(&fake_gh)
@@ -846,7 +789,7 @@ fn gh_gate_allows_same_repo_api_endpoint() {
 #[test]
 fn gh_gate_allows_explicit_api_repo_from_unverifiable_cwd() {
     let temp = tempfile::tempdir().unwrap();
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -880,7 +823,7 @@ fn gh_gate_allows_relative_api_endpoint() {
 #[test]
 fn gh_gate_allows_global_command_from_unverifiable_cwd() {
     let temp = tempfile::tempdir().unwrap();
-    let output = Command::new(binary_path())
+    let output = cplt_cmd()
         .arg("gh-gate")
         .arg("--real-gh")
         .arg("/usr/bin/true")
@@ -1570,9 +1513,8 @@ mod sandbox_integration {
 
         // Create a git repo so scope check can detect the remote
         let run_git = |args: &[&str]| {
-            Command::new("git")
+            git_cmd(tmp.path())
                 .args(args)
-                .current_dir(tmp.path())
                 .env("GIT_AUTHOR_NAME", "Test")
                 .env("GIT_AUTHOR_EMAIL", "test@test.com")
                 .env("GIT_COMMITTER_NAME", "Test")
@@ -1803,7 +1745,7 @@ fi
 // config can be approved. Asserting only on the state enum is how the
 // not-a-git-repo case slipped through review.
 mod trust_accept_guard {
-    use super::binary_path;
+    use crate::common::cplt_cmd;
     use std::path::Path;
     use std::process::Command;
 
@@ -1835,7 +1777,7 @@ mod trust_accept_guard {
     /// `cplt trust accept --all` in `dir`, with the trust store redirected out
     /// of the developer's real `~/.config/cplt`. Returns (combined output, ok).
     fn trust_accept_all(dir: &Path, store: &Path) -> (String, bool) {
-        let out = Command::new(binary_path())
+        let out = cplt_cmd()
             .args(["trust", "accept", "--all"])
             .current_dir(dir)
             .env("CPLT_CONFIG", store.join("config.toml"))

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -23,7 +23,7 @@
 use std::process::Command;
 
 mod common;
-use common::{binary_in_path, binary_path, cplt_cmd, git_cmd, temp_repo};
+use common::{binary_in_path, cplt_cmd, temp_repo};
 
 /// Run `cplt gh-gate` with default block policy.
 /// Returns (stdout, stderr, exit_success).
@@ -1454,6 +1454,8 @@ fn git_gate_protect_default_blocks_multi_refspec_with_main() {
 
 #[cfg(target_os = "macos")]
 mod sandbox_integration {
+    use crate::common::{binary_path, git_cmd};
+
     use super::*;
     use std::fs;
 

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -11,12 +11,16 @@
 //!
 //! Run: cargo test --test e2e_projects
 
+mod common;
+
 #[cfg(target_os = "macos")]
 mod project_tests {
     use std::fmt::Write as _;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
+
+    use crate::common::{cplt_cmd, git_cmd};
     use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 
     static PROJECT_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -58,10 +62,6 @@ mod project_tests {
                 return;
             }
         };
-    }
-
-    fn binary_path() -> PathBuf {
-        PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
     }
 
     // ── TempProject ────────────────────────────────────────────────
@@ -112,9 +112,8 @@ mod project_tests {
         /// Initialize a git repo with an initial commit.
         fn git_init(&self) {
             let run = |args: &[&str]| {
-                Command::new("git")
+                git_cmd(self.dir.path())
                     .args(args)
-                    .current_dir(self.dir.path())
                     .env("GIT_AUTHOR_NAME", "Test")
                     .env("GIT_AUTHOR_EMAIL", "test@example.com")
                     .env("GIT_COMMITTER_NAME", "Test")
@@ -328,7 +327,7 @@ fun main() {
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_copilot_dir.display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate"])
             .args(["--project-dir", &project.canonical_path().to_string_lossy()])
             // Explicit so the test's intended fake "copilot" can't be silently
@@ -1011,9 +1010,8 @@ fi
         require_sandbox!();
         let project = TempProject::scaffold_node();
         let bare = TempProject::new("bare");
-        let status = Command::new("git")
+        let status = git_cmd(bare.path())
             .args(["init", "--bare", "--quiet"])
-            .current_dir(bare.path())
             .status()
             .expect("git init --bare");
         assert!(status.success(), "git init --bare should succeed");
@@ -1224,7 +1222,7 @@ allow_env_files = true
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate"])
             .args(["--project-dir", &project.canonical_path().to_string_lossy()])
             .args(["--", "--version"])
@@ -1343,7 +1341,7 @@ if [ "${GIT_TERMINAL_PROMPT:-}" = "0" ]; then echo "RESULT:env_hardening_git:OK"
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate"])
             .args(["--project-dir", &project.canonical_path().to_string_lossy()])
             .args(["--agent", "copilot"])
@@ -2555,7 +2553,7 @@ if [ -n "${CLASSPATH:-}" ]; then echo "RESULT:env_classpath:OK"; else echo "RESU
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate"])
             .args(["--project-dir", &project.canonical_path().to_string_lossy()])
             .args(["--agent", "copilot"])
@@ -2772,7 +2770,7 @@ esac
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{current_path}", fake_dir.display());
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--yes", "--no-validate"])
             .args(["--project-dir", &project.canonical_path().to_string_lossy()])
             .args(["--scratch-dir"])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,8 +3,12 @@
 //! These tests invoke sandbox-exec and verify kernel-level enforcement.
 //! They ONLY run on macOS — skipped on Linux/CI via #[cfg(target_os = "macos")].
 
+mod common;
+
 #[cfg(target_os = "macos")]
 mod macos_tests {
+    use crate::common::{cplt_cmd, git_cmd};
+
     use std::ffi::OsString;
     use std::fs::{self, File};
     use std::io::{Read, Seek, SeekFrom};
@@ -64,10 +68,6 @@ mod macos_tests {
     }
 
     /// Path to the built binary.
-    fn binary_path() -> PathBuf {
-        PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
-    }
-
     fn home_dir() -> PathBuf {
         let home = std::env::var("HOME").unwrap();
         fs::canonicalize(&home).unwrap()
@@ -2536,7 +2536,7 @@ if not owned_ok or sibling_result != 'SIBLING_BLOCKED':
 
     #[test]
     fn binary_shows_help() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--help")
             .output()
             .expect("binary should exist");
@@ -2549,7 +2549,7 @@ if not owned_ok or sibling_result != 'SIBLING_BLOCKED':
 
     #[test]
     fn binary_shows_version() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--version")
             .output()
             .expect("binary should exist");
@@ -2561,7 +2561,14 @@ if not owned_ok or sibling_result != 'SIBLING_BLOCKED':
 
     #[test]
     fn binary_rejects_root_project_dir() {
-        let output = Command::new(binary_path())
+        // Every absolute path is "inside" `/`, so the usual
+        // `CPLT_CONFIG=/dev/null/nonexistent` isolation trips the
+        // config-inside-the-project refusal before the check under test.
+        // Isolate through an empty HOME instead.
+        let home = tempfile::tempdir().unwrap();
+        let output = cplt_cmd()
+            .env_remove("CPLT_CONFIG")
+            .env("HOME", home.path())
             .args(["--project-dir", "/", "--no-validate", "--", "--version"])
             .output()
             .expect("binary should exist");
@@ -2577,7 +2584,7 @@ if not owned_ok or sibling_result != 'SIBLING_BLOCKED':
     #[test]
     fn binary_rejects_home_project_dir() {
         let home = std::env::var("HOME").unwrap();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(["--project-dir", &home, "--no-validate", "--", "--version"])
             .output()
             .expect("binary should exist");
@@ -2814,7 +2821,7 @@ except Exception as e:
         // No require_sandbox!(): `--print-profile` only generates and prints the
         // SBPL text; it never invokes sandbox-exec, so it runs even when nested.
         let project = fs::canonicalize(".").unwrap();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--proxy-forced",
                 "--print-profile",
@@ -2839,14 +2846,13 @@ except Exception as e:
     fn binary_print_profile_does_not_write_agents_md() {
         let dir = tempfile::tempdir().unwrap();
         let project = fs::canonicalize(dir.path()).unwrap();
-        let git_ok = Command::new("git")
-            .args(["init", "--quiet"])
-            .current_dir(&project)
-            .status()
-            .is_ok_and(|s| s.success());
-        if !git_ok {
-            return; // no git on this machine — nothing to assert
-        }
+        assert!(
+            git_cmd(&project)
+                .args(["init", "--quiet"])
+                .status()
+                .is_ok_and(|s| s.success()),
+            "git init should succeed"
+        );
 
         // Outside the project: cplt refuses a CPLT_CONFIG the repo controls
         // (issue #261).
@@ -2854,7 +2860,7 @@ except Exception as e:
         let config = config_home.path().join("cplt-config.toml");
         fs::write(&config, "[sandbox]\nbrief = true\nagents_md = true\n").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--print-profile",
                 "--project-dir",

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -9,8 +9,12 @@
 //! - Network port filtering (ABI v4+)
 //! - seccomp syscall blocking
 
+mod common;
+
 #[cfg(target_os = "linux")]
 mod linux_tests {
+    use crate::common::cplt_cmd;
+
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -82,13 +86,9 @@ mod linux_tests {
     }
 
     /// Path to the built binary.
-    fn binary_path() -> PathBuf {
-        PathBuf::from(env!("CARGO_BIN_EXE_cplt"))
-    }
-
     /// Run a shell command inside the cplt sandbox and return (exit_code, stdout, stderr).
     fn run_sandboxed(project_dir: &Path, script: &str) -> (i32, String, String) {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -131,7 +131,7 @@ mod linux_tests {
         args.extend_from_slice(extra_flags);
         args.extend_from_slice(&["--", "-c", script]);
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(&args)
             .env("HOME", home_dir())
             .output()
@@ -148,7 +148,7 @@ mod linux_tests {
 
     /// Run a shell command inside the sandbox with a custom HOME directory.
     fn run_sandboxed_home(project_dir: &Path, home: &Path, script: &str) -> (i32, String, String) {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -192,7 +192,7 @@ mod linux_tests {
         args.extend_from_slice(extra_flags);
         args.extend_from_slice(&["--", "-c", script]);
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args(&args)
             .env("HOME", home)
             .output()
@@ -265,7 +265,7 @@ mod linux_tests {
         fs::create_dir_all(&ssh_dir).unwrap();
         fs::write(ssh_dir.join("test_key"), "secret").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -427,7 +427,7 @@ mod linux_tests {
         fs::create_dir_all(&ssh_dir).unwrap();
         fs::write(ssh_dir.join("test_key"), "secret_key_data").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -462,7 +462,7 @@ mod linux_tests {
         fs::create_dir_all(&ssh_dir).unwrap();
         fs::write(ssh_dir.join("test_key"), "secret_key_data").unwrap();
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -1090,7 +1090,7 @@ print('CONNECTED')
 
     #[test]
     fn binary_shows_help() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--help")
             .output()
             .expect("Failed to run cplt --help");
@@ -1101,7 +1101,7 @@ print('CONNECTED')
 
     #[test]
     fn binary_shows_version() {
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .arg("--version")
             .output()
             .expect("Failed to run cplt --version");
@@ -1112,7 +1112,7 @@ print('CONNECTED')
     fn binary_print_profile_shows_landlock() {
         require_landlock!();
         let project = create_test_project();
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--print-profile",
                 "--project-dir",
@@ -1156,7 +1156,7 @@ print('CONNECTED')
         require_landlock!();
         let project = create_test_project();
         // Set a dangerous env var and verify it's stripped
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -1205,7 +1205,7 @@ print('CONNECTED')
             exit $fail
         "#;
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -1422,7 +1422,7 @@ print('CONNECTED')
         let project = create_test_project();
 
         // Inject credential-like vars into the cplt parent process env
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",
@@ -1506,7 +1506,7 @@ print('CONNECTED')
         let current_path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{}:{}", bin_dir.display(), current_path);
 
-        let output = Command::new(binary_path())
+        let output = cplt_cmd()
             .args([
                 "--yes",
                 "--no-validate",

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -9658,6 +9658,10 @@ fn repo_config_state_uncommitted_when_gitignored() {
     let status = std::process::Command::new("git")
         .args(["status", "--porcelain", "--", ".cplt.toml"])
         .current_dir(tmp.path())
+        // As in `git_in`: the developer's global config (core.excludesFile,
+        // status.showUntrackedFiles) must not decide what this precondition sees.
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .output()
         .unwrap();
     assert!(

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -3,6 +3,9 @@
 //! These tests verify core logic without invoking sandbox-exec,
 //! so they run on any platform (Linux CI, macOS, etc.).
 
+mod common;
+use common::git_cmd;
+
 use cplt::discover::copilot_pkg_dir;
 use cplt::is_unsafe_root;
 use cplt::proxy::{is_blocked_in_content, is_domain_match, is_private_hostname, is_private_ip};
@@ -9339,15 +9342,12 @@ use cplt::audit::{AuditReport, Baseline};
 /// Run a git command in `dir`, panicking on failure. Uses fixed identity and
 /// disables GPG signing so the test is hermetic.
 fn git_in(dir: &std::path::Path, args: &[&str]) {
-    let status = std::process::Command::new("git")
+    let status = git_cmd(dir)
         .args(args)
-        .current_dir(dir)
         .env("GIT_AUTHOR_NAME", "t")
         .env("GIT_AUTHOR_EMAIL", "t@e.x")
         .env("GIT_COMMITTER_NAME", "t")
         .env("GIT_COMMITTER_EMAIL", "t@e.x")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .output()
         .expect("git runs");
     assert!(status.status.success(), "git {args:?} failed");
@@ -9655,13 +9655,8 @@ fn repo_config_state_uncommitted_when_gitignored() {
     std::fs::write(tmp.path().join(".cplt.toml"), PROPOSE).unwrap();
 
     // Precondition: git status really does report nothing here.
-    let status = std::process::Command::new("git")
+    let status = git_cmd(tmp.path())
         .args(["status", "--porcelain", "--", ".cplt.toml"])
-        .current_dir(tmp.path())
-        // As in `git_in`: the developer's global config (core.excludesFile,
-        // status.showUntrackedFiles) must not decide what this precondition sees.
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .output()
         .unwrap();
     assert!(


### PR DESCRIPTION
Closes #245.

## The audit

Every suite, looking for anything that reads the real `$HOME`, the developer's config, or the checkout's git remote.

| Suite | Binary spawns without `CPLT_CONFIG` | Raw `git` without `GIT_CONFIG_GLOBAL` | cwd = the checkout |
|---|---|---|---|
| `e2e.rs` | 97 of 145 | 19 | `project_dir()` throughout |
| `e2e_guards.rs` | 19 (gates take explicit flags, so config never reached them) | 2 | 2 helpers on `CARGO_MANIFEST_DIR` |
| `e2e_projects.rs` | 5 | 2 | — |
| `integration.rs` | 6 | 1 | `fs::canonicalize(".")` |
| `integration_linux.rs` | 14 | 0 | — |
| `unit_tests.rs` | 0 | 1 | — |
| `e2e_git_hardening.rs` | 0 | 0 (already the good pattern) | — |

`e2e_guards.rs` was described as clean. It is clean on the config axis only by accident: `gh-gate` and `git-gate` take every policy value as an explicit flag and never load a config file, so a hostile config changes nothing there. The two `git-gate` helpers still ran in `CARGO_MANIFEST_DIR`, which is the same cwd dependence the six origin-dependent tests had — inert today because no `allow_push` rule is under test, live the moment one is. They now use `temp_repo("navikt/cplt")`.

Two axes the issue did not name turned out to be larger than the config one:

- **Global git config.** `commit.gpgsign`, `core.hooksPath` and `init.defaultBranch` reach every fixture repo. Only 5 of ~35 `git init`/`git commit` call sites cleared them, and `-c commit.gpgSign=false` was sprinkled at some sites and not others — the whack-a-mole that a helper exists to end.
- **PATH.** `e2e_init_global_empty_home` isolates `HOME` and then asserts "nothing detected", but `cplt init --global` also detects agents from `PATH`. It fails on any machine with an agent CLI installed and passes on CI because CI has none.

## The fix

`tests/common/mod.rs`, shared by all six suites:

- `cplt_cmd()` — the binary with `CPLT_CONFIG=/dev/null/nonexistent`. The idiom from `e2e.rs:102` becomes the default path.
- `cplt_cmd_with_ambient_config()` — the loud opt-out. One caller: the test that is itself about config discovery.
- `git_cmd(dir)` — git with `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`.
- `temp_repo(remote)` — throwaway repo with a known `origin`.
- `binary_path()`, `binary_in_path()` — one definition instead of four.

A test now has to opt out of isolation rather than remember to opt in. The convention is written down in AGENTS.md next to the test-tier table.

## Proof

Each fix demonstrated by making the ambient state hostile first.

**Mutation 1 — a config with `preset = "strict"`, `gh_guard.enabled`, `git_guard.enabled`, `inherit_env`, `allow_localhost_any`, `allow_tmp_exec`, `allow_msbuild`, `scratch_dir = false`** (injected as `CPLT_CONFIG` in the parent environment, which any test that does not set the variable inherits — exactly what reading `~/.config/cplt/config.toml` does):

| | before | after |
|---|---|---|
| `e2e` | 7 failed | 0 failed |
| `integration` | 2 failed | 0 failed |
| others | 0 | 0 |

Among the seven: `e2e_env_strips_cloud_credentials` and `e2e_env_injects_hardening_vars`. A test asserting that cloud credentials do not reach the sandbox was passing only because the machine had not set `inherit_env = true`.

**Mutation 2 — a global git config with `commit.gpgsign = true` against a nonexistent key, `core.hooksPath` pointing at a failing `pre-commit`, and `init.defaultBranch = trunk`:**

| | before | after |
|---|---|---|
| `e2e` | 10 failed | 0 failed |
| `e2e_projects` | 2 failed | 0 failed |

(One `integration` test, `real_profile_allows_git_execution`, fails under this mutation both before and after: the sandbox denies reading the mutation's own config path. That is the harness leaking into the sandboxed child, not an ambient dependency.)

**Mutation 3 — `origin` retargeted to `https://github.com/evil-fork/not-cplt.git`:** all suites green before and after. The six origin-dependent tests were genuinely fixed earlier; the `CARGO_MANIFEST_DIR` cwd in the two `git-gate` helpers is preventive, and this PR does not claim it was live.

## Also fixed

`e2e_trust_accept_all_approves_proposals` failed roughly 4 runs in 5 here. The trust store lives at `<parent of CPLT_CONFIG>/trust/`, keyed on a fingerprint derived from the repo path. Both paths are deterministic, and `make_trust_repo` wiped the repo dir but not the config dir — so a store written by an earlier run made the repo start out *approved*, and "before accept, should be pending" failed. Intermittent because the id in the path depends on how many other tests ran first. Six consecutive green runs after wiping the config dir too.

## The three related issues

- **#220** (`e2e_projects` intermittent) — plausibly closed, not provably. `TempProject::git_init` was one of the unisolated `git commit` sites, so a machine or runner with `commit.gpgsign` or a global `pre-commit` hook would fail it intermittently, which fits the four sightings. The one flake I could actually reproduce and fix was in `e2e.rs`, not `e2e_projects.rs`. Leave #220 open until a run without a sighting is long enough to mean something.
- **#126** (harness hardening) — partially. It removes one silent skip (`binary_print_profile_does_not_write_agents_md` returned early "if git is missing"; `git_cmd` panics in that case anyway) and it removes several vacuous tests. The `require_copilot!` / `require_sandbox!` skip machinery and the untested-enforcement gaps are untouched. Does not close it.
- **#281** (CodeQL `rust/log-injection` on `assert!` messages) — not touched. This PR adds `assert!` messages interpolating fixture paths, so it may add alerts of the same shape. Report them there rather than dismissing them here.

## Unrelated finding: why `cargo test --test e2e` hangs

Reproduced here, in a checkout under `$HOME` (so not the `/tmp` exec-denial). `cargo test --test e2e` ran for 683 s and had to be killed; the same suite finishes in 5 s once the cause is removed.

`sample(1)` on a wedged child:

```
cplt::run_doctor  (main.rs:4297)
  cplt::discover::discover_all
    cplt::discover::discover_agents
      std::process::Command::output
        poll  (libsystem_kernel)
```

`discover_agents` (`src/discover.rs:207-238`) probes each of `copilot`, `opencode`, `antigravity`/`agy`, `claude` with `--version` via `Command::output()`, which blocks until the child closes its pipes. There is no timeout. On a machine where any one of those binaries is on `PATH` and does not exit — `claude --version` invoked from inside a Claude Code session is the case here — every `cplt doctor` invocation hangs forever, and `e2e.rs` has six of them.

This is a product bug, not a test bug: any user with a wedged agent binary on `PATH` gets a `cplt doctor` that never returns. Fixing it means a wait-with-timeout around the probe, which is a behaviour change in a security tool and out of scope for an isolation PR. Worth its own issue. Left as is here.
