### PR TITLE
test(extraction): copy the fixture script in from a child process

### DIFF
--- a/src/copilot_extract.rs
+++ b/src/copilot_extract.rs
@@ -684,14 +684,17 @@ mod copilot_extraction_tests {
         std::fs::create_dir_all(&bindir).unwrap();
         std::fs::create_dir_all(&pkg).unwrap();
         let bin = bindir.join("copilot");
-        // Staged write, then rename. Writing this script and exec'ing it under
-        // its final name races every other test thread: `Command::spawn` forks,
-        // and a fork that happens while this file is still open for writing
-        // inherits the writable descriptor, so the exec comes back ETXTBSY.
-        // Under `cargo test` that surfaces as an unexplained intermittent
-        // failure on whichever extraction test lost the race. A rename is
-        // atomic, and the descriptor is closed before the name exists.
-        let staging = bindir.join("copilot.staging");
+        // Write the script here, then have a *child process* copy it into
+        // place. Writing it in-process and exec'ing it races every other test
+        // thread: `Command::spawn` forks, and a fork that happens while this
+        // file is open for writing inherits the writable descriptor, so our
+        // exec comes back ETXTBSY. #285 tried to close that with a staged
+        // write plus an atomic rename, but ETXTBSY is a property of the inode,
+        // not of the name — renaming hands the exec the very inode that was
+        // open for writing, so the race survived and recurred. Copying via
+        // `cp` gives `bin` a fresh inode whose only writable descriptor lives
+        // and dies inside the child, where no fork of ours can inherit it.
+        let staging = root.join("copilot.staging");
         std::fs::write(
             &staging,
             format!(
@@ -703,8 +706,13 @@ mod copilot_extraction_tests {
             ),
         )
         .unwrap();
-        std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o755)).unwrap();
-        std::fs::rename(&staging, &bin).unwrap();
+        let copied = std::process::Command::new("cp")
+            .arg(&staging)
+            .arg(&bin)
+            .status()
+            .unwrap();
+        assert!(copied.success(), "cp of the fake copilot failed: {copied}");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
         Fixture {
             root,
             home,


### PR DESCRIPTION
`copilot_extract::copilot_extraction_tests::recovers_from_an_empty_current_version_dir`
failed again on Linux CI, in run [33915118897 attempt 1][run] on #331, after
#285 was supposed to have fixed it. It passed on rerun.

## The evidence

The failure message #285 added did its job:

```
---- copilot_extract::copilot_extraction_tests::recovers_from_an_empty_current_version_dir stdout ----
[cplt] Extracting Copilot runtime (first run after update)...

panicked at src/copilot_extract.rs:829:9:
extraction failed: Err("Failed to spawn copilot for extraction: Text file busy (os error 26)
  Try running '/tmp/cplt-extract-4203-empty-dir/bin/copilot --version' manually to trigger extraction")
```

Same errno, same test, six hours after #285 merged. So the diagnosis was
right and the fix was not.

## Correcting #285

#285 read ETXTBSY correctly — a fork from a parallel test thread inherits the
writable descriptor `std::fs::write` holds on the fixture script, and if that
child has not reached its own `exec` yet when we exec the script, ours comes
back "Text file busy". Its fix, and the comment it left in the source, then
got the mechanism wrong:

> A rename is atomic, and the descriptor is closed before the name exists.

`rename(2)` moves a name, not an inode. Linux refuses the exec when the
*inode* being loaded has an open writable file description (`i_writecount`),
which is exactly the inode the staged file already had — the rename hands
that same inode to the exec under a new name. The staged write and rename
changed nothing about the race, and the comment has been telling readers the
window was shut when it was still wide open. This PR replaces that comment
with the real mechanism.

## The fix

Write the script to a staging path as before, then have `cp` — a child
process — create the file that actually gets executed. The final binary is a
fresh inode whose only writable descriptor is opened and closed inside the
child, so no fork of ours can ever be holding it. The staged file keeps its
own inode and is never executed, so a descriptor inherited from that write is
harmless.

No retries, no sleeps, no serialisation.

## What else was checked and ruled out

- **Every spawn path goes through the fixture binary.** Both `Command::new`
  sites in the module take `copilot_bin`, which is `Fixture::bin` in tests;
  nothing execs a freshly written file by another route.
- **The fixture directory name cannot collide.** `cplt-extract-{pid}-{name}`
  is unique per test — each `fixture()` call site passes a distinct `name` —
  so separate test binaries and separate tests never share a root, and no
  state is shared through the real filesystem between these tests.
- **Not Linux-specific in cause, only in symptom.** macOS is laxer about
  ETXTBSY for interpreter scripts, which is why it recurs on Linux CI. The
  fix is portable either way.
- **Unrelated to #220.** That intermittent is a per-binary port counter
  starting from a fixed base, so parallel test binaries pick the same port —
  a name-allocation collision, not a file-descriptor lifetime. Different
  cause, left alone.

[run]: https://github.com/navikt/cplt/actions/runs/33915118897
