### PR TITLE
ci: run CI and CodeQL on pull requests to any base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+  # Deliberately unfiltered by base branch. `branches: [main]` filters on a
+  # PR's BASE, so a PR stacked on another feature branch got no CI at all — no
+  # ci-ok, no unit tests. The `stack branches` ruleset requires ci-ok on
+  # `stack/**` bases, which under a base filter is unsatisfiable by
+  # construction: the check can never report, so the PR sits blocked forever.
+  # Listing prefixes instead (`stack/**`) would only move the hole to ad-hoc
+  # stacks (#354 is based on `fix/...`), so every PR gets checked regardless of
+  # base. Cost is one run per stacked PR; the concurrency group below keys on
+  # `github.ref`, which for a PR is `refs/pull/<n>/merge` — unique per PR — so a
+  # stack rebasing at once runs in parallel and each PR only cancels its own
+  # older runs.
   pull_request:
-    branches: [main]
   # Run the required checks on the merge queue's temporary ref. The ruleset
   # requires unit-tests / integration-tests / linux-integration-tests before
   # merge; without this trigger those checks never report in the merge_group

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -20,8 +20,10 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # Unfiltered by base branch, for the same reason as ci.yaml: the `stack
+  # branches` ruleset requires a CodeQL result on `stack/**` bases, and a base
+  # filter means no run ever reports there.
   pull_request:
-    branches: [main]
   # The ruleset gates merges on code scanning, so the analysis has to report in
   # the merge queue's temporary ref too — otherwise queued entries wait out the
   # 60-minute timeout and fail to merge. Same reasoning as ci.yaml.


### PR DESCRIPTION
## Problem

`pull_request: branches: [main]` in both `ci.yaml` and `codeql.yaml` filters on a pull request's **base** branch. A PR stacked on another feature branch therefore gets no workflow run at all — no `ci-ok`, no unit tests, no CodeQL. #354 is stacked on #351 and has an empty check list right now.

The `stack branches` ruleset added today requires `ci-ok` and CodeQL results on `refs/heads/stack/**/*` bases. Against this trigger that is not a gate, it is a deadlock: neither check can ever report on such a PR, so it would sit BLOCKED forever.

## Why not just add `stack/**`

It would relocate the hole rather than close it. #354's base is `fix/cplt-exec-grant-overlap`, which matches no prefix convention, and nothing makes contributors adopt one. Dropping the base filter is the smaller diff and fixes the general case: one run per pull request, which is the count that was always intended.

## Cost

Bounded. The `concurrency` group keys on `github.ref`, which for a `pull_request` event is `refs/pull/<n>/merge` — unique per PR. A stack of three rebasing at once runs in parallel rather than queueing behind one another, and each PR still cancels only its own superseded runs. The added minutes are exactly the stacked PRs that previously ran nothing.

## Not touched

- `merge_group` — load-bearing, per its comment.
- `push: branches: [main]`.
- `release.yaml` is unaffected: its `workflow_run` trigger filters on the triggering run's head branch, which for any PR run is the PR head, never `main`.

## Verification

A probe PR stacked on this branch demonstrates the trigger firing where it previously did not — linked in a comment below. For a `pull_request` event GitHub resolves workflows from the merge ref, so a PR whose head contains this change is checked even before it lands on `main`.

Note for after merge: #354 stays unchecked until its base (#351) picks up this commit, since its merge ref does not contain it yet.