### PR TITLE
fix(doctor): grade Windows-side tools under WSL instead of ticking them green

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -322,9 +322,9 @@ const TOOLS_TO_CHECK: &[&str] = &[
 /// These are the tools cplt itself and the agents depend on: a Windows `npm`
 /// installs the win32 platform package into the Windows tree, which is exactly
 /// how a user ended up with a Copilot CLI that could not start (#271). The
-/// build tools (`gradle`, `yarn`, `java`, ...) are only warned about: a build
-/// started from one runs as a Windows process outside the sandbox, which is
-/// worth saying but is not a broken install.
+/// rest — build tools, language runtimes, the `app_dirs()` applications — are
+/// only warned about: running one starts a Windows process outside the sandbox,
+/// which is worth saying but is not a broken install.
 const WSL_CRITICAL_TOOLS: &[&str] = &["gh", "git", "node", "npm"];
 
 use crate::sandbox::app_dirs;
@@ -485,7 +485,7 @@ fn tool_lines(tools: &[ToolInfo], wsl: bool) -> (Vec<String>, bool) {
             } else {
                 format!(
                     "  {}\u{26a0}{} {}: {} is a Windows install reached through WSL interop; \
-                     a build started from it runs as a Windows process, outside the sandbox.",
+                     running it starts a Windows process, outside the sandbox.",
                     ui::stdout_color(ui::YELLOW),
                     ui::stdout_color(ui::RESET),
                     tool.name,
@@ -2193,7 +2193,7 @@ mod wsl_tool_report_tests {
         );
     }
 
-    /// A build tool is only warned about — it is not a broken install.
+    /// A non-critical tool is only warned about — it is not a broken install.
     #[test]
     fn windows_side_build_tool_is_warned_not_failed() {
         let tools = vec![tool(

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -313,8 +313,19 @@ pub fn discover_agents() -> Vec<AgentInfo> {
 // ── Tool discovery ──────────────────────────────────────────────
 
 const TOOLS_TO_CHECK: &[&str] = &[
-    "gh", "git", "node", "cargo", "python3", "java", "go", "gradle", "yarn",
+    "gh", "git", "node", "npm", "cargo", "python3", "java", "go", "gradle", "yarn",
 ];
+
+/// Tools whose Windows-side resolution under WSL is a hard failure, not a
+/// warning.
+///
+/// These are the tools cplt itself and the agents depend on: a Windows `npm`
+/// installs the win32 platform package into the Windows tree, which is exactly
+/// how a user ended up with a Copilot CLI that could not start (#271). The
+/// build tools (`gradle`, `yarn`, `java`, ...) are only warned about: a build
+/// started from one runs as a Windows process outside the sandbox, which is
+/// worth saying but is not a broken install.
+const WSL_CRITICAL_TOOLS: &[&str] = &["gh", "git", "node", "npm"];
 
 use crate::sandbox::app_dirs;
 use crate::sandbox::home_tool_dirs;
@@ -433,6 +444,58 @@ pub fn discover_all(home_dir: &Path, project_dir: &Path) -> Discovery {
 }
 
 // ── Reporting ───────────────────────────────────────────────────
+
+/// The lines doctor prints for the discovered tools, and whether they leave the
+/// critical checks passing.
+///
+/// Split out of `print_report` so a test can assert on what doctor actually
+/// emits for a Windows-side tool, not merely on the predicate in isolation.
+///
+/// Under WSL, interop appends the Windows `PATH` after the distro's, so a tool
+/// only resolves to `/mnt/<drive>/…` when no Linux-side install exists. Such a
+/// binary cannot run in the Linux namespace and cannot be sandboxed by
+/// Landlock, so printing an unconditional green tick for it was how doctor
+/// concluded "all critical checks passed" for a setup that could not work
+/// (#271). Same predicate, and the same reasoning, as the agents loop above.
+fn tool_lines(tools: &[ToolInfo], wsl: bool) -> (Vec<String>, bool) {
+    let mut critical_ok = true;
+    let lines = tools
+        .iter()
+        .map(|tool| {
+            if !crate::agent::is_wsl_interop_binary(&tool.path, wsl) {
+                return format!(
+                    "  {}\u{2713}{} {}: {}",
+                    ui::stdout_color(ui::GREEN),
+                    ui::stdout_color(ui::RESET),
+                    tool.name,
+                    tool.path.display()
+                );
+            }
+            if WSL_CRITICAL_TOOLS.contains(&tool.name.as_str()) {
+                critical_ok = false;
+                format!(
+                    "  {}\u{2717}{} {}: {} is a Windows install reached through WSL interop \
+                     and cannot run in the Linux sandbox. Install {} inside the WSL distro.",
+                    ui::stdout_color(ui::RED),
+                    ui::stdout_color(ui::RESET),
+                    tool.name,
+                    tool.path.display(),
+                    tool.name
+                )
+            } else {
+                format!(
+                    "  {}\u{26a0}{} {}: {} is a Windows install reached through WSL interop; \
+                     a build started from it runs as a Windows process, outside the sandbox.",
+                    ui::stdout_color(ui::YELLOW),
+                    ui::stdout_color(ui::RESET),
+                    tool.name,
+                    tool.path.display()
+                )
+            }
+        })
+        .collect();
+    (lines, critical_ok)
+}
 
 impl Discovery {
     /// Print a human-readable diagnostic report. Returns true if all critical checks pass.
@@ -606,15 +669,14 @@ impl Discovery {
             ui::stdout_color(ui::BOLD),
             ui::stdout_color(ui::RESET)
         );
-        for tool in &self.tools.tools {
-            println!(
-                "  {}✓{} {}: {}",
-                ui::stdout_color(ui::GREEN),
-                ui::stdout_color(ui::RESET),
-                tool.name,
-                tool.path.display()
-            );
+        let (tool_lines, tools_ok) = tool_lines(
+            &self.tools.tools,
+            cfg!(target_os = "linux") && crate::agent::is_wsl(),
+        );
+        for line in &tool_lines {
+            println!("{line}");
         }
+        critical_ok &= tools_ok;
         let missing: Vec<&&str> = TOOLS_TO_CHECK
             .iter()
             .filter(|name| !self.tools.tools.iter().any(|t| t.name == **name))
@@ -2098,5 +2160,71 @@ ELECTRON_RUN_AS_NODE=1 "/Applications/Visual Studio Code.app/Contents/Frameworks
         // Non-zero exit is "ran, said nothing useful" — not a timeout.
         let bad = fake_binary(dir.path(), "broken", "exec false");
         assert_eq!(probe_version(&bad, &["--version"]), VersionProbe::Unknown);
+    }
+}
+
+#[cfg(test)]
+mod wsl_tool_report_tests {
+    use super::*;
+
+    fn tool(name: &str, path: &str) -> ToolInfo {
+        ToolInfo {
+            name: name.to_string(),
+            path: PathBuf::from(path),
+        }
+    }
+
+    /// The doctor line itself, not the predicate: a Windows-side `npm` must be
+    /// graded red and must fail the critical checks (#271).
+    #[test]
+    fn windows_side_critical_tool_is_reported_red_and_fails_critical() {
+        let tools = vec![tool("npm", "/mnt/c/Users/N129069/AppData/Roaming/npm/npm")];
+        let (lines, ok) = tool_lines(&tools, true);
+        assert!(!ok, "a Windows-side npm must fail the critical checks");
+        assert!(
+            lines[0].contains('\u{2717}') && !lines[0].contains('\u{2713}'),
+            "expected a red cross, got: {}",
+            lines[0]
+        );
+        assert!(
+            lines[0].contains("/mnt/c/Users/N129069/AppData/Roaming/npm/npm"),
+            "the line must name the offending path, got: {}",
+            lines[0]
+        );
+    }
+
+    /// A build tool is only warned about — it is not a broken install.
+    #[test]
+    fn windows_side_build_tool_is_warned_not_failed() {
+        let tools = vec![tool(
+            "gradle",
+            "/mnt/c/apps/Gradle/gradle-8.10.2/bin/gradle",
+        )];
+        let (lines, ok) = tool_lines(&tools, true);
+        assert!(
+            ok,
+            "a Windows-side gradle is a warning, not a critical failure"
+        );
+        assert!(
+            lines[0].contains('\u{26a0}'),
+            "expected a warning sign, got: {}",
+            lines[0]
+        );
+    }
+
+    /// Off WSL, `/mnt/c` is an ordinary mount and the tool is fine.
+    #[test]
+    fn mnt_path_outside_wsl_stays_green() {
+        let tools = vec![tool("npm", "/mnt/c/npm")];
+        let (lines, ok) = tool_lines(&tools, false);
+        assert!(ok);
+        assert!(lines[0].contains('\u{2713}'), "got: {}", lines[0]);
+    }
+
+    /// npm is the tool the reporter actually tripped over, so it has to be
+    /// probed at all (#271).
+    #[test]
+    fn npm_is_checked() {
+        assert!(TOOLS_TO_CHECK.contains(&"npm"));
     }
 }


### PR DESCRIPTION
Closes #271 — the tools half of the WSL grading bug.

## What was wrong

The agents half was already fixed in #204: `is_wsl_interop_binary` grades a Windows-side agent red, so the issue's headline example no longer reproduces. The tools loop never got the same treatment — it printed an unconditional green tick for every tool `which` resolved, so a WSL user whose tools came from the Windows side through interop got a full green report and `All critical checks passed` for binaries that cannot run in the Linux namespace and cannot be sandboxed by Landlock.

Worse, `npm` was not in `TOOLS_TO_CHECK` at all. That is the root cause the reporter actually hit: Ubuntu's `nodejs` package does not bundle npm, so `node` resolved Linux-side and looked fine while `npm` alone fell through to the Windows install, made `npm root -g` a Windows path, and pulled the win32 platform package for the Copilot CLI. Partial shadowing is the dangerous case, and doctor could not even see it.

## What changed

- `npm` added to `TOOLS_TO_CHECK`.
- The tools loop applies `is_wsl_interop_binary`, the same predicate and the same WSL gate the agents loop uses. `gh`, `git`, `node` and `npm` are red and fail the critical checks; everything else (gradle, yarn, java, …) gets a warning saying a build started from it runs as a Windows process outside the sandbox. That split is the one the issue proposes.
- The per-tool lines moved into `tool_lines(&[ToolInfo], wsl) -> (Vec<String>, bool)` so the behaviour is testable. `print_report` prints exactly what it returns and cannot drift from it.

Off WSL, `/mnt/c` stays an ordinary mount and a tool there is still green — the gate is `is_wsl()`, unchanged.

## Tests

Four in `discover::wsl_tool_report_tests`, asserting on the emitted line rather than the predicate:

- `windows_side_critical_tool_is_reported_red_and_fails_critical` — a `/mnt/c/Users/.../npm/npm` produces a ✗, names the path, and returns `critical_ok == false`.
- `windows_side_build_tool_is_warned_not_failed` — a Windows gradle produces ⚠ and leaves the critical checks passing.
- `mnt_path_outside_wsl_stays_green` — same path with `wsl == false` stays ✓.
- `npm_is_checked`.

**Mutation check:** replacing the predicate with `if true` (restoring the unconditional green) fails `windows_side_critical_tool_is_reported_red_and_fails_critical` and `windows_side_build_tool_is_warned_not_failed`, the latter with `expected a warning sign, got:   ✓ gradle: /mnt/c/apps/Gradle/gradle-8.10.2/bin/gradle`. Restored, all four pass.

## Gates

`cargo fmt --check`, `cargo test --lib` (959), `cargo test --test unit_tests` (331), `cargo clippy --all-targets -- -D warnings` — all clean.

## Not done

The `/etc/wsl.conf` `automount.root` ceiling documented on `is_windows_interop_path` still applies: a relocated mount root is not detected. Unchanged by this PR, and the failure mode stays the preferred one — the tool fails later with its path in the message rather than being refused while working.