### PR TITLE
fix(sandbox): stop a /tmp read grant shadowing a nested write grant

### DIFF
--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -210,6 +210,13 @@ pub(crate) fn test_functionality(
 ///    and run it; an `allow.exec` grant only reaches what already existed at
 ///    launch, on a mount that stays EROFS.
 ///
+/// 4c. Any writable bind from step 4 that lives *beneath* a read-only bind from
+///    step 4b is re-emitted, so the narrower write grant is not covered by the
+///    broader read grant (mounts apply in argument order). Without this,
+///    `--project-dir /tmp/work/repo` together with `--allow-read /tmp/work`
+///    left the project dir EROFS while every diagnostic still reported it
+///    writable.
+///
 /// 5. Finally, for every path in `ro_protect` that exists, `--ro-bind <p> <p>`
 ///    is emitted *after* the writable binds so it shadows them read-only. This
 ///    is the Finding 1 persistence mitigation: the project's `.git/hooks` lives
@@ -314,6 +321,7 @@ pub(crate) fn build_bwrap_args(
     // `bound_writable` is the set that actually got a `--bind`, not every
     // writable rule: the `/tmp` rule itself is writable and is deliberately
     // never bound, so testing against the rules would skip every path under it.
+    let mut bound_readonly: Vec<&Path> = Vec::new();
     for rule in fs_rules.iter().filter(|r| !r.access.write) {
         let path = &rule.path;
         if !path.starts_with("/tmp") || path == Path::new("/tmp") {
@@ -329,6 +337,31 @@ pub(crate) fn build_bwrap_args(
         }
         let path_str = path.to_string_lossy().into_owned();
         args.extend(["--ro-bind".to_string(), path_str.clone(), path_str]);
+        bound_readonly.push(path.as_path());
+    }
+
+    // ── Re-emit writable binds shadowed by a read-only bind above ──
+    // The skip above handles a read path *inside* a writable bind. The reverse
+    // nesting — a writable bind beneath a broader read grant, e.g.
+    // `--project-dir /tmp/work/repo` with `--allow-read /tmp/work` — is not
+    // covered by it: bwrap applies mounts in argument order, so the later
+    // `--ro-bind /tmp/work` covers the earlier `--bind /tmp/work/repo` and the
+    // project dir comes up EROFS. That is the same mechanic the git-persistence
+    // overlays below use on purpose, and it is silent here: Landlock still
+    // grants the write, `--print-profile` still reports it writable, and
+    // nothing at startup says otherwise (AGENTS.md, "No silent grants").
+    //
+    // Re-emitting the narrower writable bind after the broader read-only one
+    // restores the intended precedence: the read grant still covers the rest of
+    // the tree, the write grant still wins where the user asked for it.
+    // `bound_writable` is shallowest-first, so parents stay bound before
+    // children here too. Still before `ro_protect` below, which must keep
+    // shadowing writable binds.
+    for w in &bound_writable {
+        if bound_readonly.iter().any(|ro| w.starts_with(ro)) {
+            let w_str = w.to_string_lossy().into_owned();
+            args.extend(["--bind".to_string(), w_str.clone(), w_str]);
+        }
     }
 
     // ── Read-only overlays for git-persistence paths (Finding 1) ──
@@ -1016,6 +1049,53 @@ mod tests {
         assert!(
             bind_idx > tmpfs_idx,
             "writable bind under /tmp must come after --tmpfs /tmp to shadow it"
+        );
+    }
+
+    #[test]
+    fn a_read_only_bind_does_not_shadow_a_writable_bind_beneath_it() {
+        // #305 regression: the ro-bind loop skipped a read path *inside* a
+        // writable bind, but not the reverse nesting — a writable bind beneath
+        // a broader read grant. bwrap applies mounts in argument order, so
+        // `--ro-bind /tmp/work` after `--bind /tmp/work/repo` covers the
+        // project dir and it comes up EROFS, silently: Landlock and
+        // --print-profile both still call it writable.
+        //
+        // `writable_paths_under_tmp_survive_the_tmp_shadow` does not catch this:
+        // it passes a single writable rule with no read rule above it, so no
+        // ro-bind is ever emitted and there is nothing to shadow the write.
+        let base = tempfile::TempDir::new_in("/tmp").expect("tempdir under /tmp");
+        let project = base.path().join("repo");
+        std::fs::create_dir(&project).expect("mkdir repo");
+
+        let base_str = base.path().to_string_lossy().into_owned();
+        let proj_str = project.to_string_lossy().into_owned();
+        let rules = vec![
+            writable_rule(&proj_str),
+            FsRule {
+                path: base.path().to_path_buf(),
+                access: FsAccess {
+                    read: true,
+                    write: false,
+                    execute: false,
+                    ioctl: false,
+                },
+            },
+        ];
+        let args = build_bwrap_args(&rules, &[], &DenyMasks::default());
+
+        let last_ro = args
+            .windows(3)
+            .rposition(|w| w[0] == "--ro-bind" && w[1] == base_str && w[2] == base_str)
+            .expect("the read grant must still be bound back over the tmpfs (#299)");
+        let last_rw = args
+            .windows(3)
+            .rposition(|w| w[0] == "--bind" && w[1] == proj_str && w[2] == proj_str)
+            .expect("the writable path must be bound");
+        assert!(
+            last_rw > last_ro,
+            "a writable bind nested under a read-only bind must be re-emitted after it, \
+             or the write grant is silently downgraded to EROFS: {args:?}"
         );
     }
 

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1892,6 +1892,45 @@ print('CONNECTED')
     }
 
     #[test]
+    fn bwrap_project_dir_under_tmp_stays_writable_with_a_read_grant_above_it() {
+        require_bwrap!();
+
+        // #305 regression: the read-only bind-backs that make non-writable
+        // rules under /tmp visible were emitted after the writable binds, so a
+        // read grant on an ANCESTOR of the project dir covered the project's
+        // own writable bind (bwrap applies mounts in argument order) and the
+        // project came up EROFS. Silently: Landlock still granted the write and
+        // --print-profile still reported it writable.
+        let base = tempfile::Builder::new()
+            .prefix("cplt-bwrap-ro-over-rw")
+            .tempdir_in("/tmp")
+            .expect("Failed to create base under /tmp");
+        let project = base.path().join("repo");
+        fs::create_dir(&project).expect("mkdir repo");
+        fs::write(project.join("test.txt"), "hello from nested project").unwrap();
+
+        let (exit, stdout, stderr) = run_sandboxed_with_flags(
+            &project,
+            &[
+                "--use-bubblewrap",
+                "--allow-read",
+                &base.path().to_string_lossy(),
+            ],
+            "cat test.txt && echo ok > written.txt && cat written.txt",
+        );
+        assert_eq!(
+            exit, 0,
+            "a read grant on an ancestor must not turn the project dir read-only: {stderr}"
+        );
+        assert!(stdout.contains("hello from nested project"), "{stdout}");
+        assert!(stdout.contains("ok"), "{stdout}");
+        assert!(
+            project.join("written.txt").exists(),
+            "the write must reach the host, not a shadowed mount"
+        );
+    }
+
+    #[test]
     fn bwrap_exec_from_tmp_still_denied() {
         require_bwrap!();
         let project = create_test_project();


### PR DESCRIPTION
## The bug

[#305](https://github.com/navikt/cplt/pull/305) added read-only bind-backs so non-writable rules under `/tmp` stay visible inside bubblewrap's private tmpfs. The loop skips a path when a writable bind already covers it:

```rust
if bound_writable.iter().any(|w| path.starts_with(w)) { continue; }
```

That covers the read path being **inside** a writable bind. It does not cover the reverse nesting — a writable bind **beneath** a broader read grant. bwrap applies mounts in argument order, so a later `--ro-bind` on an ancestor covers an earlier `--bind` on a descendant. This file relies on exactly that mechanic twelve lines below, where the git-persistence overlays are documented as "emitted last so they shadow the writable project bind above".

Repro:

```
cplt --project-dir /tmp/work/repo --allow-read /tmp/work
```

or `allow.write = ["/tmp/x/out"]` with `allow.read = ["/tmp/x"]`. The args come out as `--bind /tmp/work/repo … --ro-bind /tmp/work …` and the project directory is EROFS inside the namespace.

It is silent, which is what makes it a `no-silent-grants` violation (AGENTS.md) rather than a papercut: Landlock still reports the path writable, `--print-profile` still reports it writable, startup says nothing, and project-dir-under-`/tmp` is a supported configuration. The user believes they have a write grant they do not have.

## The fix

Re-emit the narrower writable binds after the read-only ones — before the `ro_protect` git-persistence overlays, which must keep shadowing writable binds. `bound_writable` is already sorted shallowest-first, so parents stay bound before children in the re-emission too.

**Alternatives and what they would have cost:**

- **Skip the `ro-bind` when it has a writable descendant.** Cheapest diff, wrong: it loses the read grant on the whole rest of the tree and reintroduces the [#299](https://github.com/navikt/cplt/issues/299) silent-drop it was added to fix — trading one silent grant for another.
- **Split the `ro-bind` around its writable descendants.** Would need to enumerate the ancestor's siblings and bind each one individually, which only works when the ancestor is a directory, has to be recomputed for each nesting level, and re-breaks whenever a new entry appears in the parent between launch and use. More code, more failure modes, same outcome.

Re-emission is the option the file already uses everywhere else — precedence expressed as argument order, most-specific last.

## Tests

Two new tests, both failing before the fix.

`a_read_only_bind_does_not_shadow_a_writable_bind_beneath_it` (unit, `src/sandbox_bubblewrap.rs`) asserts the last `--bind` for the nested writable path comes after the last `--ro-bind` for its ancestor.

`bwrap_project_dir_under_tmp_stays_writable_with_a_read_grant_above_it` (`tests/integration_linux.rs`) is the one that matters: it actually runs `cplt --use-bubblewrap --project-dir <tmp>/repo --allow-read <tmp>` and writes a file. Before the fix the write fails with EROFS inside the namespace. This is the assertion that confirms bwrap's ordering behaves as described, rather than reasoning about it.

### Why the existing test does not cover this

`writable_paths_under_tmp_survive_the_tmp_shadow` passes today despite the bug, and is unchanged here. It builds args from a **single writable rule** with no read rule above it, so the `ro-bind` loop emits nothing and there is nothing to shadow the writable bind. It tests the writable bind against `--tmpfs /tmp` only, which is a different shadow. Same for `bwrap_project_dir_under_tmp_is_visible` on the integration side — no `--allow-read` ancestor, so no `ro-bind`.

## Linux evidence

This cannot be observed on macOS — the whole module is `#[cfg(target_os = "linux")]`.

| Run | Head | What it proves |
| --- | --- | --- |
| [33903242521](https://github.com/navikt/cplt/actions/runs/33903242521) | `8c1ae3d` — fix deleted, both tests kept | `unit-tests` and `linux-integration-tests` both **fail** on the unit assertion. The dumped args are the bug verbatim: `… "--bind", "/tmp/.tmpc2s52j/repo", "/tmp/.tmpc2s52j/repo", "--ro-bind", "/tmp/.tmpc2s52j", "/tmp/.tmpc2s52j"` — writable bind first, read-only ancestor last. |
| [33903572272](https://github.com/navikt/cplt/actions/runs/33903572272) | `8978c3f` — fix deleted **and** the unit test dropped | The unit failure aborts `cargo test` before the integration target, so the first run never reached the behavioural test. With the unit test removed, `unit-tests` goes green and `linux-integration-tests` fails on `bwrap_project_dir_under_tmp_stays_writable_with_a_read_grant_above_it` — the sandboxed write really does fail inside the namespace. This is the run that confirms bwrap's ordering produces EROFS, rather than reasoning about it. |
| [33903715460](https://github.com/navikt/cplt/actions/runs/33903715460) | `ff10af9` — the fix | all green |

The red runs are the point: same branch, only the fix removed, so the new assertions are demonstrably capable of failing on Linux rather than green-by-construction.

## Audit: the same one-directional nesting assumption elsewhere

Checked every `starts_with` in the bwrap arg construction. Nothing else in this class:

- **Deny-mask pruning** (`build_deny_masks`): drops a deny path nested under a kept deny directory. Ancestor-covers-descendant is the correct direction here — a tmpfs over the parent already hides the child, so pruning loses nothing.
- **Deny masks vs. every bind**: emitted last, deliberately shadowing everything. Deny winning over allow is the intended precedence.
- **`ro_protect` (git persistence) vs. writable binds**: emitted after, deliberately shadowing them. That is the Finding 1 mitigation, documented as such, not a silent surprise.
- **Writable binds among themselves**: sorted shallowest-first, so a nested writable bind is already re-emitted after its parent.

Only the `/tmp` read-only bind-backs had the gap, and only in the direction fixed here.
