### PR TITLE
fix(git-guard): protect a default branch whose name has a slash

### DIFF
--- a/docs/git-guard.md
+++ b/docs/git-guard.md
@@ -98,6 +98,7 @@ target branch:
 | `git push origin main` | `main` | Blocked |
 | `git push origin master` | `master` | Blocked |
 | `git push origin develop`, in a repo whose default is `develop` | `develop` | Blocked |
+| `git push origin release/2026`, in a repo whose default is `release/2026` | `release/2026` | Blocked |
 | `git push origin feature/x`, in a repo with no recorded default branch | `feature/x` | Blocked — the default branch is unknown |
 | `git push origin HEAD:refs/heads/main` | `main` (from refspec) | Blocked |
 | `git push origin HEAD:main` | `main` (from refspec) | Blocked |
@@ -110,8 +111,11 @@ The default branch is the one the repository actually has. The guard reads it
 from the local `refs/remotes/<remote>/HEAD` symref that `git clone` and
 `git remote set-head` write, so a repository whose default is `develop`,
 `trunk` or `production` is protected under the setting that promises it — no
-network call is made. `main` and `master` stay protected as a floor alongside
-it, recognized with or without an `origin/` prefix. When several refspecs are
+network call is made. A default branch with a slash in it (`release/2026`) is
+compared whole, because that is how both sides arrive: the symref gives up only
+its `<remote>/` prefix, and the push argument is the branch name entire. `main`
+and `master` stay protected as a floor alongside it, recognized with or without
+an `origin/` prefix. When several refspecs are
 given, the guard checks all of them and blocks if any names a protected branch,
 so `git push origin feature main` does not slip through.
 

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2547,9 +2547,28 @@ const DEFAULT_BRANCH_NAMES: &[&str] = &["main", "master"];
 /// `develop`, `trunk` or `production` must be covered — a hardcoded name list
 /// alone silently protects nothing there.
 fn is_protected_branch(branch: &str, default_branch: Option<&str>) -> bool {
-    // Strip remote prefix if present (e.g., "origin/main" → "main")
+    // A `refs/heads/`-qualified refspec target reaches here unstripped when the
+    // refspec has no colon (`git push origin refs/heads/release/2026`);
+    // `refspec_target_branch` only strips the prefix off the `src:dst` form.
+    let branch = branch.strip_prefix("refs/heads/").unwrap_or(branch);
+    // Last path segment, so a remote-qualified `origin/main` still matches the
+    // unslashed floor names below.
     let short = branch.rsplit('/').next().unwrap_or(branch);
-    DEFAULT_BRANCH_NAMES.contains(&short) || default_branch == Some(short)
+    DEFAULT_BRANCH_NAMES.contains(&short)
+        // The whole name, because the two sides arrive differently: `branch`
+        // comes from push argv or `symbolic-ref --short HEAD`, so it is the
+        // branch name entire — `release/2026`, slashes and all — while
+        // `default_branch` comes from the `refs/remotes/<remote>/HEAD` symref
+        // with only the `<remote>/` prefix taken off, so it is `release/2026`
+        // too. Comparing last segments alone asked `"release/2026" == "2026"`
+        // and a repository whose default branch has a slash in it was silently
+        // unprotected — the exact under-protection #346 was written to remove,
+        // surviving in the comparison.
+        || default_branch == Some(branch)
+        // Kept for the remote-qualified spelling of an unslashed default
+        // (`origin/develop` against a default of `develop`). It can only add
+        // protection: a false match here blocks a push, never allows one.
+        || default_branch == Some(short)
 }
 
 /// Extract the target branch from `git push` arguments.
@@ -3837,6 +3856,53 @@ mod tests {
     }
 
     #[test]
+    fn is_protected_branch_covers_a_slashed_default_branch() {
+        // A default branch is free to have a slash in it. Comparing only the
+        // last path segment asked `"release/2026" == "2026"` and left such a
+        // repository's default branch pushable.
+        assert!(is_protected_branch("release/2026", Some("release/2026")));
+        assert!(is_protected_branch(
+            "refs/heads/release/2026",
+            Some("release/2026")
+        ));
+        assert!(is_protected_branch("main", Some("release/2026")));
+        // Neighbours of a slashed default are still feature branches.
+        assert!(!is_protected_branch("release/2025", Some("release/2026")));
+        assert!(!is_protected_branch("2026", Some("release/2026")));
+        assert!(!is_protected_branch("feature/x", Some("release/2026")));
+    }
+
+    #[test]
+    fn protect_default_blocks_slashed_default_branch() {
+        let Some((_tmp, repo)) =
+            scratch_repo_with_default("release/2026", "https://github.com/o/o.git", "release/2026")
+        else {
+            return;
+        };
+        let git = which_git().unwrap();
+        let dir = repo.to_string_lossy().into_owned();
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "release/2026"]).is_err());
+        assert!(
+            gate_push_in(
+                &git,
+                &dir,
+                &["push", "origin", "HEAD:refs/heads/release/2026"]
+            )
+            .is_err()
+        );
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "refs/heads/release/2026"]).is_err());
+        // Bare `git push` on the checked-out default branch, too.
+        assert!(gate_push_in(&git, &dir, &["push"]).is_err());
+        // A second refspec must not smuggle it past the first.
+        assert!(
+            gate_push_in(&git, &dir, &["push", "origin", "feature/x", "release/2026"]).is_err()
+        );
+        // Feature branches in the same repository stay pushable.
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "release/2025"]).is_ok());
+        assert!(gate_push_in(&git, &dir, &["push", "origin", "feature/x"]).is_ok());
+    }
+
+    #[test]
     fn extract_push_target_handles_refspecs() {
         assert_eq!(
             extract_push_target_branch(&["origin", "feature"], None),
@@ -3963,6 +4029,16 @@ mod tests {
     /// A scratch git repo on `branch`, with `origin` pointing at `origin_url`.
     /// `None` when git is unavailable.
     fn scratch_repo(branch: &str, origin_url: &str) -> Option<(tempfile::TempDir, PathBuf)> {
+        scratch_repo_with_default(branch, origin_url, "main")
+    }
+
+    /// Same, with the remote's default branch spelled out — including the
+    /// slashed forms (`release/2026`) a repository is free to use.
+    fn scratch_repo_with_default(
+        branch: &str,
+        origin_url: &str,
+        default_branch: &str,
+    ) -> Option<(tempfile::TempDir, PathBuf)> {
         let git = which_git()?;
         let tmp = tempfile::tempdir().ok()?;
         let repo = tmp.path().join("repo");
@@ -3987,7 +4063,7 @@ mod tests {
         run(&[
             "symbolic-ref",
             "refs/remotes/origin/HEAD",
-            "refs/remotes/origin/main",
+            &format!("refs/remotes/origin/{default_branch}"),
         ])?;
         Some((tmp, repo))
     }


### PR DESCRIPTION
## The defect

`is_protected_branch` (`src/gh_proxy.rs`) compared only the **last path segment** of the pushed branch against the resolved default branch:

```rust
let short = branch.rsplit('/').next().unwrap_or(branch);
DEFAULT_BRANCH_NAMES.contains(&short) || default_branch == Some(short)
```

The two sides do not arrive in the same shape:

- `branch` comes from push argv (via `refspec_target_branch`) or from `symbolic-ref --short HEAD`. It is the branch name **entire** — `release/2026`, slashes and all.
- `default_branch` comes from the `refs/remotes/<remote>/HEAD` symref with only the `<remote>/` prefix stripped by `resolve_default_branch`. It is `release/2026` too.

So in a repository whose default branch is `release/2026` the comparison was `"release/2026" == "2026"` — false. `git push origin release/2026` was **allowed** under `protect_default_branch_only`.

That is the same silent under-protection #346 was written to remove, surviving in the comparison #346 added. The setting promises to protect the default branch; in any repository that puts a slash in its default branch name it protected nothing. A no-silent-grants violation of the second, worse kind (`AGENTS.md` "No silent grants", `SECURITY.md` "A property that holds across all of them"): the restriction silently did nothing, and the config still listed it.

## The fix

Compare the **whole** branch name, and strip a `refs/heads/` prefix first.

The `refs/heads/` strip is load-bearing on its own: `refspec_target_branch` only removes that prefix from the `src:dst` form, so a colon-free push refspec — `git push origin refs/heads/release/2026` — reached the comparison with the prefix still attached and missed even a whole-name compare.

The last-segment comparison is kept, for two reasons and neither is the slashed case:

- `DEFAULT_BRANCH_NAMES` (`main`/`master`) are unslashed, and the floor must still catch the remote-qualified `origin/main`.
- `default_branch == Some(short)` catches the `origin/develop` spelling of an unslashed default (an existing test asserts it).

Both can only ever **add** protection — a false match there blocks a push, it never allows one — so keeping them cannot reintroduce the hole. Threading the remote name into `is_protected_branch` so the `<remote>/` prefix could be stripped precisely was the alternative; it buys nothing here, because the only thing the imprecise strip costs is over-blocking a branch literally named `feature/main`, which fails closed.

## Tests

- `is_protected_branch_covers_a_slashed_default_branch` — the comparison directly, including the `refs/heads/`-qualified form, and the near-misses that must stay allowed (`release/2025`, the bare `2026`, `feature/x`).
- `protect_default_blocks_slashed_default_branch` — end to end through `gate_git` in a fixture repo whose recorded default is `release/2026`: the plain push, both refspec spellings, the bare `git push` on the checked-out default, and the second-refspec smuggle (`git push origin feature/x release/2026`). Feature branches in the same repo stay pushable.
- `scratch_repo` grew `scratch_repo_with_default`, because every #346 fixture hardcoded `refs/remotes/origin/main`. That is why this survived review: none of #346's tests could have caught it.

## Mutation check

Deleting the added `|| default_branch == Some(branch)` line and rerunning:

- `is_protected_branch_covers_a_slashed_default_branch` fails — `assertion failed: is_protected_branch("release/2026", Some("release/2026"))`
- `protect_default_blocks_slashed_default_branch` fails — `assertion failed: gate_push_in(&git, &dir, &["push", "origin", "release/2026"]).is_err()`

Line restored, both green.

## Gates

`cargo fmt`, `cargo test --lib` (947 passed), `cargo test --test unit_tests` (331 passed), `cargo test --test e2e_git_hardening` (11 passed), `cargo clippy --all-targets -- -D warnings` — all run locally on macOS, all clean.

## Exposure

Small: #346 shipped hours ago. The defect is real regardless — and `navikt/cplt`'s own default is `main`, so nothing here was exposed by it.
