### PR TITLE
fix(landlock): grant exec on the cplt binary so the guard wrappers can re-enter

### DIFF
--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -358,8 +358,8 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
     // always do that when cplt lived in a granted directory, and it can skip the
     // wrapper entirely by calling git by absolute path. The guard is a policy on
     // intent, not a boundary.
-    if let Ok(cplt_bin) = std::env::current_exe() {
-        fs_rules.push(FsRule {
+    match std::env::current_exe() {
+        Ok(cplt_bin) => fs_rules.push(FsRule {
             path: cplt_bin,
             access: FsAccess {
                 read: true,
@@ -367,7 +367,16 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                 execute: true,
                 ioctl: false,
             },
-        });
+        }),
+        // Say so rather than silently rebuilding the bug. Dropping the rule
+        // quietly is exactly the failure this commit fixes, and the symptom —
+        // every git command failing with "Permission denied" from a wrapper —
+        // gives no hint of the cause.
+        Err(e) => crate::ui::warn(&format!(
+            "cannot locate the cplt binary ({e}); the gh and git guard wrappers \
+             re-execute it, so every guarded command will fail with \
+             \"Permission denied\". Disable the guards or reinstall cplt."
+        )),
     }
 
     // ── Tool directories: read + execute ──

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -336,6 +336,40 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
         });
     }
 
+    // ── The cplt binary itself: read + execute ──
+    //
+    // The guard wrappers are `exec <cplt> git-gate ...` / `gh-gate ...` — they
+    // re-enter this binary from inside the sandbox to reach the decision. macOS
+    // gets that for free from a blanket `(allow process-exec)`; Landlock has no
+    // such thing, so without an explicit rule the wrapper dies with
+    // "exec: /path/to/cplt: Permission denied" and *every* git command fails —
+    // `status`, `log`, `--version`, not only `push`.
+    //
+    // It worked at all only by accident of layout: `/usr/local` is in
+    // LINUX_TOOL_DIRS, so an install there re-entered fine, while `install.sh`'s
+    // default of `~/.local/bin` did not. The guard's own design requires this
+    // grant; leaving it to depend on where the user installed cplt is what made
+    // it look like it worked.
+    //
+    // The file, not its directory: `~/.local/bin` holds whatever else the user
+    // put there, and none of it needs to become executable inside the sandbox.
+    // No boundary is given up — `gh-gate`/`git-gate` take their policy from
+    // argv, so an agent that can exec cplt can pass its own flags, but it could
+    // always do that when cplt lived in a granted directory, and it can skip the
+    // wrapper entirely by calling git by absolute path. The guard is a policy on
+    // intent, not a boundary.
+    if let Ok(cplt_bin) = std::env::current_exe() {
+        fs_rules.push(FsRule {
+            path: cplt_bin,
+            access: FsAccess {
+                read: true,
+                write: false,
+                execute: true,
+                ioctl: false,
+            },
+        });
+    }
+
     // ── Tool directories: read + execute ──
     for &p in LINUX_TOOL_DIRS {
         fs_rules.push(FsRule {

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1355,6 +1355,60 @@ print('CONNECTED')
         assert!(stdout.contains("init"));
     }
 
+    /// The git guard must not break git on Linux.
+    ///
+    /// Its wrapper is `exec <cplt> git-gate ... -- "$@"`, so the guard only
+    /// works if the sandbox lets the agent re-execute the cplt binary. Landlock
+    /// grants EXECUTE per path and has no blanket allow, so this fails wherever
+    /// cplt is not inside `LINUX_TOOL_DIRS` — which includes `install.sh`'s
+    /// default of `~/.local/bin`, and the `target/debug` build CI runs from.
+    ///
+    /// Read-only subcommands are what makes it obvious: the guard blocks pushes,
+    /// so a broken wrapper shows up as `git log` failing, not as policy.
+    #[test]
+    fn project_git_read_ops_work_under_the_git_guard() {
+        require_landlock!();
+        let project = create_test_project();
+        let script = r#"
+            git init . &&
+            git config user.email "test@test.com" &&
+            git config user.name "Test" &&
+            echo "hello" > file.txt &&
+            git add file.txt &&
+            git -c commit.gpgSign=false commit -m "init" &&
+            git --version &&
+            git status --porcelain &&
+            git log --oneline
+        "#;
+        let (code, stdout, stderr) =
+            run_sandboxed_with_flags(project.path(), &["--git-guard"], script);
+        assert_eq!(
+            code, 0,
+            "read-only git must work with the git guard on — stdout: {stdout}, stderr: {stderr}"
+        );
+        assert!(stdout.contains("init"), "stdout: {stdout}");
+
+        // Without this the test passes vacuously: `install_command_wrappers`
+        // installs nothing and warns about nothing when it cannot resolve a git,
+        // so the agent would fall through to its bare PATH git and every command
+        // above would still succeed — proving only that git works.
+        //
+        // Either verdict counts. `--git-guard` sets `enabled`, not `mode`, so
+        // which one appears follows the mode default. Both strings are written
+        // by the guard and appear in neither git's output nor the shell's.
+        let (_, push_stdout, push_stderr) = run_sandboxed_with_flags(
+            project.path(),
+            &["--git-guard"],
+            "git push origin main 2>&1 || true",
+        );
+        let combined = format!("{push_stdout}{push_stderr}");
+        assert!(
+            combined.contains("BLOCKED by sandbox") || combined.contains("WARNING (would block)"),
+            "the guard must have ruled on the push, or the assertions above prove \
+             nothing about the wrapper — stdout: {push_stdout}, stderr: {push_stderr}"
+        );
+    }
+
     #[test]
     fn project_env_vars_sanitized() {
         require_landlock!();


### PR DESCRIPTION
Second guard-breaks-git bug, same class as #338, different platform and different cause. #335 waits on this one too.

## The bug

On Linux, with `git_guard` on, **every** git command fails inside the sandbox:

```
/home/runner/.cache/cplt/tmp/<id>/bin/git: 5: exec: /home/runner/work/cplt/cplt/target/debug/cplt: Permission denied
```

The guard wrappers are `exec <cplt> git-gate ... -- "$@"`: they re-enter the cplt binary from inside the sandbox to reach the decision. macOS gets that for free from a blanket `(allow process-exec)`. Landlock has no blanket allow — it grants EXECUTE per path — and nothing ever granted the cplt binary. So the wrapper cannot start, and `git status`, `git log` and `git --version` fail along with `git push`.

## This is not a test artifact

`LINUX_TOOL_DIRS` includes `/usr/local`, so a `--dir /usr/local/bin` install re-enters fine. **`install.sh` defaults to `~/.local/bin`** (line 121), which is not in the list. So on a default Linux install, turning the guard on takes git down completely.

That it appeared to work is an accident of where the user happened to install cplt. The guard's design *requires* this grant; nothing was asking for it.

## The fix

One rule: read + execute on `current_exe()`.

The file, not its directory — `~/.local/bin` holds whatever else the user put there, and none of it needs to become executable inside the sandbox.

No boundary is given up. `gh-gate`/`git-gate` take their policy from argv, so an agent that can exec cplt can pass its own flags — but that was already true for every install in a granted directory, and the agent can skip the wrapper entirely by invoking git by absolute path. The guard is a policy on intent, not a boundary, which is the same doctrine `sandbox_exec.rs` states for the wrapper's git resolution.

macOS needs nothing: its blanket `process-exec` already covers it, which is exactly why #338's macOS-only investigation did not surface this.

## Test

`project_git_read_ops_work_under_the_git_guard` in `integration_linux.rs`, mirroring the macOS one from #338: run with `--git-guard`, assert `git --version`, `status` and `log` still work.

It also probes a push and asserts the guard's own verdict text appears, because the read-only assertions pass vacuously otherwise — `install_command_wrappers` installs nothing and warns about nothing when it cannot resolve a git, so the agent falls through to its bare PATH git and everything still succeeds, proving only that git works. Either `BLOCKED by sandbox` or `WARNING (would block)` counts: `--git-guard` sets `enabled`, not `mode`, so which one appears follows the mode default, and both are strings the guard writes that appear in neither git's output nor the shell's.

I cannot run the Linux suite locally (macOS only), so CI is the verification here. Local gates green: `cargo fmt`, `cargo test --lib` (931), `--test unit_tests` (329), `--test e2e_guards` (123), `cargo clippy --all-targets -- -D warnings`.

## How it surfaced

#338 fixed the macOS half — the wrapper substituting `/usr/bin/git`'s xcrun shim for the agent's working PATH git. With that merged and #335 rebased, macOS went green and Linux stayed red for this entirely separate reason. Both are the same shape: **the guard only worked if your layout happened to match**, and no test had ever run it in CI to find out.