### PR TITLE
fix(sandbox): grant the developer dir xcode-select selects

### DIFF
--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -354,17 +354,27 @@ pub const XCODE_SELECT_LINK: &str = "/var/db/xcode_select_link";
 /// them on any machine with a versioned or relocated Xcode — a user whose only
 /// git is `/usr/bin/git` then has no git inside the sandbox at all (#342).
 ///
-/// Returns `None` when the link is absent, when it is relative, when it names a
-/// path that would widen the sandbox ([`tool_override_path_is_safe`] — the link
-/// is root-owned, but a grant that follows a symlink still gets the same sanity
-/// check every other resolved path in this codebase gets), or when the target
-/// cannot be safely interpolated into SBPL.
+/// Returns `None` when the link is absent, when it is not a symlink, when its
+/// target does not exist, when it names a path that would widen the sandbox
+/// ([`tool_override_path_is_safe`] — the link is root-owned, but a grant that
+/// follows a symlink still gets the same sanity check every other resolved path
+/// in this codebase gets), or when the target cannot be safely interpolated
+/// into SBPL.
+///
+/// The target is canonicalized before it is checked and before it is granted.
+/// `tool_override_path_is_safe` compares paths textually and documents that its
+/// argument is already canonical, so a link target carrying `..` — or one whose
+/// own parents are symlinks — would otherwise slip past it and be emitted as a
+/// grant on whatever it really resolves to.
 ///
 /// The caller is responsible for skipping a target already covered by
 /// [`TOOL_READ_DIRS`] — the Command Line Tools case, where the selected
 /// directory is `/Library/Developer/CommandLineTools` and is already granted.
 pub fn xcode_developer_dir_from(link: &Path, home: &Path) -> Option<PathBuf> {
-    let target = std::fs::read_link(link).ok()?;
+    // `read_link` rather than `canonicalize` alone: it fails on a regular file,
+    // so a `/var/db/xcode_select_link` that is not a symlink falls back to the
+    // literal instead of granting a subpath on the file itself.
+    let target = std::fs::canonicalize(std::fs::read_link(link).ok()?).ok()?;
     if !target.is_absolute()
         || !tool_override_path_is_safe(&target, home)
         || validate_sbpl_path(&target).is_err()

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -328,10 +328,51 @@ pub(super) const TOOL_READ_DIRS: &[&str] = &[
     "/Library/Developer/CommandLineTools",
     // Xcode.app developer tools — needed when xcode-select points to the full
     // Xcode install instead of standalone CommandLineTools. /usr/bin/git and
-    // other shims load libxcrun.dylib from this path.
+    // other shims load libxcrun.dylib from this path. Only the *default*
+    // install location; the directory actually selected is resolved at profile
+    // generation by [`xcode_developer_dir_from`], and this literal is the
+    // fallback for when that resolution finds nothing.
     "/Applications/Xcode.app/Contents/Developer",
     "/Library/Java/JavaVirtualMachines",
 ];
+
+/// Symlink macOS maintains pointing at the directory `xcode-select` selected.
+///
+/// It is a symlink, not a file containing a path, on every macOS version cplt
+/// supports — so `read_link` answers the question with no subprocess. Shelling
+/// out to `xcode-select -p` would put an unbounded child process on the profile
+/// generation path in the parent, which is what made `cplt doctor` hang (#298).
+pub const XCODE_SELECT_LINK: &str = "/var/db/xcode_select_link";
+
+/// The developer directory `xcode-select` currently points at, if it is safe
+/// to grant read access to.
+///
+/// `/usr/bin/git`, `/usr/bin/clang`, `/usr/bin/make` and `/usr/bin/python3` on
+/// macOS are xcrun shims: each one `dlopen`s `libxcrun.dylib` from under the
+/// selected developer directory and exits 1 if that open is denied. Granting
+/// only the default `/Applications/Xcode.app/Contents/Developer` breaks all of
+/// them on any machine with a versioned or relocated Xcode — a user whose only
+/// git is `/usr/bin/git` then has no git inside the sandbox at all (#342).
+///
+/// Returns `None` when the link is absent, when it is relative, when it names a
+/// path that would widen the sandbox ([`tool_override_path_is_safe`] — the link
+/// is root-owned, but a grant that follows a symlink still gets the same sanity
+/// check every other resolved path in this codebase gets), or when the target
+/// cannot be safely interpolated into SBPL.
+///
+/// The caller is responsible for skipping a target already covered by
+/// [`TOOL_READ_DIRS`] — the Command Line Tools case, where the selected
+/// directory is `/Library/Developer/CommandLineTools` and is already granted.
+pub fn xcode_developer_dir_from(link: &Path, home: &Path) -> Option<PathBuf> {
+    let target = std::fs::read_link(link).ok()?;
+    if !target.is_absolute()
+        || !tool_override_path_is_safe(&target, home)
+        || validate_sbpl_path(&target).is_err()
+    {
+        return None;
+    }
+    Some(target)
+}
 
 /// Suffixes of env var names that indicate secrets/credentials.
 /// Vars matching a prefix allowlist entry BUT also matching one of these

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -24,7 +24,7 @@ use super::policy::{
     DENIED_CACHE_PREFIXES, DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS, EXEC_IN_WRITABLE,
     GPG_SIGNING_ALLOW_FILES, PROTECTED_IN_GITDIR, PROTECTED_IN_ROOT, PathBinDir, Protected,
     ResolvedToolDir, SENSITIVE_PROJECT_PATTERNS, SYSTEM_READ_FILES, TOOL_READ_DIRS,
-    active_tool_dirs, app_dirs, escape_regex, nested_alternation, path_bin_dirs,
+    XCODE_SELECT_LINK, active_tool_dirs, app_dirs, escape_regex, nested_alternation, path_bin_dirs,
     playwright_runtime_intent, validate_playwright_socket_dir, validate_sbpl_path,
 };
 
@@ -119,6 +119,7 @@ pub fn generate_profile_with_playwright_socket_dir(
         config.agent,
         config.allow_cache_exec,
         config.allow_cache_exec_any,
+        Path::new(XCODE_SELECT_LINK),
     );
     emit_copilot_install(&mut sb, config.copilot_install_dir);
     emit_gradle_toolchain_exec(&mut sb, &home);
@@ -908,6 +909,7 @@ fn emit_nested_gitdir_denies(sb: &mut String, root: &str) {
     sbpl!(sb);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_tool_dirs(
     sb: &mut String,
     home_dir: &std::path::Path,
@@ -916,12 +918,23 @@ fn emit_tool_dirs(
     agent: Agent,
     allow_cache_exec: &[String],
     allow_cache_exec_any: bool,
+    xcode_select_link: &Path,
 ) {
     let home = home_dir.to_string_lossy();
     sbpl!(sb, ";; Developer tools");
     for dir in TOOL_READ_DIRS {
         sbpl!(sb, "(allow file-read* (subpath \"{dir}\"))");
         sbpl!(sb, "(allow file-map-executable (subpath \"{dir}\"))");
+    }
+    // The developer directory xcode-select actually points at, when it is not
+    // already covered above. Without it the xcrun shims at /usr/bin/{git,clang,
+    // make,python3} cannot dlopen libxcrun.dylib and exit 1 (#342).
+    if let Some(dev) = super::policy::xcode_developer_dir_from(xcode_select_link, home_dir)
+        && !TOOL_READ_DIRS.iter().any(|d| dev.starts_with(d))
+    {
+        let p = dev.to_string_lossy();
+        sbpl!(sb, "(allow file-read* (subpath \"{p}\"))");
+        sbpl!(sb, "(allow file-map-executable (subpath \"{p}\"))");
     }
     // Home tool dirs: use discovered existing dirs if available, else include all
     let active_dirs = active_tool_dirs(home_dir, existing_home_tool_dirs);
@@ -2335,6 +2348,95 @@ mod tests {
             allow_browser: false,
             keychain_substitute: None,
             use_bubblewrap: None,
+        }
+    }
+
+    /// Emit just the developer-tools block with `xcode_select_link` pointed at a
+    /// symlink under test control, so every `xcode-select` configuration can be
+    /// exercised on a machine that only has one.
+    fn tool_dirs_block(xcode_select_link: &Path) -> String {
+        let mut sb = String::new();
+        emit_tool_dirs(
+            &mut sb,
+            std::path::Path::new("/Users/test"),
+            Some(&[]),
+            Some(&[]),
+            crate::agent::Agent::Copilot,
+            &[],
+            false,
+            xcode_select_link,
+        );
+        sb
+    }
+
+    fn link_to(dir: &tempfile::TempDir, target: &str) -> PathBuf {
+        let link = dir.path().join("xcode_select_link");
+        std::os::unix::fs::symlink(target, &link).expect("symlink");
+        link
+    }
+
+    /// #342: the selected developer directory is granted, not just the literal
+    /// default. `/usr/bin/git` and the other xcrun shims dlopen libxcrun.dylib
+    /// from here; on a versioned Xcode the literal grant covers nothing they use
+    /// and every one of them exits 1 inside the sandbox.
+    #[test]
+    fn versioned_xcode_developer_dir_is_granted() {
+        let dir = tempfile::tempdir().unwrap();
+        let selected = "/Applications/Xcode_26.6.app/Contents/Developer";
+        let sb = tool_dirs_block(&link_to(&dir, selected));
+        assert!(
+            sb.contains(&format!("(allow file-read* (subpath \"{selected}\"))")),
+            "selected developer dir must be readable:\n{sb}"
+        );
+        assert!(
+            sb.contains(&format!(
+                "(allow file-map-executable (subpath \"{selected}\"))"
+            )),
+            "libxcrun.dylib must be mappable from the selected developer dir:\n{sb}"
+        );
+    }
+
+    /// No link (or an unreadable one) falls back to the literal default install,
+    /// which stays in `TOOL_READ_DIRS` for exactly this case.
+    #[test]
+    fn absent_xcode_select_link_falls_back_to_the_literal() {
+        let dir = tempfile::tempdir().unwrap();
+        let sb = tool_dirs_block(&dir.path().join("does_not_exist"));
+        assert!(
+            sb.contains(
+                "(allow file-read* (subpath \"/Applications/Xcode.app/Contents/Developer\"))"
+            ),
+            "default install must remain granted when nothing is selected:\n{sb}"
+        );
+    }
+
+    /// Command Line Tools: `xcode_select` points at a directory `TOOL_READ_DIRS`
+    /// already grants, so no second rule is emitted for it.
+    #[test]
+    fn command_line_tools_selection_emits_no_duplicate_grant() {
+        let dir = tempfile::tempdir().unwrap();
+        let clt = "/Library/Developer/CommandLineTools";
+        let sb = tool_dirs_block(&link_to(&dir, clt));
+        assert_eq!(
+            sb.matches(&format!("(allow file-read* (subpath \"{clt}\"))"))
+                .count(),
+            1,
+            "CommandLineTools is already in TOOL_READ_DIRS:\n{sb}"
+        );
+    }
+
+    /// The link is root-owned, but a grant that follows a symlink still gets the
+    /// widening check every other resolved path gets. A link to `/` or to $HOME
+    /// would hand the sandbox the whole machine.
+    #[test]
+    fn xcode_select_link_to_an_unsafe_root_is_not_granted() {
+        for target in ["/", "/Users/test", "/Users", "/tmp"] {
+            let dir = tempfile::tempdir().unwrap();
+            let sb = tool_dirs_block(&link_to(&dir, target));
+            assert!(
+                !sb.contains(&format!("(allow file-read* (subpath \"{target}\"))")),
+                "xcode-select pointing at {target} must not widen the sandbox:\n{sb}"
+            );
         }
     }
 

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -2354,11 +2354,11 @@ mod tests {
     /// Emit just the developer-tools block with `xcode_select_link` pointed at a
     /// symlink under test control, so every `xcode-select` configuration can be
     /// exercised on a machine that only has one.
-    fn tool_dirs_block(xcode_select_link: &Path) -> String {
+    fn tool_dirs_block(home: &Path, xcode_select_link: &Path) -> String {
         let mut sb = String::new();
         emit_tool_dirs(
             &mut sb,
-            std::path::Path::new("/Users/test"),
+            home,
             Some(&[]),
             Some(&[]),
             crate::agent::Agent::Copilot,
@@ -2369,10 +2369,22 @@ mod tests {
         sb
     }
 
-    fn link_to(dir: &tempfile::TempDir, target: &str) -> PathBuf {
-        let link = dir.path().join("xcode_select_link");
+    fn link_to(dir: &Path, target: &Path) -> PathBuf {
+        let link = dir.join("xcode_select_link");
         std::os::unix::fs::symlink(target, &link).expect("symlink");
         link
+    }
+
+    /// A stand-in for a versioned Xcode: a real directory, because the resolver
+    /// canonicalizes the link target and a path that does not exist is not
+    /// granted.
+    fn fake_xcode(home: &Path, name: &str) -> PathBuf {
+        let dev = home
+            .join("Applications")
+            .join(name)
+            .join("Contents/Developer");
+        std::fs::create_dir_all(&dev).expect("mkdir");
+        dev
     }
 
     /// #342: the selected developer directory is granted, not just the literal
@@ -2381,17 +2393,17 @@ mod tests {
     /// and every one of them exits 1 inside the sandbox.
     #[test]
     fn versioned_xcode_developer_dir_is_granted() {
-        let dir = tempfile::tempdir().unwrap();
-        let selected = "/Applications/Xcode_26.6.app/Contents/Developer";
-        let sb = tool_dirs_block(&link_to(&dir, selected));
+        let tmp = tempfile::tempdir().unwrap();
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        let dev = std::fs::canonicalize(fake_xcode(&home, "Xcode_26.6.app")).unwrap();
+        let sb = tool_dirs_block(&home, &link_to(&home, &dev));
+        let dev = dev.display();
         assert!(
-            sb.contains(&format!("(allow file-read* (subpath \"{selected}\"))")),
+            sb.contains(&format!("(allow file-read* (subpath \"{dev}\"))")),
             "selected developer dir must be readable:\n{sb}"
         );
         assert!(
-            sb.contains(&format!(
-                "(allow file-map-executable (subpath \"{selected}\"))"
-            )),
+            sb.contains(&format!("(allow file-map-executable (subpath \"{dev}\"))")),
             "libxcrun.dylib must be mappable from the selected developer dir:\n{sb}"
         );
     }
@@ -2400,8 +2412,8 @@ mod tests {
     /// which stays in `TOOL_READ_DIRS` for exactly this case.
     #[test]
     fn absent_xcode_select_link_falls_back_to_the_literal() {
-        let dir = tempfile::tempdir().unwrap();
-        let sb = tool_dirs_block(&dir.path().join("does_not_exist"));
+        let tmp = tempfile::tempdir().unwrap();
+        let sb = tool_dirs_block(tmp.path(), &tmp.path().join("does_not_exist"));
         assert!(
             sb.contains(
                 "(allow file-read* (subpath \"/Applications/Xcode.app/Contents/Developer\"))"
@@ -2410,13 +2422,29 @@ mod tests {
         );
     }
 
+    /// A `/var/db/xcode_select_link` that is a regular file rather than a
+    /// symlink — the shape this file reportedly had on older macOS — must fall
+    /// back rather than grant a subpath on the file itself.
+    #[test]
+    fn regular_file_xcode_select_link_grants_nothing_extra() {
+        let tmp = tempfile::tempdir().unwrap();
+        let link = tmp.path().join("xcode_select_link");
+        std::fs::write(&link, "/Applications/Xcode_26.6.app/Contents/Developer\n").unwrap();
+        let sb = tool_dirs_block(tmp.path(), &link);
+        assert!(
+            !sb.contains(&format!("(subpath \"{}\"", link.display())),
+            "the link file itself must never be granted:\n{sb}"
+        );
+    }
+
     /// Command Line Tools: `xcode_select` points at a directory `TOOL_READ_DIRS`
     /// already grants, so no second rule is emitted for it.
     #[test]
     fn command_line_tools_selection_emits_no_duplicate_grant() {
-        let dir = tempfile::tempdir().unwrap();
-        let clt = "/Library/Developer/CommandLineTools";
-        let sb = tool_dirs_block(&link_to(&dir, clt));
+        let tmp = tempfile::tempdir().unwrap();
+        let clt = Path::new("/Library/Developer/CommandLineTools");
+        let sb = tool_dirs_block(tmp.path(), &link_to(tmp.path(), clt));
+        let clt = clt.display();
         assert_eq!(
             sb.matches(&format!("(allow file-read* (subpath \"{clt}\"))"))
                 .count(),
@@ -2430,14 +2458,32 @@ mod tests {
     /// would hand the sandbox the whole machine.
     #[test]
     fn xcode_select_link_to_an_unsafe_root_is_not_granted() {
-        for target in ["/", "/Users/test", "/Users", "/tmp"] {
-            let dir = tempfile::tempdir().unwrap();
-            let sb = tool_dirs_block(&link_to(&dir, target));
-            assert!(
-                !sb.contains(&format!("(allow file-read* (subpath \"{target}\"))")),
-                "xcode-select pointing at {target} must not widen the sandbox:\n{sb}"
-            );
+        for target in ["/", "/tmp", "/Users", "/Applications"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let home = std::fs::canonicalize(tmp.path()).unwrap();
+            let sb = tool_dirs_block(&home, &link_to(&home, Path::new(target)));
+            for granted in [target, "/private/tmp"] {
+                assert!(
+                    !sb.contains(&format!("(allow file-read* (subpath \"{granted}\"))")),
+                    "xcode-select pointing at {target} must not widen the sandbox:\n{sb}"
+                );
+            }
         }
+        // $HOME itself, via a target that only reaches it through `..` — the
+        // case that needs the target canonicalized before it is checked.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        let escape = fake_xcode(&home, "Xcode.app").join("../../../..");
+        let sb = tool_dirs_block(&home, &link_to(&home, &escape));
+        let home = home.display();
+        assert!(
+            !sb.contains(&format!("(allow file-read* (subpath \"{home}\"))")),
+            "a link target escaping to $HOME must not be granted:\n{sb}"
+        );
+        assert!(
+            !sb.contains(".."),
+            "no un-normalized path may reach the profile:\n{sb}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #342.

`TOOL_READ_DIRS` granted the literal `/Applications/Xcode.app/Contents/Developer`. On macOS `/usr/bin/git`, `/usr/bin/clang`, `/usr/bin/make` and `/usr/bin/python3` are xcrun shims that `dlopen` `libxcrun.dylib` from whatever `xcode-select` points at, so on a versioned, beta or relocated Xcode the sandbox denies that open and each shim exits 1 before the real tool runs. A user whose only git is `/usr/bin/git` has no git inside the sandbox at all. Independent of the git guard fixed in #338.

## The fix

`xcode_developer_dir_from()` reads `/var/db/xcode_select_link` with `std::fs::read_link`. No subprocess: `xcode-select -p` would put an unbounded child on the profile-generation path in the parent, which is what made `cplt doctor` hang (#298).

- The literal stays in `TOOL_READ_DIRS` as the fallback when the link is absent.
- A selection already covered by `TOOL_READ_DIRS` emits no second rule.
- The resolved target goes through `tool_override_path_is_safe` and `validate_sbpl_path`, so a link at `/`, `$HOME` or an ancestor of it is dropped rather than granted. The link is root-owned, but a grant that follows a symlink gets the same widening check every other resolved path in this codebase gets.

## What the file actually is

Checked on the dev machine before writing the code: `/var/db/xcode_select_link` is a **symlink** (`lrwxr-xr-x root:wheel`), not a plain file containing a path, and it points at `/Library/Developer/CommandLineTools`. `read_link` is therefore the right call. A non-symlink would make `read_link` return `Err`, which falls back to the literal — degraded, not broken.

## Command Line Tools

No extra grant needed. When `xcode-select` points at `/Library/Developer/CommandLineTools`, that path is already in `TOOL_READ_DIRS`; the dedupe check skips it so the profile gains no duplicate rule. Covered by `command_line_tools_selection_emits_no_duplicate_grant`.

## Configurations

Verified by test, on any machine, by pointing `emit_tool_dirs` at a symlink under test control:

- versioned Xcode (`/Applications/Xcode_26.6.app/Contents/Developer`) — granted read + `file-map-executable`
- link absent — falls back to the literal
- Command Line Tools — no duplicate grant
- link to `/`, `$HOME`, `/Users`, `/tmp` — not granted

Verified on real hardware: only the Command Line Tools configuration, which is what this machine has. The versioned-Xcode case is the one CI reproduces; the profile assertion above is the same rule the failing CI run needed.

Reasoned about, not executed: whether a real versioned Xcode's shims recover once the grant lands. The dlopen path in the CI error sits directly under the granted subpath, so the grant covers it.

## Mutation check

Replaced the resolution with `Option::<PathBuf>::None` (the literal-only behaviour). `sandbox::profile::tests::versioned_xcode_developer_dir_is_granted` FAILED, 934 passed. Restored; 935 pass.

## Gates

`cargo fmt`, `cargo test --lib` (935), `cargo test --test unit_tests` (329), `cargo clippy --all-targets -- -D warnings` (clean), and `cargo test --test integration` (65) — all green on macOS.