### PR TITLE
fix(guards): redirect a guarded name to the shim whatever its case

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6698,6 +6698,13 @@ mod tests {
         let case_insensitive_fs = bin.path().join("Git").is_file();
         for (name, guard) in [("Git", "git"), ("GIT", "git"), ("Gh", "gh"), ("GH", "gh")] {
             let real = bin.path().join(name);
+            if !case_insensitive_fs {
+                // Here the mixed-case name is a genuinely different binary, so
+                // write one: `resolve_exec_binary` only ever hands this function
+                // a path it found, and a missing file would prove nothing more
+                // than that unreadable metadata does not redirect.
+                std::fs::write(&real, "#!/bin/sh\n").unwrap();
+            }
             let expected = if case_insensitive_fs {
                 scratch.join("bin").join(guard)
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3269,6 +3269,27 @@ fn resolve_exec_binary(name: &str) -> anyhow::Result<PathBuf> {
 /// applies. Taking it as an argument keeps the shim only where cplt actually
 /// found a binary to wrap: `gh` on a machine without gh still fails with
 /// "not found in PATH" rather than with a missing shim.
+///
+/// Case is decided by the filesystem, not by the OS. `resolve_exec_binary`
+/// walks the parent PATH with `is_file()`, so on a case-insensitive volume
+/// (APFS/HFS+ by default, and ciopfs or vfat on Linux) `Git` resolves to the
+/// real git and the gate has to run; on a case-sensitive volume `Git` is a
+/// genuinely different command and redirecting it would silently run the wrong
+/// binary. Both hold on either OS — a case-sensitive APFS volume and a
+/// case-insensitive Linux mount both exist — so instead of `cfg(target_os)`,
+/// a name that differs from a guarded name only in case is redirected exactly
+/// when it resolves to the same inode as that guarded name does. That is the
+/// same question the kernel answers when it execs the path, so the two cannot
+/// disagree. Names that merely look similar (`gitk`, `ghost`, `github`) never
+/// reach the check.
+///
+/// Not taken: the general fix of resolving argv[0] against the CHILD PATH
+/// (scratch bin dir first), which would need no name list at all. The shims do
+/// not exist yet at this point — `install_command_wrappers` writes them while
+/// the sandboxed `Command` is being built, well after argv[0] is resolved — so
+/// that fix means splitting wrapper installation out of the spawn path first.
+/// With exactly two shims, both named here already, that refactor buys nothing
+/// this check does not; it becomes worth doing when a third guard appears.
 fn redirect_to_guard_shim(
     name: &str,
     real: PathBuf,
@@ -3276,15 +3297,36 @@ fn redirect_to_guard_shim(
     gh_guard_enabled: bool,
     git_guard_enabled: bool,
 ) -> PathBuf {
-    let guarded = match name {
-        "git" => git_guard_enabled,
-        "gh" => gh_guard_enabled,
+    let guarded = ["git", "gh"].into_iter().find(|guard| {
+        name.eq_ignore_ascii_case(guard) && (name == *guard || is_same_file(&real, guard))
+    });
+    let enabled = match guarded {
+        Some("git") => git_guard_enabled,
+        Some("gh") => gh_guard_enabled,
         _ => false,
     };
-    match (guarded, scratch_dir) {
-        (true, Some(scratch)) => scratch.join("bin").join(name),
+    match (guarded, enabled, scratch_dir) {
+        // The shim is written as `bin/git` / `bin/gh`, so name the shim by its
+        // real name and not by the case the caller happened to type.
+        (Some(guard), true, Some(scratch)) => scratch.join("bin").join(guard),
         _ => real,
     }
+}
+
+/// True when `real` and `<real's directory>/<name>` are the same file on disk.
+///
+/// Compares device and inode rather than the path text: that is the same
+/// question the kernel answers when it execs `real`, so it is right on a
+/// case-insensitive volume and on a case-sensitive one, with no per-OS guess.
+fn is_same_file(real: &Path, name: &str) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Some(dir) = real.parent() else {
+        return false;
+    };
+    let (Ok(a), Ok(b)) = (std::fs::metadata(real), std::fs::metadata(dir.join(name))) else {
+        return false;
+    };
+    a.dev() == b.dev() && a.ino() == b.ino()
 }
 
 /// Everything the sandbox assembly reads off the host machine.
@@ -6644,9 +6686,56 @@ mod tests {
             real
         );
 
+        // A name differing only in case is redirected exactly when it resolves
+        // to the same file the guarded name does. Whether it does is a property
+        // of the filesystem (case-insensitive on APFS/HFS+, case-sensitive on
+        // most Linux ones), so the expectation is probed rather than assumed
+        // per-OS: a case-sensitive macOS volume and a case-insensitive Linux
+        // mount both exist.
+        let bin = tempfile::tempdir().unwrap();
+        std::fs::write(bin.path().join("git"), "#!/bin/sh\n").unwrap();
+        std::fs::write(bin.path().join("gh"), "#!/bin/sh\n").unwrap();
+        let case_insensitive_fs = bin.path().join("Git").is_file();
+        for (name, guard) in [("Git", "git"), ("GIT", "git"), ("Gh", "gh"), ("GH", "gh")] {
+            let real = bin.path().join(name);
+            let expected = if case_insensitive_fs {
+                scratch.join("bin").join(guard)
+            } else {
+                real.clone()
+            };
+            assert_eq!(
+                redirect_to_guard_shim(name, real, Some(&scratch), true, true),
+                expected,
+                "{name} on a {} filesystem",
+                if case_insensitive_fs {
+                    "case-insensitive"
+                } else {
+                    "case-sensitive"
+                }
+            );
+        }
+
+        // Guard off → unchanged, whatever the case.
+        let real_git = bin.path().join("GIT");
+        assert_eq!(
+            redirect_to_guard_shim("GIT", real_git.clone(), Some(&scratch), true, false),
+            real_git
+        );
+
         // A path with a slash keeps the documented, out-of-scope behaviour
-        // (SECURITY.md), and every unguarded command is untouched.
-        for name in ["/usr/bin/git", "./git", "../gh", "ls", "gitk", "ghost"] {
+        // (SECURITY.md), and every unguarded command is untouched — including
+        // one that only looks like a guarded name in some other case.
+        for name in [
+            "/usr/bin/git",
+            "./git",
+            "../gh",
+            "./Git",
+            "ls",
+            "gitk",
+            "ghost",
+            "Gitk",
+            "GitHub",
+        ] {
             assert_eq!(
                 redirect_to_guard_shim(name, real.clone(), Some(&scratch), true, true),
                 real,

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -23,9 +23,7 @@ mod e2e_tests {
     use std::path::{Path, PathBuf};
     use std::process::Command;
 
-    use crate::common::{
-        binary_in_path, binary_path, cplt_cmd, cplt_cmd_with_ambient_config, git_cmd,
-    };
+    use crate::common::{binary_path, cplt_cmd, cplt_cmd_with_ambient_config, git_cmd};
     use std::sync::atomic::{AtomicU32, Ordering};
 
     static FAKE_COPILOT_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -5062,7 +5060,15 @@ paths = [
         // case-insensitive (APFS/HFS+ by default) — there the guard must run.
         // Where it is case-sensitive they are simply not on PATH, and cplt has
         // nothing to resolve, let alone redirect.
-        let case_insensitive_fs = binary_in_path("git").with_file_name("Git").is_file();
+        // Probe the very file `cplt exec` will resolve — the first `git` on
+        // PATH, the way `resolve_exec_binary` walks it — and not `/usr/bin/git`,
+        // which may sit on a mount with the opposite case behaviour.
+        let path_git =
+            std::env::split_paths(&std::env::var_os("PATH").expect("PATH should be set"))
+                .map(|dir| dir.join("git"))
+                .find(|candidate| candidate.is_file())
+                .expect("git should be available in PATH");
+        let case_insensitive_fs = path_git.with_file_name("Git").is_file();
         for name in ["Git", "GIT"] {
             let (ok, stderr) = push(&[
                 "--no-validate",

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -23,7 +23,9 @@ mod e2e_tests {
     use std::path::{Path, PathBuf};
     use std::process::Command;
 
-    use crate::common::{binary_path, cplt_cmd, cplt_cmd_with_ambient_config, git_cmd};
+    use crate::common::{
+        binary_in_path, binary_path, cplt_cmd, cplt_cmd_with_ambient_config, git_cmd,
+    };
     use std::sync::atomic::{AtomicU32, Ordering};
 
     static FAKE_COPILOT_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -5055,6 +5057,37 @@ paths = [
         ]);
         let (shell_ok, shell_stderr) =
             push(&["--no-validate", "exec", "-c", "git push origin main"]);
+
+        // `Git` and `GIT` reach the real git only where the filesystem is
+        // case-insensitive (APFS/HFS+ by default) — there the guard must run.
+        // Where it is case-sensitive they are simply not on PATH, and cplt has
+        // nothing to resolve, let alone redirect.
+        let case_insensitive_fs = binary_in_path("git").with_file_name("Git").is_file();
+        for name in ["Git", "GIT"] {
+            let (ok, stderr) = push(&[
+                "--no-validate",
+                "exec",
+                "--",
+                name,
+                "push",
+                "origin",
+                "main",
+            ]);
+            assert!(!ok, "exec -- {name} push must not succeed.\n{stderr}");
+            if case_insensitive_fs {
+                assert!(
+                    stderr.contains("BLOCKED by sandbox"),
+                    "exec -- {name} push resolves to the real git here, so it must meet the \
+                     same guard as the lowercase spelling.\n{stderr}"
+                );
+            } else {
+                assert!(
+                    stderr.contains("not found in PATH"),
+                    "exec -- {name} push has no binary to resolve on a case-sensitive \
+                     filesystem.\n{stderr}"
+                );
+            }
+        }
 
         assert!(
             !shell_ok && shell_stderr.contains("BLOCKED by sandbox"),


### PR DESCRIPTION
Follow-up to #406, which fixed the `cplt exec` shim bypass only for the exact spelling.

A case-insensitive filesystem resolves `Git` to the same file as `git`, but `redirect_to_guard_shim` compared the name literally, so the redirect did not fire and the real binary ran ungated:

```
cplt exec -- git push --dry-run origin main   → BLOCKED by sandbox
cplt exec -- Git push --dry-run origin main   → Everything up-to-date   (real git, no gate)
cplt exec -- Gh auth token                    → no oauth token found    (real gh, no gate)
```

`cplt exec -- sh -c 'Git push …'` was already gated, since the shell resolves against the child PATH where the shim dir comes first. Only the direct-argv form was affected.

## Approach

The redirect now matches case-insensitively but only fires when the case variant resolves to the *same file* as the guarded name, compared by `(dev, ino)`. That asks the kernel the same question it answers when it execs the path, so resolution and gate cannot disagree.

Deliberately not `cfg(target_os = "macos")`: this is a property of the filesystem, not the OS. APFS can be formatted case-sensitive, where `Git` would be a genuinely different command that must not be redirected; Linux can mount case-insensitive filesystems, where the bypass is live. The inode comparison is correct on both with no per-OS guess.

The general fix — resolving argv[0] against the child PATH — was evaluated and not taken: the shims do not exist yet at redirect time (`install_command_wrappers` runs while the sandboxed command is being built, after argv[0] is resolved), so it would require splitting wrapper installation out of the spawn path. With two shims, both named at the redirect, it buys nothing this check does not. The comment records that and says to revisit when a third guard appears.

Names with a slash stay out of scope per `SECURITY.md`, guard-disabled and no-scratch-dir paths are unchanged, and `gitk`/`ghost`/`github` never compare equal ignoring case.

## Tests

Unit and e2e tests probe the filesystem's actual case behaviour, then assert `Git`/`GIT`/`Gh`/`GH` redirect where it is case-insensitive and are left alone where it is not, so they are correct on either kind of filesystem rather than skipped. Ran non-vacuously here on APFS.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` and the full `cargo test` pass.