### PR TITLE
fix(sandbox): honour write grants in credential dirs, refuse the dirs themselves

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -215,6 +215,22 @@ Bubblewrap's private `/tmp` helps only for that stock layout. The desktop agents
 
 If your keys must be unusable by a compromised agent on Linux, unload them (`ssh-add -D`) before starting the session.
 
+### If you do need SSH inside the sandbox
+
+Three things have to line up, and the same configuration works on both platforms:
+
+```bash
+cplt config set allow.ports 22                      # outbound is 443-only by default
+cplt config set allow.read  "~/.ssh/id_ed25519"     # the key, by name
+cplt config set allow.write "~/.ssh/known_hosts"    # ssh appends on a first connection
+```
+
+Port 22 is the first gate: without it no key grant matters, because the connection never opens. `~/.ssh/config` needs its own `allow.read` if you have one. `known_hosts` needs **write**, not read — under the default `StrictHostKeyChecking` a first connection to a host appends to it, and a read-only grant fails the connection.
+
+**The directory itself cannot be granted.** `allow.read = "~/.ssh"` (or `~/.aws`, `~/.gnupg`, any of the credential directories) is refused at startup with an error naming this per-file route. macOS never honoured such a grant — the blanket subpath deny beats it whatever the config says — while Linux granted it for real, so the same config file opened every key on one platform and nothing on the other. Refusing is the only answer both backends give alike.
+
+One gap remains on Linux, unchanged and the same limitation described under [private registries](#private-registries): a grant on a *parent* — `$HOME` itself — still exposes everything under it, because Landlock cannot deny a subpath inside an allowed directory.
+
 ## D-Bus and systemd (Linux) — the session manager is reachable
 
 `XDG_RUNTIME_DIR` is on the environment allowlist, and Landlock cannot restrict `connect()` to a pathname unix socket before ABI v9 (kernel 7.1), so on a current kernel `$XDG_RUNTIME_DIR/bus` is reachable from inside the sandbox unless bubblewrap masks it. This is established by reading the code, not by running it on a host — treat it as reachable rather than demonstrated. `systemd-run --user <cmd>` hands the command to the user's systemd instance, which starts it as a new unit **outside** Landlock, seccomp and the bubblewrap namespaces. The same applies to any other D-Bus service on the session bus that can start a process.

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -163,10 +163,10 @@ pub fn generate_session_brief(resolved: &Resolved, agent: Agent, home: &Path) ->
          and similar) are unreadable by design (EPERM). Don't retry; tell the \
          user.\n",
     );
-    // `allow.read` of a path inside one of those directories is a supported
-    // configuration — the backends re-allow it after the blanket deny — so the
-    // blanket claim above needs its exceptions spelled out, or the agent will
-    // report a working read as blocked.
+    // `allow.read` or `allow.write` of a path inside one of those directories is
+    // a supported configuration — the backends re-allow it after the blanket
+    // deny — so the blanket claim above needs its exceptions spelled out, or the
+    // agent will report a working access as blocked.
     let credential_overrides = denied_dotfile_overrides(home, &resolved.allow_read);
     if !credential_overrides.is_empty() {
         let _ = writeln!(
@@ -175,6 +175,16 @@ pub fn generate_session_brief(resolved: &Resolved, agent: Agent, home: &Path) ->
              ARE readable: {}. Use them for what they are for and don't send \
              their contents anywhere.",
             credential_overrides.join(", ")
+        );
+    }
+    let credential_writes = denied_dotfile_overrides(home, &resolved.allow_write);
+    if !credential_writes.is_empty() {
+        let _ = writeln!(
+            out,
+            "- Also writable this session (`allow.write`), and readable with it: \
+             {}. `~/.ssh/known_hosts` is the usual one — `ssh` appends to it on \
+             a first connection.",
+            credential_writes.join(", ")
         );
     }
     if cfg!(target_os = "linux") {
@@ -222,23 +232,20 @@ fn ssh_port_open(resolved: &Resolved) -> bool {
 
 /// Is a private key under `~/.ssh` actually readable?
 ///
-/// The two backends disagree, so this does too:
+/// A grant naming a *file* inside `~/.ssh` opens it on both backends: macOS
+/// re-allows it after the blanket deny (`emit_denied_dotfile_overrides`), Linux
+/// emits it as a plain Landlock rule. A grant naming `~/.ssh` itself opens it on
+/// neither — `sandbox::prepare` refuses the run (#291).
 ///
-/// - **macOS**: `~/.ssh` is denied as a subpath, and `emit_denied_dotfile_overrides`
-///   re-allows approved paths afterwards — but it skips `*path == denied_dir`
-///   and emits `(literal ...)`, never a subpath. Only a grant naming a *file*
-///   inside `~/.ssh` opens anything.
-/// - **Linux**: Landlock has no denied-dotfile layer at all. Every `extra_read`
-///   path becomes a plain read rule, so a grant of `~/.ssh` — or of `~` — really
-///   does make the keys readable, and the brief must not claim otherwise.
+/// One divergence is left, and it is the ancestor gap #207 documents: a grant on
+/// `~` (or any parent of `~/.ssh`) really does make the keys readable on Linux,
+/// because Landlock cannot deny a subpath inside an allowed directory. macOS
+/// denies the subpath regardless. The brief must not claim otherwise on Linux.
 fn ssh_key_readable(allow_read: &[std::path::PathBuf], home: &Path) -> bool {
     let ssh_dir = home.join(".ssh");
     allow_read.iter().any(|p| {
-        if cfg!(target_os = "macos") {
-            p.starts_with(&ssh_dir) && *p != ssh_dir
-        } else {
-            p.starts_with(&ssh_dir) || ssh_dir.starts_with(p)
-        }
+        (p.starts_with(&ssh_dir) && *p != ssh_dir)
+            || (cfg!(not(target_os = "macos")) && ssh_dir.starts_with(p))
     })
 }
 
@@ -264,26 +271,23 @@ fn ssh_agent_reaches(resolved: &Resolved) -> bool {
         && (!cfg!(target_os = "macos") || !resolved.allow_socket.is_empty())
 }
 
-/// The `allow.read` paths that defeat a `DENIED_DOTFILES` deny, rendered with
-/// `~` for the home prefix.
+/// The granted paths that defeat a `DENIED_DOTFILES` deny, rendered with `~`
+/// for the home prefix.
 ///
 /// The Credentials section claims those directories are unreadable; this is
-/// what keeps the claim honest by naming the exceptions. Which grants count is
-/// per-backend, exactly as in [`ssh_key_readable`]: macOS re-allows approved
-/// paths per file via `emit_denied_dotfile_overrides` (which skips the
-/// directory itself), while Linux has no denied-dotfile layer at all, so a
-/// grant *at or above* the directory — `~/.aws`, or plain `~` — opens it.
-fn denied_dotfile_overrides(home: &Path, allow_read: &[std::path::PathBuf]) -> Vec<String> {
-    allow_read
+/// what keeps the claim honest by naming the exceptions. A grant on a file
+/// inside one counts on both backends, and a grant on the directory itself
+/// counts on neither (`sandbox::prepare` refuses it, #291). The one divergence
+/// left is the ancestor gap from [`ssh_key_readable`]: on Linux a grant *above*
+/// the directory — plain `~` — opens it, and Landlock cannot take it back.
+fn denied_dotfile_overrides(home: &Path, granted: &[std::path::PathBuf]) -> Vec<String> {
+    granted
         .iter()
         .filter(|p| {
             crate::sandbox::DENIED_DOTFILES.iter().any(|d| {
                 let denied = home.join(d);
-                if cfg!(target_os = "macos") {
-                    p.starts_with(&denied) && **p != denied
-                } else {
-                    p.starts_with(&denied) || denied.starts_with(p)
-                }
+                (p.starts_with(&denied) && **p != denied)
+                    || (cfg!(not(target_os = "macos")) && denied.starts_with(p))
             })
         })
         .map(|p| match p.strip_prefix(home) {
@@ -741,12 +745,12 @@ mod tests {
         assert!(brief.contains("SSH may work this session"), "{brief}");
     }
 
-    /// macOS re-allows approved paths inside `~/.ssh` per file
-    /// (`emit_denied_dotfile_overrides` skips the directory itself and emits
-    /// `(literal ...)`), so a grant of the bare directory opens nothing.
+    /// A bare `~/.ssh` grant opens nothing on either backend now: macOS never
+    /// honoured it, and since #291 `sandbox::prepare` refuses the run outright
+    /// rather than letting Linux honour it alone. The brief must not promise
+    /// keys on the strength of a grant that cannot start a session.
     #[test]
-    #[cfg(target_os = "macos")]
-    fn brief_treats_bare_ssh_dir_grant_as_no_grant_on_macos() {
+    fn brief_treats_a_bare_ssh_dir_grant_as_no_grant() {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
         resolved.allow_read = vec![home().join(".ssh")];
@@ -757,32 +761,47 @@ mod tests {
         );
         assert!(
             !brief.contains("Exceptions the user granted"),
-            "a bare directory grant is not a readable exception on macOS:\n{brief}"
+            "a bare directory grant is not a readable exception:\n{brief}"
         );
     }
 
-    /// Linux has no denied-dotfile layer — every extra_read path becomes a
-    /// plain Landlock read rule — so a grant of `~/.ssh`, or of `~`, really
-    /// does make the keys readable, and the brief must say so.
+    /// A grant on a *file* inside `~/.ssh` is the supported route on both
+    /// backends, and `allow.write` counts as well as `allow.read` — that is what
+    /// lets `ssh` append to `known_hosts` on a first connection. Before this the
+    /// write grant was inert on macOS, so the brief would have called a working
+    /// write blocked.
+    #[test]
+    fn brief_names_a_write_grant_inside_a_credential_dir() {
+        let mut resolved = base_resolved();
+        resolved.allow_ports = vec![22];
+        resolved.allow_write = vec![home().join(".ssh/known_hosts")];
+        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        assert!(
+            brief.contains("Also writable this session"),
+            "the credentials claim must name the write exception:\n{brief}"
+        );
+        assert!(brief.contains("`~/.ssh/known_hosts`"), "{brief}");
+    }
+
+    /// The one divergence left, and the one #291 deliberately did not close:
+    /// Landlock cannot deny a subpath inside an allowed directory, so a grant on
+    /// `~` really does expose the keys on Linux. macOS's subpath deny beats it.
+    /// The brief must not claim otherwise on Linux.
     #[test]
     #[cfg(target_os = "linux")]
-    fn brief_honours_a_directory_grant_on_linux() {
-        for grant in [home().join(".ssh"), home().to_path_buf()] {
-            let mut resolved = base_resolved();
-            resolved.allow_ports = vec![22];
-            resolved.allow_read = vec![grant.clone()];
-            let brief = generate_session_brief(&resolved, Agent::Claude, home());
-            assert!(
-                brief.contains("SSH may work this session"),
-                "Landlock grants {} outright:\n{brief}",
-                grant.display()
-            );
-            assert!(
-                brief.contains("Exceptions the user granted"),
-                "the credentials claim must name {}:\n{brief}",
-                grant.display()
-            );
-        }
+    fn brief_honours_an_ancestor_grant_on_linux() {
+        let mut resolved = base_resolved();
+        resolved.allow_ports = vec![22];
+        resolved.allow_read = vec![home().to_path_buf()];
+        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        assert!(
+            brief.contains("SSH may work this session"),
+            "Landlock grants $HOME outright:\n{brief}"
+        );
+        assert!(
+            brief.contains("Exceptions the user granted"),
+            "the credentials claim must name the ancestor grant:\n{brief}"
+        );
     }
 
     /// Linux + allow_localhost_any sets restrict_net_connect = false, so

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -244,8 +244,11 @@ fn ssh_port_open(resolved: &Resolved) -> bool {
 fn ssh_key_readable(allow_read: &[std::path::PathBuf], home: &Path) -> bool {
     let ssh_dir = home.join(".ssh");
     allow_read.iter().any(|p| {
-        (p.starts_with(&ssh_dir) && *p != ssh_dir)
-            || (cfg!(not(target_os = "macos")) && ssh_dir.starts_with(p))
+        // The directory itself counts on neither backend, whichever side of the
+        // prefix test it lands on.
+        *p != ssh_dir
+            && (p.starts_with(&ssh_dir)
+                || (cfg!(not(target_os = "macos")) && ssh_dir.starts_with(p)))
     })
 }
 
@@ -286,8 +289,9 @@ fn denied_dotfile_overrides(home: &Path, granted: &[std::path::PathBuf]) -> Vec<
         .filter(|p| {
             crate::sandbox::DENIED_DOTFILES.iter().any(|d| {
                 let denied = home.join(d);
-                (p.starts_with(&denied) && **p != denied)
-                    || (cfg!(not(target_os = "macos")) && denied.starts_with(p))
+                **p != denied
+                    && (p.starts_with(&denied)
+                        || (cfg!(not(target_os = "macos")) && denied.starts_with(p)))
             })
         })
         .map(|p| match p.strip_prefix(home) {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -250,7 +250,8 @@ pub fn prepare(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
     prepare_impl(config, &extra_git_dirs(config.extra_write))
 }
 
-/// Refuse to launch when a grant names a file on the hard-deny list.
+/// Refuse to launch when a grant names a hard-denied file or a credential
+/// directory.
 ///
 /// [`policy::DENIED_FILES`] is documented as not overridable, unlike
 /// [`policy::DENIED_HOME_SUBPATHS`], which `allow.read` is meant to reopen.
@@ -259,6 +260,14 @@ pub fn prepare(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
 /// in force when it is not is exactly the failure this list exists to prevent.
 /// It also lands on both backends at once — silently ineffective on macOS,
 /// silently effective on Linux, which is how #207 stayed invisible.
+///
+/// [`policy::DENIED_DOTFILES`] directories are refused for the same reason
+/// pointing the other way (#291): the grant was silently ineffective on macOS
+/// and silently *effective* on Linux, where it opened `~/.ssh` wholesale. The
+/// error names the per-file grant, which is supported on both backends, so the
+/// Linux behaviour change arrives as a message with its own fix rather than as
+/// a rule that quietly stopped applying. Only the directory itself matches —
+/// a grant on a file inside it is the supported override and still works.
 fn validate_hard_denied_grants(config: &SandboxConfig) -> Result<(), String> {
     for (key, paths) in [
         ("allow.read", config.extra_read),
@@ -270,6 +279,16 @@ fn validate_hard_denied_grants(config: &SandboxConfig) -> Result<(), String> {
             if let Some(file) = policy::hard_denied_file(config.home_dir, p) {
                 return Err(format!(
                     "{key} names {} (~/{file}), which is on the hard-deny list and cannot be granted explicitly. Remove it from your config or command line.",
+                    p.display()
+                ));
+            }
+            if let Some(dir) = policy::denied_dotfile_dir(config.home_dir, p) {
+                return Err(format!(
+                    "{key} names {} (~/{dir}), a credential directory that cannot be granted \
+                     whole: macOS denies it whatever the grant says, so honouring it on Linux \
+                     alone would mean the same config opens every key in it on one platform \
+                     and nothing on the other. Name the specific files you need instead, e.g. \
+                     ~/{dir}/<file> — that grant works on both.",
                     p.display()
                 ));
             }
@@ -1027,6 +1046,83 @@ mod tests {
                 .expect("allow.socket must be refused");
             assert!(error.contains("allow.socket"), "{error}");
         }
+    }
+
+    /// A grant naming a `DENIED_DOTFILES` directory is refused on every key and
+    /// on both backends (#291).
+    ///
+    /// It was never honoured on macOS — the generic allow is emitted before the
+    /// subpath deny and loses to it — while Linux granted it for real. Refusing
+    /// is what makes the two the same; the error has to name the per-file grant,
+    /// because that is the route that still works.
+    #[test]
+    fn prepare_rejects_a_grant_on_a_denied_dotfile_directory() {
+        let home = Path::new("/home/test");
+        for &dir in policy::DENIED_DOTFILES {
+            let granted = vec![home.join(dir)];
+
+            let mut config = test_config(home, &granted);
+            let error = prepare(&config).err().expect("allow.read must be refused");
+            assert!(error.contains("allow.read"), "{error}");
+            assert!(error.contains(dir), "{error}");
+            assert!(
+                error.contains("Name the specific files"),
+                "the error must point at the grant that does work: {error}"
+            );
+
+            config.extra_read = &[];
+            config.extra_write = &granted;
+            let error = prepare(&config).err().expect("allow.write must be refused");
+            assert!(error.contains("allow.write"), "{error}");
+
+            config.extra_write = &[];
+            config.extra_socket = &granted;
+            let error = prepare(&config)
+                .err()
+                .expect("allow.socket must be refused");
+            assert!(error.contains("allow.socket"), "{error}");
+
+            config.extra_socket = &[];
+            config.extra_exec = &granted;
+            let error = prepare(&config).err().expect("allow.exec must be refused");
+            assert!(error.contains("allow.exec"), "{error}");
+        }
+    }
+
+    /// The per-file grant is the supported route and must survive: refusing it
+    /// would close the only door SSH has left on macOS, `~/.ssh/known_hosts`
+    /// included.
+    #[test]
+    fn prepare_accepts_a_grant_inside_a_denied_dotfile_directory() {
+        let home = Path::new("/home/test");
+        let granted = vec![
+            home.join(".ssh/id_ed25519"),
+            home.join(".ssh/known_hosts"),
+            home.join(".config/gcloud/application_default_credentials.json"),
+        ];
+
+        let mut config = test_config(home, &granted);
+        assert_eq!(validate_hard_denied_grants(&config), Ok(()));
+        config.extra_read = &[];
+        config.extra_write = &granted;
+        assert_eq!(validate_hard_denied_grants(&config), Ok(()));
+    }
+
+    /// `--allow-docker` grants `~/.docker` read-only, and `~/.docker` is a
+    /// `DENIED_DOTFILES` entry. It is a first-party rule the backends emit, not
+    /// a user grant, so the #291 refusal must not be able to see it — otherwise
+    /// the flag would refuse every run it is set on.
+    #[test]
+    fn prepare_does_not_refuse_the_allow_docker_dotfile_grant() {
+        let home = Path::new("/home/test");
+        let mut config = test_config(home, &[]);
+        config.allow_docker = true;
+
+        assert_eq!(validate_hard_denied_grants(&config), Ok(()));
+        assert!(
+            prepare(&config).is_ok(),
+            "--allow-docker must not be caught by the denied-dotfile refusal"
+        );
     }
 
     /// `/` and `$HOME` are refused: an exec grant that wide is not a sandbox.

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -535,13 +535,15 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
     }
 
     // ── Extra read paths from config ──
-    // Hard-denied files (policy::DENIED_FILES) are filtered out: Landlock is
-    // grant-only, so a grant on ~/.netrc has no deny to lose to and would make
-    // the documented "not overridable" guarantee false on Linux only (#207).
-    // `prepare()` rejects such a grant before we get here — this keeps the
-    // ruleset invariant true for every caller of `generate_policy`.
+    // Hard-denied files (policy::DENIED_FILES) and credential directories
+    // (policy::DENIED_DOTFILES) are filtered out: Landlock is grant-only, so a
+    // grant on ~/.netrc or ~/.ssh has no deny to lose to and would make the
+    // documented guarantee false on Linux only (#207, #291). A grant on a file
+    // *inside* a denied dotfile directory is the supported override and passes
+    // through. `prepare()` rejects the refused forms before we get here — this
+    // keeps the ruleset invariant true for every caller of `generate_policy`.
     for p in config.extra_read {
-        if policy::hard_denied_file(home, p).is_some() {
+        if policy::grant_is_refused(home, p) {
             continue;
         }
         fs_rules.push(FsRule {
@@ -557,7 +559,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
 
     // ── Extra write paths from config ──
     for p in config.extra_write {
-        if policy::hard_denied_file(home, p).is_some() {
+        if policy::grant_is_refused(home, p) {
             continue;
         }
         fs_rules.push(FsRule {
@@ -578,7 +580,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
     // refuses an exec grant that overlaps a writable tree precisely because
     // Landlock unions the two and cannot subtract one from the other.
     for p in config.extra_exec {
-        if policy::hard_denied_file(home, p).is_some() {
+        if policy::grant_is_refused(home, p) {
             continue;
         }
         fs_rules.push(FsRule {
@@ -594,7 +596,7 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
 
     // ── Extra socket paths from config ──
     for p in config.extra_socket {
-        if policy::hard_denied_file(home, p).is_some() {
+        if policy::grant_is_refused(home, p) {
             continue;
         }
         fs_rules.push(FsRule {
@@ -1938,6 +1940,76 @@ mod tests {
             let found = policy.fs_rules.iter().any(|r| r.path == path);
             assert!(!found, "denied dotfile {dotfile} should NOT be in ruleset");
         }
+    }
+
+    /// The other half of `denied_dotfiles_not_in_ruleset`: deny-by-omission is
+    /// not enough once the user *grants* the directory. Landlock is grant-only,
+    /// so an unfiltered `allow.read = "~/.ssh"` became a working read rule and
+    /// opened every key in it — on Linux only, since macOS's subpath deny beat
+    /// the same grant (#291). `prepare()` refuses the run, and this keeps the
+    /// invariant true for every other caller of `generate_policy`.
+    #[test]
+    fn a_granted_denied_dotfile_directory_stays_out_of_the_ruleset() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let granted: Vec<PathBuf> = policy::DENIED_DOTFILES
+            .iter()
+            .map(|d| home.join(d))
+            .collect();
+
+        let mut config = test_config(&project, &home);
+        for (read, write, exec, socket) in [
+            (true, false, false, false),
+            (false, true, false, false),
+            (false, false, true, false),
+            (false, false, false, true),
+        ] {
+            config.extra_read = if read { &granted } else { &[] };
+            config.extra_write = if write { &granted } else { &[] };
+            config.extra_exec = if exec { &granted } else { &[] };
+            config.extra_socket = if socket { &granted } else { &[] };
+            let policy = generate_policy(&config);
+
+            for path in &granted {
+                assert!(
+                    !policy.fs_rules.iter().any(|r| &r.path == path),
+                    "granted denied dotfile {} must not enter the ruleset",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    /// A grant on a file *inside* one of those directories is the supported
+    /// override and must still reach the ruleset — the route the refusal above
+    /// tells users to take. `~/.ssh/known_hosts` needs write for `ssh` to append
+    /// to it on a first connection.
+    #[test]
+    fn a_granted_file_inside_a_denied_dotfile_directory_survives() {
+        let project = PathBuf::from("/home/user/project");
+        let home = PathBuf::from("/home/user");
+        let key = vec![home.join(".ssh/id_ed25519")];
+        let known_hosts = vec![home.join(".ssh/known_hosts")];
+
+        let mut config = test_config(&project, &home);
+        config.extra_read = &key;
+        config.extra_write = &known_hosts;
+        let policy = generate_policy(&config);
+
+        let read = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == key[0])
+            .expect("~/.ssh/id_ed25519 must be in the ruleset");
+        assert!(read.access.read);
+        assert!(!read.access.write, "a read grant must not become writable");
+
+        let write = policy
+            .fs_rules
+            .iter()
+            .find(|r| r.path == known_hosts[0])
+            .expect("~/.ssh/known_hosts must be in the ruleset");
+        assert!(write.access.read && write.access.write);
     }
 
     /// `--allow-docker` on Linux grants `~/.docker` read-only (#155). Off, the

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -44,9 +44,49 @@ pub const DENIED_FILES: &[&str] = &[".netrc", ".pypirc", ".gem/credentials", ".v
 /// `resolve_config_path`) while `$HOME/.netrc` may be a symlink into a
 /// dotfiles repo — comparing the unresolved forms would miss the match.
 pub fn hard_denied_file(home: &Path, path: &Path) -> Option<&'static str> {
+    denied_entry(DENIED_FILES, home, path)
+}
+
+/// The [`DENIED_DOTFILES`] directory `path` names, if any.
+///
+/// Exact directory match only. A path *inside* one of these directories is a
+/// supported override on both backends — macOS re-allows it after the blanket
+/// deny (`emit_denied_dotfile_overrides`), Linux emits it as a plain rule — and
+/// must not match here.
+///
+/// The directory itself is refused (#291). macOS could never honour it: the
+/// generic `allow.read` is emitted before the subpath deny and loses to it, so
+/// the grant sat in config looking effective and did nothing. Linux did honour
+/// it, handing an agent every key in `~/.ssh` on the strength of one config
+/// line. Refusing is the only answer both backends give alike, and it leaves
+/// the per-file grant — which works on both — as the way in.
+///
+/// Canonicalized on both sides for the same reason [`hard_denied_file`] is:
+/// grants arrive canonicalized while `~/.ssh` may be a symlink into a dotfiles
+/// repo, and comparing the unresolved forms would miss the match.
+///
+/// `--allow-docker`'s read-only `~/.docker` grant is unaffected: it is a
+/// first-party rule emitted by the backends, never a user grant on this path.
+pub fn denied_dotfile_dir(home: &Path, path: &Path) -> Option<&'static str> {
+    denied_entry(DENIED_DOTFILES, home, path)
+}
+
+/// Whether a grant on `path` must never reach a backend ruleset.
+///
+/// `sandbox::prepare` refuses both classes before a run starts; the backends
+/// consult this too, so the invariant holds for every caller of
+/// `generate_policy` and not only the ones that went through `prepare`.
+#[must_use]
+pub fn grant_is_refused(home: &Path, path: &Path) -> bool {
+    hard_denied_file(home, path).is_some() || denied_dotfile_dir(home, path).is_some()
+}
+
+/// Exact-path membership of `path` in a `$HOME`-relative deny list, comparing
+/// the literal and the canonicalized form.
+fn denied_entry(list: &[&'static str], home: &Path, path: &Path) -> Option<&'static str> {
     let canon = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
     let resolved = canon(path);
-    DENIED_FILES.iter().copied().find(|f| {
+    list.iter().copied().find(|f| {
         let denied = home.join(f);
         path == denied || resolved == canon(&denied)
     })

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -229,7 +229,7 @@ pub fn generate_profile_with_playwright_socket_dir(
     emit_user_allows(&mut sb, opts.extra_read, opts.extra_write, opts.extra_exec);
     emit_deny_rules(&mut sb, &home, opts.extra_deny);
     emit_registry_config_overrides(&mut sb, &home, opts.extra_read);
-    emit_denied_dotfile_overrides(&mut sb, &home, opts.extra_read);
+    emit_denied_dotfile_overrides(&mut sb, &home, opts.extra_read, opts.extra_write);
     emit_gpg_signing_rules(&mut sb, &home, opts.allow_gpg_signing, opts.extra_deny);
     emit_docker_rules(&mut sb, &home, opts.allow_docker, opts.extra_deny);
     emit_socket_rules(&mut sb, opts.allow_socket, opts.extra_deny);
@@ -1734,48 +1734,83 @@ fn emit_registry_config_overrides(sb: &mut String, home: &str, extra_read: &[Pat
     }
 }
 
-/// Re-allow specific files inside DENIED_DOTFILES directories when the user
-/// has explicitly approved them via `allow.read`.
+/// Every spelling of `path` that needs a re-allow, when it names a file *inside*
+/// a [`DENIED_DOTFILES`] directory. Empty when it does not.
 ///
-/// DENIED_DOTFILES uses `(deny file-read* (subpath ...))` which blocks entire
-/// directories. When a user explicitly approves a file inside one of these dirs,
-/// we emit a targeted `(allow file-read* (literal ...))` AFTER the deny so
-/// SBPL last-match-wins grants access to that specific file only.
-fn emit_denied_dotfile_overrides(sb: &mut String, home: &str, extra_read: &[PathBuf]) {
+/// A grant naming the directory itself is not an override — `sandbox::prepare`
+/// refuses it outright (#291), and honouring it here would reopen a whole
+/// credential directory on the strength of one config line.
+fn denied_dotfile_override_paths(home: &Path, path: &Path) -> Vec<String> {
+    for &dotfile in DENIED_DOTFILES {
+        let denied_dir = home.join(dotfile);
+        let resolved_dir = resolved(denied_dir.clone());
+        let Ok(rel) = path.strip_prefix(&resolved_dir) else {
+            continue;
+        };
+        if rel.as_os_str().is_empty() {
+            return Vec::new();
+        }
+        let mut forms = vec![path.to_string_lossy().into_owned()];
+        // When `~/<dotfile>` is itself a symlink the deny names the $HOME
+        // path, and the macOS sandbox matches a rule against the path as
+        // opened — so the re-allow has to cover that form as well.
+        if resolved_dir != denied_dir {
+            forms.push(denied_dir.join(rel).to_string_lossy().into_owned());
+        }
+        return forms;
+    }
+    Vec::new()
+}
+
+/// Re-allow specific files inside DENIED_DOTFILES directories when the user
+/// has explicitly approved them via `allow.read` or `allow.write`.
+///
+/// DENIED_DOTFILES uses `(deny file-read* (subpath ...))` and the matching
+/// `file-write*` deny, which block entire directories. When a user explicitly
+/// approves a file inside one of these dirs, we emit a targeted
+/// `(allow ... (literal ...))` AFTER the deny so SBPL last-match-wins grants
+/// access to that specific file only.
+///
+/// A write grant gets read as well, matching [`emit_user_allows`]: a write
+/// grant that cannot read the file it writes is not a usable grant. That is
+/// what makes `~/.ssh/known_hosts` appendable, which stock `ssh` needs on a
+/// first connection under the default `StrictHostKeyChecking`. Before this,
+/// `emit_user_allows` emitted the write grant *before* `emit_deny_rules`, the
+/// deny won, and the grant silently did nothing on macOS while working on
+/// Linux — the same shape as #291, pointing the other way.
+fn emit_denied_dotfile_overrides(
+    sb: &mut String,
+    home: &str,
+    extra_read: &[PathBuf],
+    extra_write: &[PathBuf],
+) {
     let home_path = Path::new(home);
-    let mut overrides: Vec<String> = Vec::new();
+    // A path granted both ways is emitted once, from the write list.
+    let read_only: Vec<String> = extra_read
+        .iter()
+        .filter(|p| !extra_write.contains(p))
+        .flat_map(|p| denied_dotfile_override_paths(home_path, p))
+        .collect();
+    let writable: Vec<String> = extra_write
+        .iter()
+        .flat_map(|p| denied_dotfile_override_paths(home_path, p))
+        .collect();
 
-    for path in extra_read {
-        for &dotfile in DENIED_DOTFILES {
-            let denied_dir = home_path.join(dotfile);
-            let resolved_dir = resolved(denied_dir.clone());
-            let Ok(rel) = path.strip_prefix(&resolved_dir) else {
-                continue;
-            };
-            if rel.as_os_str().is_empty() {
-                continue;
-            }
-            overrides.push(path.to_string_lossy().into_owned());
-            // When `~/<dotfile>` is itself a symlink the deny names the $HOME
-            // path, and the macOS sandbox matches a rule against the path as
-            // opened — so the re-allow has to cover that form as well.
-            if resolved_dir != denied_dir {
-                overrides.push(denied_dir.join(rel).to_string_lossy().into_owned());
-            }
-            break;
-        }
+    if read_only.is_empty() && writable.is_empty() {
+        return;
     }
-
-    if !overrides.is_empty() {
-        sbpl!(
-            sb,
-            ";; User-overridden files in sensitive directories (allow.read)"
-        );
-        for path in &overrides {
-            sbpl!(sb, "(allow file-read* (literal \"{path}\"))");
-        }
-        sbpl!(sb);
+    sbpl!(
+        sb,
+        ";; User-overridden files in sensitive directories (allow.read / allow.write)"
+    );
+    for path in &read_only {
+        sbpl!(sb, "(allow file-read* (literal \"{path}\"))");
     }
+    for path in &writable {
+        sbpl!(sb, "(allow file-read* (literal \"{path}\"))");
+        sbpl!(sb, "(allow file-write* (literal \"{path}\"))");
+    }
+    sbpl!(sb);
 }
 
 /// Allow GPG commit signing when `--allow-gpg-signing` is set.
@@ -2125,6 +2160,78 @@ mod tests {
             r#"(deny file-write* (literal "/projects/app/.git/config"))"#,
         ] {
             assert!(p.contains(rule), "MISSING without git_common_dir: {rule}");
+        }
+    }
+
+    /// `allow.write` on a file inside a `DENIED_DOTFILES` directory must reach
+    /// the profile as a post-deny re-allow, exactly as `allow.read` does.
+    ///
+    /// The concrete case: stock `ssh` appends to `~/.ssh/known_hosts` on a first
+    /// connection under the default `StrictHostKeyChecking`. Before this, the
+    /// write grant was emitted by `emit_user_allows` — i.e. *before*
+    /// `emit_deny_rules` — lost to the subpath deny, and did nothing at all on
+    /// macOS while working on Linux. Verified against the live sandbox with
+    /// `cplt check path --write`, which reported the model/probe mismatch.
+    ///
+    /// Read comes with write deliberately: a grant that can write a file it
+    /// cannot read is not a usable grant, and `emit_user_allows` pairs them the
+    /// same way.
+    #[test]
+    fn profile_extra_write_overrides_a_denied_dotfile_file() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let granted = [PathBuf::from("/Users/test/.ssh/known_hosts")];
+        let mut opts = test_options(project, home);
+        opts.extra_write = &granted;
+        let p = generate_profile(&opts);
+
+        let deny = p
+            .find(r#"(deny file-write* (subpath "/Users/test/.ssh"))"#)
+            .expect("the blanket ~/.ssh write deny must still be emitted");
+        for rule in [
+            r#"(allow file-read* (literal "/Users/test/.ssh/known_hosts"))"#,
+            r#"(allow file-write* (literal "/Users/test/.ssh/known_hosts"))"#,
+        ] {
+            let at = p
+                .find(rule)
+                .unwrap_or_else(|| panic!("missing post-deny re-allow: {rule}"));
+            assert!(
+                at > deny,
+                "re-allow must come AFTER the subpath deny (SBPL last-match-wins): {rule}"
+            );
+        }
+        // Scoped to the granted file: a sibling key stays denied.
+        assert!(
+            !p.contains(r#"(literal "/Users/test/.ssh/id_ed25519")"#),
+            "a write grant must not reopen anything but the file it names:\n{p}"
+        );
+    }
+
+    /// A grant naming the directory itself is not an override. `sandbox::prepare`
+    /// refuses such a run outright (#291), and this is the second line: even if
+    /// one reached `generate_profile`, it must not turn into a subpath re-allow
+    /// that reopens every key in `~/.ssh`.
+    #[test]
+    fn profile_never_reopens_a_denied_dotfile_directory_itself() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let granted = [PathBuf::from("/Users/test/.ssh")];
+        for (read, write) in [(true, false), (false, true)] {
+            let mut opts = test_options(project, home);
+            if read {
+                opts.extra_read = &granted;
+            }
+            if write {
+                opts.extra_write = &granted;
+            }
+            let p = generate_profile(&opts);
+            let deny = p
+                .find(r#"(deny file-read* (subpath "/Users/test/.ssh"))"#)
+                .expect("the blanket ~/.ssh deny must still be emitted");
+            assert!(
+                !p[deny..].contains(r#"(literal "/Users/test/.ssh")"#),
+                "a directory grant must produce no post-deny re-allow:\n{p}"
+            );
         }
     }
 


### PR DESCRIPTION
Closes #291, and fixes a second defect of the same shape found while investigating it.

Both halves are the pattern this repo keeps finding: a grant that is silently inert on one platform and effective on the other. #207 made a silently-dropped grant a startup error, #246 refuses an overlap rather than half-honouring it, #240 found `--allow-socket` inert on Linux while looking present. These are two more.

## Half 1 — `allow.write` inside a credential directory was inert on macOS

`emit_denied_dotfile_overrides` consulted `extra_read` only. A write grant on a file inside a `DENIED_DOTFILES` directory was emitted by `emit_user_allows` — before `emit_deny_rules` — lost to the subpath deny, and did nothing at all on macOS, not even read. On Linux the same grant worked. Nothing warned.

The concrete casualty is `~/.ssh/known_hosts`. Under the default `StrictHostKeyChecking`, stock `ssh` appends to it on a first connection, so the per-file SSH route — the one `brief.rs` recommends to users on both platforms — could not complete on macOS. There was no grant that permitted it.

Write grants now get a post-deny re-allow, with read alongside them, matching how `emit_user_allows` pairs the two. Scoped to the file named; siblings stay denied.

## Half 2 — a grant on the directory itself is refused (#291)

`allow.read = "~/.ssh"` was granted on Linux and ignored on macOS. Neither platform told the user which they were getting. It is now a startup error on all four grant keys, and the Landlock backend filters it too, so the ruleset invariant holds for every caller of `generate_policy` and not only the ones that went through `prepare`.

```
[cplt] allow.read names /Users/hans/.ssh (~/.ssh), a credential directory that cannot be
granted whole: macOS denies it whatever the grant says, so honouring it on Linux alone would
mean the same config opens every key in it on one platform and nothing on the other. Name the
specific files you need instead, e.g. ~/.ssh/<file> — that grant works on both.
```

This is option 1 from the issue. Its stated cost — "it breaks a workflow the tool currently recommends" — turned out not to hold on current `main`: nothing recommends the directory. `brief.rs:135` already tells users on both platforms to ask for "an `allow.read` of the specific key file", and no doc suggests `~/.ssh`. Half 1 is what makes that per-file route actually complete, which is why it is in the same PR and why it was built first — closing the directory route while the per-file route could not write would have closed the only working door.

An error rather than a silent narrowing, so the Linux behaviour change arrives as a message carrying its own fix.

`brief.rs` loses the `cfg!(macos)` branches that existed only to model this divergence. One divergence remains there, retargeted at what actually causes it.

## Deliberately not in scope

- **An ancestor grant (`allow.read = "~"`) is not refused.** It still exposes everything under it on Linux, because Landlock cannot deny a subpath inside an allowed directory — the same limitation #207 documents. `brief.rs` still reports it honestly on Linux, and `docs/known-impacts.md` names it as a remaining gap.
- **`--allow-docker`'s read-only `~/.docker` grant is exempt** and must stay so: it is a first-party rule the backends emit, not a user grant on that path, so the refusal cannot see it. `prepare_does_not_refuse_the_allow_docker_dotfile_grant` pins that — without it the flag would refuse every run it is set on.

## Evidence — what was run and what was read

**From a live sandbox probe on macOS**, using `cplt check path` (live probe plus static model) and `cplt exec`:

- Before: `--allow-read ~/.ssh` blocked the directory *and* every file in it; `--allow-write ~/.ssh/<file>` reported `read: blocked, write: blocked`, both with `live probe says BLOCKED, the policy model predicted ALLOWED`.
- After: the write grant reports `read: allowed, write: allowed` with no mismatch, a real `>> ~/.ssh/<file>` append succeeds inside the sandbox, and a sibling file in the same directory stays denied.
- After: the directory grant is refused on `--allow-read`, `--allow-write`, `--allow-exec` and `--allow-socket`, and `--allow-docker` still launches.

**From reading the code, not run here:** everything about Linux. This checkout runs on macOS, so the Linux half rests on `sandbox_landlock.rs` and on the cross-platform `generate_policy` model — which is exactly what `check path` was reporting as "the policy model predicted ALLOWED" on a macOS host. The `SSH_AUTH_SOCK` findings in the issue thread are likewise read-only: no agent was running in the test shell.

## Mutation checks

Both defects were reintroduced and the specific test watched to fail, then restored:

- Passing `&[]` for `extra_write` at the `emit_denied_dotfile_overrides` call site → `profile_extra_write_overrides_a_denied_dotfile_file` fails on `missing post-deny re-allow: (allow file-read* (literal ".../known_hosts"))`.
- Dropping `denied_dotfile_dir` from `grant_is_refused` and from `validate_hard_denied_grants` → `prepare_rejects_a_grant_on_a_denied_dotfile_directory` and `a_granted_denied_dotfile_directory_stays_out_of_the_ruleset` both fail.

## Gates

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (883), `cargo test --test unit_tests` (318), `cargo test --test integration` (64) — all clean on the rebased branch, after #300 cleared the clippy backlog.
