### PR TITLE
fix(config): remove the [audit] section instead of accepting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ cplt init --global    # generate a personal ~/.config/cplt/config.toml
 
 It knows JVM (Gradle/Maven), Node.js, Docker, Python, Rust, Go, Playwright, Spring Boot, Ktor, TestContainers, Next.js, Vite, Flyway, Cypress, and environment secrets from `.env.example`. Dangerous permissions come out of the generator with a risk warning attached. `--global` looks at machine-level things instead: Playwright browsers, GPG signing, registry credentials, alternative agents.
 
-Some keys are global-only and rejected from `.cplt.toml` because they are machine-specific or a local preference: `sandbox.agent`, `sandbox.quiet`, `sandbox.yes`, `sandbox.validate`, `sandbox.scratch_dir`, `sandbox.pass_env`, `sandbox.inherit_env`, `sandbox.allow_cache_exec`, `sandbox.allow_cache_exec_any`, `proxy.enabled`, `proxy.port`, `proxy.log_file`, `proxy.log_level`, `proxy.blocked_domains`, `proxy.allowed_domains`, and every `[gh_guard]`, `[git_guard]`, and `[audit]` key.
+Some keys are global-only and rejected from `.cplt.toml` because they are machine-specific or a local preference: `sandbox.agent`, `sandbox.quiet`, `sandbox.yes`, `sandbox.validate`, `sandbox.scratch_dir`, `sandbox.pass_env`, `sandbox.inherit_env`, `sandbox.allow_cache_exec`, `sandbox.allow_cache_exec_any`, `proxy.enabled`, `proxy.port`, `proxy.log_file`, `proxy.log_level`, `proxy.blocked_domains`, `proxy.allowed_domains`, and every `[gh_guard]` and `[git_guard]` key.
 
 Full details, including the trust model, path expansion rules, and the complete config file reference: [docs/configuration.md](docs/configuration.md).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,6 @@ The settings below are machine-specific or local CLI preferences, so `.cplt.toml
 | all `[proxy.subscriptions]` keys | subscription sources are security-sensitive, and a repo must not be able to add one |
 | all `[gh_guard]` keys | guard policy is configured globally, not per-repo |
 | all `[git_guard]` keys | guard policy is configured globally, not per-repo |
-| all `[audit]` keys | audit destination and level are a local concern |
 
 ### Removing values
 
@@ -170,7 +169,7 @@ cplt config validate                      # check for syntax errors and unknown 
 
 ## Configuration file
 
-The config file lives at `~/.config/cplt/config.toml`. `cplt config init` writes a commented starter template there. It covers `[proxy]`, `[proxy.subscriptions]`, `[allow]`, `[deny]`, `[sandbox]`, `[gh_guard]`, `[git_guard]`, and `[audit]`, with every key commented out and documented inline, so a fresh file changes nothing until you uncomment something. Run it and read the result rather than copying a snippet from here, since the template is generated from `src/config/path.rs` and moves with the code:
+The config file lives at `~/.config/cplt/config.toml`. `cplt config init` writes a commented starter template there. It covers `[proxy]`, `[proxy.subscriptions]`, `[allow]`, `[deny]`, `[sandbox]`, `[gh_guard]`, and `[git_guard]`, with every key commented out and documented inline, so a fresh file changes nothing until you uncomment something. Run it and read the result rather than copying a snippet from here, since the template is generated from `src/config/path.rs` and moves with the code:
 
 ```bash
 cplt config init

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -512,18 +512,6 @@ pub fn display_config(loaded: Option<&LoadedConfig>) {
         );
     }
 
-    // [audit] section
-    println!("{blue}[cplt]{nc}");
-    println!("{blue}[cplt]{nc}  [audit]");
-    println!(
-        "{blue}[cplt]{nc}    enabled               = {}{}",
-        c.audit.enabled.unwrap_or(false),
-        src(c.audit.enabled.is_some())
-    );
-    if let Some(ref dest) = c.audit.destination {
-        println!("{blue}[cplt]{nc}    destination           = {dest}");
-    }
-
     println!("{blue}[cplt]{nc} ──────────────────────────────────────────────────────");
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,9 +38,9 @@ pub use repo::{
     set_repo_value_in_doc,
 };
 pub use types::{
-    AllowConfig, AuditConfig, BlocklistSource, CliFlags, Config, DenyConfig, EnforcementMode,
-    FeatureToggle, GhGuardConfig, GhGuardPolicy, GitGuardConfig, GitGuardPolicy, GitPushRule,
-    LoadedConfig, Preset, ProxyConfig, Resolved, ResolvedPushRule, SandboxConfig,
-    SubscriptionsConfig, UnknownCommandPolicy,
+    AllowConfig, BlocklistSource, CliFlags, Config, DenyConfig, EnforcementMode, FeatureToggle,
+    GhGuardConfig, GhGuardPolicy, GitGuardConfig, GitGuardPolicy, GitPushRule, LoadedConfig,
+    Preset, ProxyConfig, Resolved, ResolvedPushRule, SandboxConfig, SubscriptionsConfig,
+    UnknownCommandPolicy,
 };
 pub use validation::{ConfigDiagnostic, DiagnosticLevel, validate_config};

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -314,14 +314,6 @@ pub fn default_config_contents() -> String {
 # remote = "fork"
 # branches = ["agent/*"]
 # force = false
-
-# ── audit logging ───────────────────────────────────────────────────────────
-# Global audit log for all sandbox gate decisions.
-# [audit]
-# enabled = false
-# destination = "stderr"      # "stderr" or file path
-# level = "blocked"           # "blocked" | "decisions" | "all"
-# format = "text"             # "text" | "jsonl"
 "#
     .to_string()
 }

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -535,40 +535,31 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         default_display: "[]",
         description: "Structured push exceptions. Each entry specifies remote/branches/force conditions under which push is allowed.",
     },
-    // [audit]
-    ConfigKeyInfo {
-        section: "audit",
-        key: "enabled",
-        value_type: ConfigValueType::Bool,
-        dangerous: false,
-        default_display: "false",
-        description: "Enable audit logging for all sandbox gate decisions.",
-    },
-    ConfigKeyInfo {
-        section: "audit",
-        key: "destination",
-        value_type: ConfigValueType::Str,
-        dangerous: false,
-        default_display: "stderr",
-        description: "Where to write audit entries: \"stderr\" or a file path.",
-    },
-    ConfigKeyInfo {
-        section: "audit",
-        key: "level",
-        value_type: ConfigValueType::Str,
-        dangerous: false,
-        default_display: "blocked",
-        description: "What to log: \"blocked\" (only blocked), \"decisions\" (all gate decisions), or \"all\" (including passthrough).",
-    },
-    ConfigKeyInfo {
-        section: "audit",
-        key: "format",
-        value_type: ConfigValueType::Str,
-        dangerous: false,
-        default_display: "text",
-        description: "Output format: \"text\" (human-readable) or \"jsonl\" (machine-parseable).",
-    },
 ];
+
+/// Sections removed from the registry, with the message shown when one is
+/// still named — by `cplt config set/get` or by a config file left on disk.
+///
+/// A key with no consumer must not be quietly accepted (AGENTS.md, "No silent
+/// grants"), and once removed it must not degrade into a bare "unknown key"
+/// either: someone who set it believed it did something, and the message is
+/// the only place that can say otherwise.
+pub(super) const REMOVED_SECTIONS: &[(&str, &str)] = &[(
+    "audit",
+    "the [audit] section was removed: nothing ever read it, so setting it only \
+     looked like it turned auditing on (issue #309). Nothing replaces it yet. \
+     Two working keys are often what people wanted: 'sandbox.audit' (the \
+     post-session project-change report, on by default) and 'proxy.log_file' \
+     (one line per proxied CONNECT). Delete the [audit] section from your config",
+)];
+
+/// The removal message for a section, if it was removed.
+pub(super) fn removed_section(section: &str) -> Option<&'static str> {
+    REMOVED_SECTIONS
+        .iter()
+        .find(|(name, _)| *name == section)
+        .map(|(_, message)| *message)
+}
 
 /// Returns all registered config keys. Used by tests to ensure every key is
 /// covered by `config show` output and other config commands.
@@ -583,6 +574,10 @@ pub fn lookup_key(dotted: &str) -> Result<&'static ConfigKeyInfo, ConfigError> {
             "invalid key format '{dotted}': expected section.key (e.g., sandbox.quiet)"
         ))
     })?;
+
+    if let Some(message) = removed_section(section) {
+        return Err(ConfigError::Validation(message.to_string()));
+    }
 
     CONFIG_KEYS
         .iter()
@@ -960,12 +955,6 @@ pub(super) const BOOL_KEYS_EXEMPT: &[(&str, &str, &str)] = &[
         "use_bubblewrap",
         "resolves to Option<bool>, not bool: `None` means auto-detect, a third \
          state the bool ladder cannot express",
-    ),
-    (
-        "audit",
-        "enabled",
-        "the [audit] section is parsed and displayed but has no consumer yet — \
-         it resolves to nothing, so there is no precedence to describe",
     ),
 ];
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -75,7 +75,6 @@ pub struct Config {
     pub sandbox: SandboxConfig,
     pub gh_guard: GhGuardConfig,
     pub git_guard: GitGuardConfig,
-    pub audit: AuditConfig,
 }
 
 /// Enforcement mode for security gates — controls rollout aggressiveness.
@@ -419,22 +418,6 @@ pub struct GitPushRule {
     pub branches: Vec<String>,
     /// Allow force push in this rule (default: false).
     pub force: Option<bool>,
-}
-
-/// `[audit]` — global audit logging for sandbox decisions.
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(default)]
-pub struct AuditConfig {
-    /// Enable audit logging (default: false).
-    pub enabled: Option<bool>,
-    /// Where to write audit entries: "stderr" or a file path (default: "stderr").
-    pub destination: Option<String>,
-    /// What to log: "blocked" (only blocked), "decisions" (all gate decisions),
-    /// "all" (includes allowed passthrough). Default: "blocked".
-    pub level: Option<String>,
-    /// Output format: "text" (human-readable) or "jsonl" (machine-parseable).
-    /// Default: "text".
-    pub format: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -69,6 +69,13 @@ fn top_level_keys() -> Vec<&'static str> {
 /// Candidate keys for the suggestion come from `CONFIG_KEYS`, so suggestions
 /// automatically cover any option present in the registry.
 pub(super) fn describe_unknown_key(path: &str) -> String {
+    // A section that was removed, rather than mistyped, gets the removal
+    // message: "unknown key" would leave someone who once set it none the
+    // wiser about why it stopped existing, or what actually works.
+    let section = path.split('.').next().unwrap_or(path);
+    if let Some(message) = super::registry::removed_section(section) {
+        return message.to_string();
+    }
     // Split off the LAST segment: everything before it is the enclosing table
     // path. Nested tables exist ([proxy.subscriptions], [[git_guard.allow_push]]),
     // and splitting on the FIRST dot would report `proxy.subscriptions.allow` as

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -5581,6 +5581,65 @@ fn config_parses_allow_tmp_exec() {
 // Config validation (unknown key detection)
 // ============================================================
 
+/// The [audit] section was settable, displayed, and read by nothing (#309).
+/// `cplt config set audit.enabled true` must now refuse at the point of
+/// writing rather than store a line no code will ever consult, and the refusal
+/// must not read as a typo — it names why the section is gone and what works.
+#[test]
+fn audit_section_keys_are_refused_by_config_set() {
+    use cplt::config::lookup_key;
+    for key in [
+        "audit.enabled",
+        "audit.destination",
+        "audit.level",
+        "audit.format",
+    ] {
+        let err = lookup_key(key)
+            .err()
+            .unwrap_or_else(|| panic!("{key} must not be settable: nothing consumes it"))
+            .to_string();
+        assert!(
+            err.contains("[audit] section was removed") && err.contains("#309"),
+            "refusal must explain the removal, got: {err}"
+        );
+        assert!(
+            err.contains("sandbox.audit"),
+            "refusal must name the live post-session report key: {err}"
+        );
+    }
+}
+
+/// `sandbox.audit` is a different, working key — the post-session
+/// project-change report. Removing the [audit] section must not touch it.
+#[test]
+fn sandbox_audit_stays_a_real_key() {
+    use cplt::config::lookup_key;
+    assert!(
+        lookup_key("sandbox.audit").is_ok(),
+        "sandbox.audit is consumed by audit::run and must remain settable"
+    );
+}
+
+/// An `[audit]` block already on disk must still LOAD (unknown keys are
+/// ignored at runtime), and `config validate` must explain the removal rather
+/// than emit a bare "unknown key".
+#[test]
+fn stale_audit_section_validates_with_the_removal_message() {
+    use cplt::config::{Config, DiagnosticLevel, validate_config};
+    let toml = "[audit]\nenabled = true\ndestination = \"stderr\"\n";
+    assert!(
+        Config::parse(toml).is_ok(),
+        "a config file with a stale [audit] section must still load"
+    );
+    let diagnostics = validate_config(toml);
+    assert!(
+        diagnostics.iter().any(|d| d.level == DiagnosticLevel::Error
+            && d.message.contains("[audit] section was removed")),
+        "validate must explain the removal: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn validate_catches_typo_in_sandbox_key() {
     use cplt::config::{DiagnosticLevel, validate_config};
@@ -7107,12 +7166,6 @@ mode = "warn"
 prevent_push = true
 prevent_force_push = true
 protect_default_branch_only = false
-
-[audit]
-enabled = false
-destination = "stderr"
-level = "blocked"
-format = "text"
 "#;
 
     // Parse the fixture so coverage is checked per-section, not by a bare


### PR DESCRIPTION
`cplt config set audit.enabled true` succeeded, `cplt config show` echoed it back, and nothing in the tree ever read it. `audit.enabled` and `audit.destination` had one reader between them, `display.rs` printing them back to the user; `audit.level` and `audit.format` had none at all. So a developer turned on what looks like an audit log, got confirmation, and got no log.

That is the failure mode AGENTS.md and SECURITY.md name under no silent grants: a setting that cannot be honoured must fail loudly where it is written, never be accepted and quietly dropped. #309 lists three options; this takes the third, because there is no consumer to implement against and marking the key "unimplemented" would leave the write succeeding.

`AuditConfig`, `Config.audit`, the four registry keys, the `config show` block and the `config init` template entry are gone. A one-entry `REMOVED_SECTIONS` table in `registry.rs` is consulted by both `lookup_key` and `describe_unknown_key`, so `config set` and `config validate` explain why the section is gone and name the keys that do work, rather than emitting a bare "unknown key" with a nonsense edit-distance suggestion.

**A stale `[audit]` block on disk still loads.** Runtime loading is deliberately forward-compatible (`deserialize_collecting_unknowns`), so an existing config degrades to the standard ignored-key warning plus the removal message. Breaking those configs would have been a worse failure than the one being fixed.

**`sandbox.audit` is untouched and is a different key** — the post-session project-change report, resolved to `Resolved::audit` and consumed by `audit::run`. The removal message names it explicitly, along with `proxy.log_file`, so nobody reads this as deprecating the audit that does exist.

Tests: `config set` refuses all four keys with a message naming the removal and `sandbox.audit`; a guard that `sandbox.audit` stays a real key; a stale `[audit]` config validates with the removal message. Mutation check: restoring the registry entries and dropping the `lookup_key` short-circuit fails the refusal test and one existing net, 2 failed / 336 passed.

`cargo fmt --check`, `cargo test --lib` (965), `cargo test --test unit_tests` (338), `cargo clippy --all-targets -- -D warnings` all clean.

One judgement call for review: this removes the section rather than implementing an audit sink. If `[audit]` should instead gain a real consumer (#309's option 1), this is the wrong direction and should be dropped.

Closes #309
