### PR TITLE
fix(sandbox): pass the SBPL profile inline, not by pathname

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,7 +86,7 @@ cplt assumes the sandboxed agent is **untrusted**, because it executes arbitrary
 | **Org/user data enumeration** | `gh api /orgs/.../audit-log` leaks PII | gh guard restricts API to `/repos/{current-repo}/...` endpoints only |
 | **DNS rebinding SSRF** | Domain resolves to `127.0.0.1` after check | Post-DNS-resolution IP validation; `--allow-private-domain` opt-in bypass for explicitly trusted internal domains |
 | **Sandbox profile injection** | Path with `\n(allow file-read* (subpath "/"))` | SBPL path character validation (macOS) |
-| **Temp file symlink attack** | Symlink at predictable `/tmp/cplt.sb` | Unique filename plus `O_CREAT\|O_EXCL` |
+| **Cross-session profile replacement** | Overwrite another session's SBPL profile in the shared temp dir before the kernel reads it | The profile is passed to `sandbox-exec -p` as an argument; it is never written to disk, so there is no file to swap |
 | **Write-then-exec in /tmp** | Drop binary in `/tmp`, execute it | Seatbelt deny (macOS) / Landlock deny (Linux); `--scratch-dir` provides a safe alternative |
 | **Cloud metadata access** | Fetch `169.254.169.254` or CGNAT range | Private IP blocklist covering all reserved ranges |
 | **Cross-project access** | Read files outside project directory | Seatbelt subpath (macOS) / Landlock ruleset (Linux) |
@@ -1186,7 +1186,7 @@ The GitHub Actions workflow runs in two stages:
 
 ### Secure temporary files
 
-- [CWE-377: Insecure Temporary File](https://cwe.mitre.org/data/definitions/377.html). Motivation for unique filenames and `O_CREAT|O_EXCL`.
+- [CWE-377: Insecure Temporary File](https://cwe.mitre.org/data/definitions/377.html). Why the SBPL profile is never written to a temp file at all, and why the files that do live in the scratch dir use `O_CREAT|O_EXCL` with mode `0600`.
 - [CWE-59: Improper Link Resolution Before File Access](https://cwe.mitre.org/data/definitions/59.html). Symlink attacks on predictable temp paths.
 
 ### AI agent sandboxing (broader context)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -903,14 +903,24 @@ The newline character is the dangerous one. A path containing `\n(allow file-rea
 
 Config file paths are additionally canonicalized (resolved to absolute paths) at load time.
 
-#### Temp file safety
+#### The profile never becomes a file
 
-The sandbox profile is written to a temp file with:
+The SBPL profile is passed to `sandbox-exec -p` as an argument. It is never written
+to disk and never handed over as a pathname.
 
-- **Unique filename:** `cplt-{PID}-{nanosecond_timestamp}.sb`
-- **Atomic creation:** `OpenOptions::create_new(true)`, which fails if the file exists and so prevents symlink following
-- **Restricted permissions:** mode `0o600`, owner read/write only
-- **Cleanup on exit:** the file is removed after sandbox-exec completes
+The profile grants every sandbox write throughout `/private/tmp` and
+`/private/var/folders`. While cplt wrote the profile to `$TMPDIR/cplt-*.sb` and
+passed `-f <path>`, one sandboxed session could overwrite another session's
+profile between the write and the kernel's read — a complete policy replacement,
+not merely corruption, since the attacker chooses the replacement text. Measured
+at 14 of 15 launches (`profile_cannot_be_swapped_by_another_session` in
+`tests/e2e.rs`, which still reproduces the attack against the old code).
+
+An oversized profile fails loudly with `E2BIG` — the argument list must fit in
+`kern.argmax` (1 MiB) alongside the environment. The kernel never sees a
+truncated profile: `sandbox-exec` either applies the whole thing or refuses to
+start. A default profile is about 25 KB and each allow/deny grant adds roughly
+2.5 KB, so the ceiling is in the low hundreds of grants.
 
 #### Unsafe root rejection
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -511,8 +511,8 @@ pub fn describe(sandbox: &PreparedSandbox) -> &str {
 
 /// Verify the sandbox mechanism works on this system.
 ///
-/// On macOS, writes the profile to a temp file and runs `/usr/bin/true`
-/// inside `sandbox-exec` to confirm enforcement is active.
+/// On macOS, runs `/usr/bin/true` inside `sandbox-exec`, with the profile
+/// passed inline (`-p`), to confirm enforcement is active.
 ///
 /// On Linux, this is a no-op (ABI checks happen during prepare).
 pub fn preflight(sandbox: &PreparedSandbox) -> Result<(), String> {
@@ -522,7 +522,7 @@ pub fn preflight(sandbox: &PreparedSandbox) -> Result<(), String> {
 /// Execute a command inside the sandbox, forwarding signals to the child.
 ///
 /// Handles platform-specific sandbox setup internally:
-/// - macOS: writes SBPL profile to temp file, invokes `sandbox-exec`
+/// - macOS: invokes `sandbox-exec` with the SBPL profile passed inline (`-p`)
 /// - Linux: applies Landlock ruleset + seccomp filter via `pre_exec`
 ///
 /// Environment handling is controlled by `extra_pass_env`, `inherit_env`,

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -722,17 +722,26 @@ const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 /// Verify the SBPL profile works by running `/usr/bin/true` inside sandbox-exec.
 #[cfg(target_os = "macos")]
 pub fn preflight(sandbox: &super::PreparedSandbox) -> Result<(), String> {
-    let profile_path = write_temp_profile(&sandbox.profile_text)?;
     // Absolute: `sandbox-exec` only ever lives in /usr/bin (SIP-protected), and
     // resolving it by name would go through the parent's PATH, which contains
     // directories the sandbox itself grants the agent write+exec on.
     let output = Command::new(SANDBOX_EXEC)
-        .arg("-f")
-        .arg(&profile_path)
+        .arg("-p")
+        .arg(&sandbox.profile_text)
         .arg("/usr/bin/true")
         .output()
-        .map_err(|e| format!("Failed to run sandbox-exec: {e}"));
-    let _ = std::fs::remove_file(&profile_path);
+        .map_err(|e| {
+            if e.raw_os_error() == Some(libc::E2BIG) {
+                format!(
+                    "Sandbox profile is too large to pass to sandbox-exec ({} bytes; the \
+                     argument list must fit in kern.argmax, 1 MiB, alongside the environment). \
+                     Reduce the number of allow/deny grants.",
+                    sandbox.profile_text.len()
+                )
+            } else {
+                format!("Failed to run sandbox-exec: {e}")
+            }
+        });
 
     let output = output?;
     if output.status.success() {
@@ -748,8 +757,13 @@ pub fn preflight(sandbox: &super::PreparedSandbox) -> Result<(), String> {
 
 /// Execute copilot inside the macOS Seatbelt sandbox.
 ///
-/// Writes the SBPL profile to a temp file, invokes `sandbox-exec`, and
-/// cleans up the profile file on exit.
+/// The profile is passed to `sandbox-exec -p` as an argument, never as a
+/// pathname. A temp file would be a cross-session policy-replacement race: the
+/// profile itself grants every sandbox write throughout `/private/tmp` and
+/// `/private/var/folders`, so another sandboxed session could swap the file
+/// between our write and the kernel's read and choose the policy we enforce.
+/// `-p` leaves nothing to swap. Oversized profiles fail loudly with `E2BIG`
+/// (`preflight` explains it); the kernel never sees a truncated profile.
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 pub fn exec(
@@ -763,16 +777,8 @@ pub fn exec(
     gh_guard: &crate::config::GhGuardPolicy,
     git_guard: &crate::config::GitGuardPolicy,
 ) -> u8 {
-    let profile_path = match write_temp_profile(&sandbox.profile_text) {
-        Ok(p) => p,
-        Err(e) => {
-            ui::error(&e.clone());
-            return 1;
-        }
-    };
-
     let mut cmd = Command::new(SANDBOX_EXEC);
-    cmd.arg("-f").arg(&profile_path).arg(copilot_bin);
+    cmd.arg("-p").arg(&sandbox.profile_text).arg(copilot_bin);
 
     configure_command(
         &mut cmd,
@@ -797,42 +803,7 @@ pub fn exec(
 
     apply_deny_env_and_credential(&mut cmd, deny_env, sandbox.keychain_substitute.as_ref());
 
-    let exit_code = spawn_and_wait(&mut cmd);
-    let _ = std::fs::remove_file(&profile_path);
-    exit_code
-}
-
-/// Write SBPL profile text to a temp file with secure creation.
-///
-/// Uses O_CREAT|O_EXCL (create_new) to prevent symlink-following attacks,
-/// and mode 0600 to restrict read access.
-#[cfg(target_os = "macos")]
-fn write_temp_profile(profile_text: &str) -> Result<std::path::PathBuf, String> {
-    use std::io::Write as _;
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let path = std::env::temp_dir().join(format!(
-        "cplt-{}-{}.sb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
-
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(&path)
-        .map_err(|e| format!("Cannot create sandbox profile: {e}"))?;
-
-    file.write_all(profile_text.as_bytes()).map_err(|e| {
-        let _ = std::fs::remove_file(&path);
-        format!("Cannot write sandbox profile: {e}")
-    })?;
-
-    Ok(path)
+    spawn_and_wait(&mut cmd)
 }
 
 // ── Linux: Landlock + seccomp ─────────────────────────────────

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -659,6 +659,25 @@ fn forward_and_wait(mut child: std::process::Child) -> u8 {
     }
 }
 
+/// Why a sandboxed process would not start.
+///
+/// `E2BIG` gets its own sentence on macOS: the SBPL profile travels in the
+/// argument list (`sandbox-exec -p`), so an unusually large grant set is the
+/// one configuration that can exceed `kern.argmax` — and `preflight` is
+/// skippable with `--no-validate`, which makes this the only place some users
+/// will see the reason.
+fn spawn_error_message(e: &std::io::Error) -> String {
+    #[cfg(target_os = "macos")]
+    if e.raw_os_error() == Some(libc::E2BIG) {
+        return format!(
+            "Failed to start sandboxed process: {e}. The SBPL profile is passed to \
+             sandbox-exec as an argument, and it must fit in kern.argmax (1 MiB) \
+             alongside the environment. Reduce the number of allow/deny grants."
+        );
+    }
+    format!("Failed to start sandboxed process: {e}")
+}
+
 /// Spawn a sandboxed command, forward signals, and wait for exit.
 ///
 /// Handles SIGTTOU/SIGTTIN suppression (Node.js terminal raw mode),
@@ -669,7 +688,7 @@ fn spawn_and_wait(cmd: &mut Command) -> u8 {
     let child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            ui::error(&format!("Failed to start sandboxed process: {e}"));
+            ui::error(&spawn_error_message(&e));
             restore_terminal_stop_signals();
             return 1;
         }
@@ -1330,5 +1349,36 @@ mod keychain_substitute_tests {
             let set: Vec<_> = cmd.get_envs().collect();
             assert_eq!(set, vec![("FOO".as_ref(), None)]);
         });
+    }
+}
+
+#[cfg(test)]
+mod spawn_error_tests {
+    use super::*;
+
+    /// `preflight` is skippable (`--no-validate`), so this is the only message
+    /// some users get when a large grant set overflows the argument list. It
+    /// has to say what to do about it, not just "argument list too long".
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn oversized_profile_spawn_failure_says_what_to_shrink() {
+        let msg = spawn_error_message(&std::io::Error::from_raw_os_error(libc::E2BIG));
+        assert!(
+            msg.contains("kern.argmax") && msg.contains("allow/deny grants"),
+            "E2BIG must be explained in terms of the profile, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn other_spawn_failures_are_reported_verbatim() {
+        let msg = spawn_error_message(&std::io::Error::from_raw_os_error(libc::ENOENT));
+        assert!(
+            !msg.contains("kern.argmax"),
+            "unexpected profile advice: {msg}"
+        );
+        assert!(
+            msg.starts_with("Failed to start sandboxed process:"),
+            "{msg}"
+        );
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5147,12 +5147,23 @@ paths = [
         let canary = fake_dir.path().join("canary");
         std::fs::write(&canary, "canary").expect("write canary");
         let script = fake_dir.path().join("copilot");
+        // Relative to the agent's cwd, which `configure_command` pins to the
+        // project dir. An absolute path would have to survive `sh` word
+        // splitting, and a checkout under "~/My Projects" would then fail the
+        // read for the wrong reason; the TempDir's own name never needs quoting.
+        let canary_rel = format!(
+            "{}/canary",
+            fake_dir
+                .path()
+                .file_name()
+                .expect("tempdir has a name")
+                .to_string_lossy()
+        );
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\nif cat {} >/dev/null 2>&1; then echo READ_ALLOWED; \
-                 else echo READ_DENIED; fi\n",
-                canary.display()
+                "#!/bin/sh\nif cat {canary_rel} >/dev/null 2>&1; then echo READ_ALLOWED; \
+                 else echo READ_DENIED; fi\n"
             ),
         )
         .expect("write fake copilot");
@@ -5171,14 +5182,18 @@ paths = [
             let hits = std::sync::Arc::clone(&hits);
             std::thread::spawn(move || {
                 let temp = std::env::temp_dir();
-                while !stop.load(Ordering::Relaxed) {
+                // Bounded, not just flagged: a panic anywhere below skips the
+                // explicit stop, and a detached thread scanning the temp dir
+                // for the rest of the process would slow every test after it.
+                let deadline = std::time::Instant::now() + std::time::Duration::from_mins(2);
+                while !stop.load(Ordering::Relaxed) && std::time::Instant::now() < deadline {
                     // A scan every millisecond, not a spin: `read_dir` over the
                     // whole system temp dir pinned a core for the length of the
                     // test and starved the other tests sharing the binary. The
                     // window a real attacker gets is the whole gap between our
                     // write and the kernel's read, so 1ms costs the attack
                     // nothing — it still lands 15/15 against the old code.
-                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    std::thread::sleep(std::time::Duration::from_micros(500));
                     let Ok(entries) = std::fs::read_dir(&temp) else {
                         continue;
                     };
@@ -5206,7 +5221,7 @@ paths = [
         let mut allowed = 0;
         let mut denied = 0;
         let mut transcript = String::new();
-        for attempt in 0..15 {
+        for attempt in 0..25 {
             let output = cplt_cmd()
                 .args(["--yes", "--deny-path"])
                 .arg(&canary)
@@ -5231,7 +5246,7 @@ paths = [
         assert_eq!(
             allowed,
             0,
-            "an attacker's SBPL profile replaced ours in {allowed}/15 launches \
+            "an attacker's SBPL profile replaced ours in {allowed}/25 launches \
              ({} temp-file overwrites landed) — the profile must not reach the \
              kernel as a pathname:\n{transcript}",
             hits.load(Ordering::Relaxed)

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5138,13 +5138,14 @@ paths = [
         require_sandbox!();
 
         let project = project_dir();
-        let canary = project.join(".cplt-e2e-profile-swap-canary");
-        std::fs::write(&canary, "canary").expect("write canary");
-
+        // Canary and fake agent both live in the TempDir, so an early panic
+        // cannot leave either behind in the checkout.
         let fake_dir = tempfile::Builder::new()
             .prefix(".cplt-e2e-fake-copilot-")
             .tempdir_in(&project)
             .expect("create fake copilot dir");
+        let canary = fake_dir.path().join("canary");
+        std::fs::write(&canary, "canary").expect("write canary");
         let script = fake_dir.path().join("copilot");
         std::fs::write(
             &script,
@@ -5171,6 +5172,13 @@ paths = [
             std::thread::spawn(move || {
                 let temp = std::env::temp_dir();
                 while !stop.load(Ordering::Relaxed) {
+                    // A scan every millisecond, not a spin: `read_dir` over the
+                    // whole system temp dir pinned a core for the length of the
+                    // test and starved the other tests sharing the binary. The
+                    // window a real attacker gets is the whole gap between our
+                    // write and the kernel's read, so 1ms costs the attack
+                    // nothing — it still lands 15/15 against the old code.
+                    std::thread::sleep(std::time::Duration::from_millis(1));
                     let Ok(entries) = std::fs::read_dir(&temp) else {
                         continue;
                     };
@@ -5219,7 +5227,6 @@ paths = [
 
         stop.store(true, Ordering::Relaxed);
         attacker.join().expect("attacker thread");
-        let _ = std::fs::remove_file(&canary);
 
         assert_eq!(
             allowed,

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5100,6 +5100,25 @@ paths = [
     // Cross-session SBPL profile replacement
     // ============================================================
 
+    /// `cplt-<pid>-<nanos>.sb`, the name the launcher used to give the profile
+    /// it wrote to the system temp dir — and nothing else that lives there.
+    fn is_generated_profile_name(name: &str) -> bool {
+        let Some(stem) = name
+            .strip_prefix("cplt-")
+            .and_then(|rest| rest.strip_suffix(".sb"))
+        else {
+            return false;
+        };
+        let mut parts = stem.split('-');
+        let (Some(pid), Some(nanos), None) = (parts.next(), parts.next(), parts.next()) else {
+            return false;
+        };
+        !pid.is_empty()
+            && !nanos.is_empty()
+            && pid.bytes().all(|b| b.is_ascii_digit())
+            && nanos.bytes().all(|b| b.is_ascii_digit())
+    }
+
     /// The profile must never reach the kernel as a pathname.
     ///
     /// The generated profile grants every sandbox write throughout
@@ -5158,8 +5177,12 @@ paths = [
                     for entry in entries.flatten() {
                         let name = entry.file_name();
                         let name = name.to_string_lossy();
-                        if name.starts_with("cplt-")
-                            && name.ends_with(".sb")
+                        // `cplt-<pid>-<nanos>.sb` exactly. Other tests park
+                        // their own fixtures in the temp dir as `cplt-test-*.sb`
+                        // and `cplt-portfilter-*.sb`; overwriting one of those
+                        // with `(allow default)` would turn a sibling test green
+                        // while proving nothing.
+                        if is_generated_profile_name(&name)
                             && std::fs::write(entry.path(), "(version 1)\n(allow default)\n")
                                 .is_ok()
                         {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5095,4 +5095,122 @@ paths = [
             "refusal should say why: {stderr}"
         );
     }
+
+    // ============================================================
+    // Cross-session SBPL profile replacement
+    // ============================================================
+
+    /// The profile must never reach the kernel as a pathname.
+    ///
+    /// The generated profile grants every sandbox write throughout
+    /// `/private/tmp` and `/private/var/folders`. While cplt handed
+    /// `sandbox-exec` a `-f <path>` under the system temp dir, any other
+    /// sandboxed session could overwrite that file between our write and the
+    /// kernel's read and choose the policy actually enforced — not a denial of
+    /// service, a complete policy replacement.
+    ///
+    /// This is that attack, run for real: a thread rewrites every `cplt-*.sb`
+    /// it sees with `(allow default)` while cplt launches repeatedly with a
+    /// canary file explicitly denied. If even one launch reads the canary, the
+    /// kernel enforced the attacker's profile. With the profile passed inline
+    /// (`-p`) there is no file to swap and every launch is denied.
+    #[test]
+    fn profile_cannot_be_swapped_by_another_session() {
+        require_sandbox!();
+
+        let project = project_dir();
+        let canary = project.join(".cplt-e2e-profile-swap-canary");
+        std::fs::write(&canary, "canary").expect("write canary");
+
+        let fake_dir = tempfile::Builder::new()
+            .prefix(".cplt-e2e-fake-copilot-")
+            .tempdir_in(&project)
+            .expect("create fake copilot dir");
+        let script = fake_dir.path().join("copilot");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif cat {} >/dev/null 2>&1; then echo READ_ALLOWED; \
+                 else echo READ_DENIED; fi\n",
+                canary.display()
+            ),
+        )
+        .expect("write fake copilot");
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod fake copilot");
+        }
+
+        // The attacker: another sandboxed cplt session, which the profile lets
+        // write anywhere under the system temp dir.
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hits = std::sync::Arc::new(AtomicU32::new(0));
+        let attacker = {
+            let stop = std::sync::Arc::clone(&stop);
+            let hits = std::sync::Arc::clone(&hits);
+            std::thread::spawn(move || {
+                let temp = std::env::temp_dir();
+                while !stop.load(Ordering::Relaxed) {
+                    let Ok(entries) = std::fs::read_dir(&temp) else {
+                        continue;
+                    };
+                    for entry in entries.flatten() {
+                        let name = entry.file_name();
+                        let name = name.to_string_lossy();
+                        if name.starts_with("cplt-")
+                            && name.ends_with(".sb")
+                            && std::fs::write(entry.path(), "(version 1)\n(allow default)\n")
+                                .is_ok()
+                        {
+                            hits.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            })
+        };
+
+        let current_path = std::env::var("PATH").unwrap_or_default();
+        let new_path = format!("{}:{current_path}", fake_dir.path().display());
+        let mut allowed = 0;
+        let mut denied = 0;
+        let mut transcript = String::new();
+        for attempt in 0..15 {
+            let output = cplt_cmd()
+                .args(["--yes", "--deny-path"])
+                .arg(&canary)
+                .args(["--", "--version"])
+                .current_dir(&project)
+                .env("PATH", &new_path)
+                .output()
+                .expect("binary should run");
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            if stdout.contains("READ_ALLOWED") {
+                allowed += 1;
+            } else if stdout.contains("READ_DENIED") {
+                denied += 1;
+            }
+            use std::fmt::Write as _;
+            let _ = writeln!(transcript, "attempt {attempt}: {}", stdout.trim());
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        attacker.join().expect("attacker thread");
+        let _ = std::fs::remove_file(&canary);
+
+        assert_eq!(
+            allowed,
+            0,
+            "an attacker's SBPL profile replaced ours in {allowed}/15 launches \
+             ({} temp-file overwrites landed) — the profile must not reach the \
+             kernel as a pathname:\n{transcript}",
+            hits.load(Ordering::Relaxed)
+        );
+        // Guard against a vacuous pass: the launches must actually have reached
+        // the fake agent inside the sandbox.
+        assert!(
+            denied > 0,
+            "no launch reached the sandboxed agent, so nothing was proven:\n{transcript}"
+        );
+    }
 }


### PR DESCRIPTION
## The finding

External security review, rated High and default-reachable.

`sandbox-exec` was handed the profile as a **pathname**: `write_temp_profile`
wrote `$TMPDIR/cplt-<pid>-<nanos>.sb`, closed it, and passed `-f <path>`
(`src/sandbox_exec.rs:725`, `:766`). The generated profile grants every sandbox
write throughout `/private/tmp` and `/private/var/folders` — so one sandboxed
session can overwrite another session's profile between our write and the
kernel's read.

That is not denial of service. The attacker supplies *valid* SBPL, so
`(allow default)` in place of our profile is a complete policy replacement. A
detached sandboxed child can also outlive its parent and lie in wait for the
next launch.

The new regression test reproduces it against the old code, which loses between
7 and 24 of 25 launches depending on machine load.

## The fix

Pass the profile inline with `sandbox-exec -p`. There is no file to swap, so
the race is closed rather than narrowed. Option 2 (unlinked fd) and option 3
(a write-denied directory) both keep a handoff; option 3 additionally relies on
the deny staying correct forever.

**Profile generation is untouched.** Only the transport changed — the byte
string the kernel compiles is identical.

### Size, measured rather than estimated

`kern.argmax` is 1 MiB on macOS, shared between argv and envp.

| profile | bytes |
|---|---|
| default, no grants | 24,917 |
| + 10 grants | 49,598 |
| + 50 grants | 147,598 |
| + 100 grants | 270,098 |
| + 200 grants (every toggle on, read/write/exec/socket/deny each) | 515,098 |

So ~25 KB baseline, ~2.5 KB per grant; the ceiling is in the low hundreds of
grants.

**No silent truncation.** Probed with synthetic profiles whose *last* rule was a
canary deny: at 112 B, 72 KB, 360 KB and 720 KB the trailing rule was enforced
correctly. Past the limit `sandbox-exec` is never started — `Command::spawn`
returns `E2BIG` ("Argument list too long"), so the kernel cannot see a partial
profile. `preflight` (on by default) translates that into an actionable message
naming the byte count and the limit.

## The regression test

`profile_cannot_be_swapped_by_another_session` (`tests/e2e.rs`) is the attack,
not a test of the new path: a thread rewrites every `cplt-*.sb` it finds with
`(allow default)` while `cplt` launches 25 times with a canary file passed to
`--deny-path`. A launch that reads the canary proves the kernel enforced the
attacker's profile.

- against `main`: **7-24 of 25 launches READ_ALLOWED** — fails
- with the fix: 0/25, every launch denied

It also asserts at least one launch actually reached the sandboxed agent, so it
cannot pass vacuously.

## Audit: does the pattern repeat?

I checked every filesystem handoff in the launcher.

- **`gh`/`git` wrapper scripts** (`sandbox_exec.rs:522`, `:592`) — written into
  the per-session scratch dir, which is `~/Library/Caches/cplt/tmp/<uuid>`, not
  the temp dir. No sandbox but the owning session holds a write grant there.
  Not the same bug.
- **`.gh-token` cache** (`sandbox_exec.rs:421`) — same scratch dir, same reason.
- **`PlaywrightSocketDir`** (`scratch.rs:177`) — *does* live under
  `/private/tmp`, but it is created with an exclusive `mkdir` and then pinned by
  device+inode, and it is re-verified on removal. Already the mitigated form of
  this class.

`write_temp_profile` was the only place in the launcher that wrote a file and
then reopened it by path across a trust boundary. It is deleted.

## Gates

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`
(917), `--test unit_tests` (322), `--test integration` (65), `--test e2e` (154),
`--test e2e_guards` (7), `--test e2e_git_hardening` (123), `--test e2e_projects`
(49) — all green on macOS.

## One trade-off, called out

The profile text is now in `sandbox-exec`'s argv, so it is visible to `ps` for
other users on the machine, where before it was a `0600` file. The profile
contains no secrets — only paths (project dir, home, grants) — and `cplt
--print-profile` already prints the whole thing on request. Trading argv
visibility of non-secret paths for the removal of a policy-replacement race is
the right side of that deal, but it is a real change and worth a second opinion.


## Review follow-ups

Both an adversarial read by a second model and the Copilot review are addressed:

- The `E2BIG` explanation moved out of `preflight` into the shared spawn error
  path, so `--no-validate` no longer degrades it to a bare "Argument list too
  long". Two unit tests cover the mapping.
- `SECURITY.md`'s threat-model table still advertised the temp file's
  `O_CREAT|O_EXCL` creation as a mitigation for a file that no longer exists;
  that row now describes the race it actually closes.
- The test's fake agent read the canary by an absolute path inlined into a `sh`
  script, which a checkout under a path with spaces would have failed for the
  wrong reason. It reads a relative path now — the agent's cwd is pinned to the
  project dir.
- The canary moved into the `TempDir`, so a panic cannot leave it in the
  checkout, and the attacker thread stops on a deadline as well as the flag, so
  no path detaches it. It scans every 500us rather than spinning, which cut its
  system time by about half.
