### PR TITLE
fix(config): warn when allow.write shadows an agent exec dir

### DIFF
--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -839,11 +839,16 @@ impl Resolved {
     /// tool directory is actually shadowed. Warning on every writable tree
     /// would fire on the ordinary case and teach people to skip it.
     ///
-    /// Best-effort by design, and existence-checked so an uninstalled tool
-    /// never produces advice about a directory that is not there. Tool homes
-    /// relocated by `CARGO_HOME` and friends are not resolved here — those
-    /// become `ToolRoot`s rather than `allow.write` grants (#152), so they
-    /// cannot be the grant this warning is about.
+    /// Best-effort by design. Tool candidates are existence-checked so an
+    /// uninstalled tool never produces advice about a directory that is not
+    /// there; agent candidates are not, because `assemble_sandbox` creates
+    /// every one of them itself, after this runs. Existence-checking those
+    /// would silence the warning on the first run after the grant is written —
+    /// the one run where it is worth reading — and start it on some later
+    /// session for no reason the user can see. Tool homes relocated by
+    /// `CARGO_HOME` and friends are not resolved here — those become
+    /// `ToolRoot`s rather than `allow.write` grants (#152), so they cannot be
+    /// the grant this warning is about.
     ///
     /// `agent_dirs` is the agent's own directories, which lose execute the same
     /// way on macOS (#343): `~/.pi/agent/bin` and `~/.cache/opencode/bin` are
@@ -868,13 +873,13 @@ impl Resolved {
                     .iter()
                     .flat_map(|a| a.process_exec_paths(home)),
             )
+            .filter(|p| p.exists())
             .chain(
                 agent_dirs
                     .iter()
                     .filter(|d| d.process_exec)
                     .map(|d| d.path.clone()),
             )
-            .filter(|p| p.exists())
             .map(|p| p.to_string_lossy().into_owned())
             .collect();
         grants_overlapping(&self.allow_write, &dirs)
@@ -2303,6 +2308,51 @@ validate = false
         for w in [&one, &many] {
             assert!(!w.contains("director "), "\"director\" is not a word: {w}");
         }
+    }
+
+    /// #343 review: cplt creates the agent's directories itself, in
+    /// `assemble_sandbox`, *after* this warning runs. Existence-checking them
+    /// like a tool directory would keep the warning silent on the first run
+    /// after the grant is written and fire it on some later session instead, so
+    /// the filter covers tool candidates only. The bin dir is deliberately not
+    /// created here: that absence is the whole test.
+    #[test]
+    fn an_agent_exec_dir_is_reported_before_cplt_creates_it() {
+        let home = std::env::temp_dir().join(format!(
+            "cplt-agent-exec-absent-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(home.join(".pi")).expect("temp home");
+
+        let bin = home.join(".pi/agent/bin");
+        assert!(!bin.exists(), "the fixture must leave the bin dir absent");
+        let agent_dirs = vec![crate::agent::AgentDir {
+            path: bin.clone(),
+            write: false,
+            map_exec: false,
+            process_exec: true,
+            write_files: vec![],
+        }];
+
+        let mut r = Config::default()
+            .merge(CliFlags::default())
+            .expect("default config merges");
+        r.allow_write = vec![home.join(".pi")];
+        let found = r.write_grants_over_exec_tool_dirs(&home, &agent_dirs);
+
+        let bin = bin.to_string_lossy().into_owned();
+        assert!(
+            found
+                .iter()
+                .any(|(g, dirs)| *g == home.join(".pi") && dirs.contains(&bin)),
+            "an agent exec dir cplt has not created yet must still be reported: {found:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// #343 review: the Linux sentence was unconditional, and it is false for

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -778,8 +778,19 @@ impl Resolved {
     /// relocated by `CARGO_HOME` and friends are not resolved here — those
     /// become `ToolRoot`s rather than `allow.write` grants (#152), so they
     /// cannot be the grant this warning is about.
+    ///
+    /// `agent_dirs` is the active agent's own directories, which lose execute
+    /// the same way (#343): `~/.pi/agent/bin` and `~/.cache/opencode/bin` are
+    /// `process_exec` with a writable parent, so `allow.write = ["~/.pi"]`
+    /// withdraws exec from the managed binaries the agent expects to run. They
+    /// are passed in rather than derived here because the set depends on the
+    /// resolved agent, which `Resolved` does not know.
     #[must_use]
-    pub fn write_grants_over_exec_tool_dirs(&self, home: &Path) -> Vec<(PathBuf, Vec<String>)> {
+    pub fn write_grants_over_exec_tool_dirs(
+        &self,
+        home: &Path,
+        agent_dirs: &[crate::agent::AgentDir],
+    ) -> Vec<(PathBuf, Vec<String>)> {
         let dirs: Vec<String> = crate::sandbox::HOME_TOOL_DIRS
             .iter()
             .filter(|d| d.process_exec)
@@ -788,6 +799,12 @@ impl Resolved {
                 crate::sandbox::app_dirs()
                     .iter()
                     .flat_map(|a| a.process_exec_paths(home)),
+            )
+            .chain(
+                agent_dirs
+                    .iter()
+                    .filter(|d| d.process_exec)
+                    .map(|d| d.path.clone()),
             )
             .filter(|p| p.exists())
             .map(|p| p.to_string_lossy().into_owned())
@@ -2077,7 +2094,7 @@ validate = false
             home.join(".nvm"),   // process_exec but absent
             home.join("work"),   // ordinary grant
         ];
-        let found = r.write_grants_over_exec_tool_dirs(&home);
+        let found = r.write_grants_over_exec_tool_dirs(&home, &[]);
 
         let rustup = home.join(".rustup").to_string_lossy().into_owned();
         assert!(
@@ -2098,11 +2115,72 @@ validate = false
         // The other direction of the overlap: a grant INSIDE an exec tool dir
         // loses the same right.
         r.allow_write = vec![home.join(".rustup/toolchains")];
-        let found = r.write_grants_over_exec_tool_dirs(&home);
+        let found = r.write_grants_over_exec_tool_dirs(&home, &[]);
         assert_eq!(
             found.len(),
             1,
             "a grant inside an exec tool dir must be reported too: {found:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #343: the agent's own directories lose execute to an `allow.write`
+    /// grant exactly like a tool directory does — `~/.pi/agent/bin` and
+    /// `~/.cache/opencode/bin` are `process_exec` with a writable parent, so a
+    /// grant on the parent silently withdraws exec from the managed binaries.
+    /// Threaded in as a candidate list, so the warning has to be told about
+    /// them; this is the test that says it was.
+    #[test]
+    fn write_grant_shadowing_an_agent_exec_dir_is_reported() {
+        let home = std::env::temp_dir().join(format!(
+            "cplt-agent-exec-warn-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(home.join(".pi/agent/bin")).expect("temp home");
+        std::fs::create_dir_all(home.join(".pi/agent/sessions")).expect("temp home");
+
+        let agent_dirs = vec![
+            crate::agent::AgentDir {
+                path: home.join(".pi/agent"),
+                write: true,
+                map_exec: false,
+                process_exec: false,
+                write_files: vec![],
+            },
+            crate::agent::AgentDir {
+                path: home.join(".pi/agent/bin"),
+                write: false,
+                map_exec: false,
+                process_exec: true,
+                write_files: vec![],
+            },
+        ];
+
+        let mut r = Config::default()
+            .merge(CliFlags::default())
+            .expect("default config merges");
+        r.allow_write = vec![
+            home.join(".pi"),                // ancestor: swallows the exec bin dir
+            home.join(".pi/agent/sessions"), // sibling: nothing executable shadowed
+        ];
+        let found = r.write_grants_over_exec_tool_dirs(&home, &agent_dirs);
+
+        let bin = home.join(".pi/agent/bin").to_string_lossy().into_owned();
+        assert!(
+            found
+                .iter()
+                .any(|(g, dirs)| *g == home.join(".pi") && dirs.contains(&bin)),
+            "a grant containing an agent exec dir must be reported and name it: {found:?}"
+        );
+        assert_eq!(
+            found.len(),
+            1,
+            "a grant that shadows nothing executable must stay silent: {found:?}"
         );
 
         std::fs::remove_dir_all(&home).ok();

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -583,38 +583,104 @@ fn grants_over_trusted_paths(
 ///
 /// Built here rather than at the call site so the wording — including the one
 /// thing a format string gets wrong every time, pluralisation — is testable.
-pub fn exec_tool_dir_warning(granted: &Path, dirs: &[String]) -> String {
+pub fn exec_tool_dir_warning(
+    granted: &Path,
+    dirs: &[String],
+    home: &Path,
+    agent_dirs: &[crate::agent::AgentDir],
+) -> String {
     let list = dirs.join(", ");
-    // Two different overlaps, and the user can only act on the right one: a
-    // grant *inside* the tool dir and a grant that swallows it are the same
-    // shadowing seen from opposite ends.
-    let overlap = if dirs.iter().any(|d| granted.starts_with(d)) {
+    let noun = if dirs.len() == 1 {
+        "directory"
+    } else {
+        "directories"
+    };
+    // Three ways the grant and the directory can overlap, and the user can only
+    // act on the right one: the grant *is* the directory, sits inside it, or
+    // swallows it. The first is the common shape for an agent config dir, whose
+    // whole path is what someone puts in `allow.write`.
+    let overlap = if dirs.len() == 1 && Path::new(&dirs[0]) == granted {
+        format!("allow.write grants the executable {noun} {list} itself.")
+    } else if dirs.iter().any(|d| granted.starts_with(d)) {
         format!(
             "allow.write grants {} — inside the executable tool directory {list}.",
             granted.display()
         )
     } else {
-        let noun = if dirs.len() == 1 {
-            "directory"
-        } else {
-            "directories"
-        };
         format!(
             "allow.write grants {}, which contains the executable tool {noun} {list}.",
             granted.display()
         )
     };
+    // The Linux half is only true where the *grant* is what pairs write with
+    // execute. A directory already writable by default is write+execute on
+    // Linux with or without the grant, so telling its owner to narrow the grant
+    // to close a hole would send them after a hole the grant did not open.
+    let (unchanged, gap): (Vec<&String>, Vec<&String>) = dirs
+        .iter()
+        .partition(|d| default_writable(Path::new(d.as_str()), home, agent_dirs));
+    let join = |v: &[&String]| v.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ");
+    use std::fmt::Write as _;
+    let mut linux = String::new();
+    if !gap.is_empty() {
+        let stays = if gap.len() == 1 { "stays" } else { "stay" };
+        let _ = write!(
+            linux,
+            " On Linux, Landlock cannot subtract a grant, so {} {stays} writable AND \
+             executable instead — the hole this deny closes on macOS is left open there.",
+            join(&gap)
+        );
+    }
+    if !unchanged.is_empty() {
+        let is = if unchanged.len() == 1 { "is" } else { "are" };
+        let _ = write!(
+            linux,
+            " On Linux {} {is} writable by default, with or without this grant, so \
+             nothing changes there and only macOS is affected.",
+            join(&unchanged)
+        );
+    }
     format!(
         "{overlap}\n  \
          cplt denies execute across an allow.write tree, because a tree that is both \
          writable and executable lets an agent drop a binary and run it. On macOS that \
          deny is enforced, so binaries under the tool directory will not run in this \
-         session. On Linux, Landlock cannot subtract a grant, so the tree stays \
-         writable AND executable instead — the hole this deny closes on macOS is left \
-         open there.\n  \
+         session.{linux}\n  \
          Narrow the write grant so it does not cover the tool directory, or use \
          allow.exec on a tree that does not overlap it."
     )
+}
+
+/// Is `path` writable by default — before any `allow.write` grant — through its
+/// own rule or an ancestor's?
+///
+/// Landlock unions a path's ancestors rather than letting a later rule subtract
+/// from an earlier one (see the `EXEC_IN_WRITABLE` and cache carve-out comments
+/// in `sandbox_landlock.rs`), so a `process_exec` directory sitting under a
+/// writable tree is already writable AND executable on Linux. Every agent
+/// directory candidate #343 added has that shape: `~/.copilot` is `write: true`
+/// itself, and `~/.pi/agent/bin` and `~/.cache/opencode/bin` inherit write from
+/// `~/.pi/agent` and `~/.cache`.
+///
+/// Derived from the *write* side of the same three sources the exec candidates
+/// come from, so it cannot drift into a second hand-maintained list.
+fn default_writable(path: &Path, home: &Path, agent_dirs: &[crate::agent::AgentDir]) -> bool {
+    crate::sandbox::HOME_TOOL_DIRS
+        .iter()
+        .filter(|d| d.write)
+        .map(|d| home.join(d.path))
+        .chain(
+            crate::sandbox::app_dirs()
+                .iter()
+                .flat_map(|a| a.write_paths(home)),
+        )
+        .chain(
+            agent_dirs
+                .iter()
+                .filter(|d| d.write)
+                .map(|d| d.path.clone()),
+        )
+        .any(|w| path.starts_with(&w))
 }
 
 /// Which `allow.write` grants overlap one of `paths`, in either direction, as
@@ -779,12 +845,14 @@ impl Resolved {
     /// become `ToolRoot`s rather than `allow.write` grants (#152), so they
     /// cannot be the grant this warning is about.
     ///
-    /// `agent_dirs` is the active agent's own directories, which lose execute
-    /// the same way (#343): `~/.pi/agent/bin` and `~/.cache/opencode/bin` are
+    /// `agent_dirs` is the agent's own directories, which lose execute the same
+    /// way on macOS (#343): `~/.pi/agent/bin` and `~/.cache/opencode/bin` are
     /// `process_exec` with a writable parent, so `allow.write = ["~/.pi"]`
-    /// withdraws exec from the managed binaries the agent expects to run. They
-    /// are passed in rather than derived here because the set depends on the
-    /// resolved agent, which `Resolved` does not know.
+    /// withdraws exec from the managed binaries the agent expects to run. On
+    /// Linux those are already write+execute through the ancestor union and the
+    /// grant takes nothing away — [`exec_tool_dir_warning`] says which case each
+    /// directory is. They are passed in rather than derived here because the set
+    /// depends on which agent's profile is built, which `Resolved` does not know.
     #[must_use]
     pub fn write_grants_over_exec_tool_dirs(
         &self,
@@ -810,6 +878,23 @@ impl Resolved {
             .map(|p| p.to_string_lossy().into_owned())
             .collect();
         grants_overlapping(&self.allow_write, &dirs)
+    }
+
+    /// Every rendered launch warning about an `allow.write` grant shadowing a
+    /// directory this run grants execute on.
+    ///
+    /// Takes the agent whose profile is actually built, not the one auto-detected
+    /// for the session. `cplt exec` and `cplt check` always build the Shell
+    /// profile, so naming Copilot's `~/.copilot` there would blame a grant for
+    /// an effect a session that never emits Copilot's rules cannot have (#343).
+    #[must_use]
+    pub fn exec_tool_dir_warnings(&self, home: &Path, agent: crate::agent::Agent) -> Vec<String> {
+        let mut agent_dirs = agent.config_dirs(home);
+        crate::agent::canonicalize_agent_dirs(&mut agent_dirs);
+        self.write_grants_over_exec_tool_dirs(home, &agent_dirs)
+            .into_iter()
+            .map(|(granted, dirs)| exec_tool_dir_warning(&granted, &dirs, home, &agent_dirs))
+            .collect()
     }
 
     /// Print comprehensive sandbox configuration summary to stderr.
@@ -2194,7 +2279,8 @@ validate = false
     #[test]
     fn exec_tool_dir_warning_pluralises_both_ways() {
         let granted = PathBuf::from("/home/u");
-        let one = exec_tool_dir_warning(&granted, &["/home/u/.rustup".to_string()]);
+        let home = PathBuf::from("/home/u");
+        let one = exec_tool_dir_warning(&granted, &["/home/u/.rustup".to_string()], &home, &[]);
         assert!(
             one.contains("contains the executable tool directory /home/u/.rustup."),
             "one shadowed dir must read \"directory\": {one}"
@@ -2203,6 +2289,8 @@ validate = false
         let many = exec_tool_dir_warning(
             &granted,
             &["/home/u/.rustup".to_string(), "/home/u/.nvm".to_string()],
+            &home,
+            &[],
         );
         assert!(
             many.contains(
@@ -2217,6 +2305,100 @@ validate = false
         }
     }
 
+    /// #343 review: the Linux sentence was unconditional, and it is false for
+    /// every agent directory the same change added. Landlock unions a path's
+    /// ancestors, so a `process_exec` dir under a writable tree is already
+    /// write+execute there and the grant takes nothing away — telling its owner
+    /// the grant opened a hole sends them to drop a grant that changes nothing.
+    /// Asserted per directory, including the mixed grant that covers both kinds.
+    #[test]
+    fn exec_tool_dir_warning_scopes_the_linux_sentence_to_where_it_is_true() {
+        let home = PathBuf::from("/home/u");
+        let copilot = crate::agent::AgentDir {
+            path: home.join(".copilot"),
+            write: true,
+            map_exec: true,
+            process_exec: true,
+            write_files: vec![],
+        };
+        let rustup = home.join(".rustup").to_string_lossy().into_owned();
+        let copilot_dir = copilot.path.to_string_lossy().into_owned();
+        // Inherits write from the `.cache` HOME_TOOL_DIRS entry, not from a
+        // rule of its own — the ancestor half of the same question.
+        let opencode = home
+            .join(".cache/opencode/bin")
+            .to_string_lossy()
+            .into_owned();
+
+        // Not writable by default: the grant really is what pairs write with
+        // execute, and Landlock really cannot take it back.
+        let w = exec_tool_dir_warning(
+            &home,
+            std::slice::from_ref(&rustup),
+            &home,
+            std::slice::from_ref(&copilot),
+        );
+        assert!(
+            w.contains(&format!("so {rustup} stays writable AND executable")),
+            "a dir that is read-only by default keeps the Linux hole sentence: {w}"
+        );
+        assert!(
+            !w.contains("writable by default"),
+            "nothing here is writable by default: {w}"
+        );
+
+        // Writable by default through its own rule, and through an ancestor's.
+        for (dir, dirs) in [
+            (&copilot_dir, vec![copilot_dir.clone()]),
+            (&opencode, vec![opencode.clone()]),
+        ] {
+            let w = exec_tool_dir_warning(&home, &dirs, &home, std::slice::from_ref(&copilot));
+            assert!(
+                !w.contains("left open there"),
+                "the grant opens no hole on Linux for {dir}: {w}"
+            );
+            assert!(
+                w.contains(&format!("On Linux {dir} is writable by default")),
+                "say what Linux actually does for {dir}: {w}"
+            );
+        }
+
+        // One grant over both kinds: each sentence names only its own dirs.
+        let both = exec_tool_dir_warning(
+            &home,
+            &[rustup.clone(), copilot_dir.clone()],
+            &home,
+            std::slice::from_ref(&copilot),
+        );
+        assert!(
+            both.contains(&format!("so {rustup} stays writable AND executable")),
+            "the hole sentence must name only the dir it is true for: {both}"
+        );
+        assert!(
+            both.contains(&format!("On Linux {copilot_dir} is writable by default")),
+            "the no-op sentence must name only the dir it is true for: {both}"
+        );
+    }
+
+    /// The nit the same review found: `granted.starts_with(dir)` is true when
+    /// they are equal, so `allow.write = ["~/.copilot"]` rendered "grants
+    /// /home/u/.copilot — inside the executable tool directory /home/u/.copilot".
+    /// Granting an agent's config dir by its own full path is the common shape.
+    #[test]
+    fn exec_tool_dir_warning_names_a_grant_on_the_directory_itself() {
+        let granted = PathBuf::from("/home/u/.copilot");
+        let w = exec_tool_dir_warning(
+            &granted,
+            &["/home/u/.copilot".to_string()],
+            &PathBuf::from("/home/u"),
+            &[],
+        );
+        assert!(
+            w.contains("grants the executable directory /home/u/.copilot itself."),
+            "a grant equal to the directory must not read as \"inside\" it: {w}"
+        );
+    }
+
     /// A grant *inside* a tool dir is the same shadowing from the other end,
     /// and gets the wording the user can act on — no pluralisation involved,
     /// since the grant sits in exactly one tree.
@@ -2225,6 +2407,8 @@ validate = false
         let w = exec_tool_dir_warning(
             &PathBuf::from("/home/u/.rustup/toolchains"),
             &["/home/u/.rustup".to_string()],
+            &PathBuf::from("/home/u"),
+            &[],
         );
         assert!(
             w.contains("inside the executable tool directory /home/u/.rustup."),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1652,16 +1652,6 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         ));
     }
 
-    // #243 closed the write-then-exec hole by denying process-exec across an
-    // allow.write tree. Nothing is dropped — the write grant is honoured in
-    // full — but a tool directory swallowed by that grant loses the execute
-    // right it had by default, and the tool then fails with nothing pointing
-    // back at the grant. Narrow: only fires where a process-exec tool dir is
-    // actually shadowed, so the ordinary `allow.write` on a work tree is silent.
-    for (granted, dirs) in resolved.write_grants_over_exec_tool_dirs(&home_dir) {
-        ui::warn(&cplt::config::exec_tool_dir_warning(&granted, &dirs));
-    }
-
     // Show unapproved permissions warning (non-fatal — deny-default keeps us safe)
     if !unapproved_proposals.is_empty() && !resolved.quiet {
         ui::warn(&format!(
@@ -1739,6 +1729,24 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
 
     if !resolved.quiet {
         ui::info(&format!("Agent:    {}", active_agent.display_name()));
+    }
+
+    // #243 closed the write-then-exec hole by denying process-exec across an
+    // allow.write tree. Nothing is dropped — the write grant is honoured in
+    // full — but a tool directory swallowed by that grant loses the execute
+    // right it had by default, and the tool then fails with nothing pointing
+    // back at the grant. Narrow: only fires where a process-exec tool dir is
+    // actually shadowed, so the ordinary `allow.write` on a work tree is silent.
+    // After agent resolution, not with the other grant warnings above, because
+    // the agent's own exec dirs are part of the candidate set (#343) and they
+    // depend on which agent is running. Canonicalized to match `allow.write`,
+    // which `resolve_config_path` already resolved.
+    {
+        let mut agent_dirs = active_agent.config_dirs(&home_dir);
+        agent::canonicalize_agent_dirs(&mut agent_dirs);
+        for (granted, dirs) in resolved.write_grants_over_exec_tool_dirs(&home_dir, &agent_dirs) {
+            ui::warn(&cplt::config::exec_tool_dir_warning(&granted, &dirs));
+        }
     }
 
     // Hint about API keys for agents that need them

--- a/src/main.rs
+++ b/src/main.rs
@@ -1305,6 +1305,23 @@ struct ResolvedContext {
     unapproved_proposals: Vec<String>,
 }
 
+/// Warn about `allow.write` grants that shadow a directory this run grants
+/// execute on (#243, #343).
+///
+/// `agent` is the agent whose profile is actually built, not the one detected
+/// for the session: `cplt exec` and `cplt check` always build Shell, and a
+/// warning naming Copilot's `~/.copilot` there would describe an effect that
+/// session cannot have.
+fn warn_exec_tool_dir_shadowing(
+    resolved: &config::Resolved,
+    home_dir: &std::path::Path,
+    agent: agent::Agent,
+) {
+    for w in resolved.exec_tool_dir_warnings(home_dir, agent) {
+        ui::warn(&w);
+    }
+}
+
 /// Load config, merge CLI flags, resolve paths, detect agent, print info messages.
 fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContext> {
     // Canonicalize CLI paths for consistency with config path handling
@@ -1729,24 +1746,6 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
 
     if !resolved.quiet {
         ui::info(&format!("Agent:    {}", active_agent.display_name()));
-    }
-
-    // #243 closed the write-then-exec hole by denying process-exec across an
-    // allow.write tree. Nothing is dropped — the write grant is honoured in
-    // full — but a tool directory swallowed by that grant loses the execute
-    // right it had by default, and the tool then fails with nothing pointing
-    // back at the grant. Narrow: only fires where a process-exec tool dir is
-    // actually shadowed, so the ordinary `allow.write` on a work tree is silent.
-    // After agent resolution, not with the other grant warnings above, because
-    // the agent's own exec dirs are part of the candidate set (#343) and they
-    // depend on which agent is running. Canonicalized to match `allow.write`,
-    // which `resolve_config_path` already resolved.
-    {
-        let mut agent_dirs = active_agent.config_dirs(&home_dir);
-        agent::canonicalize_agent_dirs(&mut agent_dirs);
-        for (granted, dirs) in resolved.write_grants_over_exec_tool_dirs(&home_dir, &agent_dirs) {
-            ui::warn(&cplt::config::exec_tool_dir_warning(&granted, &dirs));
-        }
     }
 
     // Hint about API keys for agents that need them
@@ -2620,6 +2619,8 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         active_agent,
         unapproved_proposals: _,
     } = resolve_context(&cli, false)?;
+
+    warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
 
     // Probe the host for everything the sandbox profile depends on.
     let probe = HostProbe::probe(&mut resolved, &home_dir, &project_dir);
@@ -3623,6 +3624,11 @@ fn run_exec_command(
     // Always use the Shell sandbox policy
     let active_agent = agent::Agent::Shell;
 
+    // Shell, not the agent `resolve_context` detected: exec builds the Shell
+    // profile, so a warning about another agent's directories would name an
+    // effect this session cannot have (#343).
+    warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
+
     // Build the resolved Shell sandbox (discovery → proxy → prepare). Shared
     // with `cplt check`, which runs its probes under the identical policy.
     let AssembledSandbox {
@@ -4006,6 +4012,9 @@ fn run_check_command(
         active_agent,
         unapproved_proposals: _,
     } = resolve_context(cli, true)?;
+
+    // Shell, not `active_agent`: `check` probes under the Shell profile.
+    warn_exec_tool_dir_shadowing(&resolved, &home_dir, agent::Agent::Shell);
 
     // check prints its own report; never prompt.
     resolved.yes = true;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4203,6 +4203,54 @@ paths = [
         );
     }
 
+    /// #343 review: `exec` ignores the agent `resolve_context` detected and
+    /// always builds the Shell profile, so a warning about the detected agent's
+    /// directories describes a session that was never assembled. The tool-dir
+    /// half of the same warning must stay live on `exec`, or this test would
+    /// pass on a warning that had simply stopped working.
+    #[test]
+    fn e2e_exec_does_not_warn_about_an_agent_it_does_not_run() {
+        require_sandbox!();
+        let fake_home = std::env::temp_dir().join(format!(
+            ".cplt-e2e-exec-agent-warn-{}",
+            FAKE_COPILOT_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&fake_home);
+        std::fs::create_dir_all(fake_home.join(".copilot")).unwrap();
+        std::fs::create_dir_all(fake_home.join(".rustup")).unwrap();
+
+        let output = cplt_cmd()
+            .args([
+                "--no-validate",
+                "--agent",
+                "copilot",
+                "--allow-write",
+                fake_home.join(".copilot").to_str().unwrap(),
+                "--allow-write",
+                fake_home.join(".rustup").to_str().unwrap(),
+                "exec",
+                "--",
+                "/usr/bin/true",
+            ])
+            .env("HOME", fake_home.to_str().unwrap())
+            .current_dir(project_dir())
+            .output()
+            .expect("cplt exec should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(".rustup"),
+            "exec must still warn about a shadowed tool directory: {stderr}"
+        );
+        assert!(
+            !stderr.contains(".copilot"),
+            "exec builds the Shell profile and never emits Copilot's rules, so it \
+             must not blame the grant for withdrawing exec there: {stderr}"
+        );
+
+        let _ = std::fs::remove_dir_all(&fake_home);
+    }
+
     #[test]
     fn e2e_exec_exit_code_pass_through() {
         require_sandbox!();


### PR DESCRIPTION
#322 added a warning when an `allow.write` grant swallows a `process_exec` tool directory, because #243 makes such a grant silently withdraw execute from the tree. The candidate list covered `HOME_TOOL_DIRS` and app dirs, but not the active agent's own directories.

So `allow.write = ["~/.pi"]` still withdraws exec from `~/.pi/agent/bin` with nothing pointing back at the grant.

`write_grants_over_exec_tool_dirs` now takes the resolved agent's dirs as a third candidate source, filtered on `process_exec`. `Resolved` does not know which agent is running, so the caller supplies them; the warning loop moved in `main.rs` to just after agent resolution, and canonicalizes the dirs to match the already-resolved `allow.write` paths.

Agent dirs that qualify on current main:

- `~/.pi/agent/bin` — `write:false`, writable parent. The case from the issue.
- `~/.cache/opencode/bin` — same shape, not named in the issue.
- `~/.copilot` — `write:true` and `process_exec:true`. It qualifies: `emit_user_write_exec_denies` appends its denies after the agent-dir allows, SBPL is last-match-wins, and `~/.copilot` is not in `EXEC_IN_WRITABLE`. Keeping the filter as plain `process_exec` rather than adding `!write` avoids hiding it.

One behavioural consequence of the move: with no agent installed and no `--agent`, `run()` bails before the warning. That path errors out regardless, and `check` / `--print-profile` still reach it.

New lib test covers both directions; deleting the threading fails it while the existing tool-dir test still passes.

The `~/.copilot` AgentDir grant in `sandbox_landlock.rs` is untouched — #324 remains open.

Closes #343