### PR TITLE
fix(proxy): enforce an empty domain allowlist instead of allowing all

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -39,7 +39,7 @@ cplt config set proxy.log_file "~/.config/cplt/proxy.log"
 | `--proxy-forced` / `--no-proxy-forced` | Force **all** egress through the proxy (opt-in, default off): make the proxy mandatory and restrict kernel egress to the proxy port. Fails closed; conflicts with `--no-proxy`. See [Proxy-forced mode](#proxy-forced-mode). |
 | `--proxy-port <PORT>`       | Which port the proxy listens on (default: 0, OS-assigned ephemeral).                             |
 | `--blocked-domains <FILE>`  | Domains to block, one per line. Re-read every ~5s, so you can edit it live. |
-| `--allowed-domains <FILE>`  | Domains to allow. Only listed domains can connect. Validated at startup (fail-closed); re-read every ~5s. |
+| `--allowed-domains <FILE>`  | Domains to allow. Setting it turns the allowlist on, and only listed domains can connect — an empty file therefore blocks everything, and a missing file is a startup error. Re-read every ~5s. |
 | `--default-allowlist`       | Enable the agent's built-in default allowlist for this run (opt-in, default off): restrict egress to the agent's fail-closed domain set merged with `--allowed-domains`. See [Default allowlist](#default-allowlist-fail-closed-networking). |
 | `--allow-all-domains`       | Escape hatch: disable the default allowlist for this run and allow all domains (blocklist still applies). Also ignores any `--allowed-domains` file. |
 | `--proxy-log <FILE>`        | Append a line per connection to this file for post-session audit.                                |
@@ -147,7 +147,14 @@ proxy.business.githubcopilot.com
 telemetry.business.githubcopilot.com
 ```
 
-> **Note:** Both the allowlist and blocklist are re-read from disk every ~5 seconds (TTL-cached), so you can edit them live mid-session and changes take effect within seconds without restarting cplt. If a file becomes unreadable at runtime, the last-known-good list is kept (fail-safe). At startup, an unreadable allowlist makes cplt exit with an error (fail-closed).
+> **Setting `allowed_domains` is what turns the allowlist on, not the file's contents.** The two ways to say "no allowlist" are not the same thing:
+>
+> - **No `allowed_domains` key** (and no `--allowed-domains`, no `default_allowlist`): no allowlist, every domain is allowed. This is the default.
+> - **`allowed_domains` pointing at an empty or all-comment file**: an allowlist with nothing on it, so every domain is blocked.
+>
+> A configured `allowed_domains` file that does not exist is a startup error rather than a silent fallback to allow-all. Use `--allow-all-domains` to allow everything for a single run without editing config.
+
+> **Note:** Both the allowlist and blocklist are re-read from disk every ~5 seconds (TTL-cached), so you can edit them live mid-session and changes take effect within seconds without restarting cplt. If a file becomes unreadable or is deleted at runtime, the last-known-good list is kept (fail-safe); if it becomes *empty*, that is a real edit and the allowlist tightens to blocking everything. At startup, an unreadable or missing allowlist makes cplt exit with an error (fail-closed).
 >
 > The `allow_private_domains` list in `config.toml` is also re-read every ~5 seconds. Domains from other sources, meaning `--allow-private-domain` CLI flags and trust-approved `[propose.proxy] allow_private_domains` entries from a repo `.cplt.toml`, are preserved for the whole session regardless of config changes.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4036,6 +4036,19 @@ fn run_check_command(
     // Snapshot the effective net policy BEFORE prepare_shell_sandbox mutates
     // resolved (it only changes the proxy port and tool-path env, neither of
     // which affects domain/port classification, but snapshot early to be safe).
+    // Same fail-closed refusal the proxy makes at startup. Without it, `check net`
+    // would report BLOCKED-ALLOWLIST for every host when the configured file is
+    // missing or unreadable (parse_lines_file returns None for both, and
+    // build_net_policy would then see an active-but-empty allowlist) while the
+    // live run refuses to start at all. Check must not describe a state the proxy
+    // never reaches — that divergence is the defect this whole change fixes.
+    if !resolved.allow_all_domains
+        && let Some(ref path) = resolved.allowed_domains
+        && proxy::parse_lines_file(path).is_none()
+    {
+        ui::error(&proxy::missing_allowlist_error(path));
+        return Ok(ExitCode::FAILURE);
+    }
     let net_policy = build_net_policy(&resolved, active_agent);
 
     let AssembledSandbox {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2185,11 +2185,15 @@ fn start_proxy_if_enabled(
                 }
                 Err(e) => bail!("Failed to load allowed domains: {e}"),
             }
-        } else if !resolved.quiet {
-            ui::info(&format!(
-                "Domain allowlist file: {} (not found)",
-                path.display()
-            ));
+        } else {
+            // Fail closed, loudly. A configured allowlist whose file is absent
+            // used to print an informational line (suppressed by -q) and then
+            // run with no allowlist at all — the user asked for restricted
+            // egress and silently got allow-all. `DomainPolicy::build` refuses
+            // this too; the check is repeated here so the refusal arrives
+            // before anything else starts and carries the full explanation
+            // rather than being wrapped in "Failed to start proxy".
+            bail!("{}", proxy::missing_allowlist_error(path));
         }
     }
 
@@ -3906,6 +3910,13 @@ fn build_net_policy(resolved: &config::Resolved, agent: agent::Agent) -> proxy::
     } else {
         Vec::new()
     };
+    // Same intent bit `start_proxy_if_enabled` computes and hands the live
+    // proxy (via `DomainPolicy::build`). Without it, `cplt check net` would
+    // report ALLOWED for every host under an enabled-but-empty allowlist that
+    // the proxy blocks — a self-consistent wrong answer to the one command a
+    // user runs to verify the setup.
+    let allowlist_active = !default_allowlist.is_empty()
+        || (!resolved.allow_all_domains && resolved.allowed_domains.is_some());
     let allowed_domains = if default_allowlist.is_empty() {
         file_domains
     } else {
@@ -3939,6 +3950,7 @@ fn build_net_policy(resolved: &config::Resolved, agent: agent::Agent) -> proxy::
     proxy::NetPolicy {
         allowed_ports: ports,
         allowed_domains,
+        allowlist_active,
         blocked_domains,
         allow_localhost_ports: resolved.allow_localhost.clone(),
         allow_localhost_any: resolved.allow_localhost_any,
@@ -6651,6 +6663,83 @@ mod tests {
     }
 
     // ── `cplt check net` must MATCH the live proxy's verdict ──────────────
+
+    /// F03: `cplt check net` is the command a user runs to verify their
+    /// allowlist. It shared the proxy's `!allowed_domains.is_empty()` reading,
+    /// so an enabled-but-empty allowlist gave a self-consistent WRONG answer:
+    /// check said ALLOWED, and so did the proxy. Both now consult the same
+    /// intent bit, so check reports the block the proxy enforces.
+    #[test]
+    fn check_net_matches_the_proxy_for_an_enabled_but_empty_allowlist() {
+        let dir = std::env::temp_dir().join(format!(
+            "cplt-check-net-empty-allowlist-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("allowed.txt");
+        std::fs::write(&path, "# every domain revoked\n").unwrap();
+
+        let toml = format!(
+            "[proxy]\nallowed_domains = \"{}\"\n",
+            path.display().to_string().replace('\\', "\\\\")
+        );
+        let resolved = toml::from_str::<config::Config>(&toml)
+            .expect("config parses")
+            .merge(config::CliFlags::default())
+            .expect("config merges");
+
+        let policy = build_net_policy(&resolved, agent::Agent::Copilot);
+        assert!(
+            policy.allowlist_active,
+            "a configured allowed_domains file is an active allowlist even with zero entries"
+        );
+        assert!(policy.allowed_domains.is_empty());
+
+        // The live proxy's own snapshot of the same configuration.
+        let live = proxy::DomainPolicy::build(
+            proxy::PolicySpec {
+                blocked_file: dir.join("no-blocklist.txt"),
+                allowed_domains_file: Some(path),
+                ..Default::default()
+            },
+            std::time::Instant::now(),
+        )
+        .expect("live policy builds")
+        .net_policy(std::time::Instant::now());
+
+        for host in ["github.com", "api.githubcopilot.com", "evil.example"] {
+            let checked = proxy::classify_connect(&policy, host, 443);
+            let enforced = proxy::classify_connect(&live, host, 443);
+            assert_eq!(
+                checked, enforced,
+                "check net and the live proxy must agree about {host}"
+            );
+            assert_eq!(
+                checked,
+                proxy::NetVerdict::BlockedAllowlist,
+                "an allowlist with nothing on it blocks {host}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn check_net_reports_allow_all_when_no_allowlist_is_configured() {
+        // The no-regression half: with no allowlist configured at all, check
+        // and the proxy both report allow-all.
+        let resolved = toml::from_str::<config::Config>("")
+            .expect("config parses")
+            .merge(config::CliFlags::default())
+            .expect("config merges");
+        let policy = build_net_policy(&resolved, agent::Agent::Copilot);
+        assert!(!policy.allowlist_active);
+        assert_eq!(
+            proxy::classify_connect(&policy, "anything.example", 443),
+            proxy::NetVerdict::Allowed
+        );
+    }
 
     #[test]
     fn check_net_non_canonical_allowlist_matches_live_blocked() {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -15,7 +15,7 @@ use crate::ui;
 #[path = "proxy_domains.rs"]
 pub mod domains;
 
-pub use domains::{DomainPolicy, PolicySpec, parse_lines_file};
+pub use domains::{DomainPolicy, PolicySpec, missing_allowlist_error, parse_lines_file};
 
 /// Controls how much the proxy logs to stderr.
 /// The audit log file (if configured) always records everything regardless of this level.
@@ -462,15 +462,7 @@ impl ProxyState {
     /// Reads the current (cache-refreshed) allowlist and blocklist so
     /// [`classify_connect`] sees exactly what the live gates would see.
     fn net_policy(&self) -> NetPolicy {
-        let now = Instant::now();
-        NetPolicy {
-            allowed_ports: self.policy.allowed_ports.clone(),
-            allowed_domains: self.policy.allowed_domains(now),
-            blocked_domains: self.policy.blocked_domains(now),
-            allow_localhost_ports: self.policy.allow_localhost_ports.clone(),
-            allow_localhost_any: self.policy.allow_localhost_any,
-            private_domains: self.policy.private_domains(now),
-        }
+        self.policy.net_policy(Instant::now())
     }
 }
 
@@ -824,12 +816,24 @@ impl NetVerdict {
 /// Built either from a live [`ProxyState`] (via [`ProxyState::net_policy`]) or
 /// directly from resolved config by the `cplt check` command. The field values
 /// mean exactly what they mean inside [`handle_connect`]: `allowed_ports`
-/// already includes 443, `allowed_domains` is the *effective* (merged) allowlist
-/// where empty means allow-all.
+/// already includes 443, and `allowed_domains` is the *effective* (merged)
+/// allowlist.
+///
+/// Whether the allowlist *enforces* is `allowlist_active`, NOT
+/// `!allowed_domains.is_empty()`. The two differ in the case that matters: an
+/// allowlist the user configured that resolves to zero domains (an empty or
+/// all-comment file). Reading emptiness as "no allowlist" made that case
+/// allow-all — a restriction accepted and silently dropped, which is the
+/// failure mode `AGENTS.md` calls out as the one that gets people hurt.
 #[derive(Debug, Clone, Default)]
 pub struct NetPolicy {
     pub allowed_ports: Vec<u16>,
     pub allowed_domains: Vec<String>,
+    /// Whether a domain allowlist is configured at all: the agent's built-in
+    /// default allowlist (`proxy.default_allowlist`) or an explicit
+    /// `allowed_domains` file. `false` is the unconfigured default, which is
+    /// allow-all. `true` with an empty `allowed_domains` denies every domain.
+    pub allowlist_active: bool,
     pub blocked_domains: Vec<String>,
     pub allow_localhost_ports: Vec<u16>,
     pub allow_localhost_any: bool,
@@ -866,8 +870,13 @@ pub fn classify_connect(policy: &NetPolicy, host: &str, port: u16) -> NetVerdict
     if !localhost_connect_allowed && !policy.allowed_ports.contains(&port) {
         return NetVerdict::BlockedPort;
     }
+    // The intent bit, not the list length, decides enforcement: an enabled
+    // allowlist with zero entries denies everything. `!allowed_domains
+    // .is_empty()` is ORed in purely as a fail-closed backstop, so a caller
+    // that forgets to set `allowlist_active` still enforces the list it built
+    // rather than silently allowing all.
     if !localhost_connect_allowed
-        && !policy.allowed_domains.is_empty()
+        && (policy.allowlist_active || !policy.allowed_domains.is_empty())
         && !is_domain_match(&host, &policy.allowed_domains)
     {
         return NetVerdict::BlockedAllowlist;

--- a/src/proxy_domains.rs
+++ b/src/proxy_domains.rs
@@ -36,7 +36,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use crate::proxy::normalize_hostname;
+use crate::proxy::{NetPolicy, normalize_hostname};
 
 /// How often file-backed domain lists are re-read from disk.
 /// Within the TTL window, cached values are returned without I/O.
@@ -135,10 +135,12 @@ pub struct PolicySpec {
     /// Domains from cached blocklist subscriptions (#144), frozen at startup.
     /// UNIONed with `blocked_file`. Tighten-only: can only ever ADD blocks.
     pub subscription_blocklist: Vec<String>,
-    /// User allowlist file. Re-read every [`RELOAD_TTL`].
+    /// User allowlist file. Re-read every [`RELOAD_TTL`]. Setting this makes
+    /// the allowlist *active*: the file must exist at startup, and an empty one
+    /// denies every domain rather than allowing all of them.
     pub allowed_domains_file: Option<PathBuf>,
-    /// Allowlist domains from CLI/config, used when the file does not exist yet
-    /// (or when there is no file at all).
+    /// Allowlist domains from CLI/config, used when there is no file at all.
+    /// A configured-but-missing file is a startup error, not a fallback.
     pub allowed_domains_initial: Vec<String>,
     /// The agent's built-in fail-closed allowlist (#52), frozen at startup.
     /// Empty = feature off (unchanged allow-all).
@@ -174,6 +176,14 @@ pub struct DomainPolicy {
     pub allow_localhost_ports: Vec<u16>,
     /// Whether every localhost port is open.
     pub allow_localhost_any: bool,
+    /// Whether a domain allowlist is configured for this session — the agent's
+    /// built-in default allowlist or an explicit `allowed_domains` file.
+    ///
+    /// This is the *intent* bit the CONNECT gate consults. It is deliberately
+    /// not derived from `allowed_domains()` being non-empty: a configured
+    /// allowlist that reloads to zero entries (someone empties the file
+    /// mid-session) must deny everything, not revert to allow-all.
+    pub allowlist_active: bool,
 }
 
 impl DomainPolicy {
@@ -183,16 +193,26 @@ impl DomainPolicy {
     /// - a blocklist file that exists but cannot be read is an error, so a
     ///   corrupt blocklist can never silently degrade to "block nothing";
     /// - an allowlist file that exists but cannot be read is an error, so a
-    ///   fail-closed allowlist can never silently degrade to "allow all".
+    ///   fail-closed allowlist can never silently degrade to "allow all";
+    /// - an allowlist file that does not exist is an error for the same reason:
+    ///   a run that was asked to restrict egress must not come up unrestricted
+    ///   because the file was never written or is absent on this machine.
     ///
-    /// A file that does not exist is not an error for either: the blocklist
-    /// starts empty and the allowlist falls back to `allowed_domains_initial`,
-    /// both of which are today's behaviour for a not-yet-written file.
+    /// A missing *blocklist* file is not an error — it starts empty, which is
+    /// today's behaviour for a not-yet-written file and does not weaken a
+    /// restriction the user asked for.
     pub fn build(spec: PolicySpec, now: Instant) -> Result<Self, String> {
         let mut ports: Vec<u16> = vec![443];
         ports.extend_from_slice(&spec.allowed_ports);
         ports.sort_unstable();
         ports.dedup();
+
+        // The intent bit: did anything ask for a domain allowlist this run?
+        // Captured from the *sources*, before any of them is read, so an
+        // allowlist that parses to zero domains still counts as active.
+        let allowlist_active = !spec.default_allowlist.is_empty()
+            || spec.allowed_domains_file.is_some()
+            || !spec.allowed_domains_initial.is_empty();
 
         let blocked_initial = if spec.blocked_file.exists() {
             parse_lines_file(&spec.blocked_file).ok_or_else(|| {
@@ -208,9 +228,8 @@ impl DomainPolicy {
         let allowlist_initial = match spec.allowed_domains_file.as_deref() {
             Some(path) if path.exists() => parse_lines_file(path)
                 .ok_or_else(|| format!("Cannot read allowed domains file {}", path.display()))?,
-            // File not written yet — seed from config, which the file will
-            // take over from at the first successful reload.
-            Some(_) | None => spec.allowed_domains_initial,
+            Some(path) => return Err(missing_allowlist_error(path)),
+            None => spec.allowed_domains_initial,
         };
 
         // Private domains whose source is read exactly once — CLI flags and
@@ -252,6 +271,7 @@ impl DomainPolicy {
             allowed_ports: ports,
             allow_localhost_ports: spec.allow_localhost_ports,
             allow_localhost_any: spec.allow_localhost_any,
+            allowlist_active,
         })
     }
 
@@ -263,11 +283,30 @@ impl DomainPolicy {
     }
 
     /// Effective allowlist: the reloadable user file merged with the agent's
-    /// built-in defaults. Empty = allow-all (the feature is off); non-empty
-    /// means the CONNECT gate fail-closes on anything unlisted.
+    /// built-in defaults. Whether it is *enforced* is [`Self::allowlist_active`],
+    /// not whether this is empty — an active allowlist with no entries denies
+    /// every domain.
     #[must_use]
     pub fn allowed_domains(&self, now: Instant) -> Vec<String> {
         self.allowed.current(now)
+    }
+
+    /// Snapshot the effective CONNECT policy at `now` for static classification.
+    ///
+    /// This is the one place a [`NetPolicy`] is built from live policy, so the
+    /// proxy's own gates and the `cplt check net` diagnostic read the same
+    /// fields — including `allowlist_active`, which decides enforcement.
+    #[must_use]
+    pub fn net_policy(&self, now: Instant) -> NetPolicy {
+        NetPolicy {
+            allowed_ports: self.allowed_ports.clone(),
+            allowed_domains: self.allowed_domains(now),
+            allowlist_active: self.allowlist_active,
+            blocked_domains: self.blocked_domains(now),
+            allow_localhost_ports: self.allow_localhost_ports.clone(),
+            allow_localhost_any: self.allow_localhost_any,
+            private_domains: self.private_domains(now),
+        }
     }
 
     /// Effective private-domain waiver list: sticky CLI/repo entries plus the
@@ -276,6 +315,31 @@ impl DomainPolicy {
     pub fn private_domains(&self, now: Instant) -> Vec<String> {
         self.private.current(now)
     }
+}
+
+/// The startup refusal for a configured `allowed_domains` file that is not on
+/// disk.
+///
+/// Shared by `cplt`'s pre-flight check and [`DomainPolicy::build`] so the two
+/// can never disagree about whether the run may proceed. The wording has to
+/// carry the whole decision, because the two ways to mean "no allowlist" now
+/// have opposite outcomes and neither is guessable from the file's absence.
+#[must_use]
+pub fn missing_allowlist_error(path: &Path) -> String {
+    format!(
+        "Domain allowlist file not found: {}\n  \
+         This run was configured to restrict egress to an allowlist, so cplt \
+         refuses to start rather than come up allowing every domain.\n  \
+         Fix it in one of these ways:\n    \
+         - create {} with the domains you want reachable, one per line;\n    \
+         - drop the `allowed_domains` key (or --allowed-domains) to run with no \
+         allowlist, which allows all domains;\n    \
+         - pass --allow-all-domains to allow every domain for this run only.\n  \
+         Note that an EMPTY allowlist file is not the same as no allowlist: it \
+         is an allowlist with nothing on it, and blocks every domain.",
+        path.display(),
+        path.display()
+    )
 }
 
 /// Parse a one-domain-per-line file (blocklist or allowlist format).
@@ -715,26 +779,231 @@ mod tests {
     }
 
     #[test]
-    fn allowlist_falls_back_to_initial_until_the_file_exists() {
-        let dir = test_dir("allowlist-initial");
+    fn build_refuses_a_configured_allowlist_file_that_is_missing() {
+        // F03: this used to fall back to `allowed_domains_initial` (always
+        // empty in production) and start with NO allowlist — the user asked to
+        // restrict egress and silently got allow-all.
+        let dir = test_dir("allowlist-missing");
         let path = dir.join("not-written-yet.txt");
+
+        let err = DomainPolicy::build(
+            PolicySpec {
+                allowed_domains_file: Some(path.clone()),
+                allowed_domains_initial: vec!["github.com".to_string()],
+                ..PolicySpec::default()
+            },
+            Instant::now(),
+        )
+        .err()
+        .expect("a configured allowlist file that is absent must refuse startup");
+        assert!(err.contains(&path.display().to_string()), "names the file");
+        assert!(
+            err.contains("--allow-all-domains"),
+            "offers the intentional allow-all escape hatch: {err}"
+        );
+        assert!(
+            err.contains("EMPTY allowlist file is not the same as no allowlist"),
+            "distinguishes the two ways to mean 'no allowlist': {err}"
+        );
+
+        // Once written, the same spec builds and enforces the file.
+        std::fs::write(&path, "internal.example.com\n").unwrap();
+        let now = Instant::now();
+        let policy = policy(
+            PolicySpec {
+                allowed_domains_file: Some(path),
+                ..PolicySpec::default()
+            },
+            now,
+        );
+        assert_eq!(policy.allowed_domains(now), vec!["internal.example.com"]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn allowlist_initial_still_seeds_a_fileless_allowlist() {
+        // No file at all: the config-supplied domains are the whole allowlist,
+        // and they make it active.
+        let now = Instant::now();
+        let policy = policy(
+            PolicySpec {
+                allowed_domains_initial: vec!["github.com".to_string()],
+                ..PolicySpec::default()
+            },
+            now,
+        );
+        assert!(policy.allowlist_active);
+        assert_eq!(policy.allowed_domains(now), vec!["github.com"]);
+    }
+
+    /// The four states F03 conflated. `allowlist_active` is what separates
+    /// "no allowlist" (allow-all) from "an allowlist with nothing on it"
+    /// (deny-all); the effective list alone cannot tell them apart.
+    #[test]
+    fn allowlist_active_tracks_configuration_not_contents() {
+        let dir = test_dir("allowlist-states");
+        let now = Instant::now();
+
+        // 1. Disabled: nothing configured => allow-all.
+        let off = policy(PolicySpec::default(), now);
+        assert!(
+            !off.allowlist_active,
+            "nothing configured is not an allowlist"
+        );
+        assert!(off.allowed_domains(now).is_empty());
+        assert_eq!(
+            crate::proxy::classify_connect(&off.net_policy(now), "anything.example", 443),
+            crate::proxy::NetVerdict::Allowed
+        );
+
+        // 2. Enabled but empty: a file with only comments and blank lines.
+        let empty = dir.join("empty.txt");
+        std::fs::write(&empty, "# nothing here yet\n\n").unwrap();
+        let enabled_empty = policy(
+            PolicySpec {
+                allowed_domains_file: Some(empty),
+                ..PolicySpec::default()
+            },
+            now,
+        );
+        assert!(enabled_empty.allowlist_active);
+        assert!(enabled_empty.allowed_domains(now).is_empty());
+        assert_eq!(
+            crate::proxy::classify_connect(&enabled_empty.net_policy(now), "github.com", 443),
+            crate::proxy::NetVerdict::BlockedAllowlist,
+            "an allowlist with nothing on it must deny every domain, not allow all"
+        );
+
+        // 3. Enabled and populated: only the listed domain gets through.
+        let populated = dir.join("allowed.txt");
+        std::fs::write(&populated, "github.com\n").unwrap();
+        let enabled_full = policy(
+            PolicySpec {
+                allowed_domains_file: Some(populated),
+                ..PolicySpec::default()
+            },
+            now,
+        );
+        assert!(enabled_full.allowlist_active);
+        let np = enabled_full.net_policy(now);
+        assert_eq!(
+            crate::proxy::classify_connect(&np, "github.com", 443),
+            crate::proxy::NetVerdict::Allowed
+        );
+        assert_eq!(
+            crate::proxy::classify_connect(&np, "evil.example", 443),
+            crate::proxy::NetVerdict::BlockedAllowlist
+        );
+
+        // 4. Configured but missing: refused at build, never reaching a policy.
+        assert!(
+            DomainPolicy::build(
+                PolicySpec {
+                    allowed_domains_file: Some(dir.join("gone.txt")),
+                    ..PolicySpec::default()
+                },
+                now,
+            )
+            .is_err()
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn emptying_the_allowlist_file_denies_instead_of_allowing_all() {
+        // Hot reload: emptying the file is a real edit that REVOKES every
+        // domain. It must tighten to deny-all, not relax to allow-all.
+        let dir = test_dir("allowlist-emptied");
+        let path = dir.join("allowed.txt");
+        std::fs::write(&path, "github.com\n").unwrap();
+
+        let now = Instant::now();
+        let user_only = policy(
+            PolicySpec {
+                allowed_domains_file: Some(path.clone()),
+                ..PolicySpec::default()
+            },
+            now,
+        );
+        assert_eq!(
+            crate::proxy::classify_connect(&user_only.net_policy(now), "github.com", 443),
+            crate::proxy::NetVerdict::Allowed
+        );
+
+        std::fs::write(&path, "# all revoked\n").unwrap();
+        let later = stale(now);
+        assert!(user_only.allowed_domains(later).is_empty());
+        assert_eq!(
+            crate::proxy::classify_connect(&user_only.net_policy(later), "github.com", 443),
+            crate::proxy::NetVerdict::BlockedAllowlist,
+            "an emptied allowlist must revoke access, not restore allow-all"
+        );
+
+        // With `proxy.default_allowlist` on, the agent's built-in domains are
+        // sticky, so emptying the file revokes only the user's additions. That
+        // is why the exposure is an explicit `allowed_domains` file WITHOUT
+        // `--default-allowlist`.
+        std::fs::write(&path, "internal.example.com\n").unwrap();
+        let with_defaults = policy(
+            PolicySpec {
+                allowed_domains_file: Some(path.clone()),
+                default_allowlist: vec!["github.com".to_string()],
+                ..PolicySpec::default()
+            },
+            now,
+        );
+        std::fs::write(&path, "# all revoked\n").unwrap();
+        let np = with_defaults.net_policy(stale(now));
+        assert_eq!(
+            crate::proxy::classify_connect(&np, "github.com", 443),
+            crate::proxy::NetVerdict::Allowed,
+            "agent defaults survive an emptied file"
+        );
+        assert_eq!(
+            crate::proxy::classify_connect(&np, "internal.example.com", 443),
+            crate::proxy::NetVerdict::BlockedAllowlist,
+            "the user's own entry is revoked with the file"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn deleted_or_unreadable_allowlist_file_keeps_last_good() {
+        // The documented fail-safe (docs/proxy.md): a file that cannot be READ
+        // is an error condition, not an edit, so the last-good list stands.
+        // This is the deliberate asymmetry with the emptied-file case above.
+        let dir = test_dir("allowlist-deleted");
+        let path = dir.join("allowed.txt");
+        std::fs::write(&path, "github.com\n").unwrap();
 
         let now = Instant::now();
         let policy = policy(
             PolicySpec {
                 allowed_domains_file: Some(path.clone()),
-                allowed_domains_initial: vec!["github.com".to_string()],
                 ..PolicySpec::default()
             },
             now,
         );
         assert_eq!(policy.allowed_domains(now), vec!["github.com"]);
 
-        // Once written, the file takes over at the next refresh.
-        std::fs::write(&path, "internal.example.com\n").unwrap();
+        std::fs::remove_file(&path).unwrap();
+        let later = stale(now);
         assert_eq!(
-            policy.allowed_domains(stale(now)),
-            vec!["internal.example.com"]
+            policy.allowed_domains(later),
+            vec!["github.com"],
+            "a deleted allowlist keeps the last-good list"
+        );
+
+        // Unreadable rather than absent: a directory where a file belongs.
+        std::fs::create_dir(&path).unwrap();
+        let later = stale(later);
+        assert_eq!(
+            policy.allowed_domains(later),
+            vec!["github.com"],
+            "an unreadable allowlist keeps the last-good list"
         );
 
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
An **enabled** domain allowlist that resolved to zero entries meant allow-all, because enforcement gated on `!allowed_domains.is_empty()` and could not tell "no allowlist configured" from "an allowlist with nothing on it". A configured-but-missing file fell through the same way, and startup only printed `(not found)`, which `-q` suppressed. `docs/proxy.md` promised the opposite: "Only listed domains can connect."

Four states, two of them wrong before this change:

| State | Before | After |
|---|---|---|
| Not configured | allow-all | allow-all (unchanged, intended) |
| File configured, empty or all comments | **allow-all** | denies every domain |
| File configured, missing at startup | **allow-all**, message suppressible | refuses to start |
| File configured, populated | enforced | enforced |

## The fix

`NetPolicy` gains `allowlist_active`, computed in `DomainPolicy::build` from the *sources* (`default_allowlist`, `allowed_domains_file`, `allowed_domains_initial`) before any of them is read, so a list that parses to zero entries still counts as active. The gate becomes `(allowlist_active || !allowed_domains.is_empty())` — the second half kept deliberately as a fail-closed backstop, so a caller that forgets to set the bit still enforces the list it built rather than silently allowing everything.

`cplt check net` sets the same bit. That half matters as much as the enforcement change: `check` previously reused the same `is_empty()` semantics, so a user verifying their setup got a self-consistent wrong answer. There is now a test asserting check's verdict equals the live policy's verdict host by host.

`ProxyState::net_policy` was inlining the `NetPolicy` literal; it now delegates to `DomainPolicy::net_policy(now)`, which is what lets tests exercise the real snapshot instead of a hand-rolled copy, and removes the place the two could drift.

## Breaking change, deliberately

Anyone shipping `proxy.allowed_domains` with the file empty or absent on some machines is running allow-all today without knowing it. They now get a hard failure instead. CI images that create the file lazily will break. That is the point — the alternative is leaving them believing they have egress control they do not have.

The refusal names both ways to mean "no allowlist", because the distinction is the whole finding:

```
[cplt] Domain allowlist file not found: /path/to/nope.txt
  This run was configured to restrict egress to an allowlist, so cplt refuses to start rather than come up allowing every domain.
  Fix it in one of these ways:
    - create /path/to/nope.txt with the domains you want reachable, one per line;
    - drop the `allowed_domains` key (or --allowed-domains) to run with no allowlist, which allows all domains;
    - pass --allow-all-domains to allow every domain for this run only.
  Note that an EMPTY allowlist file is not the same as no allowlist: it is an allowlist with nothing on it, and blocks every domain.
```

`--allow-all-domains` already existed and already covers the intentional case; nothing new was needed.

## What is deliberately unchanged

The hot-reload asymmetry: an **emptied** file tightens (it is a real edit), while a **deleted or unreadable** file keeps last-good, which is what `docs/proxy.md:150` promises. Both halves are tested.

`default_allowlist` composition: with `proxy.default_allowlist` on, `current()` returns `sticky ∪ file`, so emptying the file revokes only the user's own additions and the agent's defaults survive. The exposure was specifically an explicit `allowed_domains` file *without* `--default-allowlist`.

## Review notes

Reviewed independently before merge. Verified there: the bit survives hot reload (it is never written after `build`); `--allow-all-domains` yields false on both the proxy and check sides because the `FeatureToggle` merge forces `default_allowlist` off and `use_allowed_file` nulls the path; both refusal sites are reached, print in full under `-q`, and exit 1; `--print-profile` returns before the proxy and `--doctor` never builds a policy, so neither reaches allow-all; and a repo `.cplt.toml` cannot propose `allowed_domains`, so no untrusted path can trip the new refusal.

One premise from the original report did **not** survive: the built-in allowlist is not empty for `pi`, `goose` or `shell`. `default_allowed_domains()` appends `PACKAGE_REGISTRY_DOMAINS` for every agent; only the per-agent infrastructure slice is empty for those three. (A doc in another repo repeated that error and is being corrected separately.)

A replaced test, `allowlist_falls_back_to_initial_until_the_file_exists`, asserted precisely the behaviour being deliberately broken. Nothing else depended on it — `allowed_domains_initial` is always empty at the one production call site.

Two pre-existing nits found and left for follow-up, both the same "self-consistent wrong answer" flavour this fixes: `build_net_policy` ignores `--observe-domains`, and the startup summary prints `Allowlist: on` even under `--allow-all-domains`.

## Verification

Tests cover all four states through `classify_connect` rather than by inspecting list contents, plus the emptied-file reload, the deleted/unreadable reload, and check/proxy parity. No network. Mutation-checked both halves: reverting the gate fails three named tests, reverting the missing-file refusal fails two; filters matched 29 and 5 tests, not zero.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `--lib` 986, `unit_tests` 340, `--bin cplt` 54, `e2e` 156, `e2e_projects` 54, `e2e_guards` 123, `e2e_git_hardening` 11, `integration` 68 — all green.

Found by an internal security review, credited to @randax. An advisory will follow once this is released.
