### PR TITLE
fix(guards): run the agent's own git in the guard wrappers

### DIFF
--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -469,6 +469,35 @@ fn install_command_wrappers(
     let cplt_str = cplt_bin.to_string_lossy();
     let mut installed_any = false;
 
+    // The git both wrappers bake in and run INSIDE the sandbox.
+    //
+    // PATH first, `trusted_git()` only as a fallback — the reverse of the
+    // parent-side rule, and deliberately so. `trusted_git()` scans
+    // `TRUSTED_BIN_DIRS` in a fixed order with `/usr/bin` first, which on macOS
+    // is `xcrun`'s shim, not git. The shim dlopens `libxcrun.dylib` out of
+    // whatever `xcode-select` points at; where that is a full `Xcode.app` rather
+    // than the Command Line Tools, the sandbox does not grant `/Applications`
+    // and *every* git through the wrapper dies with
+    // "unable to load libxcrun ... (file system sandbox blocked open())" —
+    // `git status`, `git log`, `git --version`, not just `git push`.
+    //
+    // Preferring PATH makes the guard run the same git the agent would have run
+    // without it. That is the invariant that was broken: a guard decides
+    // *whether* a command runs, and must not silently change *which* binary it
+    // is. The same substitution hits every machine whose PATH git comes from
+    // Homebrew, mise, asdf, nix-profile or snap; the Xcode shim is just the case
+    // that fails loudly instead of quietly running a different git.
+    //
+    // Safe because this path is only ever executed inside the sandbox, by the
+    // agent's own shell. A git planted on the agent's PATH gains it nothing: it
+    // can invoke any git by absolute path and skip the wrapper entirely, so the
+    // guard is a policy on intent, not a boundary. Parent-side git — the audit,
+    // repo-config trust, the gh guard's repo scope and allow_push URL pinning —
+    // stays on `trusted_git()` below, where a planted binary WOULD run
+    // unsandboxed as the user.
+    let sandbox_git =
+        which_binary("git").or_else(|| crate::git::trusted_git().map(std::path::Path::to_path_buf));
+
     // Install gh wrapper (only if gh_proxy enabled)
     if gh_guard.enabled
         && let Some(real_gh) = which_binary("gh")
@@ -508,9 +537,17 @@ fn install_command_wrappers(
         } else {
             None
         };
-        let real_git_str = real_git
-            .as_ref()
-            .map(|path| path.to_string_lossy().into_owned());
+        // `real_git` above is the parent-side probe and stays trusted. What the
+        // wrapper carries is the sandbox git: `gh-gate` re-runs it inside the
+        // sandbox to resolve scope, so a git that cannot start there turns every
+        // scope-checked `gh` command into a refusal.
+        let real_git_str = if real_git.is_some() {
+            sandbox_git
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+        } else {
+            None
+        };
         let script = crate::gh_proxy::generate_wrapper_script(
             &real_gh.to_string_lossy(),
             repo_scope.as_deref(),
@@ -525,25 +562,10 @@ fn install_command_wrappers(
         }
     }
 
-    // Install git guard wrapper (only if git_guard enabled)
-    // Trusted first, then PATH — the same call the gh wrapper above makes, and
-    // for the same reason.
-    //
-    // This path is baked into a wrapper the agent's own shell runs INSIDE the
-    // sandbox; it is never executed by the parent. A planted `git` there gains
-    // the agent nothing it does not already have: it can invoke any git by
-    // absolute path and skip the PATH wrapper entirely, so the guard is a policy
-    // on intent, not a boundary. Requiring a trusted git instead removed the
-    // guard outright on every machine whose git comes from mise, asdf,
-    // nix-profile or snap — the agent's PATH still had that git, so `git push`
-    // simply went unguarded. That is a loss with no matching gain.
-    //
-    // Parent-side git (audit, repo-config trust, gh guard scope) stays on
-    // `trusted_git()`, where a planted binary WOULD run unsandboxed.
+    // Install git guard wrapper (only if git_guard enabled). It runs
+    // `sandbox_git` — see the reasoning where that is resolved above.
     if git_guard.enabled
-        && let Some(real_git) = crate::git::trusted_git()
-            .map(std::path::Path::to_path_buf)
-            .or_else(|| which_binary("git"))
+        && let Some(real_git) = sandbox_git.clone()
     {
         // Pin each allow_push rule's remote name to the URL that name has in
         // the launch repository, so the rule identifies a repository and not

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -1447,6 +1447,14 @@ if /bin/rm -rf test-spawn-dir 2>/dev/null; then echo "RESULT:exec_rm:OK"; else e
     ///
     /// Each command's stderr is echoed on failure. Without it a broken wrapper
     /// reports `FAIL` and nothing about why, which is how this went unnoticed.
+    ///
+    /// This discriminates only while the machine's `xcode-select` points
+    /// somewhere other than the literal `/Applications/Xcode.app`, which is the
+    /// one path `TOOL_READ_DIRS` grants. On a runner whose `xcode-select` is
+    /// that exact path, `/usr/bin/git`'s xcrun shim works inside the sandbox
+    /// under the existing grant, and this test would go green even with the
+    /// wrapper resolving the shim again. The push assertion is what keeps it
+    /// honest about the *wrapper*; the shim grant itself is a separate bug.
     #[test]
     fn project_git_read_ops_work_under_the_git_guard() {
         require_sandbox!();
@@ -1469,6 +1477,15 @@ run_git git_version --version
 run_git git_status status
 run_git git_log log --oneline -1
 run_git git_branch branch
+
+# Proof the wrapper is actually in play, not that git works without it.
+if git push origin main >/dev/null 2>push-err.txt; then
+    echo "RESULT:git_push:ALLOWED"
+else
+    echo "RESULT:git_push:REFUSED"
+    sed 's/^/PUSHERR: /' push-err.txt
+fi
+rm -f push-err.txt
 "#;
         let fake_dir = create_fake_copilot(&project, script);
         let (stdout, stderr, success) = run_cplt(&project, &fake_dir, &["--git-guard"]);
@@ -1481,6 +1498,23 @@ run_git git_branch branch
         assert_result_ok(&stdout, "git_status");
         assert_result_ok(&stdout, "git_log");
         assert_result_ok(&stdout, "git_branch");
+
+        // Without this the test passes vacuously. `install_command_wrappers`
+        // installs nothing and warns about nothing when it cannot resolve a
+        // git, so the agent would get its bare PATH git and all four
+        // assertions above would still pass — proving only that git works,
+        // which was never in doubt.
+        //
+        // The exit status alone would not discriminate either: this project has
+        // no `origin`, so an unguarded push also fails, just with git's own
+        // "does not appear to be a git repository". Only the guard's own
+        // refusal text proves the wrapper ran and decided.
+        assert!(
+            stdout.contains("PUSHERR: \u{26a0}\u{fe0f} BLOCKED by sandbox"),
+            "the guard must have refused the push — without its refusal in the \
+             output the read-only assertions above prove nothing about the \
+             wrapper.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
     }
 
     #[test]

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -1431,6 +1431,58 @@ if /bin/rm -rf test-spawn-dir 2>/dev/null; then echo "RESULT:exec_rm:OK"; else e
         assert_result_ok(&stdout, "exec_rm");
     }
 
+    /// The git guard must not break git.
+    ///
+    /// With `git_guard.enabled`, every `git` in the agent's PATH is a wrapper
+    /// that execs `cplt git-gate`, which decides and then execs the real git.
+    /// Read-only subcommands are supposed to sail straight through — the guard
+    /// blocks pushes, not `git status`. Nothing covered that: every existing
+    /// git test runs with the guard off (its default), and the one wrapper test
+    /// in `e2e_guards` invokes the wrapper directly with `/usr/bin/true` as the
+    /// real git, so it never exercises a real git through a real sandbox.
+    ///
+    /// `git --version` is here as the floor: it needs no repository, no remote,
+    /// and no filesystem access beyond the binary itself, so if even that fails
+    /// the wrapper is broken rather than the policy being strict.
+    ///
+    /// Each command's stderr is echoed on failure. Without it a broken wrapper
+    /// reports `FAIL` and nothing about why, which is how this went unnoticed.
+    #[test]
+    fn project_git_read_ops_work_under_the_git_guard() {
+        require_sandbox!();
+        let project = TempProject::scaffold_node();
+
+        let script = r#"
+run_git() {
+    name="$1"
+    shift
+    if git "$@" >/dev/null 2>git-err.txt; then
+        echo "RESULT:$name:OK"
+    else
+        echo "RESULT:$name:FAIL"
+        sed 's/^/GITERR: /' git-err.txt
+    fi
+    rm -f git-err.txt
+}
+
+run_git git_version --version
+run_git git_status status
+run_git git_log log --oneline -1
+run_git git_branch branch
+"#;
+        let fake_dir = create_fake_copilot(&project, script);
+        let (stdout, stderr, success) = run_cplt(&project, &fake_dir, &["--git-guard"]);
+
+        assert!(
+            success,
+            "cplt should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_result_ok(&stdout, "git_version");
+        assert_result_ok(&stdout, "git_status");
+        assert_result_ok(&stdout, "git_log");
+        assert_result_ok(&stdout, "git_branch");
+    }
+
     #[test]
     fn project_proxy_env_vars_injected() {
         require_sandbox!();


### PR DESCRIPTION
Split out of #335, which is waiting on this.

## The bug

Turning `git_guard` on makes **every** git command fail inside the sandbox on machines where the agent's PATH git and `/usr/bin/git` are not the same binary — `git status`, `git log`, `git --version`, not just `git push`. The guard takes the whole tool down.

CI printed it once the test stopped swallowing git's stderr:

```
GITERR: xcrun: error: unable to load libxcrun (dlopen(/Applications/Xcode_26.6.app/Contents/Developer/usr/lib/libxcrun.dylib, 0x0005):
  tried: '/Applications/Xcode_26.6.app/Contents/Developer/usr/lib/libxcrun.dylib' (file system sandbox blocked open()), ...)
```

Both wrappers baked in `trusted_git()`, which scans `TRUSTED_BIN_DIRS` in a fixed order with `/usr/bin` first. On macOS `/usr/bin/git` is not git — it is an xcrun shim that dlopens `libxcrun.dylib` out of whatever `xcode-select` points at.

**Two separate faults meet here, and only one of them is this PR's:**

1. The sandbox grants a *hardcoded* `/Applications/Xcode.app/Contents/Developer` (`TOOL_READ_DIRS`, `sandbox_policy.rs:331`), and CI's `xcode-select` points at `/Applications/Xcode_26.6.app`. So the shim is broken inside the sandbox on that machine **regardless of the guards** — as are `clang`, `make` and `python3`, which are shims too. Filed separately as #342. This PR does not fix it, and a machine whose only git is `/usr/bin/git` is still broken after this merges.
2. **The guard replaced a working git with that shim.** Without the guard the agent resolves `git` through its own PATH and gets a working one — Homebrew's, on a GitHub runner. The wrapper overrode that choice. That is this PR.

The earlier version of this description blamed the sandbox for not granting `/Applications`. It grants it, just under one hardcoded name. The distinction matters: fault 1 is a live bug for anyone with a non-default Xcode and deserved its own issue rather than being buried in a guard PR's narrative.

## The fix

The wrappers prefer the PATH git and fall back to trusted.

The invariant that was broken is the general one: **a guard decides whether a command runs, not which binary it is.** The Xcode shim is only the case that fails loudly. The same substitution silently swapped git on every machine whose PATH git comes from Homebrew, mise, asdf, nix-profile or snap — those kept working, just not with the git the user configured.

This is safe, and the module already argued why in a comment two lines above the bug: the wrapper's git path is only ever executed *inside* the sandbox by the agent's own shell, where a planted git gains the agent nothing, since it can invoke any git by absolute path and skip the wrapper entirely. The guard is a policy on intent, not a boundary. Every **parent-side** use keeps `trusted_git()` — the audit, repo-config trust, the gh guard's repo-scope probe, `allow_push` URL pinning — because there a planted binary really would run unsandboxed as the user. The two needs were sharing one resolver; they are now separate.

The gh guard carried the same path into its wrapper for the scope resolution `gh-gate` runs inside the sandbox, so it had the identical failure and takes the same fix. Its exposure is narrower: inside `gh-gate`, `real_git` only feeds `resolve_invocation_repo`, while the pin is always the baked trusted `startup_repo` — so a lying git can at most let a foreign-cwd invocation proceed pinned to the startup repo, which the agent could reach by `cd`-ing there anyway.

## Test

`project_git_read_ops_work_under_the_git_guard` runs the project harness with `--git-guard` and asserts `git --version`, `status`, `log` and `branch` still work. `--version` is the floor: no repository, no remote, nothing but the binary, so a failure there is the wrapper being broken rather than the policy being strict.

It also asserts the guard **refused a push**, which is what keeps the rest from passing vacuously. `install_command_wrappers` installs nothing and warns about nothing when it cannot resolve a git, so the agent would fall through to its bare PATH git and all four read-only assertions would still print `OK` — proving only that git works, which was never in doubt. Exit status alone does not discriminate either: the temp project has no `origin`, so an unguarded push fails too, with git's own error. Only the guard's own refusal text proves the wrapper ran and decided. Mutation-checked: drop `--git-guard` and that assertion fails.

That assertion also appears to be the suite's only real-sandbox, real-wrapper push-block coverage.

The test discriminates only while CI's `xcode-select` is not literally `/Applications/Xcode.app`. If the image ever changes to that, the shim starts working under the existing grant and this could go green for the wrong reason — recorded in a comment on the test so the next person knows.

**The first commit on this branch is the test alone, against unmodified `main`, and CI failed it.** That is the proof this predates #335 rather than being caused by it.

Each command's stderr is echoed on failure. The existing scripts send git's stderr to `/dev/null`, which is why the first red run said `FAIL` and nothing else.

## Why nothing caught it

No test had ever put a real git behind the wrapper inside a real sandbox:

- every git test in `e2e_projects` runs with the guard at its default, off;
- `e2e_guards::sandbox_integration::wrapper_blocks_git_push_in_sandbox` hand-builds a wrapper with `--real-git /usr/bin/true` under a plain `/bin/sh`, exercising the decision logic and neither the sandbox nor a real git.

The guard has been opt-in long enough that nobody ran it in CI. #122's prerequisite list would have caught this if anyone had.

Local gates green: `cargo fmt`, `cargo test --lib` (924), `--test unit_tests` (323), `--test e2e_guards` (123), `--test e2e_projects`, `cargo clippy --all-targets -- -D warnings`. The failure does not reproduce on a machine whose `xcode-select` points at the Command Line Tools, so CI is the real verification.

Follow-up: #342.