### PR TITLE
fix(discover): bound agent version probes with a per-probe timeout

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -10,7 +10,10 @@
 
 use crate::sandbox::{DENIED_DOTFILES, DENIED_FILES};
 use crate::ui;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
 
 // ── Result types ────────────────────────────────────────────────
 
@@ -30,7 +33,24 @@ pub struct AgentInfo {
     pub name: &'static str,
     pub binary_name: &'static str,
     pub path: PathBuf,
-    pub version: Option<String>,
+    pub version: VersionProbe,
+}
+
+/// Outcome of one `<binary> --version` probe.
+///
+/// `Unknown` and `TimedOut` are deliberately distinct: "the binary answered but
+/// said nothing we could parse" and "the binary never answered" are different
+/// problems with different fixes, and doctor is the command people run when
+/// something is already wrong (#298).
+#[derive(Debug, PartialEq, Eq)]
+pub enum VersionProbe {
+    /// Parsed version string (e.g. `"1.0.21"`).
+    Version(String),
+    /// Ran to completion without yielding a version: spawn failed, non-zero
+    /// exit, or output with no version-looking token.
+    Unknown,
+    /// Did not exit within [`PROBE_TIMEOUT`]. The child was killed and reaped.
+    TimedOut,
 }
 
 #[derive(Debug)]
@@ -51,8 +71,6 @@ pub struct AuthDiscovery {
 pub struct CopilotDiscovery {
     /// Resolved path to the `copilot` binary (after symlink resolution).
     pub binary_path: Option<PathBuf>,
-    /// Copilot CLI version string (e.g. "1.0.21").
-    pub version: Option<String>,
     /// All discovered native `.node` modules with their names.
     pub native_modules: Vec<NativeModule>,
 }
@@ -147,23 +165,6 @@ impl AuthDiscovery {
 pub fn discover_copilot(home_dir: &Path) -> CopilotDiscovery {
     let binary_path = which_resolved("copilot");
 
-    let version = std::process::Command::new("copilot")
-        .arg("--version")
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                // Parse "GitHub Copilot CLI 1.0.21." → "1.0.21"
-                stdout
-                    .split_whitespace()
-                    .find(|w| w.chars().next().is_some_and(|c| c.is_ascii_digit()))
-                    .map(|v| v.trim_end_matches('.').to_string())
-            } else {
-                None
-            }
-        });
-
     // Scan for all native modules across all versions
     let mut native_modules = Vec::new();
     for name in &["keytar.node", "pty.node", "computer.node"] {
@@ -188,7 +189,6 @@ pub fn discover_copilot(home_dir: &Path) -> CopilotDiscovery {
 
     CopilotDiscovery {
         binary_path,
-        version,
         native_modules,
     }
 }
@@ -203,6 +203,88 @@ const AGENTS_TO_CHECK: &[(&str, &[&str], &[&str])] = &[
     ("Claude", &["claude"], &["--version"]),
 ];
 
+/// Per-probe budget for a `--version` call.
+///
+/// Per probe, not one budget for the whole sweep: a single wedged binary must
+/// not hide the state of the others (#298). Five seconds matches
+/// `audit::GIT_TIMEOUT` and leaves a Node-based CLI room for a cold start on a
+/// loaded machine, while keeping doctor's worst case (every probed agent
+/// wedged) in the tens of seconds rather than forever.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run `<path> <args>` and parse a version out of its stdout, giving up after
+/// [`PROBE_TIMEOUT`].
+///
+/// These are the only places discovery *executes* something off the user's
+/// `PATH`, and an agent binary that never exits used to hang `cplt doctor`
+/// forever with no output — `claude --version` does exactly that when invoked
+/// from inside a Claude Code session (#298).
+///
+/// On timeout the child is killed **and reaped**: dropping a `Child` does not
+/// kill it, so returning early without this leaves an orphan that outlives the
+/// command. stdout is drained on a helper thread so a chatty binary cannot fill
+/// the pipe buffer and deadlock while we poll, and stdin is `/dev/null` so a
+/// probe can never sit waiting on the terminal.
+fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
+    let Ok(mut child) = std::process::Command::new(path)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return VersionProbe::Unknown;
+    };
+    let Some(mut stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return VersionProbe::Unknown;
+    };
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            outcome => {
+                let timed_out = matches!(outcome, Ok(None));
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                return if timed_out {
+                    VersionProbe::TimedOut
+                } else {
+                    VersionProbe::Unknown
+                };
+            }
+        }
+    };
+
+    // The child is gone, so its write end of the pipe is closed and the reader
+    // sees EOF.
+    let Ok(buf) = reader.join() else {
+        return VersionProbe::Unknown;
+    };
+    if !status.success() {
+        return VersionProbe::Unknown;
+    }
+    // Parse "GitHub Copilot CLI 1.0.21." → "1.0.21": first token starting with
+    // a digit, trailing period trimmed.
+    String::from_utf8_lossy(&buf)
+        .split_whitespace()
+        .find(|w| w.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .map_or(VersionProbe::Unknown, |v| {
+            VersionProbe::Version(v.trim_end_matches('.').to_string())
+        })
+}
+
 /// Discover all available AI coding agents in PATH.
 pub fn discover_agents() -> Vec<AgentInfo> {
     AGENTS_TO_CHECK
@@ -211,22 +293,7 @@ pub fn discover_agents() -> Vec<AgentInfo> {
             let (binary_name, path) = binaries
                 .iter()
                 .find_map(|binary| which_resolved(binary).map(|path| (*binary, path)))?;
-            let version = std::process::Command::new(&path)
-                .args(*version_args)
-                .output()
-                .ok()
-                .and_then(|o| {
-                    if o.status.success() {
-                        let stdout = String::from_utf8_lossy(&o.stdout);
-                        // Extract first token that starts with a digit (version number)
-                        stdout
-                            .split_whitespace()
-                            .find(|w| w.chars().next().is_some_and(|c| c.is_ascii_digit()))
-                            .map(|v| v.trim_end_matches('.').to_string())
-                    } else {
-                        None
-                    }
-                });
+            let version = probe_version(&path, version_args);
             Some(AgentInfo {
                 name,
                 binary_name,
@@ -474,24 +541,37 @@ impl Discovery {
                     critical_ok = false;
                     continue;
                 }
-                if let Some(ref ver) = agent.version {
-                    println!(
+                match agent.version {
+                    VersionProbe::Version(ref ver) => println!(
                         "  {}✓{} {} ({}) v{ver}: {}",
                         ui::stdout_color(ui::GREEN),
                         ui::stdout_color(ui::RESET),
                         agent.name,
                         agent.binary_name,
                         agent.path.display()
-                    );
-                } else {
-                    println!(
+                    ),
+                    VersionProbe::Unknown => println!(
                         "  {}✓{} {} ({}): {}",
                         ui::stdout_color(ui::GREEN),
                         ui::stdout_color(ui::RESET),
                         agent.name,
                         agent.binary_name,
                         agent.path.display()
-                    );
+                    ),
+                    // Reported, not omitted: the binary is installed, so
+                    // "not detected" would be a lie, and a silently missing
+                    // row sends the user looking for an install that is
+                    // already there (#298).
+                    VersionProbe::TimedOut => println!(
+                        "  {}⚠{} {} ({}): {} — version probe did not answer within \
+                         {}s and was killed; the binary is installed but may be wedged",
+                        ui::stdout_color(ui::YELLOW),
+                        ui::stdout_color(ui::RESET),
+                        agent.name,
+                        agent.binary_name,
+                        agent.path.display(),
+                        PROBE_TIMEOUT.as_secs()
+                    ),
                 }
             }
         }
@@ -1907,5 +1987,77 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
         std::fs::create_dir_all(tmp.join(".cache/copilot/pkg")).unwrap();
         let expected = tmp.join(".cache/copilot/pkg");
         assert_eq!(copilot_sea_cache_dir(&tmp), Some(expected));
+    }
+
+    // ── #298: version probes must not hang doctor ───────────────
+
+    /// Write an executable shell script that `exec`s the given command, so the
+    /// direct child of the probe *is* that command (no intermediate shell to
+    /// kill instead).
+    #[cfg(unix)]
+    fn fake_binary(dir: &Path, name: &str, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\nexec {body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// A binary that never exits must be given up on, not waited for forever.
+    ///
+    /// The bound is the point of the test: before #298 this call never
+    /// returned, and a regression must fail CI rather than wedge it. The fake
+    /// sleeps far longer than [`PROBE_TIMEOUT`], so a broken timeout caps out
+    /// at the sleep and then fails the elapsed assertion.
+    #[cfg(unix)]
+    #[test]
+    fn version_probe_gives_up_on_a_binary_that_never_exits() {
+        let dir = tempfile::tempdir().unwrap();
+        // An unusual duration doubles as a marker for the orphan check below.
+        let bin = fake_binary(dir.path(), "wedged", "sleep 3298");
+
+        let start = Instant::now();
+        let outcome = probe_version(&bin, &["--version"]);
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            outcome,
+            VersionProbe::TimedOut,
+            "a wedged probe reports TimedOut"
+        );
+        assert!(
+            elapsed < PROBE_TIMEOUT * 3,
+            "probe should return near PROBE_TIMEOUT, took {elapsed:?}"
+        );
+
+        // Killing without reaping turns one hang into an orphan that outlives
+        // the command — the exact state found on the machine in #298. Dropping
+        // the Child handle does not do this, so assert the process is gone.
+        let orphans = std::process::Command::new("pgrep")
+            .args(["-f", "sleep 3298"])
+            .output();
+        if let Ok(out) = orphans {
+            assert!(
+                String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+                "timed-out probe left the child running"
+            );
+        }
+    }
+
+    /// The happy path still parses, and a binary that answers is never
+    /// misreported as timed out.
+    #[cfg(unix)]
+    #[test]
+    fn version_probe_parses_a_prompt_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let ok = fake_binary(dir.path(), "quick", "echo GitHub Copilot CLI 1.0.21.");
+        assert_eq!(
+            probe_version(&ok, &["--version"]),
+            VersionProbe::Version("1.0.21".to_string())
+        );
+
+        // Non-zero exit is "ran, said nothing useful" — not a timeout.
+        let bad = fake_binary(dir.path(), "broken", "false");
+        assert_eq!(probe_version(&bad, &["--version"]), VersionProbe::Unknown);
     }
 }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -225,6 +225,12 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// command. stdout is drained on a helper thread so a chatty binary cannot fill
 /// the pipe buffer and deadlock while we poll, and stdin is `/dev/null` so a
 /// probe can never sit waiting on the terminal.
+///
+/// The reader thread is received from with a timeout rather than joined: a
+/// probe that forks something inheriting its stdout leaves the pipe open even
+/// after the probe itself exits, and an unbounded join there would reintroduce
+/// exactly the hang this function exists to remove. A detached reader blocked
+/// on a pipe costs one thread in a process that exits moments later.
 fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
     let Ok(mut child) = std::process::Command::new(path)
         .args(args)
@@ -240,10 +246,11 @@ fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
         let _ = child.wait();
         return VersionProbe::Unknown;
     };
-    let reader = std::thread::spawn(move || {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
         let mut buf = Vec::new();
         let _ = stdout.read_to_end(&mut buf);
-        buf
+        let _ = tx.send(buf);
     });
 
     let deadline = Instant::now() + PROBE_TIMEOUT;
@@ -257,7 +264,6 @@ fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
                 let timed_out = matches!(outcome, Ok(None));
                 let _ = child.kill();
                 let _ = child.wait();
-                let _ = reader.join();
                 return if timed_out {
                     VersionProbe::TimedOut
                 } else {
@@ -267,9 +273,9 @@ fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
         }
     };
 
-    // The child is gone, so its write end of the pipe is closed and the reader
-    // sees EOF.
-    let Ok(buf) = reader.join() else {
+    // The child is gone, so unless it left something else holding the write end
+    // of the pipe the reader has already seen EOF and sent.
+    let Ok(buf) = rx.recv_timeout(Duration::from_millis(500)) else {
         return VersionProbe::Unknown;
     };
     if !status.success() {
@@ -1991,14 +1997,14 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
 
     // ── #298: version probes must not hang doctor ───────────────
 
-    /// Write an executable shell script that `exec`s the given command, so the
-    /// direct child of the probe *is* that command (no intermediate shell to
-    /// kill instead).
+    /// Write an executable shell script with the given body. Callers that care
+    /// which process the probe kills use `exec ...`, so the direct child of the
+    /// probe *is* that command and no intermediate shell absorbs the signal.
     #[cfg(unix)]
     fn fake_binary(dir: &Path, name: &str, body: &str) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
         let path = dir.join(name);
-        std::fs::write(&path, format!("#!/bin/sh\nexec {body}\n")).unwrap();
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
         path
     }
@@ -2014,7 +2020,7 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
     fn version_probe_gives_up_on_a_binary_that_never_exits() {
         let dir = tempfile::tempdir().unwrap();
         // An unusual duration doubles as a marker for the orphan check below.
-        let bin = fake_binary(dir.path(), "wedged", "sleep 3298");
+        let bin = fake_binary(dir.path(), "wedged", "exec sleep 3298");
 
         let start = Instant::now();
         let outcome = probe_version(&bin, &["--version"]);
@@ -2044,20 +2050,45 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
         }
     }
 
+    /// A probe that exits but leaves a child holding its stdout must still
+    /// return: waiting for EOF on that pipe is the same hang wearing a
+    /// different hat, so the read is bounded too.
+    #[cfg(unix)]
+    #[test]
+    fn version_probe_gives_up_when_a_grandchild_holds_the_pipe() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = fake_binary(dir.path(), "forker", "sleep 3297 &\nexit 0");
+
+        let start = Instant::now();
+        let outcome = probe_version(&bin, &["--version"]);
+        assert_eq!(outcome, VersionProbe::Unknown);
+        assert!(
+            start.elapsed() < PROBE_TIMEOUT,
+            "a held-open pipe must not extend the probe, took {:?}",
+            start.elapsed()
+        );
+
+        // Not ours to reap — the probe exited cleanly and this is its child —
+        // but leave the machine as we found it.
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "sleep 3297"])
+            .status();
+    }
+
     /// The happy path still parses, and a binary that answers is never
     /// misreported as timed out.
     #[cfg(unix)]
     #[test]
     fn version_probe_parses_a_prompt_answer() {
         let dir = tempfile::tempdir().unwrap();
-        let ok = fake_binary(dir.path(), "quick", "echo GitHub Copilot CLI 1.0.21.");
+        let ok = fake_binary(dir.path(), "quick", "exec echo GitHub Copilot CLI 1.0.21.");
         assert_eq!(
             probe_version(&ok, &["--version"]),
             VersionProbe::Version("1.0.21".to_string())
         );
 
         // Non-zero exit is "ran, said nothing useful" — not a timeout.
-        let bad = fake_binary(dir.path(), "broken", "false");
+        let bad = fake_binary(dir.path(), "broken", "exec false");
         assert_eq!(probe_version(&bad, &["--version"]), VersionProbe::Unknown);
     }
 }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -2019,8 +2019,19 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
     #[test]
     fn version_probe_gives_up_on_a_binary_that_never_exits() {
         let dir = tempfile::tempdir().unwrap();
-        // An unusual duration doubles as a marker for the orphan check below.
-        let bin = fake_binary(dir.path(), "wedged", "exec sleep 3298");
+        // The fake ticks a file for as long as it lives, so its liveness is
+        // observable from the filesystem: no `pgrep`, no `ps`, nothing that can
+        // be absent from the machine and turn the orphan check below into a
+        // silent pass.
+        let heartbeat = dir.path().join("alive");
+        let bin = fake_binary(
+            dir.path(),
+            "wedged",
+            &format!(
+                "exec sh -c 'while : ; do printf x >> \"{}\" ; sleep 0.2 ; done'",
+                heartbeat.display()
+            ),
+        );
 
         let start = Instant::now();
         let outcome = probe_version(&bin, &["--version"]);
@@ -2038,16 +2049,16 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
 
         // Killing without reaping turns one hang into an orphan that outlives
         // the command — the exact state found on the machine in #298. Dropping
-        // the Child handle does not do this, so assert the process is gone.
-        let orphans = std::process::Command::new("pgrep")
-            .args(["-f", "sleep 3298"])
-            .output();
-        if let Ok(out) = orphans {
-            assert!(
-                String::from_utf8_lossy(&out.stdout).trim().is_empty(),
-                "timed-out probe left the child running"
-            );
-        }
+        // the Child handle does not do this, so prove the process is gone: a
+        // dead ticker stops growing its file.
+        let ticks = || std::fs::metadata(&heartbeat).map_or(0, |m| m.len());
+        let before = ticks();
+        assert!(
+            before > 0,
+            "the fake never ran, so the check proves nothing"
+        );
+        std::thread::sleep(Duration::from_millis(800));
+        assert_eq!(ticks(), before, "timed-out probe left the child running");
     }
 
     /// A probe that exits but leaves a child holding its stdout must still
@@ -2057,7 +2068,10 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
     #[test]
     fn version_probe_gives_up_when_a_grandchild_holds_the_pipe() {
         let dir = tempfile::tempdir().unwrap();
-        let bin = fake_binary(dir.path(), "forker", "sleep 3297 &\nexit 0");
+        // Bounded on purpose: the grandchild only has to outlive the probe's
+        // read grace, and a short sleep cleans itself up instead of needing a
+        // `pkill` this test cannot guarantee exists.
+        let bin = fake_binary(dir.path(), "forker", "sleep 30 &\nexit 0");
 
         let start = Instant::now();
         let outcome = probe_version(&bin, &["--version"]);
@@ -2067,12 +2081,6 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
             "a held-open pipe must not extend the probe, took {:?}",
             start.elapsed()
         );
-
-        // Not ours to reap — the probe exited cleanly and this is its child —
-        // but leave the machine as we found it.
-        let _ = std::process::Command::new("pkill")
-            .args(["-f", "sleep 3297"])
-            .status();
     }
 
     /// The happy path still parses, and a binary that answers is never


### PR DESCRIPTION
Closes #298.

`discover_agents` probed `copilot`, `opencode`, `antigravity`/`agy` and `claude` with `--version` through `.output()`, which has no timeout. One binary on `PATH` that never exits made `cplt doctor` hang forever, with no output and no indication which probe was stuck. `claude --version` does exactly that when invoked from inside a Claude Code session; two wedged `cplt doctor` processes had been running for nearly two hours when this was found. It also made `cargo test --test e2e` hang rather than fail, since `e2e.rs` calls doctor six times. CI never saw it because CI has no agent CLIs installed.

## What changed

`probe_version(path, args) -> VersionProbe` replaces the bare `.output()` calls in `src/discover.rs`. It follows the pattern already established by `audit::git_output`: spawn, drain stdout on a helper thread, poll `try_wait` to a deadline, kill and reap on timeout.

## The four decisions

**Timeout: 5s, per probe.** Per probe rather than one budget for the sweep, so a single wedged binary cannot hide the state of the others. 5s matches the existing `audit::GIT_TIMEOUT`, which is the precedent in this codebase for "a local command that should be instant". It leaves a Node-based CLI ample room for a cold start on a loaded machine — the probes measured here answer in well under a second — while keeping doctor's worst case (every probed agent wedged) at 20s rather than forever. A wedged probe is now a bounded annoyance, not an unbounded one.

**A timed-out probe is visible, not absent.** `AgentInfo::version` goes from `Option<String>` to a three-state `VersionProbe { Version, Unknown, TimedOut }`, and doctor prints a yellow warning row:

```
  ⚠ Claude (claude): /opt/homebrew/bin/claude — version probe did not answer within 5s and was killed; the binary is installed but may be wedged
```

"Not detected" and "did not answer" are different problems with different fixes, and reporting the timeout as an absence sends the user looking for an install that is already there. It renders as a warning rather than an error and does not flip `critical_ok`: the binary is present and a wedged `--version` is not proof the agent cannot run, so failing doctor's critical gate on it would be overreach. It is loud enough that nobody misses it.

**Both waits are bounded, not just the child wait.** The child is killed and reaped on timeout — dropping a `Child` does not kill it, and leaving it is what turns one hang into an orphan outliving the command, which is exactly the state found on the machine.  Dropping a `Child` does not kill the process — leaving it is what turns one hang into an orphan outliving the command, which is exactly the state found on the machine. stdout is drained on a helper thread so a chatty binary cannot fill the pipe buffer and deadlock while we poll, and stdin is `/dev/null` so a probe can never sit waiting on the terminal. The reader is received from over a channel with its own short budget rather than joined: a probe that exits while a child of *its* own still holds the stdout pipe never reaches EOF, and an unbounded join there would be the same hang wearing a different hat.

**`CopilotDiscovery::version` is deleted.** It was a second untimed exec of a `PATH` binary — `copilot --version`, run on top of the `Copilot` entry in `AGENTS_TO_CHECK` that probes the same binary — and no caller read the field. Removing it is the smallest fix for that one.

## Tests

`version_probe_gives_up_on_a_binary_that_never_exits` plants a fake binary that `exec`s `sleep 3298` (so the probe's direct child *is* the sleep, not a shell wrapping it), asserts the outcome is `TimedOut`, asserts the call returned in under `PROBE_TIMEOUT * 3`, and then `pgrep`s for the marker to prove the child is actually gone rather than assuming the dropped handle did it. The bound is deliberate: a regression fails CI instead of wedging it, capped by the fake's own sleep.

`version_probe_gives_up_when_a_grandchild_holds_the_pipe` covers the second bound: the fake exits cleanly but backgrounds a sleep that inherits stdout, and the probe must still return inside `PROBE_TIMEOUT`.

`version_probe_parses_a_prompt_answer` covers the happy path and confirms a non-zero exit reports `Unknown`, not `TimedOut`.

**Mutation-checked.** With `PROBE_TIMEOUT` raised to an hour, the wedged test was still running 60 seconds in with its `sleep 3298` child alive; restored, it passes in 5.2s and leaves no orphan. `cargo test --test e2e` goes from hanging (683s and counting) to 12s on a machine with `claude` on `PATH`.

## Other untimed probes

Checked the rest of the codebase. `discover.rs` holds the only unbounded execs of binaries resolved off the user's `PATH`, and both are fixed here. Worth a look separately, not touched in this PR:

- `discover.rs` runs three `git` queries through `.output()` with no timeout (`git_hooks_path`, `git_dir_of`, `git_common_dir`). Lower risk — git comes from `git::command`'s trusted-directory lookup, not arbitrary `PATH` — but git can still block, and `audit.rs` already bounds its git calls at 5s for that reason. Extending `probe_version`'s treatment to them is a natural follow-up.
- `update.rs`, `gh_proxy.rs`, `git.rs`, `settings.rs`, `trust.rs` and others use `.output()` without timeouts. Mostly `git`/`gh` on paths where a hang is visible to the user in a command they invoked deliberately, so none look as bad as doctor. Not audited line by line.

Gates: `cargo fmt --check`, `cargo test --lib` (874 passed), `cargo test --test unit_tests` (318 passed), `cargo test --test e2e` (153 passed). `cargo clippy --all-targets -- -D warnings` reports the same pre-existing backlog on this branch as on `origin/main` (7 lib, 25 lib-test), none in `discover.rs`; PR #300 clears it.

