### PR TITLE
docs: the git guard blocks by default, it does not warn

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,7 +121,7 @@ cplt assumes the sandboxed agent is **untrusted**, because it executes arbitrary
 | **Data exfiltration** | POST secrets to `https://evil.com/collect` | Filesystem isolation (credentials unreadable) |
 | **Secret file access** | Read `~/.netrc`, `~/.npmrc`, `~/.vault-token` | Seatbelt deny rules (macOS) / Landlock deny (Linux) |
 | **Destructive GitHub ops** | `gh repo delete`, `gh pr merge`, `gh release create` | gh guard command interception (on by default) |
-| **Unreviewed code push** | `git push origin main` | git guard command interception (on by default, `warn` mode) |
+| **Unreviewed code push** | `git push origin main` | git guard command interception (on by default, `block` mode, default branch) |
 | **Git alias push bypass** | `git -c alias.p=push p origin main` | git guard blocks `-c alias.*` and denies unknown subcommands |
 | **Git subtree push bypass** | `git subtree push --prefix=lib origin main` | `subtree` in explicit block list, plus deny-unknown policy |
 | **Multi-refspec bypass** | `git push origin feature main` | git guard checks ALL refspecs, not just the first |

--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -22,14 +22,14 @@ cplt config set gh_guard.scope_check true           # enforce repo-scoping on wr
 cplt config set gh_guard.block_auth_token true      # deny "gh auth token" exfiltration
 cplt config set gh_guard.unknown_command block      # block unrecognized gh commands
 
-# git guard — on by default, in warn mode
+# git guard — on by default, in block mode, scoped to the default branch
 cplt config set git_guard.mode warn                # block | warn | audit (default block)
 cplt config set git_guard.enabled false             # opt out entirely
 cplt config set git_guard.prevent_push true         # block git push/request-pull
 ```
 
-`--preset strict` puts the git guard in `block` mode; `--preset permissive` and
-`--preset full-trust` turn both guards off. Every refusal prints the flag and
+`--preset strict` widens the git guard from the default branch to every push;
+`--preset permissive` and `--preset full-trust` turn both guards off. Every refusal prints the flag and
 the config key that undo it.
 
 Both guards take a `mode`. `block` prints the message and exits non-zero.
@@ -75,7 +75,7 @@ allow_api_write = false     # allow gh api write (POST/PUT/PATCH) to current rep
 
 [git_guard]
 enabled = true              # intercept git push, request-pull, send-pack
-mode = "warn"               # block | warn | audit (default warn)
+mode = "block"              # block | warn | audit (default block)
 prevent_push = true         # treat push/request-pull as violations
 prevent_force_push = true   # block force push, even where a plain push is allowed
 ```

--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -10,9 +10,9 @@ Its sibling, the git guard, blocks `git push`, `git request-pull`, and
 
 ## Configuration
 
-Both guards are **enabled by default**. The gh guard blocks; the git guard
-starts in `warn` mode, so a `git push` still goes through and only prints a
-warning until you escalate it.
+Both guards are **enabled by default**, and both block. The gh guard blocks
+across its whole policy table; the git guard blocks pushes to the default
+branch, and lets feature branches through.
 
 ```bash
 # gh guard — on by default, in block mode
@@ -23,14 +23,14 @@ cplt config set gh_guard.block_auth_token true      # deny "gh auth token" exfil
 cplt config set gh_guard.unknown_command block      # block unrecognized gh commands
 
 # git guard — on by default, in block mode, scoped to the default branch
-cplt config set git_guard.mode warn                # block | warn | audit (default block)
+cplt config set git_guard.mode block               # block | warn | audit (default block)
 cplt config set git_guard.enabled false             # opt out entirely
 cplt config set git_guard.prevent_push true         # block git push/request-pull
 ```
 
 `--preset strict` widens the git guard from the default branch to every push;
 `--preset permissive` and `--preset full-trust` turn both guards off. Every refusal prints the flag and
-the config key that undo it.
+the config key that undoes it.
 
 Both guards take a `mode`. `block` prints the message and exits non-zero.
 `warn` prints the same message behind `⚠️  WARNING (would block):` and runs the


### PR DESCRIPTION
#387 flipped `git_guard.mode` to `block` and `protect_default_branch_only` to `true` in the standard preset, but three places still described the old default:

- `SECURITY.md:124` threat table: "on by default, `warn` mode"
- `docs/gh-guard.md:25` comment: "on by default, in warn mode"
- `docs/gh-guard.md:78` sample config: `mode = "warn"   # ... (default warn)`

They contradicted `docs/git-guard.md:10` and the code, so a reader checking whether pushes are really blocked was told they are not.

Also corrected in passing: "`--preset strict` puts the git guard in `block` mode" was true before #387. Both presets are `block` now (`src/config/types.rs:298,311`); strict differs by scope, blocking every push rather than only the default branch (`:299,312`).

Docs only, no behaviour change.

Found while updating an article about cplt for an English audience, where the same stale claim would have understated what ships.