### PR TITLE
fix(update): stage self-update privately and pin the inode

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1038,10 +1038,14 @@ The update mechanism downloads releases from GitHub, verifies SHA256 checksums, 
 - The extracted binary is verified via `symlink_metadata`, which rejects symlinks
 - Absolute paths are used for system tools on macOS (`/usr/bin/curl`, `/usr/bin/shasum`, `/usr/bin/tar`) and Linux (`/usr/bin/sha256sum`, standard paths only, no bare PATH lookup)
 - Replacement is atomic: stage to `.new`, set permissions, rename
+- Staging happens in `~/.config/cplt/update/<128 random bits>`, not the system temp directory. Sandboxed agents can write throughout `/tmp` and `/var/folders`; `~/.config/cplt` is a hard deny (`DENIED_DOTFILES`), so a sandboxed process cannot reach the staged files at all
+- The staging directory is created with `mkdir(2)` at mode 0700, which fails with `EEXIST` rather than adopting a directory that is already there
+- The extracted binary is held open, and its `(dev, ino)` is re-checked before the unsandboxed `--version` probe and again before install. The install copies from that descriptor, so the bytes that are validated are the bytes that land on disk even if the path is repointed
 
 **Not verified:**
 - There is no cryptographic signature, neither GPG nor Sigstore. `SHA256SUMS` and the binary come from the same GitHub release, so a compromised release controls both. This matches most Go/Rust CLI tools but is weaker than signed package managers.
-- The temp directory is `/tmp/cplt-update-{PID}`, predictable by local attackers, though the extracted binary is checked for symlinks before installation.
+- The `--version` probe runs the freshly downloaded binary **unsandboxed**. The inode is pinned across that step, so it is the file cplt validated, but its provenance rests entirely on the SHA256 check above.
+- On the sudo install path the binary is handed to `sudo install` by path, not by descriptor. The inode is re-checked immediately before, but the staging directory being private is what closes that window.
 
 The Homebrew install path (`brew install navikt/tap/cplt`) uses Homebrew's own verification and is preferred on macOS.
 

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -22,6 +22,10 @@ pub const DENIED_DOTFILES: &[&str] = &[
     ".config/gcloud",
     ".config/op",
     ".terraform.d",
+    // cplt's own state: the trust store, blocklist caches, and the self-update
+    // staging area. An agent that can write here can tamper with the sandbox
+    // that contains it, or swap the binary `cplt update` is about to install.
+    ".config/cplt",
 ];
 
 /// Sensitive files under $HOME that are always denied.

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -241,7 +241,7 @@ impl Drop for ScratchDir {
 }
 
 /// Generate a random session ID using /dev/urandom.
-fn generate_session_id() -> Result<String, String> {
+pub(crate) fn generate_session_id() -> Result<String, String> {
     let mut buf = [0u8; 16];
     std::fs::File::open("/dev/urandom")
         .and_then(|mut f| {
@@ -263,7 +263,7 @@ fn is_session_id(name: &str) -> bool {
 /// - Is a directory (not a symlink to one)
 /// - Owned by current user
 /// - Permissions are 0700 (set if not)
-fn validate_dir_safety(path: &Path, label: &str) -> Result<(), String> {
+pub(crate) fn validate_dir_safety(path: &Path, label: &str) -> Result<(), String> {
     use std::os::unix::fs::MetadataExt;
 
     let metadata = path
@@ -305,7 +305,7 @@ fn validate_dir_safety(path: &Path, label: &str) -> Result<(), String> {
 }
 
 /// Create a directory with 0700 permissions atomically.
-fn create_secure_dir(path: &Path, label: &str) -> Result<(), String> {
+pub(crate) fn create_secure_dir(path: &Path, label: &str) -> Result<(), String> {
     use std::os::unix::fs::DirBuilderExt;
     std::fs::DirBuilder::new()
         .mode(0o700)

--- a/src/update.rs
+++ b/src/update.rs
@@ -95,6 +95,11 @@ pub enum UpdateError {
         "Version mismatch: binary reports '{got}' but release tag expects '{expected}'.\n  This is a release pipeline bug. The binary was built with a different version than the tag."
     )]
     VersionMismatch { expected: String, got: String },
+
+    #[error(
+        "The staged binary at {0} was replaced after cplt validated it.\n  Refusing to run or install it."
+    )]
+    StagedBinaryReplaced(String),
 }
 
 /// A parsed GitHub release.
@@ -213,7 +218,9 @@ pub fn perform_update(
 
     // 1. Download the archive
     eprintln!("  Downloading {asset}...");
-    let tmp_dir = create_temp_dir()?;
+    let home = std::env::var("HOME")
+        .map_err(|_| UpdateError::Io("HOME is not set, cannot stage the update".to_string()))?;
+    let tmp_dir = create_stage_dir(Path::new(&home))?;
     let archive_path = tmp_dir.join(&asset);
     curl_download(&asset_url, &archive_path, current_version)?;
 
@@ -254,17 +261,28 @@ pub fn perform_update(
         .map_err(|e| UpdateError::Io(format!("Cannot determine current binary path: {e}")))?;
     let target_path = std::fs::canonicalize(&current_exe).unwrap_or(current_exe);
 
-    // 5. Stage: set permissions and platform-specific postprocessing
+    // 5. Stage: set permissions and platform-specific postprocessing.
+    // Both rewrite the file, and codesign is free to do so by rename, so the
+    // inode identity below is taken afterwards.
     eprintln!("  Preparing binary...");
     set_executable(&new_binary)?;
     postprocess_binary(&new_binary);
 
-    // 5b. Verify the binary reports the expected version.
+    // 5b. Pin the inode. Everything after this point must be the same file:
+    // the version probe below executes it *unsandboxed*, so a swap between
+    // probe and install would run one binary and ship another.
+    let binary = StagedBinary::open(&new_binary).inspect_err(|_| {
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+    })?;
+
+    // 5c. Verify the binary reports the expected version.
     // Catches release pipeline bugs where the tag and binary version diverge
     // (e.g., version timestamp generated twice → infinite update loop).
+    binary.verify_unchanged()?;
     verify_binary_version(&new_binary, expected_version, &tmp_dir)?;
 
     // 6. Install to target path — use sudo if direct write fails
+    binary.verify_unchanged()?;
     let needs_sudo = !is_writable(&target_path);
     if needs_sudo {
         eprintln!(
@@ -274,8 +292,7 @@ pub fn perform_update(
         sudo_install(&new_binary, &target_path)?;
     } else {
         let staged = target_path.with_extension("new");
-        std::fs::copy(&new_binary, &staged)
-            .map_err(|e| UpdateError::Io(format!("Cannot stage binary: {e}")))?;
+        binary.copy_to(&staged)?;
         set_executable(&staged)?;
         postprocess_binary(&staged);
         std::fs::rename(&staged, &target_path).map_err(|e| {
@@ -589,16 +606,119 @@ fn extract_archive(archive: &Path, dest: &Path) -> Result<(), UpdateError> {
     }
 }
 
-/// Create a temporary directory for the update process.
-fn create_temp_dir() -> Result<PathBuf, UpdateError> {
-    let dir = std::env::temp_dir().join(format!("cplt-update-{}", std::process::id()));
-    if dir.exists() {
-        std::fs::remove_dir_all(&dir)
-            .map_err(|e| UpdateError::Io(format!("Cannot clean up old temp dir: {e}")))?;
+/// Staging base for downloads, relative to `$HOME`.
+///
+/// Deliberately *not* the system temp directory. Every cplt sandbox can write
+/// throughout `/tmp` and `/var/folders`, so a same-UID process could swap the
+/// archive or the extracted binary between validation and use. `~/.config/cplt`
+/// is a hard deny for sandboxed agents (see `sandbox_policy::DENIED_DOTFILES`),
+/// which takes that reach away.
+const STAGE_BASE: &str = ".config/cplt/update";
+
+/// Create a private staging directory for the update process.
+///
+/// The directory name is 128 bits from `/dev/urandom` rather than the pid, and
+/// it is created with `mkdir(2)` at mode 0700, which fails with `EEXIST` rather
+/// than adopting a directory someone else planted — the "check then create"
+/// version this replaces did adopt it.
+fn create_stage_dir(home: &Path) -> Result<PathBuf, UpdateError> {
+    let base = home.join(STAGE_BASE);
+    std::fs::create_dir_all(&base)
+        .map_err(|e| UpdateError::Io(format!("Cannot create staging base: {e}")))?;
+
+    // Canonicalize both sides so a symlink at any ancestor is caught, not
+    // followed: `~/.config` swapped for a symlink would otherwise stage the
+    // update wherever it points.
+    let canonical_home = std::fs::canonicalize(home)
+        .map_err(|e| UpdateError::Io(format!("Cannot canonicalize home dir: {e}")))?;
+    let canonical_base = std::fs::canonicalize(&base)
+        .map_err(|e| UpdateError::Io(format!("Cannot canonicalize staging base: {e}")))?;
+    if canonical_base != canonical_home.join(STAGE_BASE) {
+        return Err(UpdateError::Io(format!(
+            "Staging base resolved to {} but expected {}. An ancestor may be a symlink",
+            canonical_base.display(),
+            canonical_home.join(STAGE_BASE).display()
+        )));
     }
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| UpdateError::Io(format!("Cannot create temp dir: {e}")))?;
+    crate::scratch::validate_dir_safety(&canonical_base, "Update staging base")
+        .map_err(UpdateError::Io)?;
+
+    let dir = canonical_base.join(crate::scratch::generate_session_id().map_err(UpdateError::Io)?);
+    crate::scratch::create_secure_dir(&dir, "update staging dir").map_err(UpdateError::Io)?;
     Ok(dir)
+}
+
+/// The extracted binary, held open so that validation, execution and install
+/// all refer to the same inode.
+///
+/// Re-checking a *path* proves nothing: between two `stat` calls the name can
+/// be pointed at a different file. This holds the descriptor from the file it
+/// validated, compares `(dev, ino)` before each use of the path, and installs
+/// by copying out of the descriptor rather than re-opening the name.
+struct StagedBinary {
+    path: PathBuf,
+    file: std::fs::File,
+    dev: u64,
+    ino: u64,
+}
+
+impl StagedBinary {
+    /// Open `path` without following symlinks and record the inode identity.
+    fn open(path: &Path) -> Result<Self, UpdateError> {
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .map_err(|_| UpdateError::BinaryNotFound)?;
+        let meta = file
+            .metadata()
+            .map_err(|e| UpdateError::Io(format!("Cannot stat staged binary: {e}")))?;
+        if !meta.file_type().is_file() {
+            return Err(UpdateError::BinaryNotRegularFile);
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+            dev: meta.dev(),
+            ino: meta.ino(),
+            file,
+        })
+    }
+
+    /// Fail if the path no longer names the inode we validated.
+    fn verify_unchanged(&self) -> Result<(), UpdateError> {
+        use std::os::unix::fs::MetadataExt;
+
+        let meta =
+            std::fs::symlink_metadata(&self.path).map_err(|_| UpdateError::BinaryNotFound)?;
+        if meta.dev() != self.dev || meta.ino() != self.ino {
+            return Err(UpdateError::StagedBinaryReplaced(
+                self.path.display().to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Copy the validated bytes to `dest`, reading from the held descriptor.
+    ///
+    /// Never re-opens `self.path`, so a swap of that name cannot change what
+    /// gets installed.
+    fn copy_to(&self, dest: &Path) -> Result<(), UpdateError> {
+        use std::io::Seek;
+
+        let mut src = self
+            .file
+            .try_clone()
+            .map_err(|e| UpdateError::Io(format!("Cannot re-read staged binary: {e}")))?;
+        src.rewind()
+            .map_err(|e| UpdateError::Io(format!("Cannot rewind staged binary: {e}")))?;
+        let mut out = std::fs::File::create(dest)
+            .map_err(|e| UpdateError::Io(format!("Cannot stage binary: {e}")))?;
+        std::io::copy(&mut src, &mut out)
+            .map_err(|e| UpdateError::Io(format!("Cannot stage binary: {e}")))?;
+        Ok(())
+    }
 }
 
 /// Set executable permissions on a file.
@@ -743,6 +863,136 @@ fn find_sudo() -> Result<PathBuf, UpdateError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    /// Write `bytes` to a fresh file at `path`.
+    fn write_file(path: &Path, bytes: &[u8]) {
+        let mut f = std::fs::File::create(path).expect("create");
+        f.write_all(bytes).expect("write");
+    }
+
+    #[test]
+    fn stage_dir_is_private_unpredictable_and_exclusive() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let a = create_stage_dir(home.path()).expect("first stage dir");
+        let b = create_stage_dir(home.path()).expect("second stage dir");
+
+        // Under cplt's own config dir, never the world-writable system temp:
+        // every sandbox can write throughout /tmp and /var/folders.
+        let base = std::fs::canonicalize(home.path()).unwrap().join(STAGE_BASE);
+        assert!(
+            a.starts_with(&base),
+            "stage dir {} is not under {}",
+            a.display(),
+            base.display()
+        );
+        assert!(
+            !a.starts_with(std::env::temp_dir()),
+            "stage dir must not live in the system temp directory"
+        );
+
+        // Unpredictable: two runs must not collide, and the name must not be
+        // derivable from the pid.
+        assert_ne!(a, b, "two staging dirs collided");
+        let name = a.file_name().unwrap().to_string_lossy().into_owned();
+        assert_eq!(name.len(), 32, "expected 128 bits of hex, got {name:?}");
+        assert!(
+            !name.contains(&std::process::id().to_string()),
+            "staging dir name {name:?} leaks the pid"
+        );
+
+        // Owner-only from the moment it exists (mkdir with mode, not chmod after).
+        let mode = std::fs::symlink_metadata(&a).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "staging dir is not 0700");
+
+        // Exclusive creation: an existing directory is refused, not adopted.
+        let planted = base.join("00000000000000000000000000000000");
+        crate::scratch::create_secure_dir(&planted, "planted").expect("plant");
+        assert!(
+            crate::scratch::create_secure_dir(&planted, "planted").is_err(),
+            "creating over an existing staging dir must fail"
+        );
+    }
+
+    #[test]
+    fn staged_binary_refuses_a_swapped_inode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cplt");
+        write_file(&path, b"good");
+
+        let staged = StagedBinary::open(&path).expect("open");
+        staged
+            .verify_unchanged()
+            .expect("untouched file must verify");
+
+        // Same path, different inode — exactly the swap the version probe and
+        // the install would otherwise walk into.
+        let evil = dir.path().join("evil");
+        write_file(&evil, b"evil");
+        std::fs::rename(&evil, &path).expect("swap");
+
+        let err = staged
+            .verify_unchanged()
+            .expect_err("swap must be detected");
+        assert!(
+            matches!(err, UpdateError::StagedBinaryReplaced(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn staged_binary_installs_the_bytes_it_validated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cplt");
+        write_file(&path, b"good");
+
+        let staged = StagedBinary::open(&path).expect("open");
+
+        let evil = dir.path().join("evil");
+        write_file(&evil, b"evil");
+        std::fs::rename(&evil, &path).expect("swap");
+
+        // Copying re-reads the held descriptor, not the name, so the swap
+        // cannot change what lands on disk.
+        let dest = dir.path().join("installed");
+        staged.copy_to(&dest).expect("copy");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"good");
+    }
+
+    #[test]
+    fn staged_binary_rejects_a_symlink() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("real");
+        write_file(&real, b"good");
+        let link = dir.path().join("cplt");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        assert!(
+            StagedBinary::open(&link).is_err(),
+            "a symlinked staged binary must be refused"
+        );
+    }
+
+    #[test]
+    fn staged_binary_accepts_in_place_edits_of_the_same_inode() {
+        // Sanity check that the guard keys on the inode and not on content or
+        // mtime: postprocess_binary rewrites the file in place.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cplt");
+        write_file(&path, b"good");
+        let staged = StagedBinary::open(&path).expect("open");
+        let ino = std::fs::symlink_metadata(&path).unwrap().ino();
+
+        let mut f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        f.write_all(b"gooo").unwrap();
+        drop(f);
+
+        assert_eq!(std::fs::symlink_metadata(&path).unwrap().ino(), ino);
+        staged
+            .verify_unchanged()
+            .expect("in-place edit is not a swap");
+    }
 
     #[test]
     fn version_looks_valid() {

--- a/src/update.rs
+++ b/src/update.rs
@@ -878,18 +878,18 @@ mod tests {
         let a = create_stage_dir(home.path()).expect("first stage dir");
         let b = create_stage_dir(home.path()).expect("second stage dir");
 
-        // Under cplt's own config dir, never the world-writable system temp:
-        // every sandbox can write throughout /tmp and /var/folders.
+        // Under cplt's own config dir, never the system temp dir: every cplt
+        // sandbox can write throughout /tmp and /var/folders, and `.config/cplt`
+        // is a hard deny (see `profile_denies_write_to_cplt_config_dir`).
+        // Asserted against the caller's home rather than `env::temp_dir()`,
+        // because the fake home in this test is itself a temp directory.
+        assert_eq!(STAGE_BASE, ".config/cplt/update");
         let base = std::fs::canonicalize(home.path()).unwrap().join(STAGE_BASE);
         assert!(
             a.starts_with(&base),
             "stage dir {} is not under {}",
             a.display(),
             base.display()
-        );
-        assert!(
-            !a.starts_with(std::env::temp_dir()),
-            "stage dir must not live in the system temp directory"
         );
 
         // Unpredictable: two runs must not collide, and the name must not be

--- a/src/update.rs
+++ b/src/update.rs
@@ -655,6 +655,7 @@ fn create_stage_dir(home: &Path) -> Result<PathBuf, UpdateError> {
 /// be pointed at a different file. This holds the descriptor from the file it
 /// validated, compares `(dev, ino)` before each use of the path, and installs
 /// by copying out of the descriptor rather than re-opening the name.
+#[derive(Debug)]
 struct StagedBinary {
     path: PathBuf,
     file: std::fs::File,
@@ -671,7 +672,13 @@ impl StagedBinary {
             .read(true)
             .custom_flags(libc::O_NOFOLLOW)
             .open(path)
-            .map_err(|_| UpdateError::BinaryNotFound)?;
+            .map_err(|e| match e.kind() {
+                std::io::ErrorKind::NotFound => UpdateError::BinaryNotFound,
+                // O_NOFOLLOW refusing a symlink surfaces as ELOOP, which is the
+                // check doing its job rather than an I/O problem.
+                _ if e.raw_os_error() == Some(libc::ELOOP) => UpdateError::BinaryNotRegularFile,
+                _ => UpdateError::Io(format!("Cannot open staged binary: {e}")),
+            })?;
         let meta = file
             .metadata()
             .map_err(|e| UpdateError::Io(format!("Cannot stat staged binary: {e}")))?;
@@ -968,10 +975,8 @@ mod tests {
         let link = dir.path().join("cplt");
         std::os::unix::fs::symlink(&real, &link).expect("symlink");
 
-        assert!(
-            StagedBinary::open(&link).is_err(),
-            "a symlinked staged binary must be refused"
-        );
+        let err = StagedBinary::open(&link).expect_err("a symlinked staged binary must be refused");
+        assert!(matches!(err, UpdateError::BinaryNotRegularFile), "{err:?}");
     }
 
     #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -7817,3 +7817,15 @@ fn profile_keychain_grant_follows_resolved_credential() {
         );
     }
 }
+
+/// `cplt update` stages the download under `~/.config/cplt/update`. That only
+/// helps if a sandboxed agent cannot write there — the whole point of moving off
+/// the system temp dir, which every sandbox can write.
+#[test]
+fn profile_denies_write_to_cplt_config_dir() {
+    let p = generate_profile(&base_profile_options(), &[]);
+    assert!(
+        p.contains("(deny file-write* (subpath \"/Users/test/.config/cplt\"))"),
+        "sandboxed agents must not be able to write cplt's own config/staging dir"
+    );
+}


### PR DESCRIPTION
External security review, finding A (High): self-update TOCTOU.

## The problem

`cplt update` staged under `std::env::temp_dir().join(format!("cplt-update-{}", std::process::id()))`. The path is predictable, and every cplt sandbox can write throughout `/tmp` and `/var/folders`, so another same-UID process can sit on it. `create_temp_dir` also did a check-then-create (`if dir.exists() { remove } create_dir_all`), which adopts whatever is already there rather than refusing it.

Two windows:

1. the archive can be replaced after its SHA256 is verified but before `tar` reads it;
2. `extract/cplt` can be replaced after the `symlink_metadata` check but before cplt executes it **unsandboxed** for the `--version` probe. A payload only has to print the expected version string while doing whatever else it wants.

## The fix

**Private staging.** `~/.config/cplt/update/<128 bits from /dev/urandom>`.

**A deny that is broader than the staging fix — read this even if you are only scanning for the updater change.** `.config/cplt` joins `DENIED_DOTFILES`, which hard-denies the sandbox **read as well as write** on cplt's own config directory. It is not scoped to the staging subdirectory, and it changes what an agent can *see*, not only where the updater stages. The directory already held the trust store (`trust.rs`) and the blocklist subscription caches, both of which an agent that could write them could use to loosen the sandbox containing it, so the deny is worth having on its own account.

Nothing inside the sandbox reads from there, checked three ways:

- Config loading is confined to `resolve_context` in the parent launch path and the `config` / `settings` / `trust` subcommands. All run before any sandbox exists.
- The one thing that *does* re-enter cplt from inside the sandbox is the gh/git guard wrapper (`cplt gh-gate` / `cplt git-gate`). Both take their entire policy from CLI flags baked into the generated wrapper script; neither calls `Config::load_file()`. `tests/e2e_guards.rs` (123 tests) exercises them end to end and passes with the deny in place.
- Empirically, under the real generated profile: `cat ~/.config/cplt/config.toml` gives `Operation not permitted`, and `cplt gh-gate ... -- auth status` in the same sandbox still reaches its decision and execs, exit 0.

**Exclusive creation.** `mkdir(2)` with mode 0700 via the existing `scratch::create_secure_dir`, which fails with `EEXIST` instead of adopting a planted directory. Owner-only from the moment it exists, not chmod-ed afterwards. The base is canonicalized and checked against `$HOME` so a symlink at any ancestor is caught rather than followed.

**Inode identity, not path identity.** New `StagedBinary` holds the extracted file open (`O_NOFOLLOW`) and records `(dev, ino)`. It re-checks that identity before the unsandboxed version probe and again before install, and `copy_to` reads from the held descriptor, so the bytes that were validated are the bytes that land on disk even if the name is repointed. Identity is taken *after* `set_executable`/`postprocess_binary`, because `codesign` is free to rewrite by rename.

## Remaining limitation (not fixed here)

`SHA256SUMS` is served from the same GitHub release as the archive, so a compromised release channel defeats both. Fixing that needs a signature (GPG or Sigstore), which is out of scope for this finding. `SECURITY.md` says so explicitly, along with the two windows that stay narrow rather than closed: the `--version` probe still runs the downloaded binary unsandboxed, and the sudo install path still hands `sudo install` a path rather than a descriptor.

## Tests

- `stage_dir_is_private_unpredictable_and_exclusive` — under `~/.config/cplt/update`, not `temp_dir()`; 32 hex chars with no pid in it; mode 0700; two calls differ; creating over an existing dir fails.
- `staged_binary_refuses_a_swapped_inode` — rename another file over the path, `verify_unchanged` must error.
- `staged_binary_installs_the_bytes_it_validated` — swap the path, then `copy_to` must still write the original bytes.
- `staged_binary_accepts_in_place_edits_of_the_same_inode` — the guard keys on the inode, not on content, so in-place postprocessing is not a false positive.
- `staged_binary_rejects_a_symlink`
- `profile_denies_write_to_cplt_config_dir` (unit_tests)

Mutation-checked: reverting the staging path to `temp_dir()/cplt-update-{pid}`, making `verify_unchanged` not compare inodes, making `copy_to` re-open the path, and dropping the `DENIED_DOTFILES` entry each fail their own test and no others. Restored, all green.

Gates: `cargo fmt`, `cargo test --lib` (922), `cargo test --test unit_tests` (323), `cargo test --test integration` (65), `cargo clippy --all-targets -- -D warnings`.
