### PR TITLE
fix(sandbox): refuse every grant inside cplt's own state directory

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,6 +25,7 @@ pub use editing::{
 };
 pub use error::ConfigError;
 pub use loading::exec_tool_dir_warning;
+pub(crate) use path::canonicalize_deepest;
 pub(crate) use path::lexically_normalized;
 pub use path::{
     CustomConfigVerdict, classify_custom_config, collapse_tilde, config_dir, config_path,

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -381,7 +381,7 @@ pub(crate) fn lexically_normalized(path: &Path) -> PathBuf {
 /// actually land. This also covers a canonicalize failure that is not ENOENT —
 /// a permission-denied ancestor, or ELOOP — where the unresolved fallback would
 /// likewise name a path the kernel never matches.
-fn canonicalize_deepest(path: &Path) -> PathBuf {
+pub(crate) fn canonicalize_deepest(path: &Path) -> PathBuf {
     let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
     let mut cur = path;
     loop {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -287,9 +287,10 @@ fn validate_hard_denied_grants(config: &SandboxConfig) -> Result<(), String> {
                 return Err(format!(
                     "{key} names {} — inside cplt's own state directory ({}). Nothing in there \
                      can be granted, not even a single file: it holds the config, the trust \
-                     store, the blocklist cache and the per-repo local files, so an agent that \
-                     can write there approves its own next launch. Remove it from your config \
-                     or command line.",
+                     store, the blocklist cache and the per-repo local files, which decide what \
+                     the next launch allows. Reading them tells an agent exactly which \
+                     protections to work around; writing them lets it approve its own next \
+                     launch. Remove it from your config or command line.",
                     p.display(),
                     dir.display()
                 ));

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -262,6 +262,12 @@ pub fn prepare(config: &SandboxConfig) -> Result<PreparedSandbox, String> {
 /// It also lands on both backends at once — silently ineffective on macOS,
 /// silently effective on Linux, which is how #207 stayed invisible.
 ///
+/// cplt's own state directory is refused as a whole *subtree*
+/// ([`policy::cplt_state_dir_grant`]), which is the one place the per-file
+/// override below does not apply: every file in it — config, trust store,
+/// blocklist cache, per-repo local files — decides what the next run is
+/// allowed to do, so a grant on any of them is self-perpetuating.
+///
 /// [`policy::DENIED_DOTFILES`] directories are refused for the same reason
 /// pointing the other way (#291): the grant was silently ineffective on macOS
 /// and silently *effective* on Linux, where it opened `~/.ssh` wholesale. The
@@ -277,6 +283,17 @@ fn validate_hard_denied_grants(config: &SandboxConfig) -> Result<(), String> {
         ("allow.socket", config.extra_socket),
     ] {
         for p in paths {
+            if let Some(dir) = policy::cplt_state_dir_grant(config.home_dir, p) {
+                return Err(format!(
+                    "{key} names {} — inside cplt's own state directory ({}). Nothing in there \
+                     can be granted, not even a single file: it holds the config, the trust \
+                     store, the blocklist cache and the per-repo local files, so an agent that \
+                     can write there approves its own next launch. Remove it from your config \
+                     or command line.",
+                    p.display(),
+                    dir.display()
+                ));
+            }
             if let Some(file) = policy::hard_denied_file(config.home_dir, p) {
                 return Err(format!(
                     "{key} names {} (~/{file}), which is on the hard-deny list and cannot be granted explicitly. Remove it from your config or command line.",
@@ -1390,10 +1407,17 @@ mod tests {
             let error = prepare(&config).err().expect("allow.read must be refused");
             assert!(error.contains("allow.read"), "{error}");
             assert!(error.contains(dir), "{error}");
-            assert!(
-                error.contains("Name the specific path"),
-                "the error must point at the grant that does work: {error}"
-            );
+            // cplt's own state directory has no per-file grant to point at —
+            // it is refused as a whole subtree and says so instead.
+            if dir == policy::CPLT_STATE_DIR {
+                assert!(error.contains("state directory"), "{error}");
+                assert!(!error.contains("Name the specific path"), "{error}");
+            } else {
+                assert!(
+                    error.contains("Name the specific path"),
+                    "the error must point at the grant that does work: {error}"
+                );
+            }
 
             config.extra_read = &[];
             config.extra_write = &granted;
@@ -1431,6 +1455,75 @@ mod tests {
         config.extra_read = &[];
         config.extra_write = &granted;
         assert_eq!(validate_hard_denied_grants(&config), Ok(()));
+    }
+
+    /// cplt's own state directory is the exception to the per-file override:
+    /// every file in it decides what the *next* run may do — the trust store
+    /// approves a repo's `.cplt.toml [propose]`, the config carries the grants,
+    /// the blocklist cache carries the egress policy — so a grant on any of
+    /// them is self-perpetuating. Refused as a subtree, on every grant key,
+    /// including a path that does not exist yet (naming a file before creating
+    /// it would otherwise walk straight through a canonicalize-only check).
+    #[test]
+    fn prepare_rejects_a_grant_inside_the_cplt_state_directory() {
+        let home = Path::new("/home/test");
+        let state = home.join(policy::CPLT_STATE_DIR);
+        for tail in ["", "trust", "local", "config.toml", "not/created/yet"] {
+            let granted = vec![if tail.is_empty() {
+                state.clone()
+            } else {
+                state.join(tail)
+            }];
+            let mut config = test_config(home, &granted);
+
+            for key in ["allow.read", "allow.write", "allow.exec", "allow.socket"] {
+                config.extra_read = &[];
+                config.extra_write = &[];
+                config.extra_exec = &[];
+                config.extra_socket = &[];
+                match key {
+                    "allow.read" => config.extra_read = &granted,
+                    "allow.write" => config.extra_write = &granted,
+                    "allow.exec" => config.extra_exec = &granted,
+                    _ => config.extra_socket = &granted,
+                }
+                let error = prepare(&config)
+                    .err()
+                    .unwrap_or_else(|| panic!("{key} on {tail:?} must be refused"));
+                assert!(error.contains(key), "{error}");
+                assert!(error.contains(".config/cplt"), "{error}");
+                assert!(
+                    error.contains("state directory"),
+                    "the error must name the reason: {error}"
+                );
+            }
+        }
+    }
+
+    /// The subtree rule is cplt's own directory, not `~/.config` at large.
+    #[test]
+    fn a_grant_on_another_config_subdirectory_is_untouched() {
+        let home = Path::new("/home/test");
+        let granted = vec![home.join(".config/foo"), home.join(".config/cpltish")];
+        let config = test_config(home, &granted);
+        assert_eq!(validate_hard_denied_grants(&config), Ok(()));
+    }
+
+    /// `CPLT_CONFIG` moves the real files, so the refusal has to move with
+    /// them — the state directory is wherever the config actually lives.
+    #[test]
+    fn a_grant_inside_a_relocated_state_directory_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&dir).unwrap();
+        let granted = vec![dir.join("trust")];
+
+        temp_env::with_var("CPLT_CONFIG", Some(dir.join("config.toml")), || {
+            let config = test_config(Path::new("/home/test"), &granted);
+            let error = validate_hard_denied_grants(&config)
+                .expect_err("a grant in the relocated state dir must be refused");
+            assert!(error.contains("state directory"), "{error}");
+        });
     }
 
     /// `--allow-docker` grants `~/.docker` read-only, and `~/.docker` is a

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -4,6 +4,7 @@
 //! path validation, tool directory permissions, and hardening env vars.
 
 use crate::agent::Agent;
+use crate::config;
 use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
 
@@ -26,8 +27,13 @@ pub const DENIED_DOTFILES: &[&str] = &[
     // cplt's own state: the trust store, blocklist caches, and the self-update
     // staging area. An agent that can write here can tamper with the sandbox
     // that contains it, or swap the binary `cplt update` is about to install.
-    ".config/cplt",
+    // Unlike every other entry, no per-file override is allowed either — see
+    // [`cplt_state_dir_grant`].
+    CPLT_STATE_DIR,
 ];
+
+/// cplt's own state directory, relative to `$HOME`.
+pub const CPLT_STATE_DIR: &str = ".config/cplt";
 
 /// Sensitive files under $HOME that are always denied.
 pub const DENIED_FILES: &[&str] = &[".netrc", ".pypirc", ".gem/credentials", ".vault-token"];
@@ -74,6 +80,34 @@ pub fn hard_denied_file(home: &Path, path: &Path) -> Option<&'static str> {
 /// first-party rule emitted by the backends, never a user grant on this path.
 pub fn denied_dotfile_dir(home: &Path, path: &Path) -> Option<&'static str> {
     denied_entry(DENIED_DOTFILES, home, path)
+}
+
+/// The cplt state directory containing `path`, if a grant names anything
+/// inside it.
+///
+/// A *subtree* test, unlike [`denied_dotfile_dir`]: for every other
+/// [`DENIED_DOTFILES`] entry a per-file grant is a supported and useful
+/// override (`~/.ssh/known_hosts`), but nothing inside cplt's own state
+/// directory is ever a legitimate grant. It holds the config, the trust store,
+/// the blocklist subscription cache and the per-repo local files — an agent
+/// that can write any of them approves its own next launch, and the widening
+/// perpetuates itself.
+///
+/// Both locations are checked: `$HOME/.config/cplt` and whatever `CPLT_CONFIG`
+/// relocates the directory to, since the override moves the real files.
+/// The grant is resolved with [`config::canonicalize_deepest`] so a path that
+/// does not exist yet still matches — otherwise the check is sidestepped by
+/// naming a file before creating it — and the lexical form is compared too, so
+/// a symlink out of the directory is refused as well.
+#[must_use]
+pub fn cplt_state_dir_grant(home: &Path, path: &Path) -> Option<PathBuf> {
+    let resolved = config::canonicalize_deepest(path);
+    [config::config_dir(), Some(home.join(CPLT_STATE_DIR))]
+        .into_iter()
+        .flatten()
+        .find(|dir| {
+            resolved.starts_with(config::canonicalize_deepest(dir)) || path.starts_with(dir)
+        })
 }
 
 /// Whether a grant on `path` must never reach a backend ruleset.

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -117,7 +117,12 @@ pub fn cplt_state_dir_grant(home: &Path, path: &Path) -> Option<PathBuf> {
 /// `generate_policy` and not only the ones that went through `prepare`.
 #[must_use]
 pub fn grant_is_refused(home: &Path, path: &Path) -> bool {
-    hard_denied_file(home, path).is_some() || denied_dotfile_dir(home, path).is_some()
+    hard_denied_file(home, path).is_some()
+        || denied_dotfile_dir(home, path).is_some()
+        // Subtree, unlike the two above: nothing inside cplt's own state
+        // directory may be granted, so a backend reached without going through
+        // `sandbox::prepare` refuses the same paths that `prepare` does.
+        || cplt_state_dir_grant(home, path).is_some()
 }
 
 /// Exact-path membership of `path` in a `$HOME`-relative deny list, comparing


### PR DESCRIPTION
Found while planning #340, whose per-repo user files land in this directory. Also closes item 2 of #426.

## The gap

`~/.config/cplt` is in `DENIED_DOTFILES`, so granting the directory itself is refused. But a grant on a path *inside* a denied dotfile directory is a **supported override** on both backends — documented, tested, and useful for `~/.ssh/id_ed25519`. Nothing excluded cplt's own state from that override:

```
--allow-write ~/.config/cplt        →  refused
--allow-write ~/.config/cplt/trust  →  (allow file-write* (subpath ".../cplt/trust"))
```

That directory holds the config, the trust store, the blocklist subscription cache, and — once #340 lands — the per-repo local files. An agent that can write there can add a trust entry approving its own `.cplt.toml [propose]` for the next launch. With the local layer it could grant itself write over the file that holds its own per-repo policy, so a single user mistake becomes a permanent foothold rather than a one-session one.

It needs the user to have made the grant, so this is a footgun rather than a live vulnerability. What makes it worth closing anyway is that **the refusal message for the parent directory recommended it**:

> Name the specific path you need inside it instead, e.g. `~/.config/cplt/<file>` — that grant works on both.

## The fix

`validate_hard_denied_grants` refuses any `allow.read` / `allow.write` / `allow.exec` / `allow.socket` path resolving inside `config_dir()`, as a subtree. Nothing in there can be granted, not even a single file.

The shared denied-dotfile advice stays as it is, because it is correct and actionable for every other entry — watering it down to remain true for cplt would cost `~/.ssh` its useful remedy for the sake of a case that no longer reaches that branch. cplt gets its own message that offers no route in, because there isn't one.

Paths are compared after canonicalizing as deep as they exist, with a lexical fallback, so a symlink pointing out of the state directory is refused, and so is a path that does not exist yet. `CPLT_CONFIG` relocates the state directory and the refusal follows it to the real location.

## Verified

```
--allow-write ~/.config/cplt              → refused, state-directory message
--allow-write ~/.config/cplt/trust        → refused
--allow-write ~/.config/cplt/local/x.toml → refused
--allow-read  ~/.ssh/known_hosts          → still granted (override intact)
--allow-write ~/.config/foo               → still granted (unaffected)
CPLT_CONFIG=/tmp/relo/config.toml --allow-write /tmp/relo/trust → refused, naming the real dir
```

The pinned tests for the per-file override on other denied dotfile directories pass unchanged; if they had not, the rule would have been generalised too far.

## Not covered

A grant on an *ancestor* (`~/.config`, `$HOME`) is not caught here. Those are refused for other reasons today, but on Linux a write grant on an ancestor unions over the state directory the same way `DENIED_FILES` already documents — the same known Landlock limitation, not new here. State outside `config_dir()` (`~/.cache/cplt`, `~/Library/Caches/cplt`) is untouched by this rule. The backend-side `grant_is_refused` still tests exact matches only; `prepare` refuses first, so nothing reaches it by the normal path, and adding the subtree test there is the defence-in-depth follow-up.