### PR TITLE
fix(git-guard): fail closed on unpinnable rules and unknown default branches

### DIFF
--- a/docs/git-guard.md
+++ b/docs/git-guard.md
@@ -47,11 +47,13 @@ authorize `git -C ../other-repo push origin main`, even though the other
 checkout also calls its remote `origin`.
 
 Pinning needs a *trusted* git binary (the same one the gh guard uses to capture
-its repo scope), because it runs unsandboxed in the parent at launch. On a
-machine where cplt cannot find one, it says so and the rules fall back to
-matching the bare name — which is where a rule does apply to another
-repository's same-named remote. Fix the git installation cplt is warning about
-rather than relying on the fallback.
+its repo scope), because it runs unsandboxed in the parent at launch. A rule
+that cannot be pinned — no trusted git, or no such remote in the launch
+repository — authorizes nothing at all, and cplt warns about it at launch. It
+does not fall back to matching the bare name: that fallback grants exactly the
+cross-repository authorization pinning exists to prevent, in every repository
+the agent can reach. Fix what the warning names — add the remote to the project
+repository, or fix the git installation — and the rule works again.
 
 URLs are compared after normalization, so the spellings of one remote are one
 remote: `git@github.com:navikt/cplt.git`, `ssh://git@github.com/navikt/cplt`,
@@ -64,12 +66,10 @@ the name it expands to), and local paths — those compare as the literal string
 git reports.
 
 Nothing changes in the config file format, and a rule written against a remote
-name keeps working. The one behavior change is the intended one: such a rule
-now only covers the repository that name pointed at when the session started.
-
-Two cases keep the old name matching, both of them announced rather than
-silent: the launch repository has no remote by that name, and cplt found no
-trusted git to resolve it with.
+name keeps working as long as the name resolves at launch: it then covers the
+repository that name pointed at when the session started, and only that one. A
+rule that names a remote which does not resolve covers nothing, and the block
+message says so.
 
 <details>
 <summary>CLI flag (override for a single run)</summary>
@@ -97,6 +97,8 @@ target branch:
 | `git push origin feature/fix-123` | `feature/fix-123` | Allowed |
 | `git push origin main` | `main` | Blocked |
 | `git push origin master` | `master` | Blocked |
+| `git push origin develop`, in a repo whose default is `develop` | `develop` | Blocked |
+| `git push origin feature/x`, in a repo with no recorded default branch | `feature/x` | Blocked — the default branch is unknown |
 | `git push origin HEAD:refs/heads/main` | `main` (from refspec) | Blocked |
 | `git push origin HEAD:main` | `main` (from refspec) | Blocked |
 | `git push` (bare) | resolved from the current branch via the real git, in the repository the command targets | Allowed on a feature branch, blocked on `main`/`master`, blocked if the branch cannot be resolved |
@@ -104,19 +106,31 @@ target branch:
 | `git push --force origin feature/x` | `feature/x` | Blocked while `prevent_force_push` is on, which is the default |
 | `git push --force origin main` | `main` | Blocked |
 
-The default branch names are `main` and `master`, recognized with or without an
-`origin/` prefix. When several refspecs are given, the guard checks all of them
-and blocks if any names a default branch, so `git push origin feature main`
-does not slip through.
+The default branch is the one the repository actually has. The guard reads it
+from the local `refs/remotes/<remote>/HEAD` symref that `git clone` and
+`git remote set-head` write, so a repository whose default is `develop`,
+`trunk` or `production` is protected under the setting that promises it — no
+network call is made. `main` and `master` stay protected as a floor alongside
+it, recognized with or without an `origin/` prefix. When several refspecs are
+given, the guard checks all of them and blocks if any names a protected branch,
+so `git push origin feature main` does not slip through.
+
+If the default branch cannot be resolved — no such remote, or no recorded
+`refs/remotes/<remote>/HEAD` — the guard cannot tell a feature branch from the
+protected one, so it allows no push at all and the block message says to run
+`git remote set-head <remote> -a`. The setting grants a relaxation of
+`prevent_push`; a relaxation that cannot be justified is refused, not guessed
+at. Falling back to `main`/`master` alone would leave a `develop` repository
+unprotected by a setting that says it is protected.
 
 A push with no branch in the arguments is not waved through. The guard shells
 out to the real git to resolve the current branch, and fails closed when it
 cannot: an unresolvable branch counts as protected and the push is blocked.
 
 That resolution follows the command. `-C`, `--git-dir` and `--work-tree` are
-forwarded to the guard's own git call, so `git -C ../other-repo push` is judged
-by *that* repository's branch, not by the branch of the repository the session
-was launched in.
+forwarded to the guard's own git calls, so `git -C ../other-repo push` is judged
+by *that* repository's branch and *that* repository's default branch, not by the
+repository the session was launched in.
 
 **Security note:** This mode is intentionally permissive about branches. The
 agent can push to any non-default branch, and the human review gate becomes the

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -750,7 +750,8 @@ pub struct ResolvedPushRule {
     /// `origin`. Pinning the name to the URL it had at launch is what stops a
     /// rule written for this repo's `origin` from authorizing a push to some
     /// other repo's `origin` (#215). `None` means the name could not be
-    /// resolved at launch, and matching falls back to the name alone.
+    /// resolved at launch; such a rule matches nothing, because a bare name
+    /// would match every repository's remote of that name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2370,18 +2370,49 @@ pub fn gate_git(
         // When protect_default_branch_only is set, only block pushes targeting
         // the default branch (main/master). Feature branch pushes are allowed,
         // but force push is still checked independently.
+        // Hints appended to the block message when a setting could not be
+        // honoured as written. A guard that fails closed silently is only half
+        // the fix: the operator has to learn why, and what to do about it.
+        let mut block_hints: Vec<String> = Vec::new();
+
+        // The repository's real default branch, resolved in the repo this
+        // command targets. `None` means it could not be determined.
+        let default_branch = if sub == "push"
+            && (protect_default_branch_only || !allow_push_rules.is_empty())
+        {
+            let remote = push_remote_name(&args[i + 1..]);
+            let resolved = real_git.and_then(|git| resolve_default_branch(git, &repo_args, remote));
+            if resolved.is_none() && protect_default_branch_only {
+                block_hints.push(format!(
+                    "protect_default_branch_only is set, but the default branch of remote \
+                     '{remote}' could not be determined in this repository, so the guard \
+                     cannot tell a feature branch from the protected one. Run \
+                     `git remote set-head {remote} -a` (it records refs/remotes/{remote}/HEAD \
+                     locally, no push) and retry."
+                ));
+            }
+            resolved
+        } else {
+            None
+        };
+
         if protect_default_branch_only && sub == "push" {
             let push_args = &args[i + 1..];
-            let target_branch = extract_push_target_branch(push_args);
-            let is_feature_branch = if let Some(branch) = target_branch {
-                !is_default_branch(branch)
+            let target_branch = extract_push_target_branch(push_args, default_branch.as_deref());
+            // Without a resolved default branch nothing is a proven feature
+            // branch: the relaxation this setting grants cannot be applied, so
+            // the push falls through to the normal block.
+            let is_feature_branch = if default_branch.is_none() {
+                false
+            } else if let Some(branch) = target_branch {
+                !is_protected_branch(branch, default_branch.as_deref())
             } else {
                 // No explicit branch: `git push` pushes current branch.
                 // Resolve via real git to determine if we're on a protected branch.
                 let current_branch =
                     real_git.and_then(|git| resolve_current_branch(git, &repo_args));
                 match current_branch {
-                    Some(ref b) if !is_default_branch(b) => true,
+                    Some(ref b) if !is_protected_branch(b, default_branch.as_deref()) => true,
                     Some(_) => false, // On default branch — fall through to block
                     None => false,    // Can't determine branch — fail closed for safety
                 }
@@ -2408,7 +2439,12 @@ pub fn gate_git(
         if sub == "push" && !allow_push_rules.is_empty() {
             let push_args = &args[i + 1..];
             let has_force = push_is_force(push_args);
-            let (remote, branch) = extract_push_remote_and_branch(push_args, real_git, &repo_args);
+            let (remote, branch) = extract_push_remote_and_branch(
+                push_args,
+                real_git,
+                &repo_args,
+                default_branch.as_deref(),
+            );
             // Resolve the destination remote's URL in the repository this
             // command targets. A bare `git push` with no remote uses the
             // branch's configured remote, which is `origin` in all but exotic
@@ -2418,19 +2454,41 @@ pub fn gate_git(
             });
             if matches_allow_push_rule(
                 allow_push_rules,
-                remote.as_deref(),
                 remote_url.as_deref(),
                 branch.as_deref(),
                 has_force,
             ) {
                 return Ok(());
             }
+            // A rule naming a remote that could not be pinned to a URL at
+            // launch matches nothing (see `matches_allow_push_rule`). Say so,
+            // or the operator sees a rule that looks like it should apply.
+            if let Some(name) = allow_push_rules
+                .iter()
+                .find(|r| r.remote.is_some() && r.url.is_none())
+                .and_then(|r| r.remote.clone())
+            {
+                block_hints.push(format!(
+                    "An allow_push rule names remote '{name}', but that name could not be \
+                     pinned to a repository URL at launch, so the rule authorizes nothing. \
+                     A bare remote name is not a repository identity — every repository has \
+                     an 'origin' — so matching it by name would let the rule authorize \
+                     pushes to other repositories (#215). Add the remote to the project \
+                     repository before launch (`git remote add {name} <url>`) so the rule \
+                     pins to it."
+                ));
+            }
         }
 
+        let hints = if block_hints.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", block_hints.join("\n"))
+        };
         return Err(format!(
             "⚠️ BLOCKED by sandbox: 'git {sub}' is not allowed in this environment.\n\
              Push prevention is enabled — commit your changes locally.\n\
-             This operation is restricted by the cplt sandbox to prevent unintended pushes.\n\
+             This operation is restricted by the cplt sandbox to prevent unintended pushes.{hints}\n\
              Please make a note of this for the human operator and continue with your remaining work."
         ));
     }
@@ -2471,14 +2529,27 @@ pub fn gate_git(
     Ok(())
 }
 
-/// Default branch names that are protected when `protect_default_branch_only` is active.
+/// Branch names protected under `protect_default_branch_only` regardless of what
+/// the repository's real default branch turns out to be.
+///
+/// A floor, not the answer: the repository's own default branch is resolved by
+/// [`resolve_default_branch`] and protected in addition to these. Keeping
+/// `main`/`master` protected as well costs nothing (a repo whose default is
+/// `develop` has no business pushing to a stale `main` either) and means the
+/// resolved answer can only ever add protection.
 const DEFAULT_BRANCH_NAMES: &[&str] = &["main", "master"];
 
-/// Check if a branch name is a default branch (main/master).
-fn is_default_branch(branch: &str) -> bool {
+/// Check whether a branch is protected under `protect_default_branch_only`.
+///
+/// `default_branch` is the repository's actual default as resolved by
+/// [`resolve_default_branch`]; `main`/`master` are protected on top of it. The
+/// setting promises to protect *the default branch*, so a repo whose default is
+/// `develop`, `trunk` or `production` must be covered — a hardcoded name list
+/// alone silently protects nothing there.
+fn is_protected_branch(branch: &str, default_branch: Option<&str>) -> bool {
     // Strip remote prefix if present (e.g., "origin/main" → "main")
     let short = branch.rsplit('/').next().unwrap_or(branch);
-    DEFAULT_BRANCH_NAMES.contains(&short)
+    DEFAULT_BRANCH_NAMES.contains(&short) || default_branch == Some(short)
 }
 
 /// Extract the target branch from `git push` arguments.
@@ -2486,7 +2557,10 @@ fn is_default_branch(branch: &str) -> bool {
 /// Parses refspecs like `origin feature-branch`, `origin HEAD:refs/heads/feature`,
 /// `origin +main` (force), or just `feature-branch`. Returns None if no explicit
 /// branch target found (e.g. `git push origin`, where the current branch is pushed).
-fn extract_push_target_branch<'a>(push_args: &[&'a str]) -> Option<&'a str> {
+fn extract_push_target_branch<'a>(
+    push_args: &[&'a str],
+    default_branch: Option<&str>,
+) -> Option<&'a str> {
     let positionals = push_positionals(push_args);
 
     // `git push [remote] [refspec...]`
@@ -2511,7 +2585,7 @@ fn extract_push_target_branch<'a>(push_args: &[&'a str]) -> Option<&'a str> {
             // second refspec and would be missed if we only check the first.
             for refspec in &positionals[1..] {
                 let branch = refspec_target_branch(refspec);
-                if is_default_branch(branch) {
+                if is_protected_branch(branch, default_branch) {
                     return Some(branch);
                 }
             }
@@ -2618,12 +2692,59 @@ fn resolve_remote_url(real_git: &Path, repo_args: &[&str], remote: &str) -> Opti
     }
 }
 
+/// The default branch of `remote` in the repository `repo_args` targets.
+///
+/// Read from the local `refs/remotes/<remote>/HEAD` symref that `git clone` and
+/// `git remote set-head` write, so no network call is made and the answer is the
+/// one this repository holds — resolved through `repo_args`, so `git -C
+/// ../other-repo push` is judged against *that* repo's default branch (#215).
+///
+/// `None` when the symref is missing, the remote does not exist, or git fails.
+fn resolve_default_branch(real_git: &Path, repo_args: &[&str], remote: &str) -> Option<String> {
+    // The ref name is always `refs/…`-prefixed, so a remote called `-x` cannot
+    // turn into a flag here.
+    let refname = format!("refs/remotes/{remote}/HEAD");
+    let output = std::process::Command::new(real_git)
+        .args(repo_args)
+        .args(["symbolic-ref", "--short", &refname])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // `--short` yields `origin/main`; the branch name is what callers compare.
+    let branch = value
+        .strip_prefix(&format!("{remote}/"))
+        .unwrap_or(&value)
+        .to_string();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
+/// The remote a `git push` targets, defaulting to `origin`.
+///
+/// A single positional that is a refspec (`HEAD:main`, `+main`) is not a remote
+/// name, so the push goes to the branch's configured remote — `origin` in all
+/// but exotic setups, the same assumption the allow_push path makes.
+fn push_remote_name<'a>(push_args: &[&'a str]) -> &'a str {
+    push_positionals(push_args)
+        .first()
+        .copied()
+        .filter(|r| !r.contains(':') && !r.starts_with('+'))
+        .unwrap_or(SCOPE_REMOTE)
+}
+
 /// Pin each rule's remote *name* to the URL that name has in the launch
 /// repository, so the rule identifies a repository and not just a name (#215).
 ///
 /// Runs once at wrapper-install time, in the unsandboxed parent, so `real_git`
 /// must be a [`crate::git::trusted_git`] path. A name that does not resolve
-/// (no such remote) is left with `url: None` and keeps matching by name.
+/// (no such remote) is left with `url: None`, which authorizes nothing — see
+/// [`matches_allow_push_rule`].
 #[must_use]
 pub fn resolve_push_rule_urls(
     real_git: &Path,
@@ -2652,8 +2773,9 @@ fn extract_push_remote_and_branch(
     push_args: &[&str],
     real_git: Option<&Path>,
     repo_args: &[&str],
+    default_branch: Option<&str>,
 ) -> (Option<String>, Option<String>) {
-    let target = extract_push_target_branch(push_args);
+    let target = extract_push_target_branch(push_args, default_branch);
     let branch = match target {
         Some(b) => Some(b.to_string()),
         None => real_git.and_then(|git| resolve_current_branch(git, repo_args)),
@@ -2669,7 +2791,6 @@ fn extract_push_remote_and_branch(
 /// All specified fields in a rule must match (AND logic).
 fn matches_allow_push_rule(
     rules: &[crate::config::ResolvedPushRule],
-    remote: Option<&str>,
     remote_url: Option<&str>,
     branch: Option<&str>,
     is_force: bool,
@@ -2681,23 +2802,24 @@ fn matches_allow_push_rule(
         }
         // Check remote constraint.
         //
-        // When the rule's remote name resolved to a URL at launch, the rule
-        // identifies a *repository*: the push's remote must resolve to the same
-        // URL, so a rule for this repo's `origin` does not authorize a push to
-        // another repo's `origin` (#215). An unresolvable URL on either side
-        // fails closed. Only a rule whose name never resolved falls back to
-        // matching the bare name.
-        if let Some(ref rule_remote) = rule.remote {
-            if let Some(rule_url) = rule.url.as_deref() {
-                match remote_url {
-                    Some(u) if u == rule_url => {}
-                    _ => continue,
-                }
-            } else {
-                match remote {
-                    Some(r) if r == rule_remote => {}
-                    _ => continue,
-                }
+        // A rule that names a remote identifies a *repository*, never a name:
+        // the push's remote must resolve to the same URL the rule was pinned to
+        // at launch, so a rule for this repo's `origin` does not authorize a
+        // push to another repo's `origin` (#215).
+        //
+        // An unresolvable URL on either side matches nothing. A rule that could
+        // not be pinned at launch (`url: None`) therefore authorizes nothing at
+        // all: falling back to the bare name would grant exactly the cross-repo
+        // authorization #215 exists to prevent, since every repository has a
+        // remote called `origin`. The operator is warned at launch and told why
+        // the push was blocked.
+        if rule.remote.is_some() {
+            let Some(rule_url) = rule.url.as_deref() else {
+                continue;
+            };
+            match remote_url {
+                Some(u) if u == rule_url => {}
+                _ => continue,
             }
         }
         // Check branch constraints (glob patterns)
@@ -3625,8 +3747,66 @@ mod tests {
 
     // ── protect_default_branch_only tests ──
 
+    /// `gate_git` for a push inside `repo`, under `protect_default_branch_only`.
+    fn gate_push_in(git: &Path, repo: &str, push_args: &[&str]) -> Result<(), String> {
+        let mut args = vec!["-C", repo];
+        args.extend_from_slice(push_args);
+        gate_git(&args, true, true, true, &[], Some(git))
+    }
+
     #[test]
     fn protect_default_allows_feature_branch() {
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+        for branch in ["feature/x", "copilot/fix", "dev"] {
+            assert!(
+                gate_push_in(&git, &dir, &["push", "origin", branch]).is_ok(),
+                "push to {branch} should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn protect_default_blocks_main() {
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return;
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "main"]).is_err());
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "master"]).is_err());
+    }
+
+    #[test]
+    fn protect_default_blocks_refspec_to_main() {
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return;
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "HEAD:refs/heads/main"]).is_err());
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "abc123:refs/heads/master"]).is_err());
+    }
+
+    #[test]
+    fn protect_default_allows_refspec_to_feature() {
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return;
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "HEAD:refs/heads/feature/x"]).is_ok());
+    }
+
+    #[test]
+    fn protect_default_blocks_bare_push_without_git() {
+        // When real_git is None nothing can be resolved — neither the current
+        // branch nor the repository's default branch — so every push is blocked.
+        assert!(gate_git(&["push"], true, true, true, &[], None).is_err());
+        assert!(gate_git(&["push", "origin"], true, true, true, &[], None).is_err());
         assert!(
             gate_git(
                 &["push", "origin", "feature/x"],
@@ -3636,99 +3816,38 @@ mod tests {
                 &[],
                 None
             )
-            .is_ok()
-        );
-        assert!(
-            gate_git(
-                &["push", "origin", "copilot/fix"],
-                true,
-                true,
-                true,
-                &[],
-                None
-            )
-            .is_ok()
-        );
-        assert!(gate_git(&["push", "origin", "dev"], true, true, true, &[], None).is_ok());
-    }
-
-    #[test]
-    fn protect_default_blocks_main() {
-        assert!(gate_git(&["push", "origin", "main"], true, true, true, &[], None).is_err());
-        assert!(gate_git(&["push", "origin", "master"], true, true, true, &[], None).is_err());
-    }
-
-    #[test]
-    fn protect_default_blocks_refspec_to_main() {
-        assert!(
-            gate_git(
-                &["push", "origin", "HEAD:refs/heads/main"],
-                true,
-                true,
-                true,
-                &[],
-                None
-            )
-            .is_err()
-        );
-        assert!(
-            gate_git(
-                &["push", "origin", "abc123:refs/heads/master"],
-                true,
-                true,
-                true,
-                &[],
-                None
-            )
             .is_err()
         );
     }
 
     #[test]
-    fn protect_default_allows_refspec_to_feature() {
-        assert!(
-            gate_git(
-                &["push", "origin", "HEAD:refs/heads/feature/x"],
-                true,
-                true,
-                true,
-                &[],
-                None
-            )
-            .is_ok()
-        );
-    }
-
-    #[test]
-    fn protect_default_blocks_bare_push_without_git() {
-        // When real_git is None (can't resolve branch), fail closed for safety
-        assert!(gate_git(&["push"], true, true, true, &[], None).is_err());
-        assert!(gate_git(&["push", "origin"], true, true, true, &[], None).is_err());
-    }
-
-    #[test]
-    fn is_default_branch_recognizes_main_master() {
-        assert!(is_default_branch("main"));
-        assert!(is_default_branch("master"));
-        assert!(is_default_branch("origin/main"));
-        assert!(is_default_branch("origin/master"));
-        assert!(!is_default_branch("feature/main-fix"));
-        assert!(!is_default_branch("develop"));
-        assert!(!is_default_branch("copilot/fix"));
+    fn is_protected_branch_covers_the_floor_and_the_resolved_default() {
+        assert!(is_protected_branch("main", None));
+        assert!(is_protected_branch("master", None));
+        assert!(is_protected_branch("origin/main", None));
+        assert!(!is_protected_branch("develop", None));
+        assert!(!is_protected_branch("feature/main-fix", None));
+        assert!(!is_protected_branch("copilot/fix", None));
+        // The repository's own default branch is protected as well, and the
+        // floor still holds alongside it.
+        assert!(is_protected_branch("develop", Some("develop")));
+        assert!(is_protected_branch("origin/develop", Some("develop")));
+        assert!(is_protected_branch("main", Some("develop")));
+        assert!(!is_protected_branch("feature/x", Some("develop")));
     }
 
     #[test]
     fn extract_push_target_handles_refspecs() {
         assert_eq!(
-            extract_push_target_branch(&["origin", "feature"]),
+            extract_push_target_branch(&["origin", "feature"], None),
             Some("feature")
         );
         assert_eq!(
-            extract_push_target_branch(&["origin", "HEAD:refs/heads/main"]),
+            extract_push_target_branch(&["origin", "HEAD:refs/heads/main"], None),
             Some("main")
         );
-        assert_eq!(extract_push_target_branch(&["origin"]), None);
-        assert_eq!(extract_push_target_branch(&[]), None);
+        assert_eq!(extract_push_target_branch(&["origin"], None), None);
+        assert_eq!(extract_push_target_branch(&[], None), None);
     }
 
     #[test]
@@ -3746,25 +3865,32 @@ mod tests {
     fn allow_push_rule_matches() {
         use crate::config::ResolvedPushRule;
 
+        // A rule naming a remote carries the URL that name resolved to at
+        // launch — the rule identifies a repository, not a name.
         let rules = vec![ResolvedPushRule {
             remote: Some("fork".to_string()),
             branches: vec!["agent/*".to_string()],
             force: false,
-            url: None,
+            url: Some("github.com/me/fork".to_string()),
         }];
 
-        // Matches: correct remote + matching branch
+        // Matches: the push's remote resolves to the pinned URL + matching branch
         assert!(matches_allow_push_rule(
             &rules,
-            Some("fork"),
-            None,
+            Some("github.com/me/fork"),
             Some("agent/fix-123"),
             false
         ));
-        // Doesn't match: wrong remote
+        // Doesn't match: same remote *name*, different repository
         assert!(!matches_allow_push_rule(
             &rules,
-            Some("origin"),
+            Some("github.com/someone/else"),
+            Some("agent/fix-123"),
+            false
+        ));
+        // Doesn't match: the push's remote could not be resolved at all
+        assert!(!matches_allow_push_rule(
+            &rules,
             None,
             Some("agent/fix-123"),
             false
@@ -3772,21 +3898,40 @@ mod tests {
         // Doesn't match: wrong branch
         assert!(!matches_allow_push_rule(
             &rules,
-            Some("fork"),
-            None,
+            Some("github.com/me/fork"),
             Some("main"),
             false
         ));
         // Doesn't match: force push not allowed
         assert!(!matches_allow_push_rule(
             &rules,
-            Some("fork"),
-            None,
+            Some("github.com/me/fork"),
             Some("agent/fix"),
             true
         ));
 
-        // Rule with force=true
+        // A rule whose remote name could not be pinned at launch authorizes
+        // nothing: a bare name matches every repository's remote of that name.
+        let unpinned = vec![ResolvedPushRule {
+            remote: Some("fork".to_string()),
+            branches: vec!["agent/*".to_string()],
+            force: false,
+            url: None,
+        }];
+        assert!(!matches_allow_push_rule(
+            &unpinned,
+            Some("github.com/me/fork"),
+            Some("agent/fix-123"),
+            false
+        ));
+        assert!(!matches_allow_push_rule(
+            &unpinned,
+            None,
+            Some("agent/fix-123"),
+            false
+        ));
+
+        // Rule with no remote constraint: branches only, force allowed.
         let rules_force = vec![ResolvedPushRule {
             remote: None,
             branches: vec!["agent/*".to_string()],
@@ -3795,14 +3940,12 @@ mod tests {
         }];
         assert!(matches_allow_push_rule(
             &rules_force,
-            Some("origin"),
-            None,
+            Some("github.com/any/repo"),
             Some("agent/x"),
             true
         ));
         assert!(matches_allow_push_rule(
             &rules_force,
-            Some("origin"),
             None,
             Some("agent/x"),
             false
@@ -3839,6 +3982,13 @@ mod tests {
         // `git init -b` is not available on every git these tests may meet.
         run(&["symbolic-ref", "HEAD", &format!("refs/heads/{branch}")])?;
         run(&["remote", "add", "origin", origin_url])?;
+        // `git clone` records the remote's default branch here; these fixtures
+        // stand in for cloned repos, so they record one too.
+        run(&[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+        ])?;
         Some((tmp, repo))
     }
 
@@ -3969,8 +4119,8 @@ mod tests {
                 force: false,
                 url: None,
             },
-            // A name with no such remote stays unresolved and keeps matching by
-            // name — the documented back-compat fallback.
+            // A name with no such remote stays unresolved, and an unresolved
+            // rule authorizes nothing.
             ResolvedPushRule {
                 remote: Some("fork".to_string()),
                 branches: vec![],
@@ -3987,35 +4137,42 @@ mod tests {
     fn allow_push_rule_in_gate_git() {
         use crate::config::ResolvedPushRule;
 
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/me/fork.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
         let rules = vec![ResolvedPushRule {
-            remote: Some("fork".to_string()),
+            remote: Some("origin".to_string()),
             branches: vec!["agent/*".to_string()],
             force: false,
-            url: None,
+            url: Some(crate::trust::normalize_remote_url(
+                "https://github.com/me/fork.git",
+            )),
         }];
 
-        // Push to fork agent/fix should be allowed despite prevent_push=true
+        // Push to the pinned repository's agent/* is allowed despite prevent_push
         assert!(
             gate_git(
-                &["push", "fork", "agent/fix-123"],
+                &["-C", &dir, "push", "origin", "agent/fix-123"],
                 true,
                 true,
                 false,
                 &rules,
-                None
+                Some(&git)
             )
             .is_ok()
         );
 
-        // Push to origin agent/fix should still be blocked (wrong remote)
+        // A branch outside the rule is still blocked
         assert!(
             gate_git(
-                &["push", "origin", "agent/fix-123"],
+                &["-C", &dir, "push", "origin", "main"],
                 true,
                 true,
                 false,
                 &rules,
-                None
+                Some(&git)
             )
             .is_err()
         );
@@ -4108,26 +4265,31 @@ mod tests {
             .is_err()
         );
         // But regular push to feature branch is still allowed
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
         assert!(
             gate_git(
-                &["push", "origin", "feature-branch"],
+                &["-C", &dir, "push", "origin", "feature-branch"],
                 true,
                 true,
                 true,
                 &[],
-                None
+                Some(&git)
             )
             .is_ok()
         );
         // Force push to feature branch allowed when prevent_force_push=false
         assert!(
             gate_git(
-                &["push", "--force", "origin", "feature-branch"],
+                &["-C", &dir, "push", "--force", "origin", "feature-branch"],
                 true,
                 false,
                 true,
                 &[],
-                None
+                Some(&git)
             )
             .is_ok()
         );
@@ -4147,15 +4309,20 @@ mod tests {
             )
             .is_err()
         );
-        // `git push origin feature develop` — neither is default, should be allowed
+        // `git push origin feature develop` — neither is protected here, allowed
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
         assert!(
             gate_git(
-                &["push", "origin", "feature", "develop"],
+                &["-C", &dir, "push", "origin", "feature", "develop"],
                 true,
                 true,
                 true,
                 &[],
-                None
+                Some(&git)
             )
             .is_ok()
         );
@@ -4519,14 +4686,19 @@ mod tests {
         // `+feature` is a force to a feature branch: blocked when force-push is
         // prevented, but allowed when it is not (prevent_force_push=false).
         assert!(gate_git(&["push", "origin", "+feature"], true, true, true, &[], None).is_err());
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/o/o.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
         assert!(
             gate_git(
-                &["push", "origin", "+feature"],
+                &["-C", &dir, "push", "origin", "+feature"],
                 true,
                 false,
                 true,
                 &[],
-                None
+                Some(&git)
             )
             .is_ok()
         );
@@ -4537,8 +4709,10 @@ mod tests {
     #[test]
     fn git_force_with_lease_space_form_not_value_consuming() {
         use crate::config::ResolvedPushRule;
+        // Branches-only rule: this test is about argument parsing, not about
+        // which repository a remote name identifies.
         let rules = vec![ResolvedPushRule {
-            remote: Some("origin".to_string()),
+            remote: None,
             branches: vec!["agent/*".to_string()],
             force: true,
             url: None,
@@ -4556,12 +4730,16 @@ mod tests {
             .is_ok()
         );
         // Branch parsing is correct with the flag present.
-        let (remote, branch) =
-            extract_push_remote_and_branch(&["--force-with-lease", "origin", "agent/x"], None, &[]);
+        let (remote, branch) = extract_push_remote_and_branch(
+            &["--force-with-lease", "origin", "agent/x"],
+            None,
+            &[],
+            None,
+        );
         assert_eq!(remote.as_deref(), Some("origin"));
         assert_eq!(branch.as_deref(), Some("agent/x"));
         let (remote, branch) =
-            extract_push_remote_and_branch(&["--signed", "origin", "agent/y"], None, &[]);
+            extract_push_remote_and_branch(&["--signed", "origin", "agent/y"], None, &[], None);
         assert_eq!(remote.as_deref(), Some("origin"));
         assert_eq!(branch.as_deref(), Some("agent/y"));
     }

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -577,8 +577,8 @@ fn install_command_wrappers(
         // Pinning requires `trusted_git`, not the PATH git the wrapper itself
         // uses: this call runs in the UNSANDBOXED parent, where a planted git
         // would execute as the user. With no trusted git the rules stay
-        // unpinned and keep matching by name — the pre-#215 behavior — so the
-        // operator is warned rather than left assuming the stronger guarantee.
+        // unpinned, and an unpinned rule authorizes nothing, so the operator is
+        // warned rather than left with a rule that silently does not apply.
         let mut git_guard = git_guard.clone();
         if !git_guard.allow_push.is_empty() {
             if let Some(trusted) = crate::git::trusted_git() {
@@ -593,16 +593,18 @@ fn install_command_wrappers(
                     {
                         ui::warn(&format!(
                             "git guard: allow_push remote {name:?} does not exist in this \
-                             repository, so the rule matches by name and also applies to a \
-                             remote called {name:?} in another repository."
+                             repository, so the rule cannot be pinned to a repository and \
+                             authorizes no push. Add the remote before launch \
+                             (`git remote add {name} <url>`), or drop the rule."
                         ));
                     }
                 }
             } else {
                 ui::warn(
                     "git guard could not find a trusted Git to pin allow_push remotes to \
-                     their URLs. Those rules will match by remote name, so they also apply \
-                     to a same-named remote in another repository.",
+                     their URLs. Rules naming a remote authorize no push until they can be \
+                     pinned — a bare remote name would also match a same-named remote in \
+                     another repository.",
                 );
             }
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -113,5 +113,17 @@ pub fn temp_repo(remote: &str) -> tempfile::TempDir {
             &format!("https://github.com/{remote}.git"),
         ]
     ));
+    // `git clone` records the remote's default branch here, and the git guard
+    // reads it to decide what `protect_default_branch_only` protects. A repo
+    // built by `git init` has none, which is not what these fixtures stand in
+    // for.
+    assert!(git_ok(
+        dir.path(),
+        &[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+        ]
+    ));
     dir
 }

--- a/tests/e2e_git_hardening.rs
+++ b/tests/e2e_git_hardening.rs
@@ -303,7 +303,7 @@ use cplt::gh_proxy::gate_git;
 
 /// A repo whose `origin` is `url`, checked out on `branch`, recording `default`
 /// as the remote's default branch (`None`: never recorded, as in a fetch-only
-/// clone). `None` when git is unavailable.
+/// clone). `None` when the fixture could not be built.
 fn guard_repo(url: &str, branch: &str, default: Option<&str>) -> Option<tempfile::TempDir> {
     let tmp = tempfile::tempdir().ok()?;
     let dir = tmp.path();
@@ -343,7 +343,7 @@ fn git_bin() -> PathBuf {
 fn an_unpinned_allow_push_rule_authorizes_no_repository() {
     let Some(launch) = guard_repo("https://github.com/navikt/cplt.git", "main", Some("main"))
     else {
-        return; // no git available
+        return; // fixture setup failed
     };
     let Some(other) = guard_repo("https://github.com/someone/else.git", "main", Some("main"))
     else {
@@ -417,7 +417,7 @@ fn an_unpinned_allow_push_rule_authorizes_no_repository() {
 #[test]
 fn protect_default_branch_only_protects_a_default_that_is_not_main() {
     let Some(repo) = guard_repo("https://github.com/o/o.git", "develop", Some("develop")) else {
-        return; // no git available
+        return; // fixture setup failed
     };
     let git = git_bin();
     let dir = repo.path().to_string_lossy().into_owned();
@@ -458,7 +458,7 @@ fn protect_default_branch_only_protects_a_default_that_is_not_main() {
 fn the_default_branch_is_resolved_in_the_repo_the_command_targets() {
     let Some(develop) = guard_repo("https://github.com/o/dev.git", "develop", Some("develop"))
     else {
-        return; // no git available
+        return; // fixture setup failed
     };
     let Some(mainline) = guard_repo("https://github.com/o/main.git", "main", Some("main")) else {
         return;
@@ -492,7 +492,7 @@ fn the_default_branch_is_resolved_in_the_repo_the_command_targets() {
 #[test]
 fn protect_default_branch_only_grants_nothing_when_the_default_is_unknown() {
     let Some(repo) = guard_repo("https://github.com/o/o.git", "feature/x", None) else {
-        return; // no git available
+        return; // fixture setup failed
     };
     let git = git_bin();
     let dir = repo.path().to_string_lossy().into_owned();

--- a/tests/e2e_git_hardening.rs
+++ b/tests/e2e_git_hardening.rs
@@ -291,3 +291,222 @@ fn worktree_scope_content_filter_is_detected() {
         "worktree-scope filter.evil.clean executed in the parent process"
     );
 }
+
+// ── Git guard: a setting that cannot be honoured grants nothing (#215) ──
+//
+// Both properties below are instances of the "no silent grants" rule in
+// AGENTS.md and SECURITY.md: an authorization the guard cannot *prove* must be
+// refused, not extended on the strength of a name.
+
+use cplt::config::ResolvedPushRule;
+use cplt::gh_proxy::gate_git;
+
+/// A repo whose `origin` is `url`, checked out on `branch`, recording `default`
+/// as the remote's default branch (`None`: never recorded, as in a fetch-only
+/// clone). `None` when git is unavailable.
+fn guard_repo(url: &str, branch: &str, default: Option<&str>) -> Option<tempfile::TempDir> {
+    let tmp = tempfile::tempdir().ok()?;
+    let dir = tmp.path();
+    if !common::git_ok(dir, &["init", "--quiet"]) {
+        return None;
+    }
+    assert!(common::git_ok(
+        dir,
+        &["symbolic-ref", "HEAD", &format!("refs/heads/{branch}")]
+    ));
+    assert!(common::git_ok(dir, &["remote", "add", "origin", url]));
+    if let Some(default) = default {
+        assert!(common::git_ok(
+            dir,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                &format!("refs/remotes/origin/{default}"),
+            ]
+        ));
+    }
+    Some(tmp)
+}
+
+fn git_bin() -> PathBuf {
+    common::binary_in_path("git")
+}
+
+/// An `allow_push` rule whose remote name could not be pinned to a URL at
+/// launch matches nothing — in *any* repository.
+///
+/// Two repositories, each with a remote called `origin`, pointing at different
+/// URLs. Matching such a rule by bare name authorizes a push to whichever repo
+/// the command happens to target, which is the cross-repo grant #215 exists to
+/// prevent; the single-repo case cannot tell the two behaviours apart.
+#[test]
+fn an_unpinned_allow_push_rule_authorizes_no_repository() {
+    let Some(launch) = guard_repo("https://github.com/navikt/cplt.git", "main", Some("main"))
+    else {
+        return; // no git available
+    };
+    let Some(other) = guard_repo("https://github.com/someone/else.git", "main", Some("main"))
+    else {
+        return;
+    };
+    let git = git_bin();
+
+    // Written for the launch repo's `origin`, but pinning failed at launch.
+    let unpinned = ResolvedPushRule {
+        remote: Some("origin".to_string()),
+        branches: vec!["main".to_string()],
+        force: false,
+        url: None,
+    };
+
+    for repo in [launch.path(), other.path()] {
+        let dir = repo.to_string_lossy().into_owned();
+        let err = gate_git(
+            &["-C", &dir, "push", "origin", "main"],
+            true,
+            true,
+            false,
+            std::slice::from_ref(&unpinned),
+            Some(&git),
+        )
+        .expect_err("an unpinned rule must authorize nothing");
+        assert!(
+            err.contains("pinned to a repository URL"),
+            "the block must say the rule could not be pinned, got: {err}"
+        );
+    }
+
+    // Control: pinned to the launch repo, the same rule authorizes the push
+    // there and only there.
+    let pinned = ResolvedPushRule {
+        url: Some(cplt::trust::normalize_remote_url(
+            "https://github.com/navikt/cplt.git",
+        )),
+        ..unpinned
+    };
+    let launch_dir = launch.path().to_string_lossy().into_owned();
+    let other_dir = other.path().to_string_lossy().into_owned();
+    assert!(
+        gate_git(
+            &["-C", &launch_dir, "push", "origin", "main"],
+            true,
+            true,
+            false,
+            std::slice::from_ref(&pinned),
+            Some(&git),
+        )
+        .is_ok(),
+        "a pinned rule must still authorize its own repository"
+    );
+    assert!(
+        gate_git(
+            &["-C", &other_dir, "push", "origin", "main"],
+            true,
+            true,
+            false,
+            std::slice::from_ref(&pinned),
+            Some(&git),
+        )
+        .is_err(),
+        "a pinned rule must not authorize another repository's origin"
+    );
+}
+
+/// `protect_default_branch_only` protects the repository's *actual* default
+/// branch, not a hardcoded `main`/`master`.
+#[test]
+fn protect_default_branch_only_protects_a_default_that_is_not_main() {
+    let Some(repo) = guard_repo("https://github.com/o/o.git", "develop", Some("develop")) else {
+        return; // no git available
+    };
+    let git = git_bin();
+    let dir = repo.path().to_string_lossy().into_owned();
+    let gate = |branch: &str| {
+        gate_git(
+            &["-C", &dir, "push", "origin", branch],
+            true,
+            true,
+            true,
+            &[],
+            Some(&git),
+        )
+    };
+
+    assert!(
+        gate("develop").is_err(),
+        "the repository's default branch must be protected"
+    );
+    assert!(
+        gate("main").is_err(),
+        "main/master stay protected as a floor"
+    );
+    assert!(
+        gate("feature/x").is_ok(),
+        "a feature branch is still allowed"
+    );
+
+    // A bare `git push` on the default branch is blocked too — the branch is
+    // resolved from HEAD, the default from the remote, both in this repo.
+    assert!(
+        gate_git(&["-C", &dir, "push"], true, true, true, &[], Some(&git)).is_err(),
+        "bare push while on the default branch must be blocked"
+    );
+}
+
+/// Each repository is judged by its own default branch, including through `-C`.
+#[test]
+fn the_default_branch_is_resolved_in_the_repo_the_command_targets() {
+    let Some(develop) = guard_repo("https://github.com/o/dev.git", "develop", Some("develop"))
+    else {
+        return; // no git available
+    };
+    let Some(mainline) = guard_repo("https://github.com/o/main.git", "main", Some("main")) else {
+        return;
+    };
+    let git = git_bin();
+    let gate = |repo: &Path| {
+        let dir = repo.to_string_lossy().into_owned();
+        gate_git(
+            &["-C", &dir, "push", "origin", "develop"],
+            true,
+            true,
+            true,
+            &[],
+            Some(&git),
+        )
+    };
+
+    assert!(
+        gate(develop.path()).is_err(),
+        "develop is the default branch there"
+    );
+    assert!(
+        gate(mainline.path()).is_ok(),
+        "develop is an ordinary feature branch there"
+    );
+}
+
+/// When the default branch cannot be resolved the relaxation is refused rather
+/// than guessed: `protect_default_branch_only` only permits a push it can prove
+/// is *not* to the default branch.
+#[test]
+fn protect_default_branch_only_grants_nothing_when_the_default_is_unknown() {
+    let Some(repo) = guard_repo("https://github.com/o/o.git", "feature/x", None) else {
+        return; // no git available
+    };
+    let git = git_bin();
+    let dir = repo.path().to_string_lossy().into_owned();
+    let err = gate_git(
+        &["-C", &dir, "push", "origin", "feature/x"],
+        true,
+        true,
+        true,
+        &[],
+        Some(&git),
+    )
+    .expect_err("no resolved default branch means no push is proven safe");
+    assert!(
+        err.contains("git remote set-head"),
+        "the block must say how to record the default branch, got: {err}"
+    );
+}

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -61,15 +61,41 @@ fn git_gate(args: &[&str], prevent_push: bool, prevent_force_push: bool) -> (Str
     git_gate_with_mode(args, prevent_push, prevent_force_push, "block")
 }
 
+/// A stand-in `git` that answers the guard's resolution calls with the real
+/// git but makes an actual `push` a no-op.
+///
+/// `protect_default_branch_only` resolves the repository's default branch by
+/// running git, so `/usr/bin/true` (which answers nothing) would leave every
+/// push blocked for the wrong reason — while a real git would try to reach the
+/// network on an allowed push.
+fn fake_push_git(dir: &std::path::Path) -> std::path::PathBuf {
+    let script = dir.join("fake-git.sh");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\ncase \"$1\" in push) exit 0 ;; esac\nexec {} \"$@\"\n",
+            binary_in_path("git").display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    script
+}
+
 /// Run `cplt git-gate` with protect-default-branch-only mode.
 fn git_gate_protect_default(args: &[&str]) -> (String, String, bool) {
     // The gate resolves the target repo from the cwd; a temp repo keeps that
     // independent of whatever origin the checkout running the tests has.
     let repo = temp_repo("navikt/cplt");
+    let real_git = fake_push_git(repo.path());
     let mut cmd = cplt_cmd();
     cmd.arg("git-gate")
         .arg("--real-git")
-        .arg("/usr/bin/true")
+        .arg(&real_git)
         .arg("--mode=block")
         .arg("--prevent-push=true")
         .arg("--prevent-force-push=true")

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -70,10 +70,13 @@ fn git_gate(args: &[&str], prevent_push: bool, prevent_force_push: bool) -> (Str
 /// network on an allowed push.
 fn fake_push_git(dir: &std::path::Path) -> std::path::PathBuf {
     let script = dir.join("fake-git.sh");
+    // Any invocation carrying `push` as a word is the push itself; the guard's
+    // own resolution calls (`symbolic-ref`, `rev-parse`, `remote get-url`) never
+    // do. The git path is quoted — it can contain spaces.
     std::fs::write(
         &script,
         format!(
-            "#!/bin/sh\ncase \"$1\" in push) exit 0 ;; esac\nexec {} \"$@\"\n",
+            "#!/bin/sh\ncase \" $* \" in *\" push \"*) exit 0 ;; esac\nexec '{}' \"$@\"\n",
             binary_in_path("git").display()
         ),
     )


### PR DESCRIPTION
Two git-guard defects, both instances of the **no silent grants** rule in `AGENTS.md` and `SECURITY.md`: an authorization the guard cannot prove must be refused, not extended on the strength of a name. Both were found by an adversarial review while designing multi-repo support (#344), and neither is hypothetical.

## 1. The `allow_push` fallback failed open

`matches_allow_push_rule` matched a rule's remote by **bare name** whenever the rule's `url` was `None` — that is, whenever URL pinning failed at wrapper-install time. Every repository has an `origin`, so a rule written for the launch repository's `origin` authorized a push to a *different* repository's `origin`. That is exactly the cross-repo grant #215 was written to fix, surviving in the fallback path: it warned at launch and then authorized anyway. Reachable today with `git -C ../other-repo push`.

An unpinned rule now matches nothing. The block message names the rule's remote, says it could not be pinned to a repository URL, and says what to do; the launch-time warning says the same thing instead of describing the fallback.

**This is a breaking change, and the break is the point.** If a rule of yours stops working, it was never pinned — you were receiving authorization in every repository the agent could reach, which you did not ask for. cplt already warned at launch that pinning failed; that warning now names the fix:

- `git guard: allow_push remote "fork" does not exist in this repository, so the rule cannot be pinned to a repository and authorizes no push. Add the remote before launch (`git remote add fork <url>`), or drop the rule.`
- If the warning is the no-trusted-git one instead, fix the git installation it names.

A rule with no `remote` field (branches only) is unaffected.

## 2. `protect_default_branch_only` protected a hardcoded list

`DEFAULT_BRANCH_NAMES: &["main", "master"]` was the whole of it — the actual default branch was never resolved. A repository whose default is `develop`, `trunk` or `production` got **no protection** from a setting whose name promises exactly that. That affects every repository not using `main` or `master`.

The default branch is now resolved per repository from the local `refs/remotes/<remote>/HEAD` symref that `git clone` and `git remote set-head` write — no network call — through the `-C` / `--git-dir` / `--work-tree` forwarding #215 already added, so `git -C ../other-repo push` is judged by that repository's default branch. `main`/`master` stay protected as a floor, so the resolved answer can only ever add protection.

### When the default branch cannot be resolved

**It blocks.** `protect_default_branch_only` grants a *relaxation* of `prevent_push`: it permits pushes it can prove are not to the default branch. With no resolved default there is no such proof, so the exception is not granted and the push falls through to the normal block — with a message saying to run `git remote set-head <remote> -a`. The guard already fails closed the same way when the *current* branch cannot be resolved for a bare `git push`; this is the symmetric case.

The alternative was keeping `main`/`master` as the fallback answer. It is defensible — it is never *less* protection than today, and it keeps working in a repo that never recorded an `origin/HEAD` (a fetch-only CI checkout, `git init` plus `git remote add`). It was rejected because it is the same silent under-protection this PR is fixing on the other defect: a `develop` repository would be told it is protected and would not be. The cost of failing closed is that such a repo gets the behavior it would have had without the setting at all, recoverable with one local command that the block message names. Given the other half of this PR closes a fail-open, a fallback that fails open here would have been the wrong half of the same lesson.

## Tests and mutation checks

`tests/e2e_git_hardening.rs` (this area's suite):

- `an_unpinned_allow_push_rule_authorizes_no_repository` — **two** repositories, each with a remote called `origin` pointing at a different URL. An unpinned rule authorizes neither; the control asserts a pinned rule still authorizes its own repository and not the other. A single-repo test cannot tell the two behaviors apart.
- `protect_default_branch_only_protects_a_default_that_is_not_main` — default `develop`: pushing `develop` is blocked, `main` stays blocked (floor), `feature/x` is allowed, bare `git push` on `develop` is blocked.
- `the_default_branch_is_resolved_in_the_repo_the_command_targets` — `push origin develop` is blocked in the repo whose default is `develop` and allowed in the one whose default is `main`.
- `protect_default_branch_only_grants_nothing_when_the_default_is_unknown` — no recorded `origin/HEAD`: even a feature push is blocked, and the message names `git remote set-head`.

Unit tests: `allow_push_rule_matches` covers the unpinned rule matching nothing; `is_protected_branch_covers_the_floor_and_the_resolved_default` covers the floor and the resolved default.

Mutation checks, run and confirmed:

| Defect reintroduced | Failing tests |
|---|---|
| bare-name fallback restored in `matches_allow_push_rule` | `an_unpinned_allow_push_rule_authorizes_no_repository`, `allow_push_rule_matches` |
| `is_protected_branch` back to the hardcoded list + fail-open on unresolved default | `protect_default_branch_only_protects_a_default_that_is_not_main`, `the_default_branch_is_resolved_in_the_repo_the_command_targets`, `protect_default_branch_only_grants_nothing_when_the_default_is_unknown`, `is_protected_branch_covers_the_floor_and_the_resolved_default` |

Both mutations were reverted and the full suite re-run green.

## Test-fixture change worth reviewing

`common::temp_repo` now records `refs/remotes/origin/HEAD`, because it stands in for a clone and `git init` does not write one. Without it every `protect_default_branch_only` e2e test blocks for the new reason rather than the one it is testing. `git_gate_protect_default` in `tests/e2e_guards.rs` also swaps `--real-git /usr/bin/true` for a shim that forwards resolution calls to the real git and makes `push` a no-op: the gate now has to actually resolve something, and `/usr/bin/true` answers nothing while a real git would reach the network on an allowed push.

## Gates

`cargo fmt`, `cargo test --lib`, `cargo test --test unit_tests`, `cargo clippy --all-targets -- -D warnings`, `e2e_git_hardening`, `e2e_guards`, and the full `cargo test` — all green, rebased on `main` after #338.
