### PR TITLE
fix(sandbox): reject an unsafe CLAUDE_CONFIG_DIR instead of granting write over it

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1643,6 +1643,37 @@ pub fn canonicalize_agent_dirs(dirs: &mut [AgentDir]) {
     }
 }
 
+/// The first agent config dir that resolves to a system root or `$HOME`, if any.
+///
+/// A config dir is externally influenced: `CLAUDE_CONFIG_DIR` (used raw, no
+/// subdirectory appended) and the `XDG_*` bases both come from the ambient
+/// environment. An attacker-set or fat-fingered `CLAUDE_CONFIG_DIR=/` or
+/// `=$HOME` turns into an `AgentDir { write: true }` over the whole tree. The
+/// sandbox backends are purely additive — Landlock has no deny, and macOS's
+/// late credential/persistence denies only re-cover their enumerated paths — so
+/// such a grant cannot be clawed back and everything under it degrades to
+/// writable (external audit C-02).
+///
+/// So the same veto the relocatable tool dirs already use
+/// ([`crate::sandbox::tool_override_path_is_safe`]) guards these too — it wraps
+/// `is_unsafe_root` (`/`, `$HOME`, system/temp roots) and additionally rejects
+/// any *ancestor* of `$HOME` (`/Users`, `/home`, or a deeper parent), which a
+/// bare `is_unsafe_root` misses: `CLAUDE_CONFIG_DIR=/Users` would otherwise
+/// become a writable grant over every user's home. A legitimate config dir
+/// lives at `~/.claude` or a dedicated subdirectory, which the predicate
+/// accepts. Callers must refuse to launch rather than emit the grant — a
+/// silently dropped grant would still hand the same dir to the child via the
+/// environment, which would then fail writing to a denied path with no hint why
+/// (the "No silent grants" rule in AGENTS.md).
+///
+/// Run on the *canonicalized* dirs so a symlink or `..` cannot smuggle an unsafe
+/// root past the textual comparison.
+#[must_use]
+pub fn first_unsafe_agent_dir<'a>(dirs: &'a [AgentDir], home: &Path) -> Option<&'a AgentDir> {
+    dirs.iter()
+        .find(|d| !crate::sandbox::tool_override_path_is_safe(&d.path, home))
+}
+
 /// Are we running inside WSL? Cached — it cannot change within a process.
 ///
 /// Two independent signals, both cheap reads of kernel-owned state:
@@ -2711,6 +2742,93 @@ mod tests {
             let dirs = Agent::Claude.config_dirs(home);
             assert_eq!(dirs.len(), 2, "empty override is ignored");
             assert_eq!(dirs[0].path, home.join(".claude"));
+        });
+    }
+
+    // Audit C-02: CLAUDE_CONFIG_DIR is turned into a writable AgentDir with no
+    // validation. `first_unsafe_agent_dir` is the veto that stops the grant from
+    // reaching Landlock/Seatbelt. These assert against the resolved AgentDir set
+    // config_dirs actually produces, not just the helper in isolation.
+
+    #[test]
+    fn claude_config_dir_at_filesystem_root_is_vetoed() {
+        temp_env::with_var("CLAUDE_CONFIG_DIR", Some("/"), || {
+            let home = Path::new("/Users/test");
+            let dirs = Agent::Claude.config_dirs(home);
+            // The vulnerable grant: a writable AgentDir over "/".
+            assert_eq!(dirs.len(), 1);
+            assert_eq!(dirs[0].path, PathBuf::from("/"));
+            assert!(dirs[0].write, "the grant that C-02 is about is writable");
+            // The veto catches it before it becomes an FsRule / subpath rule.
+            let bad = first_unsafe_agent_dir(&dirs, home).expect("filesystem root must be vetoed");
+            assert_eq!(bad.path, PathBuf::from("/"));
+        });
+    }
+
+    #[test]
+    fn claude_config_dir_at_home_is_vetoed() {
+        temp_env::with_var("CLAUDE_CONFIG_DIR", Some("/Users/test"), || {
+            let home = Path::new("/Users/test");
+            let dirs = Agent::Claude.config_dirs(home);
+            assert_eq!(dirs[0].path, PathBuf::from("/Users/test"));
+            assert!(
+                first_unsafe_agent_dir(&dirs, home).is_some(),
+                "$HOME itself must be vetoed"
+            );
+        });
+    }
+
+    #[test]
+    fn claude_config_dir_dedicated_subdir_is_allowed() {
+        temp_env::with_var(
+            "CLAUDE_CONFIG_DIR",
+            Some("/Users/test/.config/claude-work"),
+            || {
+                let home = Path::new("/Users/test");
+                let dirs = Agent::Claude.config_dirs(home);
+                assert_eq!(
+                    dirs[0].path,
+                    PathBuf::from("/Users/test/.config/claude-work")
+                );
+                assert!(dirs[0].write);
+                assert!(
+                    first_unsafe_agent_dir(&dirs, home).is_none(),
+                    "a dedicated subdirectory is a legitimate config dir"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn claude_config_dir_at_ancestor_of_home_is_vetoed() {
+        // A parent of $HOME that is NOT in is_unsafe_root's enumerated root
+        // list. Bare is_unsafe_root misses it; the ancestor check that
+        // tool_override_path_is_safe adds is what catches it. Granting write
+        // here would reach every sibling home under the ancestor.
+        let home = Path::new("/Users/alice/sandbox/home");
+        temp_env::with_var("CLAUDE_CONFIG_DIR", Some("/Users/alice/sandbox"), || {
+            let dirs = Agent::Claude.config_dirs(home);
+            assert_eq!(dirs[0].path, PathBuf::from("/Users/alice/sandbox"));
+            assert!(
+                !crate::is_unsafe_root(&dirs[0].path, home),
+                "precondition: bare is_unsafe_root does NOT catch this ancestor"
+            );
+            assert!(
+                first_unsafe_agent_dir(&dirs, home).is_some(),
+                "an ancestor of $HOME must be vetoed even when not an enumerated root"
+            );
+        });
+    }
+
+    #[test]
+    fn default_claude_config_dirs_pass_the_veto() {
+        temp_env::with_var_unset("CLAUDE_CONFIG_DIR", || {
+            let home = Path::new("/Users/test");
+            let dirs = Agent::Claude.config_dirs(home);
+            assert!(
+                first_unsafe_agent_dir(&dirs, home).is_none(),
+                "~/.claude and ~/.claude.json must never be vetoed"
+            );
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3432,6 +3432,25 @@ fn assemble_sandbox(
     // After pre-creation, so a dir we just made resolves too. See #171.
     agent::canonicalize_agent_dirs(&mut agent_dirs);
 
+    // An agent config dir can be relocated by an env var the user (or a repo, or
+    // an attacker) controls — CLAUDE_CONFIG_DIR is used raw, the XDG_* bases feed
+    // the rest. Like the project root and the tool dirs, one that resolves to a
+    // system root or $HOME would hand the agent a writable grant over the whole
+    // tree that the additive Landlock/Seatbelt model cannot claw back (audit
+    // C-02). Refuse loudly rather than silently narrowing or dropping the grant:
+    // a dropped grant would still pass the same dir to the child via the env,
+    // which would then fail writing to a denied path with no hint why.
+    if let Some(bad) = agent::first_unsafe_agent_dir(&agent_dirs, home_dir) {
+        bail!(
+            "cplt refuses to grant the agent the config directory derived from the \
+             environment, '{}', it is too broad (a system root, your home directory, \
+             or an ancestor of it). Point the relevant variable (CLAUDE_CONFIG_DIR, \
+             or an XDG_* base) at a dedicated subdirectory such as '{}'.",
+            bad.path.display(),
+            home_dir.join(".claude").display(),
+        );
+    }
+
     // Agent-facing sandbox brief (issue #148), session layer only. The
     // AGENTS.md layer writes into the user's repo and must not run until the
     // launch is confirmed — see `apply_persistent_sandbox_brief`, which the

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -321,6 +321,64 @@ mod e2e_tests {
         );
     }
 
+    /// Audit C-02: an externally-set `CLAUDE_CONFIG_DIR` pointing at a system
+    /// root must not become a writable grant. The refusal fires in
+    /// `assemble_sandbox`, which `--print-profile --agent claude` reaches
+    /// without needing a real Claude binary, so this exercises the full
+    /// enforcement wiring (not just the veto helper) and runs in CI.
+    #[test]
+    fn e2e_claude_config_dir_at_root_is_refused() {
+        let output = cplt_cmd()
+            .args(["--print-profile", "--agent", "claude"])
+            .env("CLAUDE_CONFIG_DIR", "/")
+            .current_dir(project_dir())
+            .output()
+            .expect("binary should run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "CLAUDE_CONFIG_DIR=/ must abort the launch.\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("config directory") && stderr.contains("too broad"),
+            "refusal should name the offending config directory.\nstderr: {stderr}"
+        );
+    }
+
+    /// The other half of C-02: a dedicated subdirectory is legitimate and must
+    /// still produce a writable grant, so the veto does not strand a user who
+    /// deliberately relocated their config dir.
+    #[test]
+    fn e2e_claude_config_dir_dedicated_subdir_is_granted() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cfg = tmp.path().join("claude-config");
+        std::fs::create_dir_all(&cfg).expect("create config dir");
+        // Match assemble_sandbox, which grants the canonicalized path.
+        let canonical = std::fs::canonicalize(&cfg).expect("canonicalize");
+
+        let output = cplt_cmd()
+            .args(["--print-profile", "--agent", "claude"])
+            .env("CLAUDE_CONFIG_DIR", &cfg)
+            .current_dir(project_dir())
+            .output()
+            .expect("binary should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "a dedicated config dir must be accepted.\nstderr: {stderr}"
+        );
+        assert!(
+            stdout.contains(&format!(
+                "(allow file-write* (subpath \"{}\"))",
+                canonical.display()
+            )),
+            "profile should grant write to the dedicated config dir.\nstdout: {stdout}"
+        );
+    }
+
     #[test]
     fn e2e_print_profile_allows_gh_config_readonly() {
         let output = cplt_cmd()


### PR DESCRIPTION
`CLAUDE_CONFIG_DIR` is on the sandbox environment allowlist, and `Agent::Claude.config_dirs()` turned any nonempty value into a writable `AgentDir` with no validation. `assemble_sandbox` pre-created and canonicalized agent dirs but never ran the `is_unsafe_root` veto that the project directory, the tool roots, and `accept_tool_dir` all apply.

So `CLAUDE_CONFIG_DIR=/` or `=$HOME` became a recursive writable grant over the whole tree. On Linux the `agent_dirs` loop emits a recursive read+write Landlock rule, and Landlock is purely additive with no deny, so nothing can claw it back — the filesystem policy collapses for Claude sessions. On macOS the late credential/persistence denies re-cover only their enumerated paths, so everything else under `$HOME` degrades to writable.

## Fix

A single veto at the choke point in `assemble_sandbox`, after `canonicalize_agent_dirs`, bails when any agent config dir fails `tool_override_path_is_safe` — the same predicate the tool-dir path uses, which rejects `is_unsafe_root` roots (`/`, `$HOME`, `/tmp`, `/var`, and the per-platform list) **and** any ancestor of `$HOME`. That last part matters: `CLAUDE_CONFIG_DIR=/Users` (macOS) or `/home` (Linux) is an ancestor of home but not an enumerated root, and would otherwise have passed.

The veto is a hard error, not a silent fallback. Accepting the value and quietly rewriting it to `~/.claude` while still passing `CLAUDE_CONFIG_DIR=/` to the child would make the child fail writing to a denied path with no hint back — the exact silent-grant failure the house rule forbids. A deliberately relocated but safe dir (`~/.config/claude-work`) still works, so no one is stranded.

Placed at the single runtime consumer of `config_dirs`, it covers every agent, not just Claude — the XDG-derived dirs for Shell/OpenCode/Goose flow through the same point (they always append a fixed subdir, so they cannot equal a root today, but the veto guards them for free and against any future raw-env addition). The bail fires before `SandboxConfig` is built, so the grant never reaches either backend on either platform.

## What this does not fix

It closes "collapse the sandbox," not "targeted writable grant." A `CLAUDE_CONFIG_DIR` pointed at a sensitive *non-root* path (`$HOME/.ssh`, `/opt/homebrew`) still becomes a writable `AgentDir` — that is a separate, narrower finding, not addressed here.

## Verification

Unit tests: `/`, `$HOME`, and an ancestor-of-home that is genuinely not an enumerated root are all vetoed; a dedicated subdir and the default `~/.claude`/`~/.claude.json` are not. The ancestor test uses a deep synthetic home so `is_unsafe_root` alone misses it — proving `tool_override_path_is_safe` is the load-bearing part. e2e via `--print-profile --agent claude`: `CLAUDE_CONFIG_DIR=/` aborts with the refusal; a dedicated subdir still produces the write grant in the profile.

Mutation-checked: downgrading the helper to bare `is_unsafe_root` fails only the ancestor test; removing the bail wiring fails the e2e refusal (its output confirmed the vuln — without the veto cplt proceeds and warns its own binary "sits under /, which the sandbox makes writable"). Filters matched non-zero counts.

`cargo fmt`, `cargo test --lib` (991), `cargo test --test unit_tests` (340), clippy for host and `x86_64-unknown-linux-gnu` — all green.

Reviewed independently before this PR. Found by an internal security review, credited to @randax. An advisory will follow once released.