### PR TITLE
fix(sandbox): protect project auto-load paths that agents execute next session

### DIFF
--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -1394,14 +1394,39 @@ mod tests {
         // The protected set is deliberately narrow: exactly the
         // `LinuxCoverage::Bwrap` entries of `PROTECTED_IN_ROOT` and
         // `PROTECTED_IN_GITDIR` — .git/hooks, .git/info/exclude, .cplt.toml,
-        // .agents/plugins and .github/hooks.
+        // .agents/plugins, .github/hooks, and the H-11 agent auto-exec paths
+        // (.opencode/{plugin,plugins,tool,tools}, opencode.json(c), .claude/settings*.json,
+        // .claude-plugin, .mcp.json, .pi/extensions, .pi/settings.json).
         // .git/config / .gitmodules must stay writable so legit in-sandbox git
         // config/remote/submodule ops (and their lock files) are not broken —
-        // even when those files exist on disk.
+        // even when those files exist on disk. Only paths that EXIST at launch
+        // are bound (nested-repo depth is macOS-only), so each H-11 path is
+        // created below to prove it reaches the bind.
         let proj = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(proj.path().join(".git/hooks")).expect("create .git/hooks");
         std::fs::create_dir_all(proj.path().join(".agents/plugins")).expect("create plugins");
         std::fs::create_dir_all(proj.path().join(".github/hooks")).expect("create .github/hooks");
+        for d in [
+            ".opencode/plugins",
+            ".opencode/plugin",
+            ".opencode/tools",
+            ".opencode/tool",
+        ] {
+            std::fs::create_dir_all(proj.path().join(d)).expect("create opencode dir");
+        }
+        std::fs::create_dir_all(proj.path().join(".claude-plugin")).expect("create claude-plugin");
+        std::fs::create_dir_all(proj.path().join(".pi/extensions")).expect("create pi ext");
+        std::fs::create_dir_all(proj.path().join(".claude")).expect("create .claude");
+        for f in [
+            ".claude/settings.json",
+            ".claude/settings.local.json",
+            ".mcp.json",
+            "opencode.json",
+            "opencode.jsonc",
+            ".pi/settings.json",
+        ] {
+            std::fs::write(proj.path().join(f), "").expect("create H-11 file");
+        }
         std::fs::create_dir_all(proj.path().join(".git/info")).expect("create .git/info");
         std::fs::write(proj.path().join(".git/info/exclude"), "").expect("create info/exclude");
         std::fs::write(proj.path().join(".git/config"), "").expect("create .git/config");
@@ -1447,6 +1472,31 @@ mod tests {
                 && w[1] == proj.path().join(".git/info/exclude").to_string_lossy()),
             ".git/info/exclude must be re-bound read-only"
         );
+        // H-11: every agent auto-exec path is `LinuxCoverage::Bwrap`, so each
+        // must reach `build_bwrap_args` as a read-only bind — the end-to-end pin
+        // that the table additions are enforced on Linux too (bubblewrap only,
+        // never Landlock).
+        for rel in [
+            ".opencode/plugins",
+            ".opencode/plugin",
+            ".opencode/tools",
+            ".opencode/tool",
+            "opencode.json",
+            "opencode.jsonc",
+            ".claude/settings.json",
+            ".claude/settings.local.json",
+            ".claude-plugin",
+            ".mcp.json",
+            ".pi/extensions",
+            ".pi/settings.json",
+        ] {
+            assert!(
+                args.windows(2)
+                    .any(|w| w[0] == "--ro-bind"
+                        && w[1] == proj.path().join(rel).to_string_lossy()),
+                "{rel} must be re-bound read-only"
+            );
+        }
         // .git/config and .gitmodules are NOT re-bound (stay writable), even
         // though both exist on disk — the narrowing, not the exists-check, is
         // what leaves them out.

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -1490,11 +1490,11 @@ mod tests {
             ".pi/extensions",
             ".pi/settings.json",
         ] {
+            let path = proj.path().join(rel).to_string_lossy().into_owned();
             assert!(
-                args.windows(2)
-                    .any(|w| w[0] == "--ro-bind"
-                        && w[1] == proj.path().join(rel).to_string_lossy()),
-                "{rel} must be re-bound read-only"
+                args.windows(3)
+                    .any(|w| w[0] == "--ro-bind" && w[1] == path && w[2] == path),
+                "{rel} must be re-bound read-only (source and dest both {path})"
             );
         }
         // .git/config and .gitmodules are NOT re-bound (stay writable), even

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -2034,6 +2034,174 @@ pub const PROTECTED_IN_ROOT: &[Protected] = &[
         why: "Copilot hook load path — runs unsandboxed on the next session in this repo",
         linux: LinuxCoverage::Bwrap,
     },
+    // ── H-11: three more agents auto-execute from the project directory ──
+    //
+    // Same class as `.agents/plugins` (#267) and `.github/hooks` (#339): a file
+    // or dir the agent writes now that runs unsandboxed on the HOST the next
+    // time an agent opens this repo. Each path below was verified against the
+    // upstream loader/config source, not a doc summary; where a claim could not
+    // be confirmed the path was left out rather than protected on a guess.
+    //
+    // `nested`/Linux reminder (see the module header and `sandbox_landlock`):
+    // Landlock enforces NONE of `PROTECTED_IN_ROOT` — on Linux the whole set is
+    // carried by the bubblewrap read-only overlay alone, and only for `Bwrap`
+    // entries. The `nested` regex ("this path at any depth") is macOS-only, and
+    // bubblewrap binds only paths that EXIST at launch, so a not-yet-created one
+    // is unprotected on Linux until it exists. Both are pre-existing properties
+    // of this table, restated because two of these entries lean on `nested` to
+    // reach a sub-path (`.claude/skills/*/.claude-plugin`, `.opencode/opencode.json`).
+
+    // OpenCode. `config/plugin.ts` globs `{plugin,plugins}/*.{ts,js}` and
+    // imports each, and `tool/registry.ts` globs `{tool,tools}/*.{js,ts}` and
+    // `import()`s each at registry init (top-level module code runs), both under
+    // every `.opencode` scan root (`config/paths.ts::directories`). So four
+    // subdirs auto-execute at startup.
+    //
+    // SURGICAL, not a whole-`.opencode/` deny: `config.ts` writes into
+    // `.opencode/` every run — `ensureGitignore` creates `.opencode/.gitignore`
+    // and the background `npm install @opencode-ai/plugin` writes
+    // `.opencode/{node_modules,package.json,*.lock}`. Denying the tree would
+    // break OpenCode's own startup. The exec content lives only in these four
+    // subdirs; the generated state at `.opencode/` root stays writable.
+    Protected {
+        rel: ".opencode/plugins",
+        tree: true,
+        nested: true,
+        why: "OpenCode plugin dir (plural) — auto-loaded on the host next session",
+        linux: LinuxCoverage::Bwrap,
+    },
+    Protected {
+        rel: ".opencode/plugin",
+        tree: true,
+        nested: true,
+        why: "OpenCode plugin dir (singular) — same `{plugin,plugins}` glob",
+        linux: LinuxCoverage::Bwrap,
+    },
+    Protected {
+        rel: ".opencode/tools",
+        tree: true,
+        nested: true,
+        why: "OpenCode custom-tool dir (plural) — import()ed at registry init",
+        linux: LinuxCoverage::Bwrap,
+    },
+    Protected {
+        rel: ".opencode/tool",
+        tree: true,
+        nested: true,
+        why: "OpenCode custom-tool dir (singular) — same `{tool,tools}` glob",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // `ConfigPaths.files` walks up from cwd loading a project-root
+    // `opencode.json`/`opencode.jsonc`; both carry a `plugin` array (npm-installed
+    // at startup), an `mcp` entry whose local `command` is spawned, and remote
+    // `instructions` URLs — all with no trust prompt. Files, and the `nested`
+    // regex also reaches the copy inside `.opencode/` (loaded by `config.ts`).
+    Protected {
+        rel: "opencode.json",
+        tree: false,
+        nested: true,
+        why: "OpenCode root config — plugin array / mcp command / remote instructions",
+        linux: LinuxCoverage::Bwrap,
+    },
+    Protected {
+        rel: "opencode.jsonc",
+        tree: false,
+        nested: true,
+        why: "OpenCode root config (jsonc) — same startup-exec surface",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // Claude Code runs the hooks declared in `<project>/.claude/settings.json`,
+    // including `SessionStart`, which fires the moment a session opens in this
+    // repo (code.claude.com/docs/en/hooks). A hook the agent plants there runs
+    // unsandboxed on the next Claude session — same class as `.github/hooks`.
+    //
+    // A FILE, not a subtree: `.claude/` also holds session state Claude writes
+    // every run (projects/, history, todos), so denying the directory would
+    // break legitimate writes. Hooks live in `settings.json`, so that one file
+    // is what is denied — the same precise scoping the HOST-side `~/.claude`
+    // deny already uses (`Agent::host_persistence_denies`).
+    Protected {
+        rel: ".claude/settings.json",
+        tree: false,
+        nested: true,
+        why: "Claude hook carrier — SessionStart etc. run unsandboxed next session",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // The project-local settings file is the same schema layered over
+    // `settings.json` (code.claude.com/docs/en/settings: it is a full settings
+    // file at the "project local" precedence level, and the hooks live-reload
+    // covers "user, project, local, and managed settings"), so it carries the
+    // same `hooks` and the same auto-exec. Denied as its own file for the same
+    // reason `settings.json` is — `.claude/` stays writable for state.
+    Protected {
+        rel: ".claude/settings.local.json",
+        tree: false,
+        nested: true,
+        why: "Claude local hook carrier — same auto-exec as settings.json",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // A `.claude-plugin/plugin.json` dropped in a `.claude/skills/<name>/` folder
+    // promotes it to a plugin `<name>@skills-dir` that auto-loads next session
+    // with no install step (code.claude.com/docs/en/plugins-reference), bundling
+    // hooks/, .mcp.json, agents/, monitors/ and bin/ — all auto-run on load.
+    // The manifest dir is the promotion gate and holds ONLY `plugin.json` (docs:
+    // "Only plugin.json goes inside .claude-plugin/"), so denying it blocks the
+    // plant without touching SKILL.md or any skill component authoring. Denied
+    // wherever it appears, since it is a pure-manifest dir with no session state;
+    // the `.claude/skills/*/.claude-plugin` case is reached by the `nested`
+    // regex (macOS-only, per the reminder above). Project-scope skills-dir
+    // plugins also gate on the workspace-trust dialog, which a `-p`/SDK session
+    // does not show — the same headless-trust gap as `.mcp.json` below.
+    Protected {
+        rel: ".claude-plugin",
+        tree: true,
+        nested: true,
+        why: "Claude skills-dir plugin manifest — promotes a skill to an auto-loaded plugin",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // `<project>/.mcp.json` auto-connects its MCP servers — spawning each local
+    // `command` — with no prompt in `-p`/SDK/cloud sessions
+    // (code.claude.com/docs/en/mcp); interactive sessions prompt first. A file
+    // the agent plants that spawns a host process on the next headless run in
+    // this repo. Protected (not merely documented like the writable `~/.claude.json`
+    // residual): unlike that home file Claude rewrites constantly, project
+    // `.mcp.json` is static, user/team-authored config Claude does not touch
+    // mid-session — `claude mcp add --scope project` is the only writer, an
+    // explicit command to run outside cplt like the other denied config here.
+    Protected {
+        rel: ".mcp.json",
+        tree: false,
+        nested: true,
+        why: "Claude project MCP config — spawns server commands unprompted in headless sessions",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // Pi auto-discovers `<project>/.pi/extensions/` at startup and runs them
+    // with full user permissions (pi.dev/docs/latest/security). A SUBTREE, not a
+    // file: the loader takes `.ts` and `.js`, any `*/package.json` carrying a
+    // `pi` field, and followed symlinks, so no single file shape covers it. The
+    // rest of `.pi/` (skills, prompts, themes) is ordinary content and stays
+    // writable. Pi is closed-source; this mirrors the decision this repo already
+    // made HOST-side, where `~/.pi/agent` denies `extensions` and `settings.json`
+    // for exactly these reasons (`Agent::host_persistence_denies`).
+    Protected {
+        rel: ".pi/extensions",
+        tree: true,
+        nested: true,
+        why: "Pi extension dir — auto-discovered and run unsandboxed next session",
+        linux: LinuxCoverage::Bwrap,
+    },
+    // `.pi/settings.json` names `packages` (npm/git-installed at startup once the
+    // project is trusted) and `extensions` paths that can point anywhere, so the
+    // file itself steers auto-execution even when `.pi/extensions/` is empty. A
+    // file — the rest of `.pi/` stays writable. The HOST-side `~/.pi/agent/settings.json`
+    // is already denied for this same reason; the project-side file was not.
+    Protected {
+        rel: ".pi/settings.json",
+        tree: false,
+        nested: true,
+        why: "Pi project settings — packages install and extensions load on trust",
+        linux: LinuxCoverage::Bwrap,
+    },
 ];
 
 /// Protected paths relative to a git directory.
@@ -2375,7 +2543,23 @@ mod tests {
         };
         assert_eq!(
             bwrap(PROTECTED_IN_ROOT),
-            [".cplt.toml", ".agents/plugins", ".github/hooks"],
+            [
+                ".cplt.toml",
+                ".agents/plugins",
+                ".github/hooks",
+                ".opencode/plugins",
+                ".opencode/plugin",
+                ".opencode/tools",
+                ".opencode/tool",
+                "opencode.json",
+                "opencode.jsonc",
+                ".claude/settings.json",
+                ".claude/settings.local.json",
+                ".claude-plugin",
+                ".mcp.json",
+                ".pi/extensions",
+                ".pi/settings.json",
+            ],
             "bubblewrap re-binds these read-only under every writable root"
         );
         assert_eq!(
@@ -2406,7 +2590,7 @@ mod tests {
         );
         assert_eq!(
             nested_alternation(PROTECTED_IN_ROOT),
-            r"\.gitmodules|\.cplt\.toml|\.agents/plugins|\.github/hooks",
+            r"\.gitmodules|\.cplt\.toml|\.agents/plugins|\.github/hooks|\.opencode/plugins|\.opencode/plugin|\.opencode/tools|\.opencode/tool|opencode\.json|opencode\.jsonc|\.claude/settings\.json|\.claude/settings\.local\.json|\.claude-plugin|\.mcp\.json|\.pi/extensions|\.pi/settings\.json",
             "a `.` in a rel path must reach the regex escaped, not as `any char`"
         );
     }

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -3110,6 +3110,107 @@ mod tests {
         );
     }
 
+    /// The four `(rel, is_tree)` groups H-11 protects: OpenCode's plugin/tool
+    /// subdirs (subtrees) and root configs (files), Claude's hook carriers and
+    /// skills-dir plugin manifest, Pi's extension dir and settings file. Kept as
+    /// one list so a table addition shows up as a diff on this test too.
+    const H11_PATHS: &[(&str, bool)] = &[
+        (".opencode/plugins", true),
+        (".opencode/plugin", true),
+        (".opencode/tools", true),
+        (".opencode/tool", true),
+        ("opencode.json", false),
+        ("opencode.jsonc", false),
+        (".claude/settings.json", false),
+        (".claude/settings.local.json", false),
+        (".claude-plugin", true),
+        (".mcp.json", false),
+        (".pi/extensions", true),
+        (".pi/settings.json", false),
+    ];
+
+    /// H-11: every path a supported agent auto-executes from the project
+    /// directory is write-denied for every writable root, subtree or file as the
+    /// vector requires, with the last-match-wins ordering behind every allow.
+    #[test]
+    fn h11_agent_persistence_paths_denied_for_every_writable_root() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let mut opts = test_options(project, home);
+        let extra_write = [std::path::PathBuf::from("/Users/test/code")];
+        opts.extra_write = &extra_write;
+        let p = generate_profile(&opts, &[]);
+
+        let last_allow = p
+            .rfind("(allow file-write*")
+            .expect("a write allow must be emitted");
+
+        for root in ["/projects/app", "/Users/test/code"] {
+            for &(rel, is_tree) in H11_PATHS {
+                let shape = if is_tree { "subpath" } else { "literal" };
+                let rule = format!("(deny file-write* ({shape} \"{root}/{rel}\"))");
+                assert!(p.contains(&rule), "missing for {root}: {rule}");
+                // Must outlive every user allow.write, or a grant reopens it.
+                let deny = p
+                    .rfind(&format!("{root}/{rel}\"))"))
+                    .unwrap_or_else(|| panic!("{rel} deny must be emitted for {root}"));
+                assert!(
+                    last_allow < deny,
+                    "a write allow at {last_allow} comes after the {root}/{rel} deny at {deny}"
+                );
+            }
+        }
+    }
+
+    /// A repo nested under a writable root exposes the same auto-exec paths to
+    /// whichever agent next opens THAT repo, so they join the nested-repo
+    /// alternation — the #247 shape, with the `.` in each rel escaped. This is
+    /// also what reaches `.claude/skills/*/.claude-plugin` and `.opencode/opencode.json`.
+    #[test]
+    fn h11_agent_persistence_paths_denied_in_nested_repos_too() {
+        let project = std::path::Path::new("/projects/app");
+        let home = std::path::Path::new("/Users/test");
+        let mut opts = test_options(project, home);
+        let extra_write = [std::path::PathBuf::from("/Users/test/code")];
+        opts.extra_write = &extra_write;
+        let p = generate_profile(&opts, &[]);
+
+        for root in ["/projects/app", "/Users/test/code"] {
+            let esc = root.replace('.', r"\.");
+            for &(rel, _) in H11_PATHS {
+                let esc_rel = rel.replace('.', r"\.");
+                let rule = format!("(deny file-write* (regex #\"^{esc}/.+/{esc_rel}($|/)\"))");
+                assert!(
+                    p.contains(&rule),
+                    "missing nested deny for {root} {rel}: {rule}"
+                );
+            }
+        }
+    }
+
+    /// Scoped precisely: `.opencode/`, `.claude/` and `.pi/` each hold session
+    /// or generated state their agent writes every run (OpenCode's
+    /// node_modules/.gitignore, Claude's projects/history, Pi's skills/prompts),
+    /// so only the executable-bearing paths inside are denied, never the dir.
+    #[test]
+    fn h11_agent_config_dirs_not_denied_wholesale() {
+        let p = generate_profile(
+            &test_options(
+                std::path::Path::new("/projects/app"),
+                std::path::Path::new("/Users/test"),
+            ),
+            &[],
+        );
+        for dir in [".opencode", ".claude", ".pi"] {
+            assert!(
+                !p.contains(&format!(
+                    "(deny file-write* (subpath \"/projects/app/{dir}\"))"
+                )),
+                "only the auto-exec path inside {dir} is denied, not the whole tree"
+            );
+        }
+    }
+
     /// #341: `.git/info/exclude` is a local, uncommitted gitignore. Writing it
     /// hides every path it names from `git status` — the review step people
     /// actually perform — so an agent can conceal what it plants. Emitted for

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1439,6 +1439,87 @@ mod macos_tests {
         );
     }
 
+    /// H-11: `.claude/settings.json` carries Claude Code hooks (`SessionStart`
+    /// et al.) that run unsandboxed on the next session in this repo. It is a
+    /// FILE deny (`literal`), not a subtree — `.claude/` stays writable for
+    /// session state — so this is the kernel proof that the file-literal shape
+    /// actually blocks the write while leaving the rest of `.claude/` open.
+    #[test]
+    fn real_profile_blocks_claude_settings_write() {
+        require_sandbox!();
+        let project = fs::canonicalize(".").unwrap();
+        let tmp = project.join(format!(".claude-settings-{}", std::process::id()));
+        fs::create_dir_all(tmp.join(".claude")).unwrap();
+        let tmp = fs::canonicalize(&tmp).unwrap();
+        let home = home_dir();
+
+        let opts = default_opts(&tmp, &home);
+        let profile = write_real_profile(&opts);
+
+        let settings = tmp.join(".claude/settings.json");
+        let denied = format!(
+            "echo '{{\"hooks\":{{}}}}' > '{}' 2>&1; echo EXIT:$?",
+            settings.display()
+        );
+        let (out_denied, _) = run_sandboxed(&profile, &denied);
+
+        // Sibling state under `.claude/` must stay writable, or we broke Claude.
+        let state = tmp.join(".claude/session-state.json");
+        let allowed = format!("echo x > '{}' 2>&1; echo EXIT:$?", state.display());
+        let (out_allowed, _) = run_sandboxed(&profile, &allowed);
+
+        fs::remove_dir_all(&tmp).ok();
+        fs::remove_file(&profile).ok();
+        assert!(
+            out_denied.contains("Operation not permitted") || out_denied.contains("EXIT:1"),
+            "writing .claude/settings.json should be blocked, got: {out_denied}"
+        );
+        assert!(
+            out_allowed.contains("EXIT:0"),
+            "other writes under .claude/ must stay allowed, got: {out_allowed}"
+        );
+    }
+
+    /// H-11: OpenCode auto-imports `.opencode/{plugin,plugins,tool,tools}/*` at
+    /// startup, but also writes `.opencode/{node_modules,.gitignore,*.lock}`
+    /// there every run. So the deny is surgical — the exec subdirs, not the
+    /// tree. Kernel proof that a plugin write is blocked while the generated
+    /// state OpenCode needs stays writable; get this wrong either way and we
+    /// leave the hole open or break OpenCode's own startup.
+    #[test]
+    fn real_profile_blocks_opencode_plugin_but_keeps_state_writable() {
+        require_sandbox!();
+        let project = fs::canonicalize(".").unwrap();
+        let tmp = project.join(format!(".opencode-surg-{}", std::process::id()));
+        fs::create_dir_all(tmp.join(".opencode/plugin")).unwrap();
+        fs::create_dir_all(tmp.join(".opencode/node_modules")).unwrap();
+        let tmp = fs::canonicalize(&tmp).unwrap();
+        let home = home_dir();
+
+        let opts = default_opts(&tmp, &home);
+        let profile = write_real_profile(&opts);
+
+        let plugin = tmp.join(".opencode/plugin/evil.ts");
+        let denied = format!("echo x > '{}' 2>&1; echo EXIT:$?", plugin.display());
+        let (out_denied, _) = run_sandboxed(&profile, &denied);
+
+        // OpenCode's own startup writes here — must stay allowed.
+        let state = tmp.join(".opencode/node_modules/marker");
+        let allowed = format!("echo x > '{}' 2>&1; echo EXIT:$?", state.display());
+        let (out_allowed, _) = run_sandboxed(&profile, &allowed);
+
+        fs::remove_dir_all(&tmp).ok();
+        fs::remove_file(&profile).ok();
+        assert!(
+            out_denied.contains("Operation not permitted") || out_denied.contains("EXIT:1"),
+            "writing .opencode/plugin/ should be blocked, got: {out_denied}"
+        );
+        assert!(
+            out_allowed.contains("EXIT:0"),
+            "OpenCode state under .opencode/ must stay writable, got: {out_allowed}"
+        );
+    }
+
     /// #341: writing `.git/info/exclude` hides whatever the agent plants from
     /// `git status`, which is the review step people actually perform.
     #[test]


### PR DESCRIPTION
The project directory is writable on both backends. `PROTECTED_IN_ROOT` read-only-protected only `.gitmodules`, `.cplt.toml`, `.agents/plugins` and `.github/hooks`, leaving several project-relative paths that supported agents **auto-execute at the next launch**. A contained agent writes one, and a later unsandboxed run of that agent runs it on the host.

## Paths added

Each verified against upstream source or docs, not assumed:

**OpenCode** (`config/plugin.ts`, `tool/registry.ts`, `config/paths.ts`): `.opencode/plugin` and `.opencode/plugins` (the loader globs `{plugin,plugins}/*.{ts,js}`), `.opencode/tool` and `.opencode/tools` (globbed and `import()`ed at registry init), and `opencode.json`/`opencode.jsonc` (a `plugin` array npm-installed at startup, a local MCP `command` that spawns, remote `instructions`).

**Claude** (hooks / settings / plugins-reference / mcp docs): `.claude/settings.json` and `.claude/settings.local.json` (hooks incl. `SessionStart`), `.claude-plugin` (a `plugin.json` under a `.claude/skills/<x>/` folder promotes it to an auto-loaded plugin bundling hooks/mcp/agents next session), and `.mcp.json` (auto-connects, spawning each local `command`, with no prompt in `-p`/SDK sessions).

**Pi** (docs + this repo's existing host-side precedent): `.pi/extensions` and `.pi/settings.json` (`packages` npm/git-installed on trust; `extensions` point anywhere). Pi is closed-source, so these mirror the decision already made host-side for `~/.pi/agent`.

## Surgical, not wholesale — and why

Each tool also writes mutable state under the same directory, so a blanket subtree deny would break the agent's own startup. Verified and avoided: OpenCode writes `.opencode/node_modules`, `.opencode/.gitignore` and lockfiles every run, so only the exec subdirs and root config files are denied — the generated state at `.opencode/` root stays writable. `.claude/` holds session state, so the two settings files are denied individually, and `.claude-plugin` is protected rather than `.claude/skills/` (the manifest dir holds only `plugin.json`, so skill authoring is untouched). A kernel `sandbox-exec` test proves both directions: the plugin write is denied while a sibling state write succeeds.

## Linux coverage is bubblewrap-only, and bounded

Landlock enforces **none** of `PROTECTED_IN_ROOT` (it is additive-only) — on Linux this set rides the bubblewrap read-only overlay alone, so a host without user namespaces has none of it. Two further Linux limits, stated because the advisory must not overclaim: the overlay binds only paths that **exist at launch**, so a not-yet-created path is unprotected until it exists; and nested-repo coverage is **macOS-only** (`git_persistence_paths` joins only each root on Linux), which also scopes the sub-path cases (`.claude/skills/*/.claude-plugin`, `.opencode/opencode.json`) to macOS.

## Verification

Tests assert the correct deny shape (subtree vs file) for every path at both roots, that the tool root directories are *not* denied wholesale, and — at the kernel level — that a protected exec path is blocked while sibling state stays writable. Mutation-checked by removing one entry (a named test fails, filter matched a non-zero count). `cargo fmt`, `cargo test --lib` (989), `cargo test --test unit_tests` (340), clippy for host and `x86_64-unknown-linux-gnu`, and the macOS `integration` project-protection suite — all green.

The path list and the bubblewrap-only scoping came from an independent review of an earlier version of this fix. Found by an internal security review, credited to @randax. An advisory will follow once released.