### PR TITLE
docs: write down the no-silent-grants rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,43 @@ This is a security tool. Changes to sandbox rules, env handling, or network poli
 
 Do not modify `blocked-domains.txt` without reviewing the domain's purpose.
 
+### No silent grants
+
+**A grant or setting that cannot be honoured must fail loudly at the point it is
+written. It must never be accepted and then quietly dropped.**
+
+Accepting a line the user wrote and ignoring it is worse than refusing it. The
+user believes they have the access, or the restriction, that they asked for.
+Nothing tells them otherwise, and the belief survives until something breaks in a
+way that never points back here.
+
+This holds in both directions. A grant that silently does nothing leaves someone
+thinking a path is reachable when it is not. A restriction that silently does
+nothing leaves someone thinking a path is closed when it is open. The second is
+the one that gets people hurt.
+
+It has been rediscovered repeatedly rather than reasoned about, which is why it
+is written down: `allow.read` on a hard-denied file worked on Linux and was
+silently overridden on macOS (#207); `--allow-socket` emitted rules `connect()`
+never consults, granting and denying nothing on Linux (#240); `allow.write`
+inside a credential directory was inert on macOS while working on Linux (#291);
+read-only grants under `/tmp` vanished inside bubblewrap's private tmpfs (#299);
+`cplt config set` accepted a path the next launch refuses (#306); `--inherit-env`
+cancelled an explicit `--pass-env` (#307); the entire `[audit]` section was
+settable, displayed, and consumed by nothing (#309).
+
+So, when adding a config key, a flag, or a grant kind:
+
+- Refuse at the earliest point that can refuse — config-set time beats
+  resolve time beats launch time. Say what is wrong and what to do instead.
+- Never let a backend difference decide whether a setting works. If it cannot be
+  enforced on one platform, that is a stated gap with a reason, not an absence.
+  `LinuxCoverage::Gap(reason)` in the protected-path tables is the pattern.
+- A key with no consumer does not ship. If it must exist ahead of its
+  implementation, mark it unimplemented everywhere it surfaces.
+- Cover it with a test that fails when the setting stops taking effect. Every
+  case above was found by a person tripping over it, never by the suite.
+
 ## Key patterns
 
 - `(deny default)` plus specific allows, so the sandbox is deny-by-default

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -502,6 +502,29 @@ file.
 
 ## Defense layers
 
+### A property that holds across all of them: no silent grants
+
+A grant or setting that cannot be honoured fails loudly at the point it is
+written. It is never accepted and then quietly dropped.
+
+This is a security property, not a usability one. A restriction that silently
+does nothing leaves an operator believing a path is closed when it is open, and
+nothing in the tool contradicts that belief. The failure is invisible by
+construction: the config still lists the setting, `cplt config show` still prints
+it, and the sandbox still starts.
+
+The property has been broken in both directions and fixed each time: `allow.read`
+on a hard-denied file worked on Linux while being silently overridden on macOS
+(#207); `--allow-socket` emitted file rules that `connect()` never consults, so
+it granted and denied nothing on Linux (#240); `allow.write` inside a credential
+directory was inert on macOS while working on Linux (#291); read-only grants
+under `/tmp` disappeared inside bubblewrap's private tmpfs (#299); the `[audit]`
+section was settable and displayed while no code consumed it (#309).
+
+Where a control genuinely cannot be enforced on a platform, that is documented as
+a stated gap with the kernel reason for it, not left as an absence. The Linux
+sections below say where those gaps are.
+
 ### Layer 0: Environment variable sanitization
 
 By default `cplt` clears the child process environment and re-adds only safe variables from an allowlist, so credentials cannot leak through inherited env vars.


### PR DESCRIPTION
Eight issues this week are one defect wearing different hats: a setting that is present, accepted, and does nothing.

| | |
|---|---|
| #207 | `allow.read` on a hard-denied file worked on Linux, silently overridden on macOS |
| #240 | `--allow-socket` emits file rules `connect()` never consults — grants nothing, denies nothing |
| #291 | `allow.write` inside a credential directory inert on macOS, working on Linux |
| #299 | read-only grants under `/tmp` vanish inside bubblewrap's private tmpfs |
| #306 | `cplt config set` accepts a path the next launch refuses, on every launch |
| #307 | `--inherit-env` cancels an explicit `--pass-env` |
| #309 | the whole `[audit]` section is settable, displayed, and consumed by nothing |
| #313 | `.cplt.toml` has no nested-repo deny, unlike `.git/hooks` and `.agents/plugins` |

Every one was found by a person tripping over it. None was caught by a test. That is the argument for writing the rule down rather than continuing to rediscover it.

## Why it is already the rule

Three fixes arrived at it independently, without anyone stating it: #207 made a hard-denied grant a startup error rather than a dropped rule, #295 refuses an exec grant overlapping a writable tree instead of half-honouring it, and #305 refuses one under a system temp dir so all three backends give the same answer. This PR does not introduce a policy. It records one the code already follows, so the next person has something to cite in review.

## What changed

**AGENTS.md** gets the working rule under Security constraints: refuse at the earliest point that can refuse, never let a backend difference decide whether a setting works, do not ship a key with no consumer, and cover it with a test that fails when the setting stops taking effect.

**SECURITY.md** states it as a property of the defense layers rather than a coding convention, because the dangerous direction is the second one. A grant that silently does nothing leaves someone thinking a path is reachable when it is not — annoying. A *restriction* that silently does nothing leaves an operator believing a path is closed when it is open, and nothing in the tool contradicts them. The config still lists the setting, `cplt config show` still prints it, and the sandbox still starts.

Where a control genuinely cannot be enforced on a platform, the rule is that it becomes a stated gap with the kernel reason attached, not an absence. `LinuxCoverage::Gap(reason)` in the protected-path tables is the shape.

Docs only. No behaviour change.
