### PR TITLE
test: make gate refusals assert the reason, not just failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,11 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       - name: Run unit and lib tests
-        run: cargo test --test unit_tests --lib --verbose
+        # --no-fail-fast: cargo stops at the first *target* that fails, so a
+        # broken lib assertion hides every integration test behind it. Two
+        # mutation-testing rounds were scored against suites that never ran for
+        # exactly that reason (issue #126). Failures still fail the job.
+        run: cargo test --no-fail-fast --test unit_tests --lib --verbose
 
   # Integration tests need macOS for sandbox-exec
   integration-tests:
@@ -140,6 +144,10 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Run all tests (skips fail the job)
+        # --no-fail-fast: cargo stops at the first *target* that fails, so a
+        # broken lib assertion hides every integration test behind it. Two
+        # mutation-testing rounds were scored against suites that never ran for
+        # exactly that reason (issue #126). Failures still fail the job.
         # CPLT_TEST_REQUIRE_SANDBOX=1 makes require_sandbox! panic instead of skip,
         # so a missing/broken sandbox-exec (a Seatbelt regression on the runner)
         # turns this job red rather than silently passing while nothing is
@@ -153,7 +161,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          cargo test --verbose -- --nocapture 2>&1 | tee "$RUNNER_TEMP/test-output.log"
+          cargo test --no-fail-fast --verbose -- --nocapture 2>&1 | tee "$RUNNER_TEMP/test-output.log"
 
       - name: Surface tests skipped for missing tooling
         if: always()
@@ -299,6 +307,10 @@ jobs:
           exit 1
 
       - name: Run all Linux tests (skips fail the job)
+        # --no-fail-fast: cargo stops at the first *target* that fails, so a
+        # broken lib assertion hides every integration test behind it. Two
+        # mutation-testing rounds were scored against suites that never ran for
+        # exactly that reason (issue #126). Failures still fail the job.
         # CPLT_TEST_REQUIRE_SANDBOX=1 makes require_landlock!/require_bwrap!/
         # require_curl! panic instead of skip, so a missing capability (e.g.
         # bubblewrap uninstalled — issue #113) turns this job red rather than
@@ -308,7 +320,7 @@ jobs:
         env:
           CPLT_TEST_REQUIRE_SANDBOX: "1"
           CPLT_TEST_PRIV_443: "1"
-        run: cargo test --verbose
+        run: cargo test --no-fail-fast --verbose
 
       - name: Stop 127.0.0.1:443 listener
         if: always()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -127,3 +127,33 @@ pub fn temp_repo(remote: &str) -> tempfile::TempDir {
     ));
     dir
 }
+
+/// Assert a gate refused a command *for the stated reason*.
+///
+/// `assert!(!ok, …)` on its own is a vacuous assertion: it passes when the
+/// command failed for any reason at all — a renamed flag clap rejects, a
+/// fixture that never got built, a panic in the harness. Tests of that shape
+/// have shipped green over guards that were never running (issue #126).
+/// Pinning the refusal text is what separates "the policy blocked it" from "it
+/// fell over on the way to the policy".
+///
+/// `reason` should be the distinguishing part of the message — the `Reason:`
+/// line, not the `BLOCKED by sandbox` banner every refusal carries.
+///
+/// # Panics
+/// If the command succeeded, or failed without emitting the refusal banner and
+/// `reason`.
+pub fn assert_refused(stderr: &str, ok: bool, reason: &str) {
+    assert!(
+        !ok,
+        "must be refused, but the gate let it through.\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("BLOCKED by sandbox"),
+        "must fail as a policy refusal, not for some other reason.\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(reason),
+        "refusal must name {reason:?}.\nstderr: {stderr}"
+    );
+}

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -23,7 +23,7 @@
 use std::process::Command;
 
 mod common;
-use common::{binary_in_path, cplt_cmd, temp_repo};
+use common::{assert_refused, binary_in_path, cplt_cmd, temp_repo};
 
 /// Run `cplt gh-gate` with default block policy.
 /// Returns (stdout, stderr, exit_success).
@@ -191,37 +191,32 @@ fn gh_gate_allows_api_get() {
 #[test]
 fn gh_gate_blocks_repo_delete() {
     let (_, stderr, ok) = gh_gate(&["repo", "delete", "navikt/cplt"]);
-    assert!(!ok, "gh repo delete should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should show BLOCKED: {stderr}");
+    assert_refused(&stderr, ok, "deletes entire repository");
 }
 
 #[test]
 fn gh_gate_blocks_repo_edit() {
     let (_, stderr, ok) = gh_gate(&["repo", "edit", "--visibility", "private"]);
-    assert!(!ok, "gh repo edit should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should show BLOCKED: {stderr}");
+    assert_refused(&stderr, ok, "modifies repo settings");
 }
 
 #[test]
 fn gh_gate_blocks_repo_archive() {
     let (_, stderr, ok) = gh_gate(&["repo", "archive"]);
-    assert!(!ok, "gh repo archive should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should show BLOCKED: {stderr}");
+    assert_refused(&stderr, ok, "irreversible state change");
 }
 
 #[test]
 fn gh_gate_blocks_repo_fork() {
     let (_, stderr, ok) = gh_gate(&["repo", "fork"]);
-    assert!(!ok, "gh repo fork should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should show BLOCKED: {stderr}");
+    assert_refused(&stderr, ok, "creates new repo");
 }
 
 // pr merge is always blocked (human decision), pr close is ScopeCheck
 #[test]
 fn gh_gate_blocks_pr_merge_always() {
     let (_, stderr, ok) = gh_gate(&["pr", "merge", "42"]);
-    assert!(!ok, "gh pr merge should ALWAYS be blocked (human decision)");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "merging is a human decision");
 }
 
 #[test]
@@ -233,8 +228,9 @@ fn gh_gate_allows_pr_close_in_scope() {
 #[test]
 fn gh_gate_blocks_pr_merge_cross_repo() {
     let (_, stderr, ok) = gh_gate(&["pr", "merge", "42", "-R", "evil-org/other"]);
-    assert!(!ok, "gh pr merge cross-repo should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    // `pr merge` is Decision::Block outright, so the refusal is the merge
+    // policy, not the scope check — pin that rather than implying otherwise.
+    assert_refused(&stderr, ok, "merging is a human decision");
 }
 
 #[test]
@@ -246,8 +242,7 @@ fn gh_gate_allows_issue_close_in_scope() {
 #[test]
 fn gh_gate_blocks_issue_close_cross_repo() {
     let (_, stderr, ok) = gh_gate(&["issue", "close", "99", "-R", "evil-org/other"]);
-    assert!(!ok, "gh issue close cross-repo should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "outside the startup repo");
 }
 
 // ============================================================
@@ -257,18 +252,17 @@ fn gh_gate_blocks_issue_close_cross_repo() {
 #[test]
 fn gh_gate_blocks_auth_token() {
     let (_, stderr, ok) = gh_gate(&["auth", "token"]);
-    assert!(!ok, "gh auth token should be blocked");
-    assert!(
-        stderr.contains("BLOCKED"),
-        "should mention blocked: {stderr}"
-    );
+    // block_auth_token routes `gh auth token` to the cached-token file rather
+    // than the real gh; with no cached token the refusal is this one. Turning
+    // the policy off execs the real gh instead, which the sibling
+    // `gh_gate_auth_token_allowed_when_disabled` pins.
+    assert_refused(&stderr, ok, "No cached token available");
 }
 
 #[test]
 fn gh_gate_blocks_auth_token_with_hostname() {
     let (_, stderr, ok) = gh_gate(&["auth", "token", "--hostname", "github.com"]);
-    assert!(!ok, "gh auth token with hostname should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "No cached token available");
 }
 
 #[test]
@@ -293,8 +287,7 @@ fn gh_gate_auth_token_allowed_when_disabled() {
 #[test]
 fn gh_gate_blocks_unknown_command() {
     let (_, stderr, ok) = gh_gate(&["totally-new-command", "arg1"]);
-    assert!(!ok, "unknown gh commands should be blocked by default");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "not recognized by the policy table");
 }
 
 #[test]
@@ -317,18 +310,13 @@ fn gh_gate_allows_pr_list_cross_repo() {
 #[test]
 fn gh_gate_blocks_cross_repo_pr_close() {
     let (_, stderr, ok) = gh_gate(&["pr", "close", "42", "-R", "evil-org/other-repo"]);
-    assert!(
-        !ok,
-        "cross-repo gh pr close should be blocked by scope check"
-    );
-    assert!(stderr.contains("BLOCKED"), "should mention scope: {stderr}");
+    assert_refused(&stderr, ok, "outside the startup repo");
 }
 
 #[test]
 fn gh_gate_blocks_cross_repo_pr_merge() {
     let (_, stderr, ok) = gh_gate(&["pr", "merge", "42", "--repo", "evil-org/other-repo"]);
-    assert!(!ok, "cross-repo pr merge should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "merging is a human decision");
 }
 
 #[test]
@@ -760,25 +748,19 @@ fn gh_gate_blocks_conflicting_hostname_flag() {
         "evil.example",
         "/repos/navikt/cplt/pulls",
     ]);
-    assert!(!ok, "conflicting GitHub host must be blocked");
-    assert!(stderr.contains("outside the approved host"), "{stderr}");
+    assert_refused(&stderr, ok, "outside the approved host");
 }
 
 #[test]
 fn gh_gate_blocks_conflicting_hostname_for_allow_command() {
     let (_, stderr, ok) = gh_gate(&["--hostname", "evil.example", "repo", "view"]);
-    assert!(!ok, "allow command must not retarget the GitHub host");
-    assert!(stderr.contains("outside the approved host"), "{stderr}");
+    assert_refused(&stderr, ok, "outside the approved host");
 }
 
 #[test]
 fn gh_gate_blocks_fully_qualified_external_api_endpoint() {
     let (_, stderr, ok) = gh_gate(&["api", "https://evil.example/repos/navikt/cplt"]);
-    assert!(!ok, "external fully qualified API endpoint must be blocked");
-    assert!(
-        stderr.contains("outside 'https://api.github.com'"),
-        "{stderr}"
-    );
+    assert_refused(&stderr, ok, "outside 'https://api.github.com'");
 }
 
 #[test]
@@ -803,10 +785,7 @@ fn gh_gate_scope_check_disabled() {
 fn gh_gate_blocks_cross_repo_api_endpoint() {
     // API GET to a different repo's endpoint — scope check blocks it
     let (_, stderr, ok) = gh_gate(&["api", "/repos/evil-org/other-repo/pulls"]);
-    assert!(
-        !ok,
-        "cross-repo API GET via URL path should be blocked: stderr={stderr}"
-    );
+    assert_refused(&stderr, ok, "outside the startup repo");
 }
 
 #[test]
@@ -877,11 +856,7 @@ fn gh_gate_allows_global_command_from_unverifiable_cwd() {
 fn gh_gate_blocks_non_repo_api_endpoint() {
     // Endpoints like /user, /orgs don't target the current repo — blocked for security
     let (_, stderr, ok) = gh_gate(&["api", "/user"]);
-    assert!(!ok, "non-repo API endpoints should be blocked");
-    assert!(
-        stderr.contains("BLOCKED") || stderr.contains("blocked"),
-        "should indicate blocked: {stderr}"
-    );
+    assert_refused(&stderr, ok, "outside the startup repo");
 }
 
 // ============================================================
@@ -913,25 +888,29 @@ fn gh_gate_audit_mode_allows_blocked_command() {
 #[test]
 fn gh_gate_blocks_api_post_with_dash_x() {
     let (_, stderr, ok) = gh_gate(&["api", "-X", "POST", "/repos/navikt/cplt/issues"]);
-    assert!(!ok, "gh api POST should be blocked (mutating): {stderr}");
+    assert_refused(&stderr, ok, "gh api with non-GET method");
 }
 
 #[test]
 fn gh_gate_blocks_api_post_combined_flag() {
     let (_, stderr, ok) = gh_gate(&["api", "-XPOST", "/repos/navikt/cplt/issues"]);
-    assert!(!ok, "gh api -XPOST should be blocked (mutating): {stderr}");
+    assert_refused(&stderr, ok, "gh api with non-GET method");
 }
 
 #[test]
 fn gh_gate_blocks_api_delete() {
-    let (_, _, ok) = gh_gate(&["api", "-XDELETE", "/repos/navikt/cplt/issues/1"]);
-    assert!(!ok, "gh api DELETE should be blocked");
+    let (_, stderr, ok) = gh_gate(&["api", "-XDELETE", "/repos/navikt/cplt/issues/1"]);
+    assert_refused(&stderr, ok, "gh api DELETE is destructive");
 }
 
 #[test]
 fn gh_gate_blocks_api_with_input_flags() {
-    let (_, _, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "-f", "title=pwned"]);
-    assert!(!ok, "gh api with -f (implies POST) should be blocked");
+    let (_, stderr, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "-f", "title=pwned"]);
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
+    );
 }
 
 // ============================================================
@@ -963,17 +942,14 @@ fn gh_gate_allow_api_write_permits_post_in_scope() {
 fn gh_gate_allow_api_write_still_blocks_graphql() {
     // GraphQL must remain blocked even with --allow-api-write — arbitrary mutations
     // cannot be statically scope-checked.
-    let (_, _, ok) = gh_gate_with_opts(&["api", "graphql"], &["--allow-api-write"]);
-    assert!(
-        !ok,
-        "gh api graphql must be blocked even with allow_api_write"
-    );
+    let (_, stderr, ok) = gh_gate_with_opts(&["api", "graphql"], &["--allow-api-write"]);
+    assert_refused(&stderr, ok, "arbitrary mutations");
 }
 
 #[test]
 fn gh_gate_allow_api_write_blocks_cross_repo_post() {
     // Scope check must still apply: POST to another repo is blocked.
-    let (_, _, ok) = gh_gate_with_opts(
+    let (_, stderr, ok) = gh_gate_with_opts(
         &[
             "api",
             "repos/evil-org/other-repo/issues",
@@ -984,16 +960,13 @@ fn gh_gate_allow_api_write_blocks_cross_repo_post() {
         ],
         &["--allow-api-write"],
     );
-    assert!(
-        !ok,
-        "gh api POST to a different repo must still be blocked by scope check"
-    );
+    assert_refused(&stderr, ok, "outside the startup repo");
 }
 
 #[test]
 fn gh_gate_default_still_blocks_api_post() {
     // Regression: default (no --allow-api-write) must still block writes.
-    let (_, _, ok) = gh_gate(&[
+    let (_, stderr, ok) = gh_gate(&[
         "api",
         "repos/navikt/cplt/pulls/comments/123/replies",
         "--method",
@@ -1001,9 +974,10 @@ fn gh_gate_default_still_blocks_api_post() {
         "--field",
         "body=test",
     ]);
-    assert!(
-        !ok,
-        "gh api POST must be blocked by default (no allow_api_write)"
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
     );
 }
 
@@ -1038,40 +1012,57 @@ fn gh_gate_allows_version_command() {
 #[test]
 fn gh_gate_blocks_field_equals_form() {
     // Agent tries: gh api /repos/x/y/issues --field=title=pwned
-    let (_, _, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "--field=title=pwned"]);
-    assert!(
-        !ok,
-        "--field=value form must be detected as write operation"
+    let (_, stderr, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "--field=title=pwned"]);
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
     );
 }
 
 #[test]
 fn gh_gate_blocks_raw_field_equals_form() {
-    let (_, _, ok) = gh_gate(&[
+    let (_, stderr, ok) = gh_gate(&[
         "api",
         "/repos/navikt/cplt/issues",
         "--raw-field=body=hacked",
     ]);
-    assert!(!ok, "--raw-field=value form must be detected as write");
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
+    );
 }
 
 #[test]
 fn gh_gate_blocks_input_equals_form() {
-    let (_, _, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "--input=-"]);
-    assert!(!ok, "--input=- form must be detected as write");
+    let (_, stderr, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "--input=-"]);
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
+    );
 }
 
 #[test]
 fn gh_gate_blocks_short_f_combined() {
     // Agent tries: gh api /repos/x/y/issues -ftitle=pwned
-    let (_, _, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "-ftitle=pwned"]);
-    assert!(!ok, "-f<value> combined form must be detected as write");
+    let (_, stderr, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "-ftitle=pwned"]);
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
+    );
 }
 
 #[test]
 fn gh_gate_blocks_short_f_uppercase_combined() {
-    let (_, _, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "-Ftitle=pwned"]);
-    assert!(!ok, "-F<value> combined form must be detected as write");
+    let (_, stderr, ok) = gh_gate(&["api", "/repos/navikt/cplt/issues", "-Ftitle=pwned"]);
+    assert_refused(
+        &stderr,
+        ok,
+        "gh api with input flags implies write operation",
+    );
 }
 
 // -- GraphQL bypass --
@@ -1080,42 +1071,37 @@ fn gh_gate_blocks_short_f_uppercase_combined() {
 fn gh_gate_blocks_graphql_endpoint() {
     // Agent tries: echo '{"query":"mutation{...}"}' | gh api graphql
     let (_, stderr, ok) = gh_gate(&["api", "graphql"]);
-    assert!(
-        !ok,
-        "gh api graphql must be blocked (arbitrary mutations via stdin)"
-    );
-    assert!(
-        stderr.contains("graphql"),
-        "should mention graphql: {stderr}"
-    );
+    // The old assertion only required "graphql" in stderr, which the echoed
+    // command line supplies for any refusal at all. Pin the reason instead.
+    assert_refused(&stderr, ok, "arbitrary mutations");
 }
 
 #[test]
 fn gh_gate_blocks_graphql_with_slash() {
-    let (_, _, ok) = gh_gate(&["api", "/graphql"]);
-    assert!(!ok, "gh api /graphql must be blocked");
+    let (_, stderr, ok) = gh_gate(&["api", "/graphql"]);
+    assert_refused(&stderr, ok, "arbitrary mutations");
 }
 
 #[test]
 fn gh_gate_blocks_graphql_trailing_slash() {
     // Trailing slash should not bypass the graphql block
-    let (_, _, ok) = gh_gate(&["api", "graphql/"]);
-    assert!(!ok, "gh api graphql/ must be blocked");
-    let (_, _, ok) = gh_gate(&["api", "/graphql/"]);
-    assert!(!ok, "gh api /graphql/ must be blocked");
+    let (_, stderr, ok) = gh_gate(&["api", "graphql/"]);
+    assert_refused(&stderr, ok, "arbitrary mutations");
+    let (_, stderr, ok) = gh_gate(&["api", "/graphql/"]);
+    assert_refused(&stderr, ok, "arbitrary mutations");
 }
 
 #[test]
 fn gh_gate_blocks_graphql_with_query_params() {
-    let (_, _, ok) = gh_gate(&["api", "graphql?foo=bar"]);
-    assert!(!ok, "gh api graphql?foo=bar must be blocked");
+    let (_, stderr, ok) = gh_gate(&["api", "graphql?foo=bar"]);
+    assert_refused(&stderr, ok, "arbitrary mutations");
 }
 
 #[test]
 fn gh_gate_blocks_graphql_with_method() {
     // Even explicit GET to graphql should be blocked (mutations can be sent as GET with query param)
-    let (_, _, ok) = gh_gate(&["api", "-XGET", "graphql"]);
-    assert!(!ok, "gh api GET graphql must still be blocked");
+    let (_, stderr, ok) = gh_gate(&["api", "-XGET", "graphql"]);
+    assert_refused(&stderr, ok, "arbitrary mutations");
 }
 
 // ============================================================
@@ -1205,29 +1191,25 @@ fn git_gate_allows_stash() {
 #[test]
 fn git_gate_blocks_push() {
     let (_, stderr, ok) = git_gate(&["push"], true, true);
-    assert!(!ok, "git push should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_push_with_remote() {
     let (_, stderr, ok) = git_gate(&["push", "origin", "main"], true, true);
-    assert!(!ok, "git push origin main should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_push_force() {
     let (_, stderr, ok) = git_gate(&["push", "--force", "origin", "main"], true, true);
-    assert!(!ok, "git push --force should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_send_pack() {
     let (_, stderr, ok) = git_gate(&["send-pack", "origin"], true, true);
-    assert!(!ok, "git send-pack should be blocked (push equivalent)");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 // ============================================================
@@ -1243,11 +1225,7 @@ fn git_gate_allows_push_when_not_prevented() {
 #[test]
 fn git_gate_blocks_force_push_when_prevented() {
     let (_, stderr, ok) = git_gate(&["push", "--force", "origin", "main"], false, true);
-    assert!(
-        !ok,
-        "git push --force should be blocked when prevent_force_push=true"
-    );
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 #[test]
@@ -1257,10 +1235,7 @@ fn git_gate_blocks_force_with_lease() {
         false,
         true,
     );
-    assert!(
-        !ok,
-        "git push --force-with-lease should be blocked: {stderr}"
-    );
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 #[test]
@@ -1270,14 +1245,13 @@ fn git_gate_blocks_force_if_includes() {
         false,
         true,
     );
-    assert!(!ok, "git push --force-if-includes should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_short_force_flag() {
     let (_, stderr, ok) = git_gate(&["push", "-f", "origin", "main"], false, true);
-    assert!(!ok, "git push -f should be blocked: {stderr}");
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 #[test]
@@ -1313,20 +1287,20 @@ fn git_gate_audit_mode_allows_push() {
 
 #[test]
 fn git_gate_blocks_push_with_refspec() {
-    let (_, _, ok) = git_gate(&["push", "origin", "HEAD:refs/heads/main"], true, true);
-    assert!(!ok, "git push with refspec should still be blocked");
+    let (_, stderr, ok) = git_gate(&["push", "origin", "HEAD:refs/heads/main"], true, true);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_push_with_set_upstream() {
-    let (_, _, ok) = git_gate(&["push", "--set-upstream", "origin", "feature"], true, true);
-    assert!(!ok, "git push --set-upstream should still be blocked");
+    let (_, stderr, ok) = git_gate(&["push", "--set-upstream", "origin", "feature"], true, true);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_push_u_shorthand() {
-    let (_, _, ok) = git_gate(&["push", "-u", "origin", "feature"], true, true);
-    assert!(!ok, "git push -u should still be blocked");
+    let (_, stderr, ok) = git_gate(&["push", "-u", "origin", "feature"], true, true);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 // -- Force-push =value form bypass --
@@ -1339,23 +1313,17 @@ fn git_gate_blocks_force_with_lease_equals_ref() {
         false,
         true,
     );
-    assert!(
-        !ok,
-        "--force-with-lease=<ref> must be detected as force push: {stderr}"
-    );
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_force_if_includes_equals_ref() {
-    let (_, _, ok) = git_gate(
+    let (_, stderr, ok) = git_gate(
         &["push", "--force-if-includes=HEAD~3", "origin", "main"],
         false,
         true,
     );
-    assert!(
-        !ok,
-        "--force-if-includes=<ref> must be detected as force push"
-    );
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 // ============================================================
@@ -1365,15 +1333,13 @@ fn git_gate_blocks_force_if_includes_equals_ref() {
 #[test]
 fn git_gate_protect_default_blocks_push_to_main() {
     let (_, stderr, ok) = git_gate_protect_default(&["push", "origin", "main"]);
-    assert!(!ok, "push to main should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_protect_default_blocks_push_to_master() {
     let (_, stderr, ok) = git_gate_protect_default(&["push", "origin", "master"]);
-    assert!(!ok, "push to master should be blocked");
-    assert!(stderr.contains("BLOCKED"), "should block: {stderr}");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
@@ -1391,27 +1357,21 @@ fn git_gate_protect_default_allows_push_to_copilot_branch() {
 #[test]
 fn git_gate_protect_default_blocks_bare_push() {
     // Bare push can't verify branch (real-git=/usr/bin/true) → fail closed
-    let (_, _, ok) = git_gate_protect_default(&["push"]);
-    assert!(
-        !ok,
-        "bare git push should be blocked when branch can't be resolved"
-    );
+    let (_, stderr, ok) = git_gate_protect_default(&["push"]);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_protect_default_blocks_push_with_remote_only() {
     // `git push origin` — can't verify branch → fail closed
-    let (_, _, ok) = git_gate_protect_default(&["push", "origin"]);
-    assert!(
-        !ok,
-        "push with only remote should be blocked when branch can't be resolved"
-    );
+    let (_, stderr, ok) = git_gate_protect_default(&["push", "origin"]);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_protect_default_blocks_refspec_to_main() {
-    let (_, _, ok) = git_gate_protect_default(&["push", "origin", "HEAD:refs/heads/main"]);
-    assert!(!ok, "push with refspec targeting main should be blocked");
+    let (_, stderr, ok) = git_gate_protect_default(&["push", "origin", "HEAD:refs/heads/main"]);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
@@ -1423,8 +1383,8 @@ fn git_gate_protect_default_allows_refspec_to_feature() {
 
 #[test]
 fn git_gate_protect_default_blocks_origin_slash_main() {
-    let (_, _, ok) = git_gate_protect_default(&["push", "origin", "origin/main"]);
-    assert!(!ok, "push to origin/main should be blocked");
+    let (_, stderr, ok) = git_gate_protect_default(&["push", "origin", "origin/main"]);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 // ── Security hardening tests ────────────────────────────────────
@@ -1433,48 +1393,47 @@ fn git_gate_protect_default_blocks_origin_slash_main() {
 fn git_gate_blocks_alias_via_dash_c() {
     // `-c alias.p=push` must be caught to prevent bypass
     let (_, stderr, ok) = git_gate(&["-c", "alias.p=push", "p", "origin", "main"], true, true);
-    assert!(!ok, "git -c alias.p=push should be blocked: {stderr}");
+    assert_refused(&stderr, ok, "git alias definitions via -c are blocked");
 }
 
 #[test]
 fn git_gate_blocks_unknown_subcommand_when_push_prevented() {
     // Unknown subcommands blocked to prevent alias-based bypass
-    let (_, _, ok) = git_gate(
+    let (_, stderr, ok) = git_gate(
         &["subtree", "push", "--prefix=lib", "origin", "main"],
         true,
         true,
     );
-    assert!(!ok, "git subtree push should be blocked");
-    let (_, _, ok) = git_gate(&["random-extension"], true, true);
-    assert!(
-        !ok,
-        "unknown git subcommand should be blocked when push prevented"
-    );
+    assert_refused(&stderr, ok, "'subtree push' performs a remote write");
+    let (_, stderr, ok) = git_gate(&["random-extension"], true, true);
+    assert_refused(&stderr, ok, "only known git subcommands are allowed");
 }
 
 #[test]
 fn git_gate_protect_default_blocks_force_push_to_feature() {
     // Force push to feature branch must be blocked when prevent_force_push=true
-    let (_, _, ok) = git_gate_protect_default(&["push", "--force", "origin", "feature-branch"]);
-    assert!(!ok, "force push to feature branch should be blocked");
-    let (_, _, ok) = git_gate_protect_default(&["push", "-f", "origin", "my-feature"]);
-    assert!(!ok, "-f to feature branch should be blocked");
-    let (_, _, ok) = git_gate_protect_default(&["push", "--force-with-lease", "origin", "feature"]);
-    assert!(!ok, "--force-with-lease to feature should be blocked");
+    let (_, stderr, ok) =
+        git_gate_protect_default(&["push", "--force", "origin", "feature-branch"]);
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
+    let (_, stderr, ok) = git_gate_protect_default(&["push", "-f", "origin", "my-feature"]);
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
+    let (_, stderr, ok) =
+        git_gate_protect_default(&["push", "--force-with-lease", "origin", "feature"]);
+    assert_refused(&stderr, ok, "Force push prevention is enabled");
 }
 
 #[test]
 fn git_gate_protect_default_blocks_multi_refspec_with_main() {
     // `git push origin feature main` should be blocked (main is a default branch)
-    let (_, _, ok) = git_gate_protect_default(&["push", "origin", "feature", "main"]);
-    assert!(!ok, "multi-refspec including main should be blocked");
-    let (_, _, ok) = git_gate_protect_default(&[
+    let (_, stderr, ok) = git_gate_protect_default(&["push", "origin", "feature", "main"]);
+    assert_refused(&stderr, ok, "Push prevention is enabled");
+    let (_, stderr, ok) = git_gate_protect_default(&[
         "push",
         "origin",
         "HEAD:refs/heads/feature",
         "HEAD:refs/heads/master",
     ]);
-    assert!(!ok, "multi-refspec including master should be blocked");
+    assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 // ============================================================

--- a/tests/integration_linux.rs
+++ b/tests/integration_linux.rs
@@ -1573,65 +1573,59 @@ print('CONNECTED')
         (port, handle)
     }
 
-    /// Full-stack proxy wiring test: --allow-localhost PORT sets NO_PROXY and opens
-    /// the Landlock TCP path so curl can reach the listener directly.
+    /// Full-stack proxy wiring test, both directions against one live listener:
+    /// `--allow-localhost PORT` sets NO_PROXY and opens the Landlock TCP path so
+    /// curl reaches the listener; without the flag the same request must fail.
     ///
     /// Data flow: curl → (NO_PROXY set) → direct TCP → Landlock allows PORT → listener
+    ///
+    /// The negative half used to bind an ephemeral port and *drop* the listener
+    /// before running curl, so it passed on ECONNREFUSED whether or not anything
+    /// was enforced (issue #126). Both halves now talk to a listener that is
+    /// really there, and the positive control lives in the same test: if the
+    /// deny half ever passed because the sandbox could not reach the port at
+    /// all, the allow half fails too and says so.
     ///
     /// This test would fail if:
     /// - allow_localhost_ports is not wired from CLI into sandbox_exec (NO_PROXY not set)
     /// - Landlock does not open the port when --allow-localhost is given
+    /// - loopback is reachable *without* --allow-localhost
     #[test]
-    fn proxy_allows_curl_to_localhost_with_allow_flag() {
+    fn proxy_localhost_reachable_only_with_allow_flag() {
         require_landlock!(4);
         require_curl!();
         let project = create_test_project();
         let (port, server_handle) = start_http_echo_server();
 
         let script = format!(
-            "curl --max-time 5 -s http://127.0.0.1:{port}/ && echo CURL_OK || echo CURL_FAIL"
+            "curl --max-time 5 -sf http://127.0.0.1:{port}/ && echo CURL_OK || echo CURL_FAIL"
         );
-        let (_, stdout, stderr) = run_sandboxed_with_flags(
+
+        // Negative: no --allow-localhost. The listener is up, so a pass here can
+        // only come from enforcement (Landlock TCP deny, or the proxy refusing
+        // to forward), never from "nothing was listening".
+        let (_, denied_stdout, denied_stderr) = run_sandboxed(project.path(), &script);
+        assert!(
+            denied_stdout.contains("CURL_FAIL"),
+            "without --allow-localhost, curl to a live 127.0.0.1:{port} must fail; \
+             stdout: {denied_stdout} stderr: {denied_stderr}"
+        );
+
+        // Positive control: same script, same live listener, flag added.
+        let (_, allowed_stdout, allowed_stderr) = run_sandboxed_with_flags(
             project.path(),
             &["--allow-localhost", &port.to_string()],
             &script,
         );
 
-        // Unblock the server if curl didn't connect
+        // Unblock the server if curl never connected.
         let _ = std::net::TcpStream::connect(("127.0.0.1", port));
         server_handle.join().ok();
 
         assert!(
-            stdout.contains("CURL_OK"),
-            "--allow-localhost {port}: curl to 127.0.0.1:{port} must succeed; stdout: {stdout} stderr: {stderr}"
-        );
-    }
-
-    /// Negative case: without --allow-localhost, curl to localhost must be blocked.
-    /// Without the flag, NO_PROXY is not set → curl routes through the cplt proxy →
-    /// proxy returns 405 (plain HTTP) or the Landlock TCP deny fires first.
-    #[test]
-    fn proxy_blocks_curl_to_localhost_without_allow_flag() {
-        require_landlock!(4);
-        require_curl!();
-        let project = create_test_project();
-
-        // Use a high ephemeral port. There's nothing listening, but the test
-        // only needs to verify the connection attempt is blocked, not that a
-        // real server responds.
-        let listener =
-            std::net::TcpListener::bind("127.0.0.1:0").expect("Failed to bind test listener");
-        let port = listener.local_addr().unwrap().port();
-        drop(listener); // Close it — we don't want connections to succeed
-
-        let script = format!(
-            "curl --max-time 3 -sf http://127.0.0.1:{port}/ 2>&1 && echo CURL_OK || echo CURL_FAIL"
-        );
-        let (_, stdout, _) = run_sandboxed(project.path(), &script);
-
-        assert!(
-            stdout.contains("CURL_FAIL"),
-            "without --allow-localhost, curl to 127.0.0.1:{port} must fail; got: {stdout}"
+            allowed_stdout.contains("CURL_OK"),
+            "--allow-localhost {port}: curl to 127.0.0.1:{port} must succeed — without this \
+             control the deny above proves nothing; stdout: {allowed_stdout} stderr: {allowed_stderr}"
         );
     }
 
@@ -1895,13 +1889,22 @@ print('CONNECTED')
         require_bwrap!();
         let project = create_test_project();
 
+        // What PID 1 is on *this* host, whatever it is called. Keying on the
+        // literal "systemd" made this test pass on any runner whose init has
+        // another name — a container with tini, a non-systemd distro — while
+        // asserting nothing (issue #126).
+        let host_init = fs::read_to_string("/proc/1/comm")
+            .expect("host /proc/1/comm must be readable to have anything to compare against");
+        let host_init = host_init.trim();
+        assert!(!host_init.is_empty(), "host /proc/1/comm was empty");
+
         let (exit, stdout, _) =
             run_sandboxed_bwrap(project.path(), "cat /proc/1/comm 2>&1 || echo 'blocked'");
         assert_eq!(exit, 0);
         // PID 1 inside the namespace is bwrap/the helper, never the host init.
         assert!(
-            !stdout.contains("systemd") || stdout.contains("blocked"),
-            "Should not see host init in PID namespace: {stdout}"
+            stdout.contains("blocked") || stdout.trim() != host_init,
+            "PID 1 in the namespace must not be the host init ({host_init:?}): {stdout}"
         );
     }
 


### PR DESCRIPTION
Closes the Tier 3 items of #126 that are about **vacuous negative assertions** — a check that reads as present and is not.

## The class of defect

`assert!(!ok, "…")` passes when the command failed for *any* reason: a renamed flag clap rejects, a fixture that never got built, a panic in the harness. Nine defects found in one review round were this shape, and in every one the helper was tested while the call site was not.

## What changed

**`tests/common/mod.rs`** — one new helper:

```rust
assert_refused(&stderr, ok, "gh api graphql allows arbitrary mutations");
```

It asserts the command failed, that it failed as a policy refusal (`BLOCKED by sandbox`), and that the refusal names the given reason. `assert!(!ok, …)` no longer appears anywhere in `tests/e2e_guards.rs`, so the convention is greppable.

**`tests/e2e_guards.rs`** — all 58 negative gate assertions converted, each pinned to the gate's own `Reason:` line (probed from the real binary, not guessed). Net −11 lines.

Two were weaker than they looked and are now honest:

- `gh_gate_blocks_graphql_endpoint` asserted `stderr.contains("graphql")` — satisfied by the echoed command line for *any* refusal.
- `gh_gate_blocks_cross_repo_pr_close` said "should mention scope" while asserting only the generic banner. Its sibling `gh_gate_blocks_pr_merge_cross_repo` is now pinned to `merging is a human decision`, because `pr merge` is `Decision::Block` outright — the scope check never runs there, and the old name implied otherwise.

**`tests/integration_linux.rs`** — the two named in #126:

- `proxy_blocks_curl_to_localhost_without_allow_flag` bound an ephemeral port and **dropped the listener** before running curl, so ECONNREFUSED passed it whether or not anything was enforced. Merged with the standalone allow-flag test it duplicated into `proxy_localhost_reachable_only_with_allow_flag`: both halves run against one live listener, positive control in the same test.
- `bwrap_cannot_see_host_init` keyed on the literal `"systemd"`, passing on any host whose init has another name. Now compares the sandboxed `/proc/1/comm` against the host's real one.

**`.github/workflows/ci.yaml`** — `cargo test --no-fail-fast` in all three test steps. cargo stops at the first failing *target*, so a broken lib assertion hides every integration test behind it; that hid two mutation-testing rounds in one day. Failures still fail the job.

## Mutation evidence

Injecting a wrong-reason failure into the gh harness (an unrecognised flag, so cplt exits non-zero before any policy runs):

| | passed | failed |
|---|---|---|
| before | 82 | 41 |
| after | 65 | 58 |

17 tests that previously shipped green over a gate that never ran now go red. The Linux pair is verified in a separate red CI run (see comment below).

## Not done, deliberately

- **Silent-skip visibility** — already built. `require_sandbox!`/`require_landlock!`/`require_bwrap!`/`require_curl!` panic under `CPLT_TEST_REQUIRE_SANDBOX=1`, and the macOS job counts residual skip markers and fails on unexpected ones.
- **A positive-control framework** — rejected. Where the refusal text distinguishes the cause, pinning it is the cheaper proof; a control only earns its place where the message cannot tell the intended block from a blanket one (the `protect_default_branch_only` tests, whose controls are the adjacent `_allows_` tests in the same file).

Refs #126
