### PR TITLE
feat(multi-repo): name additional repositories with --repo-dir

### DIFF
--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1308,7 +1308,9 @@ fn scope_label(scope: &[String]) -> String {
     scope.join(", ")
 }
 
-fn repos_match(left: &str, right: &str) -> bool {
+/// Two `owner/name` spellings naming the same repository: GitHub is
+/// case-insensitive and an origin URL may carry a `.git` suffix.
+pub(crate) fn repos_match(left: &str, right: &str) -> bool {
     left.trim_end_matches(".git")
         .eq_ignore_ascii_case(right.trim_end_matches(".git"))
 }

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -11,7 +11,7 @@
 //! The proxy is implemented as a shell wrapper placed ahead of the real
 //! `gh` in `$PATH`. The wrapper calls back to cplt for policy decisions.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Policy decision for a `gh` command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1239,22 +1239,22 @@ fn evaluate_api(cmd: &ParsedCommand, allow_api_write: bool) -> PolicyResult {
 /// that don't start with a deny-listed prefix.
 pub fn is_repo_in_scope(
     cmd: &ParsedCommand,
-    startup_repo: &str,
+    scope: &[String],
     invocation_repo: Option<&str>,
-) -> bool {
+) -> Option<String> {
     // Check -R/--repo flag first
     if let Some(target) = &cmd.repo_flag {
-        return repos_match(target, startup_repo);
+        return scope_member(scope, target);
     }
 
     // For gh api: extract repo from endpoint path like /repos/{owner}/{repo}/...
     if cmd.command == "api" {
         if let Some(ref endpoint) = cmd.api_endpoint {
             let Ok(endpoint) = github_api_endpoint_path(endpoint) else {
-                return false;
+                return None;
             };
             if let Some(endpoint_repo) = extract_repo_from_api_path(endpoint) {
-                return repos_match(&endpoint_repo, startup_repo);
+                return scope_member(scope, &endpoint_repo);
             }
             // Write operations (input flags or non-GET method) require an explicit
             // /repos/{owner}/{repo}/... path — no relative-path fallback.
@@ -1263,7 +1263,7 @@ pub fn is_repo_in_scope(
             let is_write =
                 cmd.has_input_flags || matches!(cmd.method.as_deref(), Some(m) if m != "GET");
             if is_write {
-                return false;
+                return None;
             }
             // For reads: check if this looks like a relative path (no leading absolute prefix)
             // that gh CLI resolves to the current repo (e.g., `gh api pulls/67/comments`).
@@ -1277,18 +1277,35 @@ pub fn is_repo_in_scope(
                 && !path.starts_with("graphql")
             {
                 // Relative read endpoint — gh CLI resolves to the invocation cwd's
-                // repo, which must still match the immutable startup scope.
-                return invocation_repo.is_some_and(|repo| repos_match(repo, startup_repo));
+                // repo, which must still be a member of the immutable startup scope.
+                return invocation_repo.and_then(|repo| scope_member(scope, repo));
             }
             // Absolute non-repo endpoint (e.g., /orgs/..., /user/...) — not in scope.
-            return false;
+            return None;
         }
         // No endpoint at all for gh api — shouldn't happen, but deny
-        return false;
+        return None;
     }
 
     // Non-api commands: no -R flag → implicitly targets the invocation cwd's repo.
-    invocation_repo.is_some_and(|repo| repos_match(repo, startup_repo))
+    invocation_repo.and_then(|repo| scope_member(scope, repo))
+}
+
+/// The scope member `target` names, in the spelling captured at launch.
+///
+/// The launch-time spelling is what gets pinned into `GH_REPO`, so a `-R` that
+/// differs only in case or a `.git` suffix still pins the canonical member.
+fn scope_member(scope: &[String], target: &str) -> Option<String> {
+    scope
+        .iter()
+        .find(|member| repos_match(target, member))
+        .cloned()
+}
+
+/// How the scope set is named in a refusal. Identical to the old single-value
+/// wording when the set has one member.
+fn scope_label(scope: &[String]) -> String {
+    scope.join(", ")
 }
 
 fn repos_match(left: &str, right: &str) -> bool {
@@ -1357,9 +1374,10 @@ fn resolve_invocation_repo(real_git: Option<&Path>) -> Result<String, String> {
 fn out_of_scope_cwd_error(
     cmd: &ParsedCommand,
     invocation_repo: &str,
-    startup_repo: &str,
+    scope: &[String],
     hint: &str,
 ) -> String {
+    let startup_repo = scope_label(scope);
     format!(
         "⚠️ BLOCKED by sandbox: 'gh {}{}' was invoked from repository '{invocation_repo}' outside the startup repo '{startup_repo}'.\n\
          Reason: implicit repository targets must resolve to the repository captured at sandbox startup.\n\
@@ -1376,36 +1394,56 @@ fn out_of_scope_cwd_error(
 
 /// Approval for an Allow-tier (read-only) command.
 ///
-/// The startup scope stays authoritative and is pinned into `GH_REPO`. An
-/// implicit repo-scoped read from a *different* repository is blocked instead of
-/// being silently answered from the startup repo. An unverifiable cwd keeps the
-/// previous behaviour (pin to the startup repo): these commands are read-only,
-/// and the startup repo is the safe target.
+/// The startup scope stays authoritative and the *matched member* is pinned into
+/// `GH_REPO`. An implicit repo-scoped read from a repository outside the set is
+/// blocked instead of being silently answered from a member of it.
+///
+/// With several members the pin is only ever the member the command itself
+/// names, or the one its cwd resolves to. When neither is known, a one-member
+/// scope still pins (nothing else can be meant), a larger one pins nothing:
+/// picking a member on the command's behalf is #213 with N repositories to
+/// guess wrong about.
 fn allow_tier_approval(
     cmd: &ParsedCommand,
     policy: &GatePolicy,
-    resolve_scope: impl FnOnce() -> Result<String, String>,
+    resolve_scope: impl FnOnce() -> Result<Vec<String>, String>,
     real_git: Option<&Path>,
 ) -> Result<GateApproval, String> {
     if !policy.scope_check {
         return Ok(GateApproval::default());
     }
-    let Ok(startup_repo) = resolve_scope() else {
+    let Ok(scope) = resolve_scope() else {
         return Ok(GateApproval::default());
     };
+    // An explicit target (-R, or a /repos/{owner}/{repo} path) that names a
+    // member pins to that member, never to the launch repository.
+    if let Some(member) = is_repo_in_scope(cmd, &scope, None) {
+        return Ok(approval_from_scope(Some(member)));
+    }
     if allow_tier_requires_invocation_repo_check(cmd)
         && let Ok(invocation_repo) = resolve_invocation_repo(real_git)
-        && !repos_match(&invocation_repo, &startup_repo)
     {
-        return Err(out_of_scope_cwd_error(
-            cmd,
-            &invocation_repo,
-            &startup_repo,
-            "Run it from the startup repository's checkout, or name the target \
-             explicitly with -R owner/repo where the command accepts it.",
-        ));
+        let Some(member) = scope_member(&scope, &invocation_repo) else {
+            return Err(out_of_scope_cwd_error(
+                cmd,
+                &invocation_repo,
+                &scope,
+                "Run it from the startup repository's checkout, or name the target \
+                 explicitly with -R owner/repo where the command accepts it.",
+            ));
+        };
+        return Ok(approval_from_scope(Some(member)));
     }
-    Ok(approval_from_scope(Some(startup_repo)))
+    Ok(approval_from_scope(single_member(&scope)))
+}
+
+/// The only member of a one-repository scope, or `None` when there is a choice
+/// to be made — which the guard never makes on the command's behalf.
+fn single_member(scope: &[String]) -> Option<String> {
+    match scope {
+        [only] => Some(only.clone()),
+        _ => None,
+    }
 }
 
 /// Extract "owner/repo" from a GitHub API endpoint path.
@@ -1558,14 +1596,15 @@ fn shell_escape(s: &str) -> String {
 /// with an error message.
 ///
 /// `real_gh` is the path to the real `gh` binary.
-/// `repo_scope` is the repository verified before the sandboxed agent starts.
+/// `repo_scope` is the set of repositories verified before the sandboxed agent
+/// starts — the launch repository plus every `--repo-dir` root on GitHub.
 /// `real_git` is the trusted Git binary used to verify an implicit target's cwd.
 /// `cplt_bin` is the path to the cplt binary (for calling `gh-gate`).
 /// Policy flags are baked into the wrapper invocation so the gate doesn't
 /// re-read config at runtime (security: agent could edit config files).
 pub fn generate_wrapper_script(
     real_gh: &str,
-    repo_scope: Option<&str>,
+    repo_scope: &[String],
     real_git: Option<&str>,
     cplt_bin: &str,
     policy: &crate::config::GhGuardPolicy,
@@ -1573,8 +1612,10 @@ pub fn generate_wrapper_script(
     let cplt_escaped = shell_escape(cplt_bin);
     let gh_escaped = shell_escape(real_gh);
     let repo_scope_flag = repo_scope
+        .iter()
         .map(|repo| format!("--repo-scope {}", shell_escape(repo)))
-        .unwrap_or_default();
+        .collect::<Vec<_>>()
+        .join(" ");
     let real_git_flag = real_git
         .map(|git| format!("--real-git {}", shell_escape(git)))
         .unwrap_or_default();
@@ -1729,7 +1770,7 @@ pub fn gate(
                 "no git in a trusted directory, so the repository scope cannot be verified"
                     .to_string()
             })?;
-            detect_current_repo(git, project_dir)
+            detect_current_repo(git, project_dir).map(|repo| vec![repo])
         },
         trusted,
     )
@@ -1749,29 +1790,32 @@ pub fn gate_with_git(
     gate_with_scope_resolver(
         args,
         policy,
-        || detect_current_repo(real_git, project_dir),
+        || detect_current_repo(real_git, project_dir).map(|repo| vec![repo]),
         Some(real_git),
     )
 }
 
 /// Evaluate a `gh` command using startup scope and a trusted Git binary for cwd checks.
 ///
-/// The startup scope remains authoritative. The invocation cwd is consulted only
-/// for implicit repository targets, and only as evidence that the command still
-/// refers to that immutable scope.
+/// The startup scope remains authoritative. It is a *set*: the launch repository
+/// plus every `--repo-dir` root whose origin is on GitHub. The invocation cwd is
+/// consulted only for implicit repository targets, and only as evidence that the
+/// command still refers to a member of that immutable set.
 pub fn gate_with_repo_scope(
     args: &[&str],
     policy: &GatePolicy,
-    repo_scope: Option<&str>,
+    repo_scope: &[String],
     real_git: Option<&Path>,
 ) -> Result<GateApproval, String> {
     gate_with_scope_resolver(
         args,
         policy,
         || {
-            repo_scope
-                .map(str::to_owned)
-                .ok_or_else(|| "repository scope was unavailable at sandbox startup".to_string())
+            if repo_scope.is_empty() {
+                Err("repository scope was unavailable at sandbox startup".to_string())
+            } else {
+                Ok(repo_scope.to_vec())
+            }
         },
         real_git,
     )
@@ -1780,7 +1824,7 @@ pub fn gate_with_repo_scope(
 fn gate_with_scope_resolver(
     args: &[&str],
     policy: &GatePolicy,
-    resolve_scope: impl FnOnce() -> Result<String, String>,
+    resolve_scope: impl FnOnce() -> Result<Vec<String>, String>,
     real_git: Option<&Path>,
 ) -> Result<GateApproval, String> {
     let Some(cmd) = parse_command(args) else {
@@ -1852,7 +1896,7 @@ fn gate_with_scope_resolver(
                 return Ok(GateApproval::default());
             }
 
-            let startup_repo = resolve_scope().map_err(|reason| {
+            let scope = resolve_scope().map_err(|reason| {
                 format!(
                     "⚠️ BLOCKED by sandbox: 'gh {} {}' cannot verify target repository scope.\n\
                      Reason: {reason}.\n\
@@ -1882,17 +1926,19 @@ fn gate_with_scope_resolver(
                 None
             };
 
-            if is_repo_in_scope(&cmd, &startup_repo, invocation_repo.as_deref()) {
+            if let Some(member) = is_repo_in_scope(&cmd, &scope, invocation_repo.as_deref()) {
+                // The matched member, never the launch repository: pinning the
+                // launch repo with a set in play is #213, N repositories wide.
                 Ok(GateApproval {
-                    repo_scope: Some(format!("github.com/{startup_repo}")),
+                    repo_scope: Some(format!("github.com/{member}")),
                 })
             } else if let Some(invocation_repo) = invocation_repo.as_deref()
-                && !repos_match(invocation_repo, &startup_repo)
+                && scope_member(&scope, invocation_repo).is_none()
             {
                 Err(out_of_scope_cwd_error(
                     &cmd,
                     invocation_repo,
-                    &startup_repo,
+                    &scope,
                     "Run it from the startup repository's checkout.",
                 ))
             } else {
@@ -1910,7 +1956,7 @@ fn gate_with_scope_resolver(
                         .as_deref()
                         .or(cmd.api_endpoint.as_deref())
                         .unwrap_or("unknown"),
-                    startup_repo,
+                    scope_label(&scope),
                     result.reason,
                 ))
             }
@@ -3582,6 +3628,34 @@ pub fn capture_repo_facts(real_git: &Path, project_dir: &Path) -> RepoFacts {
     facts
 }
 
+/// What a `--repo-dir` root is, captured in the unsandboxed parent at launch.
+///
+/// Same rule as [`capture_repo_facts`]: `real_git` must be a
+/// [`crate::git::trusted_git`] path, and the answers are taken once, before the
+/// agent can touch the repository they describe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamedRoot {
+    /// Canonical path of the root.
+    pub path: PathBuf,
+    /// `owner/name` from `origin`. `None` when the origin is not a GitHub URL,
+    /// which is not an error — the root simply stays out of the gh scope set.
+    pub repo: Option<String>,
+    /// `git rev-parse --git-common-dir`, canonicalized. Identifies the
+    /// repository regardless of which linked worktree of it is being used.
+    pub git_common_dir: String,
+}
+
+/// Capture [`NamedRoot`] facts for one `--repo-dir` root.
+#[must_use]
+pub fn capture_named_root(real_git: &Path, dir: &Path) -> NamedRoot {
+    let d = dir.to_string_lossy().into_owned();
+    NamedRoot {
+        path: std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf()),
+        repo: detect_current_repo(real_git, dir).ok(),
+        git_common_dir: git_common_dir(real_git, &["-C", d.as_str()]).unwrap_or_default(),
+    }
+}
+
 /// Whether `project_dir` has any remote configured at all.
 ///
 /// Separates "no default branch could be captured" into its two cases: a repo
@@ -3784,6 +3858,11 @@ exec {cplt_escaped} git-gate --real-git {git_escaped} {mode_flag} {prevent_push_
 #[allow(clippy::disallowed_methods)] // test code: no unsandboxed parent to protect (#239)
 mod tests {
     use super::*;
+
+    /// Test shim: the single-repository scope these cases were written for.
+    fn in_scope(cmd: &ParsedCommand, repo: &str, invocation_repo: Option<&str>) -> bool {
+        is_repo_in_scope(cmd, &[repo.to_string()], invocation_repo).is_some()
+    }
 
     /// Test shim for [`gate_git`] that supplies the launch-time [`RepoFacts`]
     /// for the repository the invocation targets, the way `sandbox_exec`
@@ -4093,13 +4172,9 @@ mod tests {
             has_input_flags: false,
             api_endpoint: None,
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", Some("navikt/cplt")));
-        assert!(!is_repo_in_scope(
-            &cmd,
-            "navikt/cplt",
-            Some("evil-org/other-repo")
-        ));
-        assert!(!is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(in_scope(&cmd, "navikt/cplt", Some("navikt/cplt")));
+        assert!(!in_scope(&cmd, "navikt/cplt", Some("evil-org/other-repo")));
+        assert!(!in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4112,7 +4187,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: None,
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4125,7 +4200,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: None,
         };
-        assert!(!is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(!in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4138,7 +4213,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: None,
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4151,7 +4226,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: None,
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(in_scope(&cmd, "navikt/cplt", None));
     }
 
     // ── API endpoint scope tests ──
@@ -4166,7 +4241,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("/repos/other/repo/pulls".to_string()),
         };
-        assert!(!is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(!in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4179,7 +4254,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("/repos/navikt/cplt/pulls".to_string()),
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4193,7 +4268,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("/user".to_string()),
         };
-        assert!(!is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(!in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4206,7 +4281,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("/orgs/navikt/members".to_string()),
         };
-        assert!(!is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(!in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4220,7 +4295,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("pulls/67/comments".to_string()),
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", Some("navikt/cplt")));
+        assert!(in_scope(&cmd, "navikt/cplt", Some("navikt/cplt")));
     }
 
     #[test]
@@ -4233,7 +4308,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("pulls?state=open".to_string()),
         };
-        assert!(is_repo_in_scope(&cmd, "navikt/cplt", Some("navikt/cplt")));
+        assert!(in_scope(&cmd, "navikt/cplt", Some("navikt/cplt")));
     }
 
     #[test]
@@ -4247,7 +4322,7 @@ mod tests {
             has_input_flags: false,
             api_endpoint: Some("/repos/navikt/cplt/pulls".to_string()),
         };
-        assert!(!is_repo_in_scope(&cmd, "navikt/cplt", None));
+        assert!(!in_scope(&cmd, "navikt/cplt", None));
     }
 
     #[test]
@@ -4351,7 +4426,7 @@ mod tests {
         let policy = crate::config::GhGuardPolicy::default();
         let script = generate_wrapper_script(
             "/usr/bin/gh",
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             Some("/usr/bin/git"),
             "/usr/local/bin/cplt",
             &policy,
@@ -4376,7 +4451,7 @@ mod tests {
         };
         let script = generate_wrapper_script(
             "/usr/bin/gh",
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             Some("/usr/bin/git"),
             "/usr/local/bin/cplt",
             &policy,
@@ -4487,7 +4562,7 @@ mod tests {
                 api_endpoint: Some(endpoint.to_string()),
             };
             assert!(
-                !is_repo_in_scope(&cmd, "navikt/cplt", None),
+                !in_scope(&cmd, "navikt/cplt", None),
                 "write to top-level endpoint '{endpoint}' must not be in scope",
             );
         }
@@ -4988,7 +5063,7 @@ mod tests {
         let policy = crate::config::GhGuardPolicy::default();
         let script = generate_wrapper_script(
             "/path/with'quote/gh",
-            Some("navikt/repo'with-quote"),
+            &["navikt/repo'with-quote".to_string()],
             Some("/path/with'quote/git"),
             "/path/with\"dq/cplt",
             &policy,

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,16 @@ struct Cli {
     #[arg(long, short = 'd', value_name = "DIR")]
     project_dir: Option<PathBuf>,
 
+    /// Name another git repository the agent works in, as a first-class
+    /// repository alongside the launch one: `gh` commands may target it.
+    /// Must be a repository toplevel inside the project directory — a nested
+    /// clone already has the project directory's file access, so this declares
+    /// its identity, not new access. Siblings are not supported yet; for
+    /// edit-only access to one, use --allow-write.
+    /// Can be specified multiple times.
+    #[arg(long = "repo-dir", value_name = "DIR")]
+    repo_dirs: Vec<PathBuf>,
+
     /// Enable a local CONNECT proxy that logs and filters outbound connections.
     /// cplt routes all agent traffic through it with the HTTP_PROXY and
     /// HTTPS_PROXY env vars. Block known-bad domains with --blocked-domains.
@@ -851,8 +861,9 @@ NOTE:
         real_gh: PathBuf,
 
         /// Repository scope captured before the sandboxed agent started.
+        /// Repeatable: the launch repository plus each `--repo-dir` root.
         #[arg(long)]
-        repo_scope: Option<String>,
+        repo_scope: Vec<String>,
 
         /// Trusted Git binary used to verify implicit repository targets from cwd.
         #[arg(long)]
@@ -1138,6 +1149,134 @@ fn detect_project_root() -> Option<PathBuf> {
     }
 }
 
+/// The toplevel of the git repository containing `dir`, canonicalized.
+///
+/// `None` when `dir` is not in a repository (or there is no trusted git, in
+/// which case nothing can be verified and the caller must refuse).
+fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = cplt::git::command(dir, &["rev-parse", "--show-toplevel"])?
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    std::fs::canonicalize(path.trim()).ok()
+}
+
+/// Validate the `--repo-dir` roots against the launch repository.
+///
+/// A named root is a first-class repository the agent works in, not a grant:
+/// stage 1 accepts only roots *nested* in the project directory, which already
+/// carries the filesystem access as one subtree, so naming one declares its
+/// identity and changes no file rule.
+///
+/// Every refusal here is a launch-time refusal on purpose. The set decides what
+/// `gh` may target and what `GH_REPO` is pinned to, so a root that is not the
+/// repository the user thinks it is would misdirect writes — the #213 shape.
+fn validate_repo_dirs(
+    cli_dirs: &[PathBuf],
+    project_dir: &Path,
+    home_dir: &Path,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if cli_dirs.is_empty() {
+        return Ok(Vec::new());
+    }
+    if git_toplevel(project_dir).as_deref() != Some(project_dir) {
+        bail!(
+            "--repo-dir needs the launch directory to be a git repository, and\n  \
+             {}\n  \
+             is not one (or its toplevel is elsewhere). A plain directory holding \
+             repositories is `--project-dir <parent>`, which grants the whole tree \
+             without claiming any repository identity.",
+            project_dir.display()
+        );
+    }
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for raw in cli_dirs {
+        let dir = std::fs::canonicalize(raw)
+            .map_err(|e| anyhow::anyhow!("Cannot resolve --repo-dir {}: {e}", raw.display()))?;
+
+        // No symlinked final component. The project dir is agent-writable, so a
+        // symlink planted there last session would silently redirect the
+        // identity this launch grants (#216's confused deputy, one level down).
+        let named = std::path::absolute(raw)
+            .map_err(|e| anyhow::anyhow!("Cannot resolve --repo-dir {}: {e}", raw.display()))?;
+        let unresolved_leaf = match (named.parent(), named.file_name()) {
+            (Some(parent), Some(name)) => std::fs::canonicalize(parent).map(|p| p.join(name)).ok(),
+            // A filesystem root has no leaf to plant a symlink as; `is_unsafe_root`
+            // refuses it below anyway.
+            _ => Some(dir.clone()),
+        };
+        if unresolved_leaf.as_ref() != Some(&dir) {
+            bail!(
+                "--repo-dir {} resolves through a symlink, to\n  {}\n  \
+                 A symlink inside the project directory is agent-writable, so the \
+                 repository it names could be changed between sessions. Name the \
+                 real path.",
+                raw.display(),
+                dir.display()
+            );
+        }
+
+        if dir == project_dir {
+            bail!(
+                "--repo-dir {} is the launch repository itself, which is always in scope.",
+                raw.display()
+            );
+        }
+        if project_dir.starts_with(&dir) {
+            bail!(
+                "--repo-dir {} contains the launch repository; launch from it and name the \
+                 inner one.",
+                raw.display()
+            );
+        }
+        if is_unsafe_root(&dir, home_dir) {
+            bail!(
+                "cplt refuses to treat '{}' as a repository, it is too broad.",
+                dir.display()
+            );
+        }
+        match git_toplevel(&dir) {
+            Some(top) if top == dir => {}
+            // A plain directory inside the launch repository is not a
+            // repository of its own, and pointing at the launch repo's toplevel
+            // would only name something this flag refuses anyway.
+            Some(top) if top == project_dir => bail!(
+                "--repo-dir {} is a plain directory in the launch repository, not a \
+                 repository of its own; for a plain directory use `--allow-write`.",
+                raw.display()
+            ),
+            Some(top) => bail!(
+                "--repo-dir {} is inside a repository but is not its toplevel. Name the \
+                 toplevel instead:\n  --repo-dir {}",
+                raw.display(),
+                top.display()
+            ),
+            None => bail!(
+                "--repo-dir {} is not a git repository; for a plain directory use \
+                 `--allow-write`.",
+                raw.display()
+            ),
+        }
+        if !dir.starts_with(project_dir) {
+            bail!(
+                "--repo-dir {} is outside the project directory\n  {}\n  \
+                 sibling repositories are not yet supported; use `--allow-write` for \
+                 edit-only.",
+                raw.display(),
+                project_dir.display()
+            );
+        }
+        if roots.contains(&dir) {
+            bail!("--repo-dir {} was given twice.", raw.display());
+        }
+        roots.push(dir);
+    }
+    Ok(roots)
+}
+
 // Use library's is_unsafe_root
 use cplt::is_unsafe_root;
 use cplt::sandbox::ToolRoot;
@@ -1308,6 +1447,9 @@ struct ResolvedContext {
     config_path: Option<PathBuf>,
     home_dir: PathBuf,
     project_dir: PathBuf,
+    /// Validated `--repo-dir` roots: repositories the agent works in alongside
+    /// the launch one. Empty unless the flag was given.
+    repo_dirs: Vec<PathBuf>,
     active_agent: agent::Agent,
     unapproved_proposals: Vec<String>,
 }
@@ -1439,6 +1581,8 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             project_dir.display()
         );
     }
+
+    let repo_dirs = validate_repo_dirs(&cli.repo_dirs, &project_dir, &home_dir)?;
 
     let (cfg, config_path) = match config::Config::load_file() {
         Ok(Some(loaded)) => (loaded.config, Some(loaded.path)),
@@ -1859,6 +2003,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         config_path,
         home_dir,
         project_dir,
+        repo_dirs,
         active_agent,
         unapproved_proposals,
     })
@@ -2587,13 +2732,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
                     },
                     allow_api_write: allow_api_write && !no_allow_api_write,
                 };
-                run_gh_gate(
-                    &real_gh,
-                    repo_scope.as_deref(),
-                    real_git.as_deref(),
-                    &args,
-                    &policy,
-                )
+                run_gh_gate(&real_gh, &repo_scope, real_git.as_deref(), &args, &policy)
             }
             Command::GitGate {
                 real_git,
@@ -2656,6 +2795,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         config_path,
         home_dir,
         project_dir,
+        repo_dirs,
         active_agent,
         unapproved_proposals: _,
     } = resolve_context(&cli, false)?;
@@ -2862,6 +3002,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             &prepared,
             &agent_bin,
             &copilot_args,
+            &repo_dirs,
             &resolved.pass_env,
             resolved.inherit_env,
             &disabled_categories,
@@ -3020,7 +3161,7 @@ enum GateEffect {
 fn decide_gh_gate(
     args: &[String],
     policy: &gh_proxy::GatePolicy,
-    repo_scope: Option<&str>,
+    repo_scope: &[String],
     real_git: Option<&Path>,
 ) -> GateEffect {
     // Intercept `gh auth token` — serve from cached file instead of blocking.
@@ -3056,7 +3197,7 @@ fn decide_gh_gate(
 /// If blocked, prints an error message and exits with code 1.
 fn run_gh_gate(
     real_gh: &Path,
-    repo_scope: Option<&str>,
+    repo_scope: &[String],
     real_git: Option<&Path>,
     args: &[String],
     policy: &gh_proxy::GatePolicy,
@@ -3733,6 +3874,7 @@ fn run_exec_command(
         config_path,
         home_dir,
         project_dir,
+        repo_dirs,
         unapproved_proposals: _,
         // active_agent from resolve_context is ignored — exec always uses Shell
         active_agent: _,
@@ -3850,6 +3992,7 @@ fn run_exec_command(
             &prepared,
             &exec_bin,
             &exec_args,
+            &repo_dirs,
             &resolved.pass_env,
             resolved.inherit_env,
             &disabled_categories,
@@ -3913,6 +4056,7 @@ fn probe_shell(
         prepared,
         &shell,
         &args,
+        &[],
         &resolved.pass_env,
         resolved.inherit_env,
         disabled,
@@ -4190,9 +4334,13 @@ fn run_check_command(
         config_path,
         home_dir,
         project_dir,
+        repo_dirs,
         active_agent,
         unapproved_proposals: _,
     } = resolve_context(cli, true)?;
+    // `cplt check` does not yet report per named root; the flag is still
+    // validated by resolve_context, so a bad one is refused here too.
+    let _ = &repo_dirs;
 
     // Shell, not `active_agent`: `check` probes under the Shell profile.
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, agent::Agent::Shell);
@@ -6792,7 +6940,7 @@ mod tests {
         let effect = decide_gh_gate(
             &gh_args(&["pr", "create", "--repo", "navikt/cplt"]),
             &gh_policy(config::EnforcementMode::Block),
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             None,
         );
         assert_eq!(
@@ -6807,7 +6955,7 @@ mod tests {
         let effect = decide_gh_gate(
             &gh_args(&["pr", "create", "--repo", "someone/else"]),
             &gh_policy(config::EnforcementMode::Block),
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             None,
         );
         let GateEffect::Refuse(msg) = effect else {
@@ -6840,7 +6988,7 @@ mod tests {
             let effect = decide_gh_gate(
                 &gh_args(&["pr", "create", "--repo", "someone/else"]),
                 &gh_policy(mode),
-                Some("navikt/cplt"),
+                &["navikt/cplt".to_string()],
                 None,
             );
             match effect {
@@ -6863,13 +7011,13 @@ mod tests {
         let warn = decide_gh_gate(
             &args,
             &gh_policy(config::EnforcementMode::Warn),
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             None,
         );
         let audit = decide_gh_gate(
             &args,
             &gh_policy(config::EnforcementMode::Audit),
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             None,
         );
         assert_ne!(
@@ -6892,7 +7040,7 @@ mod tests {
             config::EnforcementMode::Audit,
         ] {
             assert_eq!(
-                decide_gh_gate(&gh_args(&["auth", "token"]), &gh_policy(mode), None, None),
+                decide_gh_gate(&gh_args(&["auth", "token"]), &gh_policy(mode), &[], None),
                 GateEffect::ServeCachedToken,
                 "{mode} must not let `gh auth token` reach the real binary"
             );
@@ -6907,7 +7055,7 @@ mod tests {
         let effect = decide_gh_gate(
             &gh_args(&["auth", "git-credential", "get"]),
             &gh_policy(config::EnforcementMode::Block),
-            Some("navikt/cplt"),
+            &["navikt/cplt".to_string()],
             None,
         );
         assert_eq!(
@@ -6923,7 +7071,7 @@ mod tests {
             decide_gh_gate(
                 &gh_args(&["--version"]),
                 &gh_policy(config::EnforcementMode::Block),
-                Some("navikt/cplt"),
+                &["navikt/cplt".to_string()],
                 None,
             ),
             GateEffect::ExecPlain { notice: None }
@@ -7223,5 +7371,174 @@ mod tests {
             return;
         }
         assert!(!in_git_work_tree(dir.path()));
+    }
+
+    // ── --repo-dir validation (#344, stage 1) ────────────────────────────
+
+    /// `git init` in `dir`; `false` when this machine has no usable git, which
+    /// makes every `--repo-dir` case untestable and the caller returns early.
+    fn init_repo(dir: &Path) -> bool {
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(dir)
+            .status()
+            .is_ok_and(|s| s.success())
+    }
+
+    /// A canonical temp dir: on macOS `/var` is a symlink, and the validator
+    /// compares canonical paths.
+    fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = std::fs::canonicalize(dir.path()).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn repo_dir_accepts_a_nested_repository() {
+        let (_guard, project) = canonical_tempdir();
+        let inner = project.join("inner");
+        std::fs::create_dir(&inner).unwrap();
+        if !init_repo(&project) || !init_repo(&inner) {
+            return;
+        }
+        let roots = validate_repo_dirs(
+            std::slice::from_ref(&inner),
+            &project,
+            Path::new("/nonexistent-home"),
+        )
+        .unwrap();
+        assert_eq!(roots, vec![inner]);
+    }
+
+    #[test]
+    fn repo_dir_refuses_a_plain_directory() {
+        let (_guard, project) = canonical_tempdir();
+        let plain = project.join("notarepo");
+        std::fs::create_dir(&plain).unwrap();
+        if !init_repo(&project) {
+            return;
+        }
+        let err = validate_repo_dirs(&[plain], &project, Path::new("/nonexistent-home"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--allow-write"), "{err}");
+    }
+
+    #[test]
+    fn repo_dir_refuses_a_subdirectory_and_names_the_toplevel() {
+        let (_guard, project) = canonical_tempdir();
+        let inner = project.join("inner");
+        let sub = inner.join("src");
+        std::fs::create_dir_all(&sub).unwrap();
+        if !init_repo(&project) || !init_repo(&inner) {
+            return;
+        }
+        let err = validate_repo_dirs(&[sub], &project, Path::new("/nonexistent-home"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(&inner.display().to_string()), "{err}");
+    }
+
+    #[test]
+    fn repo_dir_refuses_a_sibling_repository() {
+        let (_guard, root) = canonical_tempdir();
+        let project = root.join("project");
+        let sibling = root.join("sibling");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::create_dir(&sibling).unwrap();
+        if !init_repo(&project) || !init_repo(&sibling) {
+            return;
+        }
+        let err = validate_repo_dirs(&[sibling], &project, Path::new("/nonexistent-home"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("sibling repositories are not yet supported"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn repo_dir_refuses_the_launch_repository_and_its_ancestor() {
+        let (_guard, root) = canonical_tempdir();
+        let project = root.join("project");
+        std::fs::create_dir(&project).unwrap();
+        if !init_repo(&root) || !init_repo(&project) {
+            return;
+        }
+        let err = validate_repo_dirs(
+            std::slice::from_ref(&project),
+            &project,
+            Path::new("/nonexistent-home"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("is the launch repository itself"), "{err}");
+
+        let err = validate_repo_dirs(&[root], &project, Path::new("/nonexistent-home"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("contains the launch repository"), "{err}");
+    }
+
+    #[test]
+    fn repo_dir_refuses_a_symlinked_path() {
+        let (_guard, project) = canonical_tempdir();
+        let inner = project.join("inner");
+        std::fs::create_dir(&inner).unwrap();
+        if !init_repo(&project) || !init_repo(&inner) {
+            return;
+        }
+        let link = project.join("link");
+        std::os::unix::fs::symlink(&inner, &link).unwrap();
+        let err = validate_repo_dirs(&[link], &project, Path::new("/nonexistent-home"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("resolves through a symlink"), "{err}");
+    }
+
+    #[test]
+    fn repo_dir_refuses_a_duplicate() {
+        let (_guard, project) = canonical_tempdir();
+        let inner = project.join("inner");
+        std::fs::create_dir(&inner).unwrap();
+        if !init_repo(&project) || !init_repo(&inner) {
+            return;
+        }
+        let err = validate_repo_dirs(
+            &[inner.clone(), inner],
+            &project,
+            Path::new("/nonexistent-home"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("was given twice"), "{err}");
+    }
+
+    #[test]
+    fn repo_dir_refuses_a_launch_directory_that_is_not_a_repository() {
+        let (_guard, project) = canonical_tempdir();
+        let inner = project.join("inner");
+        std::fs::create_dir(&inner).unwrap();
+        if !init_repo(&inner) {
+            return;
+        }
+        let err = validate_repo_dirs(&[inner], &project, Path::new("/nonexistent-home"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("needs the launch directory to be a git repository"),
+            "{err}"
+        );
+    }
+
+    /// No flag, no validation and no git subprocess.
+    #[test]
+    fn repo_dir_is_inert_when_unused() {
+        assert!(
+            validate_repo_dirs(&[], Path::new("/does/not/exist"), Path::new("/home"))
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1197,11 +1197,26 @@ fn validate_repo_dirs(
         let dir = std::fs::canonicalize(raw)
             .map_err(|e| anyhow::anyhow!("Cannot resolve --repo-dir {}: {e}", raw.display()))?;
 
-        // No symlinked final component. The project dir is agent-writable, so a
-        // symlink planted there last session would silently redirect the
-        // identity this launch grants (#216's confused deputy, one level down).
+        // The FINAL component must not be a symlink. The project dir is
+        // agent-writable, so a symlink planted there last session would silently
+        // redirect the identity this launch grants (#216's confused deputy, one
+        // level down). A symlinked *ancestor* is deliberately tolerated: it is
+        // part of the path the user typed to reach the tree, not the name of the
+        // repository this launch pins to.
         let named = std::path::absolute(raw)
             .map_err(|e| anyhow::anyhow!("Cannot resolve --repo-dir {}: {e}", raw.display()))?;
+        // `absolute` does not fold `..`, so a trailing one leaves no leaf to
+        // check and would walk straight past the refusal below.
+        if named
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
+            bail!(
+                "--repo-dir {} contains a '..' component, which hides which \
+                 directory is actually named. Name the directory itself.",
+                raw.display()
+            );
+        }
         let unresolved_leaf = match (named.parent(), named.file_name()) {
             (Some(parent), Some(name)) => std::fs::canonicalize(parent).map(|p| p.join(name)).ok(),
             // A filesystem root has no leaf to plant a symlink as; `is_unsafe_root`
@@ -1209,6 +1224,20 @@ fn validate_repo_dirs(
             _ => Some(dir.clone()),
         };
         if unresolved_leaf.as_ref() != Some(&dir) {
+            // On a case-insensitive filesystem `canonicalize` returns the on-disk
+            // spelling, so a case variant lands here too — say so rather than
+            // blaming a symlink that is not there.
+            if unresolved_leaf
+                .as_ref()
+                .is_some_and(|leaf| leaf.as_os_str().eq_ignore_ascii_case(dir.as_os_str()))
+            {
+                bail!(
+                    "--repo-dir {} differs in case from the directory on disk,\n  {}\n  \
+                     Name it with the on-disk spelling.",
+                    raw.display(),
+                    dir.display()
+                );
+            }
             bail!(
                 "--repo-dir {} resolves through a symlink, to\n  {}\n  \
                  A symlink inside the project directory is agent-writable, so the \
@@ -3232,6 +3261,14 @@ fn perform_gate_effect(
 
 /// Replace this process with the real binary. `repo_scope` pins `GH_REPO`, which
 /// only `gh` reads — the git guard always passes `None`.
+///
+/// `GH_HOST` and `GH_REPO` are scrubbed on EVERY approved exec, pin or no pin.
+/// They are inherited targeting: `GH_HOST` redirects a read at whatever GHES the
+/// user is logged into (`hosts.yml` is readable in the sandbox) and `GH_REPO`
+/// names a repository the scope set never approved. Scrubbing here rather than
+/// refusing in the gate is the one place every allowed command passes through,
+/// so a decision path that produces no pin — an ambiguous multi-repo scope, an
+/// audit/warn notice — cannot leak them by omission.
 #[allow(clippy::disallowed_methods)] // runs INSIDE the sandbox as cplt gh-gate/git-gate; the wrapper resolves the real binary through PATH deliberately
 fn exec_real(
     real_binary: &Path,
@@ -3243,8 +3280,9 @@ fn exec_real(
 
     let mut command = std::process::Command::new(real_binary);
     command.args(args);
+    command.env_remove("GH_HOST");
+    command.env_remove("GH_REPO");
     if let Some(repo) = repo_scope {
-        command.env_remove("GH_HOST");
         command.env("GH_REPO", repo);
     }
     let err = command.exec();
@@ -7495,6 +7533,29 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("resolves through a symlink"), "{err}");
+    }
+
+    /// A trailing `..` walks past the symlinked-leaf refusal: `absolute` leaves
+    /// it in place, `file_name()` is then `None`, and the leaf check has nothing
+    /// to compare.
+    #[test]
+    fn repo_dir_refuses_a_parent_component() {
+        let (_guard, project) = canonical_tempdir();
+        let inner = project.join("inner");
+        std::fs::create_dir_all(inner.join("src")).unwrap();
+        if !init_repo(&project) || !init_repo(&inner) {
+            return;
+        }
+        let link = project.join("link");
+        std::os::unix::fs::symlink(&inner, &link).unwrap();
+        let err = validate_repo_dirs(
+            &[link.join("src").join("..")],
+            &project,
+            Path::new("/nonexistent-home"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("contains a '..' component"), "{err}");
     }
 
     #[test]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -528,11 +528,14 @@ pub fn preflight(sandbox: &PreparedSandbox) -> Result<(), String> {
 /// Environment handling is controlled by `extra_pass_env`, `inherit_env`,
 /// and `disabled_categories` — see [`build_sandbox_env()`] for details.
 /// `deny_env` contains additional env vars to strip (from repo config [deny] section).
+/// `repo_dirs` are the validated `--repo-dir` roots — first-class repositories
+/// alongside the launch one, whose identity the gh guard's scope set is built from.
 #[allow(clippy::too_many_arguments)]
 pub fn exec_sandboxed(
     sandbox: &PreparedSandbox,
     copilot_bin: &Path,
     copilot_args: &[String],
+    repo_dirs: &[PathBuf],
     extra_pass_env: &[String],
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
@@ -545,6 +548,7 @@ pub fn exec_sandboxed(
         sandbox,
         copilot_bin,
         copilot_args,
+        repo_dirs,
         extra_pass_env,
         inherit_env,
         disabled_categories,

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -556,8 +556,17 @@ fn install_command_wrappers(
                 let root = crate::gh_proxy::capture_named_root(real_git, dir);
                 match root.repo {
                     // A named root can be a second checkout of a repository
-                    // already in the set; the set dedups.
-                    Some(repo) if !repo_scope.contains(&repo) => repo_scope.push(repo),
+                    // already in the set; the set dedups. Case-insensitively:
+                    // `Navikt/LAUNCH.git` and `navikt/launch` are one repository,
+                    // and letting both in would turn a single-repository session
+                    // into an ambiguous multi-member one that pins nothing.
+                    Some(repo)
+                        if !repo_scope
+                            .iter()
+                            .any(|member| crate::gh_proxy::repos_match(member, &repo)) =>
+                    {
+                        repo_scope.push(repo);
+                    }
                     Some(_) => {}
                     None => {
                         if !quiet {

--- a/src/sandbox_exec.rs
+++ b/src/sandbox_exec.rs
@@ -86,6 +86,7 @@ fn configure_command(
     cmd: &mut Command,
     copilot_args: &[String],
     project_dir: &Path,
+    repo_dirs: &[PathBuf],
     home_dir: &Path,
     extra_pass_env: &[String],
     inherit_env: bool,
@@ -258,7 +259,15 @@ fn configure_command(
                 cache_gh_token_to_file(scratch, agent, deny_env);
             }
         }
-        install_command_wrappers(cmd, scratch, project_dir, gh_guard, git_guard, quiet);
+        install_command_wrappers(
+            cmd,
+            scratch,
+            project_dir,
+            repo_dirs,
+            gh_guard,
+            git_guard,
+            quiet,
+        );
     }
 }
 
@@ -456,6 +465,7 @@ fn install_command_wrappers(
     cmd: &mut Command,
     scratch_dir: &Path,
     project_dir: &Path,
+    repo_dirs: &[PathBuf],
     gh_guard: &crate::config::GhGuardPolicy,
     git_guard: &crate::config::GitGuardPolicy,
     quiet: bool,
@@ -525,24 +535,42 @@ fn install_command_wrappers(
         } else {
             None
         };
-        let repo_scope = if gh_guard.scope_check {
-            if let Some(real_git) = real_git.as_deref() {
-                match crate::gh_proxy::detect_current_repo(real_git, project_dir) {
-                    Ok(repo) => Some(repo),
-                    Err(reason) => {
-                        ui::warn(&format!(
-                            "gh guard could not capture repository scope: {reason}. \
-                             Scope-checked commands will be blocked."
-                        ));
-                        None
+        // The gh scope is a SET: the launch repository plus every `--repo-dir`
+        // root whose origin is on GitHub. Each member's `owner/name` is captured
+        // here, parent-side with the trusted git, and baked into the wrapper —
+        // the gate never re-derives it from inside the sandbox.
+        let mut repo_scope: Vec<String> = Vec::new();
+        if gh_guard.scope_check
+            && let Some(real_git) = real_git.as_deref()
+        {
+            match crate::gh_proxy::detect_current_repo(real_git, project_dir) {
+                Ok(repo) => repo_scope.push(repo),
+                Err(reason) => {
+                    ui::warn(&format!(
+                        "gh guard could not capture repository scope: {reason}. \
+                         Scope-checked commands will be blocked."
+                    ));
+                }
+            }
+            for dir in repo_dirs {
+                let root = crate::gh_proxy::capture_named_root(real_git, dir);
+                match root.repo {
+                    // A named root can be a second checkout of a repository
+                    // already in the set; the set dedups.
+                    Some(repo) if !repo_scope.contains(&repo) => repo_scope.push(repo),
+                    Some(_) => {}
+                    None => {
+                        if !quiet {
+                            ui::warn(&format!(
+                                "--repo-dir {} has no GitHub origin, so it is not in the gh \
+                                 scope. gh commands targeting it are refused.",
+                                dir.display()
+                            ));
+                        }
                     }
                 }
-            } else {
-                None
             }
-        } else {
-            None
-        };
+        }
         // `real_git` above is the parent-side probe and stays trusted. What the
         // wrapper carries is the sandbox git: `gh-gate` re-runs it inside the
         // sandbox to resolve scope, so a git that cannot start there turns every
@@ -556,7 +584,7 @@ fn install_command_wrappers(
         };
         let script = crate::gh_proxy::generate_wrapper_script(
             &real_gh.to_string_lossy(),
-            repo_scope.as_deref(),
+            &repo_scope,
             real_git_str.as_deref(),
             &cplt_str,
             gh_guard,
@@ -923,6 +951,7 @@ pub fn exec(
     sandbox: &super::PreparedSandbox,
     copilot_bin: &Path,
     copilot_args: &[String],
+    repo_dirs: &[PathBuf],
     extra_pass_env: &[String],
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
@@ -938,6 +967,7 @@ pub fn exec(
         &mut cmd,
         copilot_args,
         &sandbox.project_dir,
+        repo_dirs,
         &sandbox.home_dir,
         extra_pass_env,
         inherit_env,
@@ -999,6 +1029,7 @@ pub fn exec(
     sandbox: &super::PreparedSandbox,
     copilot_bin: &Path,
     copilot_args: &[String],
+    repo_dirs: &[PathBuf],
     extra_pass_env: &[String],
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
@@ -1016,6 +1047,7 @@ pub fn exec(
             wrapper,
             copilot_bin,
             copilot_args,
+            repo_dirs,
             extra_pass_env,
             inherit_env,
             disabled_categories,
@@ -1060,6 +1092,7 @@ pub fn exec(
         &mut cmd,
         copilot_args,
         &sandbox.project_dir,
+        repo_dirs,
         &sandbox.home_dir,
         extra_pass_env,
         inherit_env,
@@ -1126,6 +1159,7 @@ fn exec_bwrap(
     wrapper: &super::bubblewrap::BubblewrapWrapper,
     copilot_bin: &Path,
     copilot_args: &[String],
+    repo_dirs: &[PathBuf],
     extra_pass_env: &[String],
     inherit_env: bool,
     disabled_categories: &[HardeningCategory],
@@ -1204,6 +1238,7 @@ fn exec_bwrap(
         &mut cmd,
         &[],
         &sandbox.project_dir,
+        repo_dirs,
         &sandbox.home_dir,
         extra_pass_env,
         inherit_env,

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -2650,7 +2650,13 @@ mod trust_accept_guard {
 fn gh_repo_reporter(dir: &std::path::Path) -> std::path::PathBuf {
     use std::os::unix::fs::PermissionsExt;
     let fake_gh = dir.join("gh");
-    std::fs::write(&fake_gh, "#!/bin/sh\nprintf '%s\\n' \"$GH_REPO\"\n").unwrap();
+    // Both variables: `GH_HOST` is inherited targeting too, and must never
+    // reach the real gh (an authenticated read against any GHES otherwise).
+    std::fs::write(
+        &fake_gh,
+        "#!/bin/sh\nprintf '%s\\n%s\\n' \"$GH_REPO\" \"$GH_HOST\"\n",
+    )
+    .unwrap();
     std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
     fake_gh
 }
@@ -2678,6 +2684,7 @@ fn gh_gate_pins_the_cwd_member_and_never_the_launch_repo() {
         .arg("navikt/unleasherator")
         .arg("--")
         .args(["pr", "comment", "42", "--body", "test"])
+        .env("GH_HOST", "ghes.example")
         .current_dir(named.path())
         .output()
         .expect("cplt gh-gate should run");
@@ -2765,10 +2772,17 @@ fn gh_gate_pins_nothing_when_the_set_is_ambiguous() {
         .arg("navikt/unleasherator")
         .arg("--")
         .args(["auth", "status"])
-        .env("GH_REPO", "")
+        // Inherited targeting: with no pin produced there is nothing to overwrite
+        // these, so the scrub has to be unconditional or they reach the real gh.
+        .env("GH_REPO", "evil/x")
+        .env("GH_HOST", "ghes.example")
         .output()
         .expect("cplt gh-gate should run");
 
     assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "",
+        "an ambiguous set must pin nothing AND leak neither GH_REPO nor GH_HOST"
+    );
 }

--- a/tests/e2e_guards.rs
+++ b/tests/e2e_guards.rs
@@ -2643,3 +2643,132 @@ mod trust_accept_guard {
         assert!(out.contains("allow_docker"), "{out}");
     }
 }
+
+// ── multi-repo gh scope (#344, stage 1) ───────────────────────────────────
+
+/// A fake `gh` that reports the `GH_REPO` it was executed with.
+fn gh_repo_reporter(dir: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let fake_gh = dir.join("gh");
+    std::fs::write(&fake_gh, "#!/bin/sh\nprintf '%s\\n' \"$GH_REPO\"\n").unwrap();
+    std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
+    fake_gh
+}
+
+/// The pin follows the cwd's repository, not the launch repository.
+///
+/// This is the negative test the design requires: with a scope *set*, an
+/// implicit target resolved from the cwd must never fall back to the launch
+/// repo — that is #213 with N repositories to guess wrong about.
+#[test]
+fn gh_gate_pins_the_cwd_member_and_never_the_launch_repo() {
+    let bin = tempfile::tempdir().unwrap();
+    let fake_gh = gh_repo_reporter(bin.path());
+    let named = temp_repo("navikt/unleasherator");
+
+    let output = cplt_cmd()
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg(&fake_gh)
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
+        .arg("--repo-scope")
+        .arg("navikt/unleash")
+        .arg("--repo-scope")
+        .arg("navikt/unleasherator")
+        .arg("--")
+        .args(["pr", "comment", "42", "--body", "test"])
+        .current_dir(named.path())
+        .output()
+        .expect("cplt gh-gate should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "a member of the set is in scope");
+    assert_eq!(stdout.trim(), "github.com/navikt/unleasherator");
+    assert!(
+        !stdout.contains("navikt/unleash\n"),
+        "the pin must not fall back to the launch repository: {stdout}"
+    );
+}
+
+/// An explicit `-R` pins to the repository it names, not to the cwd's.
+#[test]
+fn gh_gate_pins_the_explicit_member_and_never_the_cwd() {
+    let bin = tempfile::tempdir().unwrap();
+    let fake_gh = gh_repo_reporter(bin.path());
+    let named = temp_repo("navikt/unleasherator");
+
+    let output = cplt_cmd()
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg(&fake_gh)
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
+        .arg("--repo-scope")
+        .arg("navikt/unleash")
+        .arg("--repo-scope")
+        .arg("navikt/unleasherator")
+        .arg("--")
+        .args(["pr", "comment", "42", "-R", "navikt/unleash", "--body", "t"])
+        .current_dir(named.path())
+        .output()
+        .expect("cplt gh-gate should run");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "github.com/navikt/unleash",
+        "the pin must follow -R, not the invocation cwd"
+    );
+}
+
+/// A repository outside the set is still refused, and the refusal names the set.
+#[test]
+fn gh_gate_refuses_a_repo_outside_the_scope_set() {
+    let output = cplt_cmd()
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg("/usr/bin/true")
+        .arg("--real-git")
+        .arg(binary_in_path("git"))
+        .arg("--repo-scope")
+        .arg("navikt/unleash")
+        .arg("--repo-scope")
+        .arg("navikt/unleasherator")
+        .arg("--")
+        .args(["pr", "close", "42", "-R", "navikt/bifrost"])
+        .output()
+        .expect("cplt gh-gate should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "outside the set must be refused");
+    assert!(
+        stderr.contains("navikt/unleash, navikt/unleasherator"),
+        "the refusal should name the whole set: {stderr}"
+    );
+}
+
+/// With several members and nothing naming one, no member is pinned: guessing
+/// is exactly the failure mode `GH_REPO` pinning exists to prevent.
+#[test]
+fn gh_gate_pins_nothing_when_the_set_is_ambiguous() {
+    let bin = tempfile::tempdir().unwrap();
+    let fake_gh = gh_repo_reporter(bin.path());
+
+    let output = cplt_cmd()
+        .arg("gh-gate")
+        .arg("--real-gh")
+        .arg(&fake_gh)
+        .arg("--repo-scope")
+        .arg("navikt/unleash")
+        .arg("--repo-scope")
+        .arg("navikt/unleasherator")
+        .arg("--")
+        .args(["auth", "status"])
+        .env("GH_REPO", "")
+        .output()
+        .expect("cplt gh-gate should run");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "");
+}


### PR DESCRIPTION
Stage 1 of #344. A session can name repositories beyond the launch one, and gh scope becomes a set rather than a single value. Stages 2 (named roots into the writable-roots set, `allow_push` and `[deny]` per root) and 3 (audit, brief, summary, `cplt check`) follow.

## The flag

`--repo-dir <DIR>`, repeatable. Each value must be a git toplevel, must not have a symlinked final component, must not be the launch repository or an ancestor of it, must not repeat, and — for this stage — must be inside the project directory. A path outside it is refused with "sibling repositories are not yet supported; use `--allow-write` for edit-only", which is honest about the boundary rather than silent. Siblings need project-grade grants in both sandbox backends, which is the only part of this series that touches kernel policy.

A root whose origin is not GitHub is accepted for later stages and excluded from gh scope with a warning, since the scope is a set of `owner/name`.

A nested named root needs no filesystem change: the project directory is already granted rwx as one subtree. Here the flag is an identity declaration.

## Facts captured at launch

Per root, in the parent, with the trusted git binary: canonical path, `origin`'s `owner/name`, and the git common directory. The last is unused in this stage and is what the next stage's push authorization keys on. This mirrors what the launch repository already gets, and for the same reason — GHSA-cm6f exists because the guard used to re-read the default branch from inside the sandbox.

## `GH_REPO` pins to the matched member

The security-critical piece, and the reason this stage is alone. `GH_REPO` is set to the repository the command actually targets — the `-R` value, the `/repos/{owner}/{repo}` path, or the repository the cwd belongs to. Never the launch repository when a set is in play.

#213 was the bug where gh silently targeted the wrong repository. Pinning to the launch repo with a set would be that bug once per named root, so both directions carry negative tests: no fall back to the launch repo for the cwd case, none to cwd for the `-R` case. A multi-member scope with an unresolvable cwd pins nothing rather than guessing, and ScopeCheck still fails closed there. A single-member scope behaves exactly as before.

## Found in review, fixed here

Adversarial review blocked the first version on a real widening: **naming a second root dropped the `GH_HOST` scrub.** Previously every Allow-tier command carried a pin, so the variable never reached the real `gh`; with no pin it survived, and `hosts.yml` is readable in-sandbox, so it was an authenticated read against any GHES the user is logged into — reached by naming a root.

```
GH_HOST=ghes.example gh search repos x   →  HOST=ghes.example    (before)
GH_REPO=evil/x gh auth status            →  REPO=evil/x          (before)
```

Both are now scrubbed unconditionally in `exec_real`, the single funnel every approved command passes through. A gate-side check would need repeating per decision path and re-auditing whenever one is added — which is exactly how this arose. The gate already refuses `--hostname`, so dropping the variables matches what cplt approves.

Two smaller findings from the same review: a trailing `..` walked past the symlinked-leaf refusal (`std::path::absolute` does not fold `..`, so `file_name()` was `None`), and scope dedup compared strings, so a launch repo and a root whose origin differed only in case both entered the set — turning a single-repository session into a multi-member one and reaching the bug above.

## What this stage deliberately leaves incomplete

Named roots are in gh scope but not in the writable-roots set, `allow_push` still pins to the launch repository, `[deny]` is not read from them, and the audit does not see them. Review confirmed none of that is unsafe as shipped: a named root must be inside the project dir so it is already writable; a push from one is refused because `describes()` compares git common directories; and `allow_push` rules cannot match a named root's origin because #382 bound them to launch-remote URLs.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` (host and `x86_64-unknown-linux-gnu`) and the full suite pass.