### PR TITLE
chore: clear the clippy backlog the newer toolchain flags

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -951,8 +951,7 @@ mod tests {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+            .is_ok_and(|s| s.success());
         if !ok {
             eprintln!("skipping: git unavailable");
             return;

--- a/src/config/editing.rs
+++ b/src/config/editing.rs
@@ -383,9 +383,9 @@ fn create_unique_temp_file(
 #[cfg(unix)]
 fn existing_or_default_mode(path: &Path, default_mode: u32) -> u32 {
     use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(path)
-        .map(|metadata| metadata.permissions().mode() & 0o777)
-        .unwrap_or(default_mode)
+    std::fs::metadata(path).map_or(default_mode, |metadata| {
+        metadata.permissions().mode() & 0o777
+    })
 }
 
 #[cfg(not(unix))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3164,8 +3164,8 @@ fn create_playwright_socket_dir(
     // SBPL rules, so a shorter path of the caller's own would then be denied at
     // bind. Both failures surface deep inside Playwright, so name the cause.
     let inherited_value = std::env::var_os("PWTEST_SOCKETS_DIR")
-        .filter(|value| !value.is_empty())
-        .is_some();
+        .as_ref()
+        .is_some_and(|value| !value.is_empty());
     if intent && caller_owned && !inherited_value {
         ui::warn(
             "PWTEST_SOCKETS_DIR is passed through but has no value, so cplt creates no \
@@ -7071,8 +7071,7 @@ mod copilot_extraction_tests {
         /// How many times the fake copilot was invoked with `--version`.
         fn version_calls(&self) -> usize {
             std::fs::read_to_string(self.root.join("version-calls"))
-                .map(|s| s.lines().count())
-                .unwrap_or(0)
+                .map_or(0, |s| s.lines().count())
         }
 
         /// Path of cplt's fast-path marker for this fixture.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -88,10 +88,10 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// tearing it down at `proxy.timeout` drops live sessions (Claude Code shows
 /// this as a request timeout). Only this ceiling closes an idle tunnel.
 // ponytail: fixed ceiling, make it configurable if anyone needs longer.
-const RELAY_IDLE_TIMEOUT: Duration = Duration::from_secs(3600);
+const RELAY_IDLE_TIMEOUT: Duration = Duration::from_hours(1);
 
 /// Fallback read-poll interval when `proxy.timeout` is 0, which the OS rejects.
-const DEFAULT_PROXY_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_PROXY_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// How often file-backed domain lists are re-read from disk.
 /// Within the TTL window, cached values are returned without I/O.
@@ -1695,10 +1695,7 @@ fn touch(last_activity: &Mutex<Instant>) {
 }
 
 fn idle_for(last_activity: &Mutex<Instant>) -> Duration {
-    last_activity
-        .lock()
-        .map(|t| t.elapsed())
-        .unwrap_or(Duration::ZERO)
+    last_activity.lock().map_or(Duration::ZERO, |t| t.elapsed())
 }
 
 /// Errors that mean "nothing to read right now", not "this tunnel is dead".
@@ -2460,7 +2457,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2489,7 +2486,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2523,7 +2520,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2560,7 +2557,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2603,7 +2600,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2701,7 +2698,7 @@ mod tests {
             config_file: Some(config_path.clone()),
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             resolver: None,
@@ -2798,7 +2795,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             resolver: None,
@@ -2835,7 +2832,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             resolver: None,
@@ -2871,7 +2868,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2918,7 +2915,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             domain_collector: Arc::new(Mutex::new(BTreeMap::new())),
@@ -2945,7 +2942,7 @@ mod tests {
             allow_localhost_any: false,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             resolver: None,
@@ -3651,7 +3648,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             upstream: None,
             upstream_no_proxy: Vec::new(),
             resolver,
@@ -3876,7 +3873,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             resolver: Some(resolver),
             upstream: None,
             upstream_no_proxy: Vec::new(),
@@ -3937,7 +3934,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: ProxyLogLevel::None,
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             resolver: Some(resolver),
             upstream: None,
             upstream_no_proxy: Vec::new(),

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -62,7 +62,7 @@ const LAZY_FETCH_TIMEOUT_SECS: u64 = 5;
 const MAX_FETCH_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Warn about a cache that has not been refreshed in this long.
-const STALE_WARN: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+const STALE_WARN: Duration = Duration::from_hours(720);
 
 /// How often lazily-refreshed subscriptions are re-fetched before a run.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -92,8 +92,8 @@ impl RefreshInterval {
     fn max_age(self) -> Option<Duration> {
         match self {
             Self::Manual => None,
-            Self::Daily => Some(Duration::from_secs(24 * 60 * 60)),
-            Self::Weekly => Some(Duration::from_secs(7 * 24 * 60 * 60)),
+            Self::Daily => Some(Duration::from_hours(24)),
+            Self::Weekly => Some(Duration::from_hours(168)),
         }
     }
 }
@@ -791,12 +791,12 @@ mod tests {
         assert_eq!(o1.len(), 1);
 
         // Shortly after: cache is fresh → not due.
-        let t1 = t0 + Duration::from_secs(60 * 60);
+        let t1 = t0 + Duration::from_hours(1);
         let o2 = refresh_if_stale(&set, &|_| panic!("should not refetch a fresh cache"), t1);
         assert!(o2.is_empty());
 
         // Two days later: cache is stale → due again.
-        let t2 = t0 + Duration::from_secs(2 * 24 * 60 * 60);
+        let t2 = t0 + Duration::from_hours(48);
         let o3 = refresh_if_stale(&set, &|_| Ok(b"a.com\nb.com\n".to_vec()), t2);
         assert_eq!(o3.len(), 1);
         assert_eq!(load_cached_domains(&set), vec!["a.com", "b.com"]);
@@ -826,7 +826,7 @@ mod tests {
         let t0 = UNIX_EPOCH + Duration::from_secs(1_000_000);
         update_all(&set, &|_| Ok(b"a.com\n".to_vec()), t0);
         // 40 days later.
-        let later = t0 + Duration::from_secs(40 * 24 * 60 * 60);
+        let later = t0 + Duration::from_hours(960);
         let warns = staleness_warnings(&set, later);
         assert_eq!(warns.len(), 1);
         assert!(warns[0].contains("days old"));

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -32,8 +32,7 @@ mod e2e_tests {
         Command::new("which")
             .arg("copilot")
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     /// Check if sandbox-exec can apply a trivial profile.
@@ -42,8 +41,7 @@ mod e2e_tests {
         Command::new("sandbox-exec")
             .args(["-p", "(version 1)(allow default)", "/usr/bin/true"])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -1463,8 +1463,7 @@ mod sandbox_integration {
         Command::new("sandbox-exec")
             .args(["-p", "(version 1)(allow default)", "/usr/bin/true"])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -37,8 +37,7 @@ mod project_tests {
         Command::new("sandbox-exec")
             .args(["-p", "(version 1)(allow default)", "/usr/bin/true"])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox
@@ -1621,16 +1620,14 @@ echo "RESULT:sent:OK"
         Command::new("gradle")
             .arg("--version")
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     fn go_available() -> bool {
         Command::new("go")
             .arg("version")
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     /// Go build to a project-local path works without --scratch-dir.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,8 +34,7 @@ mod macos_tests {
         Command::new("sandbox-exec")
             .args(["-p", "(version 1)(allow default)", "/usr/bin/true"])
             .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok_and(|o| o.status.success())
     }
 
     /// When `CPLT_TEST_REQUIRE_SANDBOX=1` is set (CI), a missing sandbox
@@ -2036,11 +2035,10 @@ mod macos_tests {
         if Command::new("java")
             .arg("-version")
             .output()
-            .map(|o| {
+            .map_or(true, |o| {
                 let stderr = String::from_utf8_lossy(&o.stderr);
                 !o.status.success() || stderr.contains("Unable to locate")
             })
-            .unwrap_or(true)
         {
             eprintln!("SKIP: java not found");
             return;
@@ -2092,11 +2090,10 @@ public class T {
         if Command::new("java")
             .arg("-version")
             .output()
-            .map(|o| {
+            .map_or(true, |o| {
                 let stderr = String::from_utf8_lossy(&o.stderr);
                 !o.status.success() || stderr.contains("Unable to locate")
             })
-            .unwrap_or(true)
         {
             eprintln!("SKIP: java not found");
             return;


### PR DESCRIPTION
CI pins Rust 1.94 and is green. A newer local toolchain reports **28 errors** across `proxy.rs`, `subscriptions.rs`, `config/editing.rs` and `audit.rs`, all pre-existing.

That has a running cost: every agent brief in this repo has had to carry an "ignore the pre-existing clippy errors in these four files" instruction. Beyond the friction, a standing exception is a good place for a real finding to hide — nobody reads past the noise to check whether error 29 is new.

It also removes a cliff. The day CI bumps its toolchain, all 28 become failures at once, on whichever PR happens to be open.

## What changed

Two lints, both mechanical:

- `Duration` constructed from a smaller unit than needed. `Duration::from_secs(3600)` becomes `Duration::from_hours(1)`.
- `map(f).unwrap_or(x)` where `map_or(x, f)` says the same thing in one call.

Applied with `cargo clippy --fix` and then read through rather than taken on trust. `from_mins` and `from_hours` both predate 1.94, so this does not move the toolchain floor.

## Verified

`cargo clippy --all-targets -- -D warnings` reports 0 on the newer toolchain, down from 28. `cargo test --lib` 872, `cargo test --test unit_tests` 318, `cargo fmt` clean. No behaviour change: every edit is a rewrite of the same value or the same control flow.