### PR TITLE
test(audit): give the settle-probe script a single-digit descriptor

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1037,11 +1037,16 @@ mod tests {
     fn sh_holding_the_probe(probe: &SettleProbe, script: &str) -> Command {
         use std::os::unix::process::CommandExt as _;
         let fd = probe.write;
+        // Keep the probe out of every OTHER child this test binary spawns:
+        // tests run in parallel, and an unrelated process holding the write end
+        // keeps the pipe open, which is precisely the "unsettled" condition
+        // under test. Only the script below gets it, through the dup2 in
+        // `pre_exec`, which clears FD_CLOEXEC on the copy it makes.
+        unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) };
         let mut cmd = Command::new("/bin/sh");
         cmd.arg("-c").arg(script);
-        // SAFETY: `dup2` and `fcntl` are async-signal-safe and touch only these
-        // two descriptors. `dup2` clears FD_CLOEXEC on the new one, so the
-        // script inherits SCRIPT_FD whatever the source fd's flags were.
+        // SAFETY: `dup2` is async-signal-safe and touches only these two
+        // descriptors.
         unsafe {
             cmd.pre_exec(move || {
                 if libc::dup2(fd, SCRIPT_FD) == -1 {

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1023,16 +1023,30 @@ mod tests {
     /// the only thing that forks between arming and settling. This test binary
     /// runs hundreds of tests in parallel, so here the descriptor is hidden
     /// from every other test's children and un-hidden in this child alone.
+    /// The descriptor number a probe-holding script sees.
+    ///
+    /// Fixed, and deliberately one digit: `/bin/sh` is dash on Debian, and dash
+    /// parses only a single digit in `>&N` / `<&N`. The probe's own fd number
+    /// depends on how many descriptors happen to be open, so a script written
+    /// against it works while that number is below 10 and silently fails to
+    /// parse above it — the redirection errors, the script produces no output,
+    /// and the test fails somewhere unrelated. That is exactly what happened on
+    /// Linux CI, and because the number varies it passed elsewhere.
+    const SCRIPT_FD: i32 = 9;
+
     fn sh_holding_the_probe(probe: &SettleProbe, script: &str) -> Command {
         use std::os::unix::process::CommandExt as _;
         let fd = probe.write;
-        unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) };
         let mut cmd = Command::new("/bin/sh");
         cmd.arg("-c").arg(script);
-        // SAFETY: `fcntl` is async-signal-safe and touches only this fd.
+        // SAFETY: `dup2` and `fcntl` are async-signal-safe and touch only these
+        // two descriptors. `dup2` clears FD_CLOEXEC on the new one, so the
+        // script inherits SCRIPT_FD whatever the source fd's flags were.
         unsafe {
             cmd.pre_exec(move || {
-                libc::fcntl(fd, libc::F_SETFD, 0);
+                if libc::dup2(fd, SCRIPT_FD) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 Ok(())
             });
         }
@@ -1077,12 +1091,11 @@ mod tests {
     #[test]
     fn settle_probe_reports_unsettled_while_a_descendant_lives() {
         let probe = SettleProbe::arm().expect("pipe");
-        let fd = probe.write;
         // The straggler's stdout goes to /dev/null, or `output()` would block
         // on the pipe until it exits and there would be nothing left to detect.
         let out = sh_holding_the_probe(
             &probe,
-            &format!("sleep 5 >/dev/null 2>&1 & printf x >&{fd}; echo $!"),
+            &format!("sleep 5 >/dev/null 2>&1 & printf x >&{SCRIPT_FD}; echo $!"),
         )
         .output()
         .expect("sh runs");


### PR DESCRIPTION
`linux-integration-tests` failed on an unrelated PR with:

```
test audit::tests::settle_probe_reports_unsettled_while_a_descendant_lives ... FAILED
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: Empty }
```

The test parses `echo $!` from a shell script. It got nothing, because the *previous* command in that script failed to parse.

`sh_holding_the_probe` handed the script the probe's own file descriptor number, which depends on how many descriptors happen to be open at that moment. On Debian `/bin/sh` is dash, and **dash parses only a single digit in `>&N` and `<&N`**. Once the probe landed on fd 10 or above, the redirection was a syntax error, the script produced no output, and the test died somewhere that says nothing about what went wrong.

Below fd 10 it passed. macOS `/bin/sh` accepts multi-digit descriptors, so it always passed there. That combination is why this looked green through the merge that introduced it and only surfaced later, on a branch that had nothing to do with the audit.

**The consequence is worse than a flaky test.** This is the test that proves the settle probe reports `unsettled` while a descendant is still alive — the Linux half of the GHSA-c47q-c3c8-7wrf fix. When the descriptor number happened to be high, the test did not verify the probe; it failed before reaching the assertion. When it was low, it did. So the Linux behaviour of that fix has been verified only intermittently, by luck of the descriptor table.

## The fix

`pre_exec` now `dup2`s the probe into a fixed fd 9, which dash accepts and which does not move with the descriptor table. `dup2` clears `FD_CLOEXEC` on the new descriptor, so the previous `fcntl` set-then-clear pair is gone as well.

Only the test helper changes. `SettleProbe` itself is untouched.

## Verification, and its limit

`cargo test --lib` is green (986), and the audit tests pass locally (25). **That is not evidence for this fix**: macOS cannot reproduce the failure, because its `/bin/sh` parses multi-digit descriptors fine. `linux-integration-tests` on this PR is the only thing that can confirm it, and it is the check to watch.

I also cannot force the failing condition locally in a way that would prove the mutant dies — reverting to `>&{fd}` reproduces nothing on this machine. Stated rather than papered over.

Found while investigating a CI failure on #375.