### PR TITLE
fix(sandbox): name the ungranted shim target instead of failing with exit 126

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -280,6 +280,50 @@ pub fn writable_tree_over(policy: &LandlockPolicy, home: &Path, path: &Path) -> 
         .max_by_key(|p| p.as_os_str().len())
 }
 
+/// The resolved target of `path`, when the policy grants execute on `path` but
+/// not on what it actually resolves to (#390).
+///
+/// Landlock resolves a symlink and checks the **target**, so a shim in a granted
+/// bin directory whose real binary lives in an ungranted one cannot be executed.
+/// The kernel refuses the `execve` and the caller sees exit 126 with nothing
+/// printed — a failure that reads as "cplt is broken" rather than "your runtime
+/// is installed somewhere the policy does not grant", and whose obvious next
+/// step (copying the binary into the project) is a far worse posture than
+/// granting the real path.
+///
+/// cplt cannot observe the refusal itself: the kernel denies the exec inside the
+/// sandbox and the parent only sees an exit status it cannot attribute. So this
+/// is a preflight — asked of the same resolved policy the run is about to
+/// enforce, before the launch, and only about the one binary cplt resolved.
+///
+/// Only sees a symlink that is still one by the time cplt resolves it, which is
+/// the reported case: `resolve_exec_binary`'s PATH branch returns the shim as
+/// found, and an agent binary discovered on PATH the same way. An *explicit*
+/// path (`cplt exec -- /path/to/shim`) is canonicalized before it gets here, so
+/// what runs is the target and there is no shim left to name — the exec still
+/// fails, and the remedy is still `--allow-exec` on that directory, but this
+/// says nothing about it.
+///
+/// Returns `None` when `path` is not a symlink, when it cannot be resolved, or
+/// when the target is granted execute anyway (the ordinary case: nvm, fnm, asdf,
+/// mise, volta and nodenv all keep shim and target under one granted root).
+#[must_use]
+pub fn shim_target_without_exec(policy: &LandlockPolicy, path: &Path) -> Option<PathBuf> {
+    let target = std::fs::canonicalize(path).ok()?;
+    if target == path {
+        return None;
+    }
+    let granted = |p: &Path| {
+        policy
+            .fs_rules
+            .iter()
+            .any(|r| r.access.execute && within(p, &r.path))
+    };
+    // Only a *shim* problem: if the policy does not grant the shim either, the
+    // exec fails for the ordinary reason and this message would misdiagnose it.
+    (granted(path) && !granted(&target)).then_some(target)
+}
+
 /// The usual install locations that *this* policy keeps non-writable, for a
 /// binary called `file_name`.
 ///

--- a/src/check.rs
+++ b/src/check.rs
@@ -309,6 +309,19 @@ pub fn writable_tree_over(policy: &LandlockPolicy, home: &Path, path: &Path) -> 
 /// mise, volta and nodenv all keep shim and target under one granted root).
 #[must_use]
 pub fn shim_target_without_exec(policy: &LandlockPolicy, path: &Path) -> Option<PathBuf> {
+    // Only a real symlink counts. `canonicalize` also normalizes `..` and
+    // resolves symlinks in PARENT components, so comparing it against the input
+    // reports a plain binary reached through `bin/../bin/node`, or through a
+    // symlinked parent directory, as a shim — a warning about a symlink the user
+    // does not have. A warning that fires on ordinary launches is how warnings
+    // get ignored.
+    if !std::fs::symlink_metadata(path)
+        .ok()?
+        .file_type()
+        .is_symlink()
+    {
+        return None;
+    }
     let target = std::fs::canonicalize(path).ok()?;
     if target == path {
         return None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1305,6 +1305,28 @@ struct ResolvedContext {
     unapproved_proposals: Vec<String>,
 }
 
+/// Warn when the binary cplt is about to launch is a shim whose real target the
+/// sandbox does not grant execute on (#390).
+///
+/// Preflight, not post-mortem: the kernel refuses the `execve` inside the
+/// sandbox and the parent sees only exit 126, with nothing to attribute it to.
+/// Naming the resolved path before launch is the only place cplt can turn that
+/// into something actionable. Not gated on `quiet` — like the writable-agent-dir
+/// warning above it, this is about the sandbox boundary, not progress.
+fn warn_shim_target_without_exec(policy: &sandbox::LandlockPolicy, bin: &Path) {
+    if let Some(target) = cplt::check::shim_target_without_exec(policy, bin) {
+        let dir = target.parent().unwrap_or(&target);
+        ui::warn(&format!(
+            "{} is a shim resolving to {}, which this run does not grant execute on. \
+             The sandbox checks the target, not the shim, so it will fail with exit 126 \
+             and no message. Grant it with --allow-exec {} (or [sandbox] allow.exec) and rerun.",
+            bin.display(),
+            target.display(),
+            dir.display()
+        ));
+    }
+}
+
 /// Warn about `allow.write` grants that shadow a directory this run grants
 /// execute on (#243, #343).
 ///
@@ -2746,6 +2768,8 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         ));
     }
 
+    warn_shim_target_without_exec(&policy, &agent_bin);
+
     // Preflight: verify the sandbox mechanism works on this system
     if !resolved.no_validate {
         match sandbox::preflight(&prepared) {
@@ -3661,6 +3685,7 @@ fn run_exec_command(
     // with `cplt check`, which runs its probes under the identical policy.
     let AssembledSandbox {
         prepared,
+        policy,
         proxy_handle,
         scratch_guard: _scratch_guard,
         #[cfg(target_os = "macos")]
@@ -3673,6 +3698,8 @@ fn run_exec_command(
         &home_dir,
         &project_dir,
     )?;
+
+    warn_shim_target_without_exec(&policy, &exec_bin);
 
     if cli.print_profile {
         println!("{}", sandbox::describe(&prepared));

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -1185,6 +1185,23 @@ pub const HOME_TOOL_DIRS: &[HomeToolDir] = &[
         map_exec: true,
         write: false,
     },
+    // volta and nodenv both put a shim in one directory and the real binary in
+    // another, and Landlock checks the *target* of the exec, not the shim (#390).
+    // Granting the whole root covers both halves: volta's `bin/` shims resolve
+    // into `tools/image/node/<version>/bin/`, nodenv's `shims/` into
+    // `versions/<version>/bin/`. Same shape, and same reason, as .nvm and .asdf.
+    HomeToolDir {
+        path: ".volta",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
+    HomeToolDir {
+        path: ".nodenv",
+        process_exec: true,
+        map_exec: true,
+        write: false,
+    },
     HomeToolDir {
         path: ".cargo/bin",
         process_exec: true,

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8665,3 +8665,103 @@ fn install_advice_drops_a_location_the_run_makes_writable() {
         "advice must not name a location this run makes writable"
     );
 }
+
+// ============================================================
+// #390: a shim in a granted bin dir whose target is ungranted
+// ============================================================
+
+/// volta and nodenv put the shim and the real binary in different directories,
+/// and Landlock checks the target. Both stores live under one home root, so one
+/// `HomeToolDir` each covers shim and target — the same shape as `.nvm`.
+#[test]
+fn volta_and_nodenv_version_stores_are_exec_granted() {
+    use cplt::sandbox::HOME_TOOL_DIRS;
+
+    for root in [".volta", ".nodenv"] {
+        let entry = HOME_TOOL_DIRS
+            .iter()
+            .find(|d| d.path == root)
+            .unwrap_or_else(|| panic!("HOME_TOOL_DIRS missing {root} (#390)"));
+        assert!(entry.process_exec, "{root} must grant process_exec");
+        assert!(
+            !entry.write,
+            "{root} must stay read-only: a writable version store lets an agent \
+             trojan a binary that runs on the next launch"
+        );
+    }
+
+    let policy = generate_policy(&base_profile_options());
+    let exec_granted = |p: &std::path::Path| {
+        policy
+            .fs_rules
+            .iter()
+            .any(|r| r.access.execute && p.starts_with(&r.path))
+    };
+    // The paths the shims actually resolve into, not just the roots.
+    for target in [
+        "/Users/test/.volta/tools/image/node/22.23.2/bin/node",
+        "/Users/test/.nodenv/versions/22.23.2/bin/node",
+    ] {
+        assert!(
+            exec_granted(std::path::Path::new(target)),
+            "{target} must be exec-granted, or the shim fails with a silent exit 126"
+        );
+    }
+}
+
+#[test]
+fn shim_pointing_outside_every_exec_grant_is_reported() {
+    use cplt::check::shim_target_without_exec;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = std::fs::canonicalize(tmp.path()).unwrap();
+    let bin = root.join("granted/bin");
+    let store = root.join("elsewhere/node-v22/bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::create_dir_all(&store).unwrap();
+    std::fs::write(store.join("node"), "#!/bin/sh\n").unwrap();
+    std::fs::write(bin.join("plain"), "#!/bin/sh\n").unwrap();
+    std::os::unix::fs::symlink(store.join("node"), bin.join("node")).unwrap();
+
+    let policy_with = |exec: &[PathBuf]| {
+        generate_policy(&SandboxConfig {
+            project_dir: &root.join("project"),
+            home_dir: &root.join("home"),
+            extra_exec: exec,
+            ..base_profile_options()
+        })
+    };
+
+    // The reported case: shim granted, target not.
+    let policy = policy_with(&[root.join("granted")]);
+    assert_eq!(
+        shim_target_without_exec(&policy, &bin.join("node")),
+        Some(store.join("node")),
+        "a shim resolving outside every exec grant must be named, not left as exit 126"
+    );
+
+    // Granting the real store silences it — the advice the warning gives works.
+    let policy = policy_with(&[root.join("granted"), root.join("elsewhere")]);
+    assert_eq!(
+        shim_target_without_exec(&policy, &bin.join("node")),
+        None,
+        "--allow-exec on the resolved store must clear the warning"
+    );
+
+    // A real binary in the granted dir is not a shim.
+    let policy = policy_with(&[root.join("granted")]);
+    assert_eq!(
+        shim_target_without_exec(&policy, &bin.join("plain")),
+        None,
+        "a non-symlink must never be reported as a shim"
+    );
+
+    // Nothing granted at all: the exec fails for the ordinary reason, and
+    // blaming the symlink would misdiagnose it.
+    let policy = policy_with(&[]);
+    assert_eq!(
+        shim_target_without_exec(&policy, &bin.join("node")),
+        None,
+        "an ungranted shim is not a shim-target problem"
+    );
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8756,6 +8756,28 @@ fn shim_pointing_outside_every_exec_grant_is_reported() {
         "a non-symlink must never be reported as a shim"
     );
 
+    // A plain binary reached through a SYMLINKED PARENT, with the path itself
+    // inside the exec grant so the ordinary ungranted-shim branch cannot be what
+    // returns None. `canonicalize` resolves parent components too, so comparing
+    // it against the input reports this as a shim resolving into the ungranted
+    // store — a warning about a symlink the user does not have. Only the
+    // symlink_metadata check on the path itself rejects it.
+    let linked_parent = root.join("granted/link");
+    std::os::unix::fs::symlink(&store, &linked_parent).unwrap();
+    let policy = policy_with(&[root.join("granted")]);
+    assert!(
+        std::fs::symlink_metadata(linked_parent.join("node"))
+            .unwrap()
+            .file_type()
+            .is_file(),
+        "fixture: the binary itself must not be a symlink, or this tests nothing"
+    );
+    assert_eq!(
+        shim_target_without_exec(&policy, &linked_parent.join("node")),
+        None,
+        "a plain binary under a symlinked parent must not be reported as a shim"
+    );
+
     // Nothing granted at all: the exec fails for the ordinary reason, and
     // blaming the symlink would misdiagnose it.
     let policy = policy_with(&[]);


### PR DESCRIPTION
Closes #390. Reported by @nortesoftware, who hit it in #180 before reaching the bug they were actually reporting.

`HOME_TOOL_DIRS` grants `~/.local/bin` with `process_exec`, but Landlock resolves the symlink and checks the **target**. A shim in a granted directory pointing into an ungranted one therefore fails to execute with exit 126 and no message at all:

```
$ cplt exec -- node --version
$ echo $?
126
```

Their node was at `~/.local/lib/node-.../bin/node`, symlinked from `~/.local/bin/node`. The natural next step — the one they took — is to copy the binary into the project directory, which is a considerably worse posture than granting the real path. An opaque 126 pushes people toward the wrong fix.

## Enumeration

`.volta` and `.nodenv` added to `HOME_TOOL_DIRS` with `process_exec + map_exec`, `write: false`, matching the existing `.nvm`/`.asdf`/`.pyenv` entries. Store paths confirmed from upstream documentation rather than guessed: volta shims at `$VOLTA_HOME/bin` resolve into `~/.volta/tools/image/node/<version>/bin/`, nodenv shims at `~/.nodenv/shims` resolve into `~/.nodenv/versions/<version>/bin/`. Both keep shim and target under one home root, so a single root entry covers both halves and a separate store entry would be redundant. nvm, fnm, asdf and mise were already handled.

## Diagnostic, and why it is preflight

cplt cannot observe the refusal. The kernel denies the `execve` **inside** the sandbox; the parent sees an exit status with nothing to attribute it to. So the check runs before launch, against the same resolved Landlock policy the run is about to enforce, on the agent binary and on `cplt exec`'s binary:

```
[cplt] .../granted/bin/fakenode is a shim resolving to .../store/bin/fakenode, which this
run does not grant execute on. The sandbox checks the target, not the shim, so it will fail
with exit 126 and no message. Grant it with --allow-exec .../store/bin ... and rerun.
```

Verified end to end against a synthetic shim, and granting the named directory makes the command run.

It stays silent when the shim itself is ungranted — there the exec fails for the ordinary reason, and blaming the symlink would misdiagnose it.

## A gap this does not cover, documented rather than papered over

`resolve_exec_binary` canonicalizes an absolute or relative path before passing it on, so `cplt exec -- /path/to/shim` reaches the sandbox as the *target* and there is no symlink left to name. The PATH branch does not canonicalize, which is the reporter's actual case (`cplt exec -- node`), and agent-binary discovery behaves the same way. The absolute-path form still fails and the remedy is still the same `--allow-exec`, but the warning is silent for it. That limitation is in the function's doc comment.

Widening the predicate to "the resolved binary has no exec grant at all" would cover it. Deliberately not done here: it goes beyond the reported problem and risks a warning that fires on ordinary launches, which is the failure mode that teaches people to ignore warnings.

## Note on #180's other half

The `NPM_CONFIG_USERCONFIG` redirect discussed in #180 is already on `main` and was verified rather than reimplemented. Its gate matches the canonicalized `~/.npmrc` against `extra_read` — the *same* predicate the re-allow itself uses, so the gate cannot drift from the grant: exactly the runs where the file is genuinely readable are the runs where the redirect is skipped.

## Verification

Mutation-checked both halves with matched counts reported: deleting the two `HOME_TOOL_DIRS` entries fails a named test (1 matched, 343 filtered), and weakening the shim predicate fails another (1 matched, 343 filtered).

`cargo fmt`, `--lib` (1013), `unit_tests` (344), clippy for host and `x86_64-unknown-linux-gnu`, plus `e2e` (160), `e2e_projects` (54), `integration` (70), `e2e_guards` (140), `e2e_git_hardening` (11) — all green, run from a checkout outside `/private/tmp`.