### PR TITLE
refactor(config): resolve every boolean key through one registry-driven ladder

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -103,21 +103,19 @@ impl Config {
         // safety features on.
         let baseline = preset.unwrap_or(Preset::Standard).baseline();
 
-        // Proxy: FeatureToggle resolves --with-proxy/--no-proxy against config default (true).
-        let with_proxy = cli.proxy.resolve(self.proxy.enabled.unwrap_or(true));
+        // Every boolean setting, resolved by the registry-driven ladder in
+        // `registry.rs` (CLI flag > config > preset baseline > default). The
+        // ladder is written once, there; nothing below re-implements it.
+        let bools = super::registry::ResolvedBools::resolve(&cli, self, baseline);
 
-        // Proxy-forced: FeatureToggle resolves --proxy-forced/--no-proxy-forced,
-        // then the explicit config value, then the preset baseline (false unless
-        // `strict`). Precedence: CLI flag > config > preset > default(off) —
-        // mirrors the toggle pattern, with the preset threaded in as the lowest
-        // layer. When true, the proxy is mandatory and kernel egress is locked
-        // to the proxy port (#53). Orchestration in main.rs enforces proxy-on +
-        // fail-closed; the conflict with an explicitly disabled proxy is
-        // reported there (so `--preset strict` with proxy.enabled=false fails
-        // closed rather than silently).
-        let proxy_forced = cli
-            .proxy_forced
-            .resolve(self.proxy.forced.unwrap_or(baseline.proxy_forced));
+        let with_proxy = bools.with_proxy;
+
+        // Forced-proxy egress (#53): when true the proxy is mandatory and kernel
+        // egress is locked to the proxy port. Orchestration in main.rs enforces
+        // proxy-on + fail-closed; the conflict with an explicitly disabled proxy
+        // is reported there, so `--preset strict` with `proxy.enabled = false`
+        // fails closed rather than silently.
+        let proxy_forced = bools.proxy_forced;
 
         // Port: CLI (if provided) > config > 0 (OS-assigned ephemeral port)
         let proxy_port = cli.proxy_port.or(self.proxy.port).unwrap_or(0);
@@ -132,25 +130,13 @@ impl Config {
             .allowed_domains
             .or_else(|| self.proxy.allowed_domains.as_ref().map(|s| expand_tilde(s)));
 
-        // Fail-closed networking opt-in (#52). `cli.default_allowlist` is a
-        // FeatureToggle where `--default-allowlist` is the ON side and
-        // `--allow-all-domains` is the OFF side (off wins), resolved against the
-        // explicit `proxy.default_allowlist` config, then the preset baseline
-        // (true only for `strict`, false otherwise). Precedence: CLI flag /
-        // `--allow-all-domains` escape hatch > config > preset > default(off) —
-        // mirrors `proxy_forced`, with the preset threaded in as the lowest
-        // layer. So `--preset strict` fails closed to the domain allowlist,
-        // while an explicit `--allow-all-domains` (OFF wins) or
-        // `proxy.default_allowlist = false` still overrides strict's baseline.
+        // Fail-closed networking opt-in (#52). The CLI layer is a pair:
+        // `--default-allowlist` is the ON side and `--allow-all-domains` the OFF
+        // side (off wins), assembled into the `FeatureToggle` in main.rs.
         // `--allow-all-domains` additionally forces allow-all: main.rs uses
         // `allow_all_domains` to clear any explicit `allowed_domains` file for
-        // the run. With no preset the baseline is Standard (false), so this
-        // resolves exactly as before — no regression.
-        let default_allowlist = cli.default_allowlist.resolve(
-            self.proxy
-                .default_allowlist
-                .unwrap_or(baseline.default_allowlist),
-        );
+        // the run.
+        let default_allowlist = bools.default_allowlist;
         let allow_all_domains = cli.allow_all_domains;
 
         // Proxy log file: CLI > config
@@ -351,12 +337,9 @@ impl Config {
         }
         deny_paths.extend(cli.deny_paths);
 
-        // Validate: --no-validate wins, then config, then true (validate by default)
-        let no_validate = if cli.no_validate {
-            true
-        } else {
-            !self.sandbox.validate.unwrap_or(true)
-        };
+        // Validation is stored inverted: the registry key is `sandbox.validate`
+        // (default on), `Resolved` carries `no_validate`.
+        let no_validate = !bools.validate;
 
         // Brief: off unless asked for. `--brief` turns it on for one run,
         // `sandbox.brief = true` for good. cplt writing files an agent then
@@ -365,23 +348,14 @@ impl Config {
         // `--no-brief` is the way back out for one run: without it, config-on
         // could only be undone by editing the config, which is no use in a
         // shared repo or a CI job. Flag beats config in both directions.
-        let brief = cli.brief.resolve(self.sandbox.brief.unwrap_or(false));
+        let brief = bools.brief;
         // AGENTS.md injection additionally writes into the user's repo, so it
         // is a second opt-in gated on `brief` — with the brief off, the
         // AGENTS.md block can never be written, whichever layer turned the
         // brief off.
-        let agents_md = brief
-            && cli
-                .agents_md
-                .resolve(self.sandbox.agents_md.unwrap_or(false));
+        let agents_md = brief && bools.agents_md;
 
-        // Allow-env-files: explicit CLI flag wins, then explicit config value,
-        // then the preset baseline (false when no preset — deny by default).
-        let allow_env_files = cli
-            .allow_env_files
-            .to_option()
-            .or(self.sandbox.allow_env_files)
-            .unwrap_or(baseline.allow_env_files);
+        let allow_env_files = bools.allow_env_files;
 
         // Allow-ports: merge config + CLI
         let mut allow_ports = self.allow.ports.clone();
@@ -395,13 +369,7 @@ impl Config {
         allow_localhost.sort_unstable();
         allow_localhost.dedup();
 
-        // Allow-localhost-any: explicit CLI flag wins, then explicit config
-        // value, then the preset baseline (false when no preset).
-        let allow_localhost_any = cli
-            .allow_localhost_any
-            .to_option()
-            .or(self.sandbox.allow_localhost_any)
-            .unwrap_or(baseline.allow_localhost_any);
+        let allow_localhost_any = bools.allow_localhost_any;
 
         // Pass-env: merge config + CLI
         let mut pass_env = self.sandbox.pass_env.clone();
@@ -409,65 +377,27 @@ impl Config {
         pass_env.sort_unstable();
         pass_env.dedup();
 
-        // Inherit-env: CLI flag wins, then config, then false (secure by default)
-        let inherit_env = if cli.inherit_env {
-            true
-        } else {
-            self.sandbox.inherit_env.unwrap_or(false)
-        };
+        let inherit_env = bools.inherit_env;
 
-        // Allow-lifecycle-scripts: explicit CLI flag wins, then explicit config
-        // value, then the preset baseline (false when no preset — blocked).
-        let allow_lifecycle_scripts = cli
-            .allow_lifecycle_scripts
-            .to_option()
-            .or(self.sandbox.allow_lifecycle_scripts)
-            .unwrap_or(baseline.allow_lifecycle_scripts);
+        let allow_lifecycle_scripts = bools.allow_lifecycle_scripts;
 
-        // Allow-gpg-signing: CLI flag wins, then config, then false (blocked by default)
-        let allow_gpg_signing = if cli.allow_gpg_signing {
-            true
-        } else {
-            self.sandbox.allow_gpg_signing.unwrap_or(false)
-        };
+        let allow_gpg_signing = bools.allow_gpg_signing;
 
         // Deny-clipboard: CLI-only tightening flag (defaults to false).
         let deny_clipboard = cli.deny_clipboard;
 
-        // Allow-jvm-attach: CLI flag wins, then config, then false (blocked by default)
-        let allow_jvm_attach = if cli.allow_jvm_attach {
-            true
-        } else {
-            self.sandbox.allow_jvm_attach.unwrap_or(false)
-        };
+        let allow_jvm_attach = bools.allow_jvm_attach;
 
-        // Allow-msbuild: CLI flag wins, then config, then false (blocked by default)
-        let allow_msbuild = if cli.allow_msbuild {
-            true
-        } else {
-            self.sandbox.allow_msbuild.unwrap_or(false)
-        };
+        let allow_msbuild = bools.allow_msbuild;
 
-        // Gradle init script: config-only opt-in (default false). Writes a
-        // cplt-managed file into the Gradle user home — behavior change the
-        // user must explicitly ask for.
-        let gradle_init = self.sandbox.gradle_init.unwrap_or(false);
+        // Config-only opt-in: writes a cplt-managed file into the Gradle user
+        // home, a behaviour change the user must explicitly ask for, so there is
+        // no CLI flag.
+        let gradle_init = bools.gradle_init;
 
-        // Allow-docker: explicit CLI flag wins, then explicit config value,
-        // then the preset baseline (false when no preset — blocked).
-        let allow_docker = cli
-            .allow_docker
-            .to_option()
-            .or(self.sandbox.allow_docker)
-            .unwrap_or(baseline.allow_docker);
+        let allow_docker = bools.allow_docker;
 
-        // Allow-tmp-exec: explicit CLI flag wins, then explicit config value,
-        // then the preset baseline (false when no preset — blocked).
-        let allow_tmp_exec = cli
-            .allow_tmp_exec
-            .to_option()
-            .or(self.sandbox.allow_tmp_exec)
-            .unwrap_or(baseline.allow_tmp_exec);
+        let allow_tmp_exec = bools.allow_tmp_exec;
 
         // Allow-cache-exec: merge config + CLI (list of subdir names)
         let mut allow_cache_exec = self.sandbox.allow_cache_exec.clone();
@@ -475,29 +405,15 @@ impl Config {
         allow_cache_exec.sort_unstable();
         allow_cache_exec.dedup();
 
-        // Allow-cache-exec-any: CLI flag wins, then config, then false (blocked by default)
-        let allow_cache_exec_any = if cli.allow_cache_exec_any {
-            true
-        } else {
-            self.sandbox.allow_cache_exec_any.unwrap_or(false)
-        };
+        let allow_cache_exec_any = bools.allow_cache_exec_any;
 
-        // Allow-browser: CLI flag wins, then config, then false (blocked by default)
-        let allow_browser = if cli.allow_browser {
-            true
-        } else {
-            self.sandbox.allow_browser.unwrap_or(false)
-        };
+        let allow_browser = bools.allow_browser;
 
-        // Keychain substitution (#242): experimental, config-only, default off.
-        // With it off the Keychain grant is exactly what `needs_keychain()` says,
-        // matching every release before this key existed.
-        let keychain_substitute = self.sandbox.keychain_substitute.unwrap_or(false);
+        // Experimental, config-only (#242). With it off the Keychain grant is
+        // exactly what `needs_keychain()` says.
+        let keychain_substitute = bools.keychain_substitute;
 
-        // Scratch-dir: FeatureToggle resolves --scratch-dir/--no-scratch-dir (default: on)
-        let scratch_dir = cli
-            .scratch
-            .resolve(self.sandbox.scratch_dir.unwrap_or(true));
+        let scratch_dir = bools.scratch_dir;
 
         // Use-bubblewrap: tri-state. --use-bubblewrap/--no-bubblewrap resolve via
         // FeatureToggle (off wins if both set); otherwise fall through to config,
@@ -507,58 +423,35 @@ impl Config {
             .to_option()
             .or(self.sandbox.use_bubblewrap);
 
-        // Quiet: FeatureToggle resolves --quiet/--no-quiet (default: off)
-        let quiet = cli.quiet.resolve(self.sandbox.quiet.unwrap_or(false));
+        let quiet = bools.quiet;
+        let audit = bools.audit;
+        let yes = bools.yes;
 
-        // Audit: FeatureToggle resolves --no-audit against config (default: on).
-        // The post-session report is on by default; --no-audit forces it off.
-        let audit = cli.audit.resolve(self.sandbox.audit.unwrap_or(true));
-
-        // Yes: FeatureToggle resolves --yes/--no-yes (default: off)
-        let yes = cli.yes.resolve(self.sandbox.yes.unwrap_or(false));
-
-        // gh-guard: CLI flag overrides enabled; sub-options come from [gh_proxy] config.
-        // Backward compat: old `sandbox.gh_proxy = true` is treated as `gh_guard.enabled = true`.
-        // Precedence: CLI flag > config value > preset baseline > default(off).
-        // Only `strict` sets the baseline on — every other preset (and none)
-        // leaves it at `false`, so resolution is unchanged for them.
-        let gh_guard_enabled_default = self
-            .gh_guard
-            .enabled
-            .or(self.sandbox.gh_proxy)
-            .unwrap_or(baseline.gh_guard_enabled);
-        let gh_guard_enabled = cli.gh_guard.resolve(gh_guard_enabled_default);
+        // gh-guard. `gh_guard.enabled` folds in the deprecated
+        // `sandbox.gh_proxy` spelling at the config layer of the ladder; the
+        // sub-options are config-only booleans on the same ladder, so a future
+        // `--gh-guard-no-scope-check` only has to grow a CLI column.
         let gh_guard = GhGuardPolicy {
-            enabled: gh_guard_enabled,
+            enabled: bools.gh_guard_enabled,
             mode: self.gh_guard.mode.unwrap_or(EnforcementMode::Block),
-            scope_check: self.gh_guard.scope_check.unwrap_or(true),
-            block_auth_token: self.gh_guard.block_auth_token.unwrap_or(true),
-            inject_token: self.gh_guard.inject_token.unwrap_or(false),
+            scope_check: bools.gh_scope_check,
+            block_auth_token: bools.gh_block_auth_token,
+            inject_token: bools.gh_inject_token,
             unknown_command: self
                 .gh_guard
                 .unknown_command
                 .unwrap_or(UnknownCommandPolicy::Block),
-            allow_api_write: self.gh_guard.allow_api_write.unwrap_or(false),
+            allow_api_write: bools.gh_allow_api_write,
         };
 
-        // git-guard: CLI flag overrides enabled. Backward compat from sandbox.git_push_prevention.
-        // Precedence: CLI flag > config value > preset baseline > default(off).
-        // Only `strict` sets the baseline on; unchanged for every other case.
-        let git_guard_enabled_default = self
-            .git_guard
-            .enabled
-            .or(self.sandbox.git_push_prevention)
-            .unwrap_or(baseline.git_guard_enabled);
-        let git_guard_enabled = cli.git_push_prevention.resolve(git_guard_enabled_default);
+        // git-guard. `git_guard.enabled` folds in the deprecated
+        // `sandbox.git_push_prevention` spelling at the config layer.
         let git_guard = GitGuardPolicy {
-            enabled: git_guard_enabled,
+            enabled: bools.git_guard_enabled,
             mode: self.git_guard.mode.unwrap_or(EnforcementMode::Block),
-            prevent_push: self.git_guard.prevent_push.unwrap_or(true),
-            prevent_force_push: self.git_guard.prevent_force_push.unwrap_or(true),
-            protect_default_branch_only: self
-                .git_guard
-                .protect_default_branch_only
-                .unwrap_or(false),
+            prevent_push: bools.git_prevent_push,
+            prevent_force_push: bools.git_prevent_force_push,
+            protect_default_branch_only: bools.git_protect_default_branch_only,
             allow_push: self
                 .git_guard
                 .allow_push
@@ -1215,48 +1108,11 @@ impl Resolved {
         let is_approved = |key: &str| approved_keys.contains(&key);
         let all_proposed = crate::repo_config::proposed_keys(&repo_config.propose);
 
-        // Boolean proposals (additive: false→true only)
-        if repo_config.propose.allow_localhost_any == Some(true)
-            && is_approved("allow_localhost_any")
-        {
-            self.allow_localhost_any = true;
-        }
-        if repo_config.propose.allow_jvm_attach == Some(true) && is_approved("allow_jvm_attach") {
-            self.allow_jvm_attach = true;
-        }
-        if repo_config.propose.allow_msbuild == Some(true) && is_approved("allow_msbuild") {
-            self.allow_msbuild = true;
-        }
-        if repo_config.propose.gradle_init == Some(true) && is_approved("gradle_init") {
-            self.gradle_init = true;
-        }
-        if repo_config.propose.allow_docker == Some(true) && is_approved("allow_docker") {
-            self.allow_docker = true;
-        }
-        if repo_config.propose.allow_tmp_exec == Some(true) && is_approved("allow_tmp_exec") {
-            self.allow_tmp_exec = true;
-        }
-        if repo_config.propose.allow_gpg_signing == Some(true) && is_approved("allow_gpg_signing") {
-            self.allow_gpg_signing = true;
-        }
-        if repo_config.propose.allow_lifecycle_scripts == Some(true)
-            && is_approved("allow_lifecycle_scripts")
-        {
-            self.allow_lifecycle_scripts = true;
-        }
-        if repo_config.propose.allow_browser == Some(true) && is_approved("allow_browser") {
-            self.allow_browser = true;
-        }
-        if repo_config.propose.allow_env_files == Some(true) && is_approved("allow_env_files") {
-            self.allow_env_files = true;
-        }
-        if repo_config.propose.gh_guard == Some(true) && is_approved("gh_guard") {
-            self.gh_guard.enabled = true;
-        }
-        if repo_config.propose.git_push_prevention == Some(true)
-            && is_approved("git_push_prevention")
-        {
-            self.git_guard.enabled = true;
+        // Boolean proposals, driven by `PROPOSE_BOOLS` (additive: false→true only).
+        for row in super::repo::PROPOSE_BOOLS {
+            if (row.propose)(&repo_config.propose) == Some(true) && is_approved(row.key) {
+                (row.apply)(self);
+            }
         }
 
         // Path proposals
@@ -2947,5 +2803,525 @@ validate = false
             !resolved.allow_localhost_any,
             "proxy.forced wins: localhost-any forced off"
         );
+    }
+}
+
+/// Per-key precedence: CLI flag > config file > preset baseline > default.
+///
+/// One row per boolean key, exercised through the real `Config::merge` — the
+/// registry table is what merge uses, so a row that stops holding means the
+/// ladder for that key actually changed, not that a mirror of it drifted.
+#[cfg(test)]
+mod precedence {
+    use super::super::registry::{BOOL_KEYS, BOOL_KEYS_EXEMPT};
+    use super::super::types::{CliFlags, Config, FeatureToggle, Preset, Resolved};
+    use super::super::{ConfigValueType, all_config_keys};
+
+    struct Ladder {
+        /// `section.key`, exactly as the registry names it.
+        key: &'static str,
+        /// The CLI flag that forces this key ON, if there is one.
+        cli_on: Option<fn(&mut CliFlags)>,
+        /// The CLI flag that forces this key OFF, if there is one. A key with
+        /// only one of the two has a one-way flag — a deliberate deviation,
+        /// recorded here rather than implied by the shape of some `if`.
+        cli_off: Option<fn(&mut CliFlags)>,
+        get: fn(&Resolved) -> bool,
+        /// Value with nothing set anywhere.
+        default: bool,
+        /// A preset that moves this key off its default, and the value it moves
+        /// it to. `None` for a key no preset controls.
+        preset: Option<(Preset, bool)>,
+    }
+
+    fn toml_for(key: &str, value: bool) -> String {
+        let (section, name) = key.split_once('.').expect("section.key");
+        format!("[{section}]\n{name} = {value}\n")
+    }
+
+    fn merge(toml: &str, cli: CliFlags) -> Resolved {
+        toml::from_str::<Config>(toml)
+            .expect("test config parses")
+            .merge(cli)
+            .expect("test config merges")
+    }
+
+    fn ladders() -> Vec<Ladder> {
+        vec![
+            Ladder {
+                key: "proxy.enabled",
+                cli_on: Some(|c| c.proxy = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.proxy = FeatureToggle::ForceOff),
+                get: |r| r.with_proxy,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "proxy.forced",
+                cli_on: Some(|c| c.proxy_forced = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.proxy_forced = FeatureToggle::ForceOff),
+                get: |r| r.proxy_forced,
+                default: false,
+                preset: Some((Preset::Strict, true)),
+            },
+            Ladder {
+                key: "proxy.default_allowlist",
+                cli_on: Some(|c| c.default_allowlist = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.default_allowlist = FeatureToggle::ForceOff),
+                get: |r| r.default_allowlist,
+                default: false,
+                preset: Some((Preset::Strict, true)),
+            },
+            Ladder {
+                key: "sandbox.validate",
+                // Deviation, deliberate: one-way `--no-validate`, and the
+                // resolved value is stored inverted.
+                cli_on: None,
+                cli_off: Some(|c| c.no_validate = true),
+                get: |r| !r.no_validate,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.brief",
+                cli_on: Some(|c| c.brief = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.brief = FeatureToggle::ForceOff),
+                get: |r| r.brief,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_env_files",
+                cli_on: Some(|c| c.allow_env_files = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.allow_env_files = FeatureToggle::ForceOff),
+                get: |r| r.allow_env_files,
+                default: false,
+                preset: Some((Preset::FullTrust, true)),
+            },
+            Ladder {
+                key: "sandbox.allow_localhost_any",
+                cli_on: Some(|c| c.allow_localhost_any = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.allow_localhost_any = FeatureToggle::ForceOff),
+                get: |r| r.allow_localhost_any,
+                default: false,
+                preset: Some((Preset::Permissive, true)),
+            },
+            Ladder {
+                key: "sandbox.inherit_env",
+                // Deviation, deliberate: one-way `--inherit-env`, no `--no-*`.
+                cli_on: Some(|c| c.inherit_env = true),
+                cli_off: None,
+                get: |r| r.inherit_env,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_lifecycle_scripts",
+                cli_on: Some(|c| c.allow_lifecycle_scripts = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.allow_lifecycle_scripts = FeatureToggle::ForceOff),
+                get: |r| r.allow_lifecycle_scripts,
+                default: false,
+                preset: Some((Preset::Permissive, true)),
+            },
+            Ladder {
+                key: "sandbox.allow_gpg_signing",
+                // Deviation, deliberate: one-way `--allow-gpg-signing`.
+                cli_on: Some(|c| c.allow_gpg_signing = true),
+                cli_off: None,
+                get: |r| r.allow_gpg_signing,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_tmp_exec",
+                cli_on: Some(|c| c.allow_tmp_exec = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.allow_tmp_exec = FeatureToggle::ForceOff),
+                get: |r| r.allow_tmp_exec,
+                default: false,
+                preset: Some((Preset::Permissive, true)),
+            },
+            Ladder {
+                key: "sandbox.scratch_dir",
+                cli_on: Some(|c| c.scratch = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.scratch = FeatureToggle::ForceOff),
+                get: |r| r.scratch_dir,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.audit",
+                // Deviation, deliberate: only the OFF side (`--no-audit`) exists.
+                cli_on: None,
+                cli_off: Some(|c| c.audit = FeatureToggle::ForceOff),
+                get: |r| r.audit,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.quiet",
+                cli_on: Some(|c| c.quiet = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.quiet = FeatureToggle::ForceOff),
+                get: |r| r.quiet,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.yes",
+                cli_on: Some(|c| c.yes = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.yes = FeatureToggle::ForceOff),
+                get: |r| r.yes,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_jvm_attach",
+                cli_on: Some(|c| c.allow_jvm_attach = true),
+                cli_off: None,
+                get: |r| r.allow_jvm_attach,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_msbuild",
+                cli_on: Some(|c| c.allow_msbuild = true),
+                cli_off: None,
+                get: |r| r.allow_msbuild,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.gradle_init",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.gradle_init,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_docker",
+                cli_on: Some(|c| c.allow_docker = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.allow_docker = FeatureToggle::ForceOff),
+                get: |r| r.allow_docker,
+                default: false,
+                preset: Some((Preset::FullTrust, true)),
+            },
+            Ladder {
+                key: "sandbox.allow_cache_exec_any",
+                cli_on: Some(|c| c.allow_cache_exec_any = true),
+                cli_off: None,
+                get: |r| r.allow_cache_exec_any,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.allow_browser",
+                cli_on: Some(|c| c.allow_browser = true),
+                cli_off: None,
+                get: |r| r.allow_browser,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "sandbox.keychain_substitute",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.keychain_substitute,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "gh_guard.enabled",
+                cli_on: Some(|c| c.gh_guard = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.gh_guard = FeatureToggle::ForceOff),
+                get: |r| r.gh_guard.enabled,
+                default: false,
+                preset: Some((Preset::Strict, true)),
+            },
+            Ladder {
+                key: "gh_guard.scope_check",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.gh_guard.scope_check,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "gh_guard.block_auth_token",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.gh_guard.block_auth_token,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "gh_guard.inject_token",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.gh_guard.inject_token,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "gh_guard.allow_api_write",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.gh_guard.allow_api_write,
+                default: false,
+                preset: None,
+            },
+            Ladder {
+                key: "git_guard.enabled",
+                cli_on: Some(|c| c.git_push_prevention = FeatureToggle::ForceOn),
+                cli_off: Some(|c| c.git_push_prevention = FeatureToggle::ForceOff),
+                get: |r| r.git_guard.enabled,
+                default: false,
+                preset: Some((Preset::Strict, true)),
+            },
+            Ladder {
+                key: "git_guard.prevent_push",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.git_guard.prevent_push,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "git_guard.prevent_force_push",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.git_guard.prevent_force_push,
+                default: true,
+                preset: None,
+            },
+            Ladder {
+                key: "git_guard.protect_default_branch_only",
+                cli_on: None,
+                cli_off: None,
+                get: |r| r.git_guard.protect_default_branch_only,
+                default: false,
+                preset: None,
+            },
+            // `sandbox.agents_md` is exercised separately: its resolved value is
+            // additionally gated on `brief`, so it does not follow the plain
+            // ladder.
+        ]
+    }
+
+    #[test]
+    fn nothing_set_gives_the_default() {
+        for l in ladders() {
+            let r = merge("", CliFlags::default());
+            assert_eq!((l.get)(&r), l.default, "{} with nothing set", l.key);
+        }
+    }
+
+    #[test]
+    fn config_beats_the_default() {
+        for l in ladders() {
+            for value in [false, true] {
+                let r = merge(&toml_for(l.key, value), CliFlags::default());
+                assert_eq!((l.get)(&r), value, "{} = {value} in config", l.key);
+            }
+        }
+    }
+
+    #[test]
+    fn preset_baseline_beats_the_default() {
+        for l in ladders() {
+            let Some((preset, value)) = l.preset else {
+                continue;
+            };
+            let r = merge(
+                "",
+                CliFlags {
+                    preset: Some(preset),
+                    ..Default::default()
+                },
+            );
+            assert_eq!((l.get)(&r), value, "{} under {preset}", l.key);
+        }
+    }
+
+    #[test]
+    fn config_beats_the_preset_baseline() {
+        for l in ladders() {
+            let Some((preset, value)) = l.preset else {
+                continue;
+            };
+            // Config says the opposite of what the preset's baseline says.
+            let r = merge(
+                &toml_for(l.key, !value),
+                CliFlags {
+                    preset: Some(preset),
+                    ..Default::default()
+                },
+            );
+            assert_eq!(
+                (l.get)(&r),
+                !value,
+                "{} = {} in config must override the {preset} baseline",
+                l.key,
+                !value
+            );
+        }
+    }
+
+    #[test]
+    fn cli_beats_config_and_preset() {
+        for l in ladders() {
+            // ON side: config says off, CLI says on.
+            if let Some(set_on) = l.cli_on {
+                let mut cli = CliFlags::default();
+                set_on(&mut cli);
+                let r = merge(&toml_for(l.key, false), cli);
+                assert!((l.get)(&r), "{}: CLI on must beat config off", l.key);
+            }
+
+            // OFF side: config says on, CLI says off. With the preset in play
+            // too, so this pins CLI above both lower layers at once.
+            if let Some(set_off) = l.cli_off {
+                let mut cli = CliFlags::default();
+                set_off(&mut cli);
+                cli.preset = l.preset.map(|(preset, _)| preset);
+                let r = merge(&toml_for(l.key, true), cli);
+                assert!(
+                    !(l.get)(&r),
+                    "{}: CLI off must beat config on (and the preset)",
+                    l.key
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn one_way_cli_flags_are_declared_as_such() {
+        // Every key must have at least one CLI flag or none at all; a key with
+        // exactly one side is a deliberate one-way flag, and the list of those
+        // is pinned here so growing one silently is not possible.
+        let one_way: Vec<&str> = ladders()
+            .iter()
+            .filter(|l| l.cli_on.is_some() != l.cli_off.is_some())
+            .map(|l| l.key)
+            .collect();
+        assert_eq!(
+            one_way,
+            [
+                "sandbox.validate",
+                "sandbox.inherit_env",
+                "sandbox.allow_gpg_signing",
+                "sandbox.audit",
+                "sandbox.allow_jvm_attach",
+                "sandbox.allow_msbuild",
+                "sandbox.allow_cache_exec_any",
+                "sandbox.allow_browser",
+            ],
+            "one-way CLI flags changed"
+        );
+    }
+
+    #[test]
+    fn agents_md_follows_the_ladder_but_stays_gated_on_brief() {
+        // The gate is deliberate: writing into the user's AGENTS.md is a second
+        // opt-in on top of the brief, so `--no-brief` suppresses it whichever
+        // layer turned agents_md on.
+        let r = merge(
+            "[sandbox]\nbrief = true\nagents_md = true\n",
+            CliFlags::default(),
+        );
+        assert!(r.agents_md, "config on + brief on");
+
+        let r = merge("[sandbox]\nagents_md = true\n", CliFlags::default());
+        assert!(!r.agents_md, "brief off must suppress agents_md");
+
+        let r = merge(
+            "[sandbox]\nbrief = true\nagents_md = true\n",
+            CliFlags {
+                brief: FeatureToggle::ForceOff,
+                ..Default::default()
+            },
+        );
+        assert!(!r.agents_md, "--no-brief must suppress agents_md");
+
+        let r = merge(
+            "[sandbox]\nbrief = true\nagents_md = true\n",
+            CliFlags {
+                agents_md: FeatureToggle::ForceOff,
+                ..Default::default()
+            },
+        );
+        assert!(!r.agents_md, "--no-agents-md must beat config on");
+    }
+
+    #[test]
+    fn legacy_spellings_feed_the_guard_keys_config_layer() {
+        let r = merge("[sandbox]\ngh_proxy = true\n", CliFlags::default());
+        assert!(
+            r.gh_guard.enabled,
+            "sandbox.gh_proxy still enables gh_guard"
+        );
+        let r = merge(
+            "[sandbox]\ngit_push_prevention = true\n",
+            CliFlags::default(),
+        );
+        assert!(r.git_guard.enabled);
+
+        // The modern key wins over the legacy one when both are set.
+        let r = merge(
+            "[sandbox]\ngh_proxy = true\n[gh_guard]\nenabled = false\n",
+            CliFlags::default(),
+        );
+        assert!(!r.gh_guard.enabled);
+    }
+
+    #[test]
+    fn every_ladder_row_is_a_real_registry_key() {
+        for l in ladders() {
+            let (section, key) = l.key.split_once('.').unwrap();
+            assert!(
+                super::super::registry::bool_key(section, key).is_some(),
+                "{} has a precedence test but no registry row",
+                l.key
+            );
+        }
+    }
+
+    #[test]
+    fn every_registry_bool_is_on_the_ladder_or_exempt() {
+        // The anti-drift net: a new boolean config key cannot be added without
+        // either joining the one precedence ladder or being listed, with a
+        // reason, in BOOL_KEYS_EXEMPT.
+        for info in all_config_keys() {
+            if info.value_type != ConfigValueType::Bool {
+                continue;
+            }
+            let on_ladder = BOOL_KEYS
+                .iter()
+                .any(|row| row.section == info.section && row.key == info.key);
+            let exempt = BOOL_KEYS_EXEMPT
+                .iter()
+                .any(|(section, key, _)| *section == info.section && *key == info.key);
+            assert!(
+                on_ladder != exempt,
+                "{}.{} must be on the precedence ladder or exempt, exactly one",
+                info.section,
+                info.key
+            );
+        }
+    }
+
+    #[test]
+    fn every_bool_key_row_names_a_registry_key() {
+        for row in BOOL_KEYS {
+            assert!(
+                all_config_keys()
+                    .iter()
+                    .any(|info| info.section == row.section
+                        && info.key == row.key
+                        && info.value_type == ConfigValueType::Bool),
+                "{}.{} is on the ladder but is not a boolean registry key",
+                row.section,
+                row.key
+            );
+        }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,8 +29,13 @@ pub use path::{
     CustomConfigVerdict, classify_custom_config, collapse_tilde, config_dir, config_path,
     default_config_contents, expand_tilde,
 };
-pub use registry::{ConfigKeyInfo, ConfigValueType, all_config_keys, lookup_key};
-pub use repo::{RepoKeyTarget, repo_key_rejection_reason, repo_key_target, set_repo_value_in_doc};
+pub use registry::{
+    BoolKeyRow, ConfigKeyInfo, ConfigValueType, all_config_keys, bool_key, lookup_key,
+};
+pub use repo::{
+    PROPOSE_BOOLS, ProposeBoolRow, RepoKeyTarget, repo_key_rejection_reason, repo_key_target,
+    set_repo_value_in_doc,
+};
 pub use types::{
     AllowConfig, AuditConfig, BlocklistSource, CliFlags, Config, DenyConfig, EnforcementMode,
     FeatureToggle, GhGuardConfig, GhGuardPolicy, GitGuardConfig, GitGuardPolicy, GitPushRule,

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -696,10 +696,15 @@ macro_rules! bool_keys {
 // the read-back accessor.
 //
 // `cli` projects the CLI layer onto a `FeatureToggle`. A key with a proper
-// `--x`/`--no-x` pair carries one directly; a one-way flag (no `--no-x`) is
-// written as `from_pair(flag, false)` so the missing OFF side is visible in the
-// table rather than implied by a differently-shaped `if` somewhere in `merge`;
-// a config-only key passes `UseDefault`.
+// `--x`/`--no-x` pair carries one directly. A ONE-WAY flag — one that can only
+// push the value in one direction, because the opposite flag does not exist —
+// is written with a literal `false` on the side it lacks, and its row says so
+// in a `one-way` doc comment. That is the point of the column: one-way-ness
+// used to be implied by the shape of an `if cli.x { true } else { .. }` in
+// `merge` and stated nowhere. The set of one-way keys is pinned by
+// `precedence::one_way_cli_flags_are_declared_as_such`, so growing or losing
+// one is a test failure, not a silent change. A config-only key passes
+// `UseDefault`.
 //
 // `baseline` is `|b| b.<field>` for the nine preset-controlled keys and a
 // literal for the rest. It is a required column: a key cannot be declared
@@ -724,6 +729,7 @@ bool_keys! {
         resolved = |r: &Resolved| r.default_allowlist;
 
     /// `sandbox.validate`, stored inverted on `Resolved` as `no_validate`.
+    /// One-way in the OFF direction: `--no-validate` only, no `--validate`.
     validate, "sandbox", "validate",
         cli = |c: &CliFlags| FeatureToggle::from_pair(false, c.no_validate),
         config = |c: &Config| c.sandbox.validate,
@@ -756,6 +762,7 @@ bool_keys! {
         baseline = |b: PresetBaseline| b.allow_localhost_any,
         resolved = |r: &Resolved| r.allow_localhost_any;
 
+    /// One-way: `--inherit-env` turns it on, there is no `--no-inherit-env`.
     inherit_env, "sandbox", "inherit_env",
         cli = |c: &CliFlags| FeatureToggle::from_pair(c.inherit_env, false),
         config = |c: &Config| c.sandbox.inherit_env,
@@ -768,6 +775,8 @@ bool_keys! {
         baseline = |b: PresetBaseline| b.allow_lifecycle_scripts,
         resolved = |r: &Resolved| r.allow_lifecycle_scripts;
 
+    /// One-way: `--allow-gpg-signing` only. A config `true` cannot be undone
+    /// for a single run.
     allow_gpg_signing, "sandbox", "allow_gpg_signing",
         cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_gpg_signing, false),
         config = |c: &Config| c.sandbox.allow_gpg_signing,
@@ -786,6 +795,7 @@ bool_keys! {
         baseline = |_: PresetBaseline| true,
         resolved = |r: &Resolved| r.scratch_dir;
 
+    /// One-way in the OFF direction: `--no-audit` only, no `--audit`.
     audit, "sandbox", "audit",
         cli = |c: &CliFlags| c.audit,
         config = |c: &Config| c.sandbox.audit,
@@ -804,12 +814,14 @@ bool_keys! {
         baseline = |_: PresetBaseline| false,
         resolved = |r: &Resolved| r.yes;
 
+    /// One-way: `--allow-jvm-attach` only.
     allow_jvm_attach, "sandbox", "allow_jvm_attach",
         cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_jvm_attach, false),
         config = |c: &Config| c.sandbox.allow_jvm_attach,
         baseline = |_: PresetBaseline| false,
         resolved = |r: &Resolved| r.allow_jvm_attach;
 
+    /// One-way: `--allow-msbuild` only.
     allow_msbuild, "sandbox", "allow_msbuild",
         cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_msbuild, false),
         config = |c: &Config| c.sandbox.allow_msbuild,
@@ -830,12 +842,14 @@ bool_keys! {
         baseline = |b: PresetBaseline| b.allow_docker,
         resolved = |r: &Resolved| r.allow_docker;
 
+    /// One-way: `--allow-cache-exec-any` only.
     allow_cache_exec_any, "sandbox", "allow_cache_exec_any",
         cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_cache_exec_any, false),
         config = |c: &Config| c.sandbox.allow_cache_exec_any,
         baseline = |_: PresetBaseline| false,
         resolved = |r: &Resolved| r.allow_cache_exec_any;
 
+    /// One-way: `--allow-browser` only.
     allow_browser, "sandbox", "allow_browser",
         cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_browser, false),
         config = |c: &Config| c.sandbox.allow_browser,

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -1,6 +1,7 @@
 //! Config key metadata registry (names, types, docs).
 
 use super::error::ConfigError;
+use super::types::{CliFlags, Config, FeatureToggle, PresetBaseline, Resolved};
 use super::validation::suggest_key;
 
 // ── Config key registry (for get/set) ────────────────────────────────
@@ -607,6 +608,333 @@ pub(super) fn type_label(vt: ConfigValueType) -> &'static str {
         ConfigValueType::ArrayOfTables => "array of tables",
     }
 }
+
+// ── Boolean precedence, driven by the key registry ───────────────────
+
+/// The one precedence rule for every boolean setting in cplt:
+///
+/// > explicit CLI flag > config file value > preset baseline > hardcoded default
+///
+/// Every boolean key resolves through this function and nowhere else. Writing
+/// the ladder once is the point: the failure mode it removes is a hand-written
+/// chain that silently drops a layer (typically the preset baseline), which in
+/// a sandbox means a restriction the user asked for quietly not applying.
+///
+/// Keys with no preset baseline pass their hardcoded default as `baseline` —
+/// the bottom layer is always supplied, never omitted.
+fn resolve_bool(cli: FeatureToggle, config: Option<bool>, baseline: bool) -> bool {
+    cli.to_option().or(config).unwrap_or(baseline)
+}
+
+/// A registry row for a boolean config key: which key it is, and how to read
+/// its final value back off a [`Resolved`].
+///
+/// `resolved` exists so consumers that report the *effective* value (`config
+/// show`, `cplt settings`) read it from this table instead of keeping their own
+/// parallel list of keys — a list that drifts, silently, behind a catch-all arm.
+pub struct BoolKeyRow {
+    pub section: &'static str,
+    pub key: &'static str,
+    pub resolved: fn(&Resolved) -> bool,
+}
+
+/// Look up the boolean registry row for a config key, if it has one.
+pub fn bool_key(section: &str, key: &str) -> Option<&'static BoolKeyRow> {
+    BOOL_KEYS
+        .iter()
+        .find(|row| row.section == section && row.key == key)
+}
+
+macro_rules! bool_keys {
+    ($(
+        $(#[$meta:meta])*
+        $field:ident, $section:literal, $key:literal,
+            cli = $cli:expr,
+            config = $config:expr,
+            baseline = $baseline:expr,
+            resolved = $resolved:expr;
+    )*) => {
+        /// Every boolean setting after the precedence ladder has been applied.
+        ///
+        /// Built once per run by [`ResolvedBools::resolve`]; `Config::merge`
+        /// copies the fields into [`Resolved`]. Nothing here is resolved by
+        /// hand.
+        #[derive(Debug, Clone, Copy)]
+        pub struct ResolvedBools {
+            $( $(#[$meta])* pub $field: bool, )*
+        }
+
+        /// Registry rows for every boolean key, in declaration order.
+        pub static BOOL_KEYS: &[BoolKeyRow] = &[
+            $( BoolKeyRow {
+                section: $section,
+                key: $key,
+                resolved: $resolved,
+            }, )*
+        ];
+
+        impl ResolvedBools {
+            /// Resolve every boolean key through [`resolve_bool`].
+            pub(super) fn resolve(
+                cli: &CliFlags,
+                config: &Config,
+                baseline: PresetBaseline,
+            ) -> Self {
+                Self {
+                    $( $field: resolve_bool(
+                        ($cli)(cli),
+                        ($config)(config),
+                        ($baseline)(baseline),
+                    ), )*
+                }
+            }
+        }
+    };
+}
+
+// Columns: struct field, config section, config key, then the three layers and
+// the read-back accessor.
+//
+// `cli` projects the CLI layer onto a `FeatureToggle`. A key with a proper
+// `--x`/`--no-x` pair carries one directly; a one-way flag (no `--no-x`) is
+// written as `from_pair(flag, false)` so the missing OFF side is visible in the
+// table rather than implied by a differently-shaped `if` somewhere in `merge`;
+// a config-only key passes `UseDefault`.
+//
+// `baseline` is `|b| b.<field>` for the nine preset-controlled keys and a
+// literal for the rest. It is a required column: a key cannot be declared
+// without stating its bottom layer.
+bool_keys! {
+    with_proxy, "proxy", "enabled",
+        cli = |c: &CliFlags| c.proxy,
+        config = |c: &Config| c.proxy.enabled,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.with_proxy;
+
+    proxy_forced, "proxy", "forced",
+        cli = |c: &CliFlags| c.proxy_forced,
+        config = |c: &Config| c.proxy.forced,
+        baseline = |b: PresetBaseline| b.proxy_forced,
+        resolved = |r: &Resolved| r.proxy_forced;
+
+    default_allowlist, "proxy", "default_allowlist",
+        cli = |c: &CliFlags| c.default_allowlist,
+        config = |c: &Config| c.proxy.default_allowlist,
+        baseline = |b: PresetBaseline| b.default_allowlist,
+        resolved = |r: &Resolved| r.default_allowlist;
+
+    /// `sandbox.validate`, stored inverted on `Resolved` as `no_validate`.
+    validate, "sandbox", "validate",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(false, c.no_validate),
+        config = |c: &Config| c.sandbox.validate,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| !r.no_validate;
+
+    brief, "sandbox", "brief",
+        cli = |c: &CliFlags| c.brief,
+        config = |c: &Config| c.sandbox.brief,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.brief;
+
+    /// Raw value only. `Config::merge` additionally gates the AGENTS.md block
+    /// on `brief`, so `Resolved::agents_md` can be false while this is true.
+    agents_md, "sandbox", "agents_md",
+        cli = |c: &CliFlags| c.agents_md,
+        config = |c: &Config| c.sandbox.agents_md,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.agents_md;
+
+    allow_env_files, "sandbox", "allow_env_files",
+        cli = |c: &CliFlags| c.allow_env_files,
+        config = |c: &Config| c.sandbox.allow_env_files,
+        baseline = |b: PresetBaseline| b.allow_env_files,
+        resolved = |r: &Resolved| r.allow_env_files;
+
+    allow_localhost_any, "sandbox", "allow_localhost_any",
+        cli = |c: &CliFlags| c.allow_localhost_any,
+        config = |c: &Config| c.sandbox.allow_localhost_any,
+        baseline = |b: PresetBaseline| b.allow_localhost_any,
+        resolved = |r: &Resolved| r.allow_localhost_any;
+
+    inherit_env, "sandbox", "inherit_env",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(c.inherit_env, false),
+        config = |c: &Config| c.sandbox.inherit_env,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.inherit_env;
+
+    allow_lifecycle_scripts, "sandbox", "allow_lifecycle_scripts",
+        cli = |c: &CliFlags| c.allow_lifecycle_scripts,
+        config = |c: &Config| c.sandbox.allow_lifecycle_scripts,
+        baseline = |b: PresetBaseline| b.allow_lifecycle_scripts,
+        resolved = |r: &Resolved| r.allow_lifecycle_scripts;
+
+    allow_gpg_signing, "sandbox", "allow_gpg_signing",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_gpg_signing, false),
+        config = |c: &Config| c.sandbox.allow_gpg_signing,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.allow_gpg_signing;
+
+    allow_tmp_exec, "sandbox", "allow_tmp_exec",
+        cli = |c: &CliFlags| c.allow_tmp_exec,
+        config = |c: &Config| c.sandbox.allow_tmp_exec,
+        baseline = |b: PresetBaseline| b.allow_tmp_exec,
+        resolved = |r: &Resolved| r.allow_tmp_exec;
+
+    scratch_dir, "sandbox", "scratch_dir",
+        cli = |c: &CliFlags| c.scratch,
+        config = |c: &Config| c.sandbox.scratch_dir,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.scratch_dir;
+
+    audit, "sandbox", "audit",
+        cli = |c: &CliFlags| c.audit,
+        config = |c: &Config| c.sandbox.audit,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.audit;
+
+    quiet, "sandbox", "quiet",
+        cli = |c: &CliFlags| c.quiet,
+        config = |c: &Config| c.sandbox.quiet,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.quiet;
+
+    yes, "sandbox", "yes",
+        cli = |c: &CliFlags| c.yes,
+        config = |c: &Config| c.sandbox.yes,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.yes;
+
+    allow_jvm_attach, "sandbox", "allow_jvm_attach",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_jvm_attach, false),
+        config = |c: &Config| c.sandbox.allow_jvm_attach,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.allow_jvm_attach;
+
+    allow_msbuild, "sandbox", "allow_msbuild",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_msbuild, false),
+        config = |c: &Config| c.sandbox.allow_msbuild,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.allow_msbuild;
+
+    /// Config-only: writes into the Gradle user home, so there is deliberately
+    /// no CLI flag to turn it on for one run.
+    gradle_init, "sandbox", "gradle_init",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.sandbox.gradle_init,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.gradle_init;
+
+    allow_docker, "sandbox", "allow_docker",
+        cli = |c: &CliFlags| c.allow_docker,
+        config = |c: &Config| c.sandbox.allow_docker,
+        baseline = |b: PresetBaseline| b.allow_docker,
+        resolved = |r: &Resolved| r.allow_docker;
+
+    allow_cache_exec_any, "sandbox", "allow_cache_exec_any",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_cache_exec_any, false),
+        config = |c: &Config| c.sandbox.allow_cache_exec_any,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.allow_cache_exec_any;
+
+    allow_browser, "sandbox", "allow_browser",
+        cli = |c: &CliFlags| FeatureToggle::from_pair(c.allow_browser, false),
+        config = |c: &Config| c.sandbox.allow_browser,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.allow_browser;
+
+    /// Experimental, config-only (#242).
+    keychain_substitute, "sandbox", "keychain_substitute",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.sandbox.keychain_substitute,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.keychain_substitute;
+
+    /// The config layer folds in the deprecated `sandbox.gh_proxy` spelling.
+    gh_guard_enabled, "gh_guard", "enabled",
+        cli = |c: &CliFlags| c.gh_guard,
+        config = |c: &Config| c.gh_guard.enabled.or(c.sandbox.gh_proxy),
+        baseline = |b: PresetBaseline| b.gh_guard_enabled,
+        resolved = |r: &Resolved| r.gh_guard.enabled;
+
+    gh_scope_check, "gh_guard", "scope_check",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.gh_guard.scope_check,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.gh_guard.scope_check;
+
+    gh_block_auth_token, "gh_guard", "block_auth_token",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.gh_guard.block_auth_token,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.gh_guard.block_auth_token;
+
+    gh_inject_token, "gh_guard", "inject_token",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.gh_guard.inject_token,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.gh_guard.inject_token;
+
+    gh_allow_api_write, "gh_guard", "allow_api_write",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.gh_guard.allow_api_write,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.gh_guard.allow_api_write;
+
+    /// The config layer folds in the deprecated `sandbox.git_push_prevention`
+    /// spelling.
+    git_guard_enabled, "git_guard", "enabled",
+        cli = |c: &CliFlags| c.git_push_prevention,
+        config = |c: &Config| c.git_guard.enabled.or(c.sandbox.git_push_prevention),
+        baseline = |b: PresetBaseline| b.git_guard_enabled,
+        resolved = |r: &Resolved| r.git_guard.enabled;
+
+    git_prevent_push, "git_guard", "prevent_push",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.git_guard.prevent_push,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.git_guard.prevent_push;
+
+    git_prevent_force_push, "git_guard", "prevent_force_push",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.git_guard.prevent_force_push,
+        baseline = |_: PresetBaseline| true,
+        resolved = |r: &Resolved| r.git_guard.prevent_force_push;
+
+    git_protect_default_branch_only, "git_guard", "protect_default_branch_only",
+        cli = |_: &CliFlags| FeatureToggle::UseDefault,
+        config = |c: &Config| c.git_guard.protect_default_branch_only,
+        baseline = |_: PresetBaseline| false,
+        resolved = |r: &Resolved| r.git_guard.protect_default_branch_only;
+}
+
+/// Boolean registry keys deliberately absent from [`BOOL_KEYS`], with the
+/// reason. Pinned by a test so a *new* boolean key cannot be added to the
+/// registry without either joining the ladder or being listed here.
+#[cfg(test)]
+pub(super) const BOOL_KEYS_EXEMPT: &[(&str, &str, &str)] = &[
+    (
+        "sandbox",
+        "gh_proxy",
+        "deprecated spelling of gh_guard.enabled; folded into that key's config layer",
+    ),
+    (
+        "sandbox",
+        "git_push_prevention",
+        "deprecated spelling of git_guard.enabled; folded into that key's config layer",
+    ),
+    (
+        "sandbox",
+        "use_bubblewrap",
+        "resolves to Option<bool>, not bool: `None` means auto-detect, a third \
+         state the bool ladder cannot express",
+    ),
+    (
+        "audit",
+        "enabled",
+        "the [audit] section is parsed and displayed but has no consumer yet — \
+         it resolves to nothing, so there is no precedence to describe",
+    ),
+];
 
 #[cfg(test)]
 mod tests {

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -629,9 +629,11 @@ fn resolve_bool(cli: FeatureToggle, config: Option<bool>, baseline: bool) -> boo
 /// A registry row for a boolean config key: which key it is, and how to read
 /// its final value back off a [`Resolved`].
 ///
-/// `resolved` exists so consumers that report the *effective* value (`config
-/// show`, `cplt settings`) read it from this table instead of keeping their own
-/// parallel list of keys — a list that drifts, silently, behind a catch-all arm.
+/// `resolved` exists so a consumer reporting the *effective* value reads it
+/// from this table instead of keeping its own parallel list of keys — a list
+/// that drifts, silently, behind a catch-all arm. `cplt settings` is the only
+/// such consumer today; `config show` renders the config file, not the
+/// resolved result, so it has no use for this.
 pub struct BoolKeyRow {
     pub section: &'static str,
     pub key: &'static str,

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -20,22 +20,115 @@ pub enum RepoKeyTarget {
     Deny(&'static str),
 }
 
+/// A boolean a repo may propose in `.cplt.toml`, described once.
+///
+/// One row per `[propose]` boolean, holding everything the four places that
+/// used to keep their own copy of this list need: the trust-store key, the
+/// global config key it corresponds to, how to read the proposal, and how to
+/// apply it. `propose` and `apply` are the only per-key code; the rest of the
+/// pipeline iterates.
+///
+/// Proposals are strictly additive — `apply` only ever sets a flag to `true`,
+/// and only for a `Some(true)` proposal whose key the user has approved. A
+/// repo can never turn a permission back off.
+pub struct ProposeBoolRow {
+    /// Name used in `[propose]` and in the trust store.
+    pub key: &'static str,
+    /// The global config key this proposal corresponds to.
+    pub config_key: (&'static str, &'static str),
+    pub propose: fn(&crate::repo_config::ProposeSection) -> Option<bool>,
+    pub apply: fn(&mut super::types::Resolved),
+}
+
+/// Every boolean a `.cplt.toml` may propose.
+pub static PROPOSE_BOOLS: &[ProposeBoolRow] = &[
+    ProposeBoolRow {
+        key: "allow_localhost_any",
+        config_key: ("sandbox", "allow_localhost_any"),
+        propose: |p| p.allow_localhost_any,
+        apply: |r| r.allow_localhost_any = true,
+    },
+    ProposeBoolRow {
+        key: "allow_jvm_attach",
+        config_key: ("sandbox", "allow_jvm_attach"),
+        propose: |p| p.allow_jvm_attach,
+        apply: |r| r.allow_jvm_attach = true,
+    },
+    ProposeBoolRow {
+        key: "allow_msbuild",
+        config_key: ("sandbox", "allow_msbuild"),
+        propose: |p| p.allow_msbuild,
+        apply: |r| r.allow_msbuild = true,
+    },
+    ProposeBoolRow {
+        key: "gradle_init",
+        config_key: ("sandbox", "gradle_init"),
+        propose: |p| p.gradle_init,
+        apply: |r| r.gradle_init = true,
+    },
+    ProposeBoolRow {
+        key: "allow_docker",
+        config_key: ("sandbox", "allow_docker"),
+        propose: |p| p.allow_docker,
+        apply: |r| r.allow_docker = true,
+    },
+    ProposeBoolRow {
+        key: "allow_tmp_exec",
+        config_key: ("sandbox", "allow_tmp_exec"),
+        propose: |p| p.allow_tmp_exec,
+        apply: |r| r.allow_tmp_exec = true,
+    },
+    ProposeBoolRow {
+        key: "allow_gpg_signing",
+        config_key: ("sandbox", "allow_gpg_signing"),
+        propose: |p| p.allow_gpg_signing,
+        apply: |r| r.allow_gpg_signing = true,
+    },
+    ProposeBoolRow {
+        key: "allow_lifecycle_scripts",
+        config_key: ("sandbox", "allow_lifecycle_scripts"),
+        propose: |p| p.allow_lifecycle_scripts,
+        apply: |r| r.allow_lifecycle_scripts = true,
+    },
+    ProposeBoolRow {
+        key: "allow_browser",
+        config_key: ("sandbox", "allow_browser"),
+        propose: |p| p.allow_browser,
+        apply: |r| r.allow_browser = true,
+    },
+    ProposeBoolRow {
+        key: "allow_env_files",
+        config_key: ("sandbox", "allow_env_files"),
+        propose: |p| p.allow_env_files,
+        apply: |r| r.allow_env_files = true,
+    },
+    // `.cplt.toml` spells these two with the legacy `sandbox.*` config keys, so
+    // `config set --repo sandbox.gh_proxy` keeps writing the name a repo file
+    // already uses.
+    ProposeBoolRow {
+        key: "gh_guard",
+        config_key: ("sandbox", "gh_proxy"),
+        propose: |p| p.gh_guard,
+        apply: |r| r.gh_guard.enabled = true,
+    },
+    ProposeBoolRow {
+        key: "git_push_prevention",
+        config_key: ("sandbox", "git_push_prevention"),
+        propose: |p| p.git_push_prevention,
+        apply: |r| r.git_guard.enabled = true,
+    },
+];
+
 /// Map a global config key to its repo config location.
 /// Returns None if the key is not valid in repo config.
 pub fn repo_key_target(key_info: &ConfigKeyInfo) -> Option<RepoKeyTarget> {
+    if PROPOSE_BOOLS
+        .iter()
+        .any(|row| row.config_key == (key_info.section, key_info.key))
+    {
+        return Some(RepoKeyTarget::ProposeBool);
+    }
     match (key_info.section, key_info.key) {
-        // Propose booleans
-        ("sandbox", "allow_localhost_any") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_jvm_attach") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_msbuild") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_docker") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_tmp_exec") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_gpg_signing") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_lifecycle_scripts") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_browser") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "allow_env_files") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "gh_proxy") => Some(RepoKeyTarget::ProposeBool),
-        ("sandbox", "git_push_prevention") => Some(RepoKeyTarget::ProposeBool),
         // Propose arrays
         ("allow", "read") => Some(RepoKeyTarget::ProposeAllow("read")),
         ("allow", "write") => Some(RepoKeyTarget::ProposeAllow("write")),

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -892,7 +892,6 @@ pub struct CliFlags {
     pub deny_clipboard: bool,
     pub allow_jvm_attach: bool,
     pub allow_msbuild: bool,
-    pub gradle_init: bool,
     /// Preset-controlled toggle (see `allow_localhost_any`).
     pub allow_docker: FeatureToggle,
     /// Preset-controlled toggle (see `allow_localhost_any`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1444,8 +1444,6 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         deny_clipboard: cli.deny_clipboard,
         allow_jvm_attach: cli.allow_jvm_attach,
         allow_msbuild: cli.allow_msbuild,
-        // Config-only opt-in; no CLI flag.
-        gradle_init: false,
         allow_docker: config::FeatureToggle::from_pair(cli.allow_docker, cli.no_allow_docker),
         allow_tmp_exec: config::FeatureToggle::from_pair(cli.allow_tmp_exec, cli.no_allow_tmp_exec),
         allow_cache_exec: cli.allow_cache_exec.clone(),

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -445,42 +445,12 @@ fn validate_repo_config(config: &RepoConfig) -> Result<(), String> {
 pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     let mut keys = Vec::new();
 
-    if propose.allow_localhost_any == Some(true) {
-        keys.push("allow_localhost_any");
+    for row in crate::config::PROPOSE_BOOLS {
+        if (row.propose)(propose) == Some(true) {
+            keys.push(row.key);
+        }
     }
-    if propose.allow_jvm_attach == Some(true) {
-        keys.push("allow_jvm_attach");
-    }
-    if propose.allow_msbuild == Some(true) {
-        keys.push("allow_msbuild");
-    }
-    if propose.gradle_init == Some(true) {
-        keys.push("gradle_init");
-    }
-    if propose.allow_docker == Some(true) {
-        keys.push("allow_docker");
-    }
-    if propose.allow_tmp_exec == Some(true) {
-        keys.push("allow_tmp_exec");
-    }
-    if propose.allow_gpg_signing == Some(true) {
-        keys.push("allow_gpg_signing");
-    }
-    if propose.allow_lifecycle_scripts == Some(true) {
-        keys.push("allow_lifecycle_scripts");
-    }
-    if propose.allow_browser == Some(true) {
-        keys.push("allow_browser");
-    }
-    if propose.allow_env_files == Some(true) {
-        keys.push("allow_env_files");
-    }
-    if propose.gh_guard == Some(true) {
-        keys.push("gh_guard");
-    }
-    if propose.git_push_prevention == Some(true) {
-        keys.push("git_push_prevention");
-    }
+
     if !propose.allow.read.is_empty() {
         keys.push("allow.read");
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -490,9 +490,13 @@ fn resolved_values(
                 get_value_from_doc(global_doc, key)
                     .unwrap_or_else(|| key.default_display.to_string())
             };
+            // Booleans read their effective value straight off the registry
+            // row, so this match never has to keep a parallel list of them —
+            // the list that silently drifted behind the `_ => fallback()` arm.
+            if let Some(row) = crate::config::bool_key(key.section, key.key) {
+                return ((key.section, key.key), (row.resolved)(resolved).to_string());
+            }
             let value = match (key.section, key.key) {
-                ("proxy", "enabled") => resolved.with_proxy.to_string(),
-                ("proxy", "forced") => resolved.proxy_forced.to_string(),
                 ("proxy", "port") => resolved.proxy_port.to_string(),
                 ("proxy", "blocked_domains") => {
                     format_optional_path(resolved.blocked_domains.as_ref())
@@ -500,7 +504,6 @@ fn resolved_values(
                 ("proxy", "allowed_domains") => {
                     format_optional_path(resolved.allowed_domains.as_ref())
                 }
-                ("proxy", "default_allowlist") => resolved.default_allowlist.to_string(),
                 ("proxy", "log_file") => format_optional_path(resolved.proxy_log_file.as_ref()),
                 ("proxy", "log_level") => resolved.proxy_log_level.as_str().to_string(),
                 ("proxy", "timeout") => resolved.proxy_timeout.as_secs().to_string(),
@@ -519,47 +522,16 @@ fn resolved_values(
                 ("sandbox", "preset") => resolved
                     .preset
                     .map_or_else(|| "standard".to_string(), |preset| preset.to_string()),
-                ("sandbox", "validate") => (!resolved.no_validate).to_string(),
-                ("sandbox", "allow_env_files") => resolved.allow_env_files.to_string(),
-                ("sandbox", "allow_localhost_any") => resolved.allow_localhost_any.to_string(),
                 ("sandbox", "pass_env") => format_strings(&resolved.pass_env),
-                ("sandbox", "inherit_env") => resolved.inherit_env.to_string(),
-                ("sandbox", "allow_lifecycle_scripts") => {
-                    resolved.allow_lifecycle_scripts.to_string()
-                }
-                ("sandbox", "allow_gpg_signing") => resolved.allow_gpg_signing.to_string(),
-                ("sandbox", "allow_tmp_exec") => resolved.allow_tmp_exec.to_string(),
-                ("sandbox", "scratch_dir") => resolved.scratch_dir.to_string(),
-                ("sandbox", "audit") => resolved.audit.to_string(),
                 ("sandbox", "use_bubblewrap") => resolved
                     .use_bubblewrap
                     .map_or_else(|| "auto-detect".to_string(), |value| value.to_string()),
-                ("sandbox", "quiet") => resolved.quiet.to_string(),
-                ("sandbox", "yes") => resolved.yes.to_string(),
-                ("sandbox", "allow_jvm_attach") => resolved.allow_jvm_attach.to_string(),
-                ("sandbox", "allow_docker") => resolved.allow_docker.to_string(),
                 ("sandbox", "allow_cache_exec") => format_strings(&resolved.allow_cache_exec),
-                ("sandbox", "allow_cache_exec_any") => resolved.allow_cache_exec_any.to_string(),
-                ("sandbox", "allow_browser") => resolved.allow_browser.to_string(),
-                ("sandbox", "keychain_substitute") => resolved.keychain_substitute.to_string(),
                 ("sandbox", "gh_proxy") => resolved.gh_guard.enabled.to_string(),
                 ("sandbox", "git_push_prevention") => resolved.git_guard.enabled.to_string(),
-                ("gh_guard", "enabled") => resolved.gh_guard.enabled.to_string(),
                 ("gh_guard", "mode") => resolved.gh_guard.mode.to_string(),
-                ("gh_guard", "scope_check") => resolved.gh_guard.scope_check.to_string(),
-                ("gh_guard", "block_auth_token") => resolved.gh_guard.block_auth_token.to_string(),
-                ("gh_guard", "inject_token") => resolved.gh_guard.inject_token.to_string(),
                 ("gh_guard", "unknown_command") => resolved.gh_guard.unknown_command.to_string(),
-                ("gh_guard", "allow_api_write") => resolved.gh_guard.allow_api_write.to_string(),
-                ("git_guard", "enabled") => resolved.git_guard.enabled.to_string(),
                 ("git_guard", "mode") => resolved.git_guard.mode.to_string(),
-                ("git_guard", "prevent_push") => resolved.git_guard.prevent_push.to_string(),
-                ("git_guard", "prevent_force_push") => {
-                    resolved.git_guard.prevent_force_push.to_string()
-                }
-                ("git_guard", "protect_default_branch_only") => {
-                    resolved.git_guard.protect_default_branch_only.to_string()
-                }
                 _ => fallback(),
             };
             ((key.section, key.key), value)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -490,9 +490,13 @@ fn resolved_values(
                 get_value_from_doc(global_doc, key)
                     .unwrap_or_else(|| key.default_display.to_string())
             };
-            // Booleans read their effective value straight off the registry
-            // row, so this match never has to keep a parallel list of them —
-            // the list that silently drifted behind the `_ => fallback()` arm.
+            // A boolean on the precedence ladder reads its effective value
+            // straight off the registry row, so this match no longer keeps a
+            // parallel list of those — the list that silently drifted behind
+            // the `_ => fallback()` arm. The booleans in `BOOL_KEYS_EXEMPT`
+            // (the legacy `sandbox.gh_proxy` / `sandbox.git_push_prevention`
+            // spellings, and `sandbox.use_bubblewrap`) are not on the ladder
+            // and still need an arm below.
             if let Some(row) = crate::config::bool_key(key.section, key.key) {
                 return ((key.section, key.key), (row.resolved)(resolved).to_string());
             }


### PR DESCRIPTION
Boolean config precedence was written longhand, once per key, in four different shapes. This makes the key registry drive it: one ladder, described once, with every deviation stated rather than implied.

## The audit came first, and found no live enforcement bug

I checked all ~50 hand-written resolution chains in `merge` before touching anything, because normalising a deliberate exception silently changes behaviour and normalising a bug silently fixes one. **The conclusion is that every shape deviation is intended.** `PresetBaseline` has exactly nine fields and all nine were being consumed correctly — no key was dropping the preset layer. That is the useful result: it means the deviations can be normalised without changing what the sandbox enforces, which is why every existing test passes unmodified and no expectation was adjusted.

| Site | Deviation | Verdict |
|---|---|---|
| `allow_env_files`, `allow_localhost_any`, `allow_tmp_exec`, `allow_docker`, `allow_lifecycle_scripts` | `cli.to_option().or(config).unwrap_or(baseline)` | the standard shape |
| `proxy_forced`, `default_allowlist`, `gh_guard.enabled`, `git_guard.enabled` | `FeatureToggle::resolve(config.unwrap_or(baseline))` | **intended** — equivalent, different spelling |
| `with_proxy`, `brief`, `scratch_dir`, `quiet`, `audit`, `yes` | `resolve(config.unwrap_or(<literal>))`, no baseline | **intended** — these keys have no preset baseline |
| `allow_gpg_signing`, `allow_jvm_attach`, `allow_msbuild`, `allow_cache_exec_any`, `allow_browser`, `inherit_env` | `if cli.x { true } else { config.unwrap_or(false) }` | **intended** — one-way CLI flag, no `--no-x`. See below |
| `sandbox.validate` | one-way `--no-validate`, stored inverted as `no_validate` | **intended** |
| `sandbox.audit` | only the OFF side (`--no-audit`) exists | **intended** |
| `agents_md` | ladder result, then `&& brief` | **intended**, already documented |
| `use_bubblewrap` | `to_option().or(config)` → `Option<bool>`, no bottom layer | **intended** — `None` = auto-detect is a real third state |
| `gradle_init`, `keychain_substitute` | config-only, CLI ignored | **intended** |
| `deny_clipboard`, `allow_all_domains` | CLI-only, no config key | **intended** |
| `gh_guard.*` / `git_guard.*` sub-options | config-only `unwrap_or(<literal>)` | **intended** |

## Two silent bugs, fixed

Neither is a precedence bug in the enforcement sense. Both are drift between hand-maintained lists of the same key set — which is the failure mode the registry is supposed to prevent.

**1. `settings::resolved_values` drift, hidden by a `_ => fallback()` catch-all.** That function kept its own list of keys mapping to resolved values. Four were missing from it: `sandbox.brief`, `sandbox.agents_md`, `sandbox.allow_msbuild`, `sandbox.gradle_init`. A missing key did not error — it fell through the catch-all to the config-file value, so `cplt settings` reported the *unresolved* value and `--brief` did not show up at all. A wrong answer that looks exactly like a right one, which is the same shape this repo keeps finding. Bools now read straight off the registry row, so the parallel list is gone and cannot drift again.

**2. `repo_key_target` was missing `gradle_init`.** A `.cplt.toml` can propose it, `proposed_keys` reports it, and `apply_repo_config` honours it — but `cplt config set --repo sandbox.gradle_init true` refused it as "not supported in repo config". The mapping is now derived from the same `PROPOSE_BOOLS` table the loader uses, so the four lists that described `[propose]` booleans are one list.

## The change

`registry.rs` owns the ladder: one `resolve_bool` (**CLI flag > config > preset baseline > default**) and a 32-row `bool_keys!` table stating all four layers per key. The baseline is a required column — a key cannot be declared without saying what its bottom layer is, which is what makes the "forgot the preset baseline" bug unrepresentable rather than merely absent. `merge` copies values out and resolves nothing itself.

`config/repo.rs` gains `PROPOSE_BOOLS`, replacing the twelve `if propose.X == Some(true) && is_approved("X")` chains in `apply_repo_config`, the parallel list in `repo_config::proposed_keys`, and the propose arm of `repo_key_target`.

### One-way CLI flags now have a column

Eight keys have a CLI flag that can only push the value one direction, because the opposite flag does not exist: `validate` and `audit` (OFF side only), `inherit_env`, `allow_gpg_signing`, `allow_jvm_attach`, `allow_msbuild`, `allow_cache_exec_any`, `allow_browser` (ON side only). That was never stated anywhere — it was implied by the shape of an `if cli.x { true } else { .. }` in the middle of fifty similar lines. Each such row now carries a `one-way` doc comment and a literal `false` on the side it lacks, and `precedence::one_way_cli_flags_are_declared_as_such` pins the exact list, so gaining or losing one is a test failure rather than a silent change.

Practical consequence worth noting, unchanged by this PR: for those six ON-only keys, a config `true` cannot be undone for a single run. That is a missing tightening escape hatch, not a weakening — filed as an observation, not fixed here.

### Deviations preserved deliberately

`sandbox.validate` resolves through the ladder and is stored inverted. `sandbox.agents_md` resolves through the ladder and *then* stays gated on `brief`, because writing into the user's AGENTS.md is a second opt-in. `sandbox.use_bubblewrap`, the deprecated `sandbox.gh_proxy` / `sandbox.git_push_prevention` spellings, and `[audit]` stay off the ladder and are listed in `BOOL_KEYS_EXEMPT` with the reason each is exempt.

### Dead field deleted

`CliFlags.gradle_init` was a `bool` that `merge` never read, `main.rs` always set to `false`, and no clap argument ever produced. Deleted (second commit, two lines plus the `main.rs` assignment). The key is config-only by design and the registry row now says so.

## Not fixed here, reported

`[audit]` — `audit.enabled` / `destination` / `level` / `format` are in the registry, settable via `config set`, and rendered by `config show`, but `Config.audit` is read only by `display.rs`. **Setting `audit.enabled = true` does nothing.** That is an unimplemented feature, not a precedence bug, so it is out of scope here and is being filed separately. It stays in `BOOL_KEYS_EXEMPT` with that reason recorded, precisely so nobody later normalises it into looking wired.

## Tests

11 new tests in `config::loading::precedence`, table-driven over the real `Config::merge` rather than over the registry, so a row that stops holding means the ladder actually changed:

- default with nothing set; config over default; preset baseline over default; config over preset baseline; CLI over both
- `agents_md`'s brief gate in all four directions
- the legacy `gh_proxy` / `git_push_prevention` spellings feeding the guard keys' config layer, with the modern key winning when both are set
- the pinned one-way-flag list
- two anti-drift tests: every boolean registry key is either on the ladder or in `BOOL_KEYS_EXEMPT` with a reason (exactly one of the two), and every ladder row names a real boolean registry key

**Mutation check.** I changed `allow_docker`'s baseline column from `|b| b.allow_docker` to `|_| false` — precisely the "hand-written chain that skips the preset baseline" bug this PR is about. `preset_baseline_beats_the_default` failed on `sandbox.allow_docker`. Restored; green again.

**No test expectation was changed.** 886 lib + 318 unit + 64 integration + 123 e2e_guards + 7 e2e_git_hardening pass unmodified. `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean on top of #300.

## Scope

Touches `src/config/` plus the two call sites that kept parallel key lists (`settings.rs`, `repo_config.rs`) and two deleted lines in `main.rs`. `parse_private_domains_from_toml`, `proxy.rs` and `sandbox*.rs` are untouched.
