### PR TITLE
docs: correct stale claims about guard defaults and static linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cplt gives you kernel-level enforcement with team-configurable policy:
 - Deny by default for credentials, secrets, and sensitive files
 - Command-level git and gh interception that blocks pushes, merges, and releases
 - Outbound network filtering with an audit log
-- No Docker, no VMs. One static binary that runs on a locked-down laptop
+- No Docker, no VMs. One binary that runs on a locked-down laptop
 - Zero-config start for developers, with escape hatches when a build genuinely needs one
 
 ## Table of contents
@@ -786,7 +786,7 @@ Internals and module layout: [docs/architecture.md](docs/architecture.md). Threa
 
 ## Security
 
-One static binary, minimal dependencies, no runtime services, no telemetry. Three defense layers, with clear boundaries between them:
+One binary, minimal dependencies, no runtime services, no telemetry. Three defense layers, with clear boundaries between them:
 
 | Layer | Enforcement | Bypassable? | What it protects |
 |---|---|---|---|
@@ -814,7 +814,7 @@ What cplt does not protect against:
 - Network attacks on allowed domains. If github.com is allowed, the agent can read and write there
 - macOS Keychain access, for agents that store auth there. Contents are password-protected, and `sandbox.keychain_substitute` can trade the grant away where an agent has another credential
 
-Our priorities, in order: **correct** (every claim is tested, every edge case has a CVE or research reference), **transparent** ([SECURITY.md](SECURITY.md) hides nothing), **simple** (one static binary, zero config required, sane defaults), and **useful** (get out of the way and let the agent work, safely).
+Our priorities, in order: **correct** (every claim is tested, every edge case has a CVE or research reference), **transparent** ([SECURITY.md](SECURITY.md) hides nothing), **simple** (one binary, zero config required, sane defaults), and **useful** (get out of the way and let the agent work, safely).
 
 More: [docs/security.md](docs/security.md) · [SECURITY.md](SECURITY.md)
 

--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -17,7 +17,7 @@ branch, and lets feature branches through.
 ```bash
 # gh guard — on by default, in block mode
 cplt config set gh_guard.enabled false              # opt out entirely
-cplt config set gh_guard.mode warn                  # block | warn | audit (default block)
+cplt config set gh_guard.mode block                 # block | warn | audit (default block)
 cplt config set gh_guard.scope_check true           # enforce repo-scoping on write commands
 cplt config set gh_guard.block_auth_token true      # deny "gh auth token" exfiltration
 cplt config set gh_guard.unknown_command block      # block unrecognized gh commands

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@ One Rust binary, and a dependency list short enough to read in a sitting (see `C
 
 1. **Correct.** Every claim is tested, and every edge case has a CVE or research reference.
 2. **Transparent.** Read [SECURITY.md](../SECURITY.md). It hides nothing.
-3. **Simple.** One static binary, zero config required, sane defaults.
+3. **Simple.** One binary, zero config required, sane defaults.
 4. **Useful.** Get out of the way and let the agent do its job, safely.
 
 For the full security model, threat analysis, and test strategy, see **[SECURITY.md](../SECURITY.md)**.

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -219,7 +219,7 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         value_type: ConfigValueType::Str,
         dangerous: false,
         default_display: "standard",
-        description: "Security posture baseline: \"strict\" (all toggles off AND gh_guard + git_guard + proxy.forced ON, fully locked down), \"standard\" (default, no-op), \"permissive\", or \"full-trust\". Only strict enables the guards/forced proxy; the others leave them at default. Individual keys/flags override it.",
+        description: "Security posture baseline: \"standard\" (the default: both guards on in block mode, the git guard scoped to the default branch), \"strict\" (all toggles off, every push blocked, proxy.forced and proxy.default_allowlist on), \"permissive\" or \"full-trust\" (both guards off, sandbox toggles loosened). Individual keys/flags override it.",
     },
     ConfigKeyInfo {
         section: "sandbox",

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -403,8 +403,8 @@ pub struct GitGuardConfig {
     /// Enable git command interception (default: true; `--preset permissive`
     /// and `--preset full-trust` turn it back off).
     pub enabled: Option<bool>,
-    /// Enforcement mode: "warn" (default), "block" (the default under
-    /// `--preset strict`), or "audit".
+    /// Enforcement mode: "block" (default), "warn" (the default under
+    /// `--preset permissive` and `--preset full-trust`), or "audit".
     pub mode: Option<EnforcementMode>,
     /// Block git push, request-pull, and send-pack (default: true).
     pub prevent_push: Option<bool>,


### PR DESCRIPTION
Two unrelated stale claims, both caught while fact-checking the `/cplt` landing page over in `navikt/copilot` against this source.

## Guard defaults, still describing the world before #387

`684ec93` fixed `SECURITY.md` and `docs/gh-guard.md`, but two places were missed, and one of them is user-visible:

- **`GitGuardConfig::mode`** (`src/config/types.rs:406`) documented `"warn"` as the default and named `--preset strict` as what puts the guard in block mode. `src/config/types.rs:303-314`: standard has blocked since #387, and strict *widens the scope* to every push rather than switching the mode. Warn is what permissive and full-trust fall back to.
- **`sandbox.preset`** (`src/config/registry.rs:222`) said "Only strict enables the guards/forced proxy; the others leave them at default." Standard enables both guards in block mode with the git guard scoped to the default branch; permissive and full-trust are the presets that turn them *off*. This string is what `cplt config` prints and what the website's config explorer renders, so it was shipping the wrong mental model to two audiences.

## "One static binary" is not true on any target we ship

Four places (`README.md:27,789,817`, `docs/security.md:9`). Release builds target `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` (`.github/workflows/release.yaml:60-62`). There is no musl target and no `crt-static` anywhere in `.github/workflows` or `.cargo`, and macOS binaries link libSystem dynamically, which Apple does not offer a way around.

The point each sentence is actually making is "no Docker, no VMs, no runtime services", and that survives dropping the word. The binary is still a single binary; it is just not a static one.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full suite: 1852 tests passing across 10 binaries.