### PR TITLE
feat(config): read a per-repo user config layer

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -567,6 +567,7 @@ mod tests {
 
     fn base_resolved() -> Resolved {
         Resolved {
+            bool_layers: Vec::new(),
             with_proxy: true,
             proxy_forced: false,
             proxy_port: 0,

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -459,7 +459,7 @@ pub fn display_config(loaded: Option<&LoadedConfig>) {
 fn guard_lines(c: &Config) -> Vec<String> {
     let src = |has_file_value: bool| if has_file_value { "" } else { " (default)" };
     let baseline = c.sandbox.preset.unwrap_or(Preset::Standard).baseline();
-    let b = ResolvedBools::resolve(&CliFlags::default(), c, baseline);
+    let b = ResolvedBools::resolve(&CliFlags::default(), None, c, baseline);
 
     vec![
         String::new(),

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1401,16 +1401,35 @@ impl Resolved {
             if (row.propose)(&repo_config.propose) != Some(true) {
                 continue;
             }
+            let (section, key) = row.ladder_key;
+            // Already on: the row changes nothing, so it must not stamp its
+            // provenance either. Attributing an unchanged value to the repo is
+            // how `config show` comes to name the wrong file.
+            if super::registry::bool_key(section, key).is_some_and(|r| (r.resolved)(self)) {
+                continue;
+            }
             if row.tighten_only {
+                // Deliberate, but never silent: `--no-gh-guard` (or an explicit
+                // `false` in global/local config) loses to a repo turning the
+                // guard on, and the user has to be able to see that happen.
+                if let Some(layer) = self
+                    .bool_layer(section, key)
+                    .filter(|l| *l != ConfigLayer::Baseline)
+                {
+                    ui::warn(&format!(
+                        ".cplt.toml proposes {} = true, which turns a guard ON. \
+                         That overrides your explicit {section}.{key} = false from the \
+                         {layer} layer — a repo may always make the sandbox stricter.",
+                        row.key
+                    ));
+                }
                 (row.apply)(self);
-                let (section, key) = row.ladder_key;
                 self.set_bool_layer(section, key, ConfigLayer::Repo);
                 continue;
             }
             if !is_approved(row.key) {
                 continue;
             }
-            let (section, key) = row.ladder_key;
             if self
                 .bool_layer(section, key)
                 .is_some_and(|l| l != ConfigLayer::Baseline)
@@ -1500,17 +1519,12 @@ impl Resolved {
             self.repo_private_domains.dedup();
         }
 
-        // Return unapproved keys for display. Tighten-only rows are excluded:
-        // they applied without an approval, so listing them as pending would ask
-        // the user to approve something already in force.
-        let tighten_only: Vec<&str> = super::repo::PROPOSE_BOOLS
-            .iter()
-            .filter(|row| row.tighten_only)
-            .map(|row| row.key)
-            .collect();
+        // Return unapproved keys for display. `proposed_keys` already omits the
+        // tighten-only rows, which applied without an approval — listing them as
+        // pending would ask the user to approve something already in force.
         all_proposed
             .into_iter()
-            .filter(|key| !is_approved(key) && !tighten_only.contains(key))
+            .filter(|key| !is_approved(key))
             .map(std::string::ToString::to_string)
             .collect()
     }
@@ -4209,6 +4223,63 @@ mod precedence {
                 expect: (false, ConfigLayer::Local),
             },
             Case {
+                // The headline change of the local-config branch: acceptance
+                // means "this repo may ask", not "this repo overrides me".
+                name: "an explicit CLI off beats an accepted repo true",
+                key: "sandbox.allow_docker",
+                global: "",
+                local: "",
+                repo: Some((|p| p.allow_docker = Some(true), &["allow_docker"])),
+                cli: Some(|c| c.allow_docker = FeatureToggle::ForceOff),
+                expect: (false, ConfigLayer::Cli),
+            },
+            Case {
+                // Same value from two layers: the higher one must own it, or
+                // `config show` credits the repo for the user's own setting.
+                name: "an explicit local true keeps its layer over an accepted repo true",
+                key: "sandbox.allow_docker",
+                global: "",
+                local: "[sandbox]\nallow_docker = true\n",
+                repo: Some((|p| p.allow_docker = Some(true), &["allow_docker"])),
+                cli: None,
+                expect: (true, ConfigLayer::Local),
+            },
+            Case {
+                name: "an explicit global true keeps its layer over an accepted repo true",
+                key: "sandbox.allow_docker",
+                global: "[sandbox]\nallow_docker = true\n",
+                local: "",
+                repo: Some((|p| p.allow_docker = Some(true), &["allow_docker"])),
+                cli: None,
+                expect: (true, ConfigLayer::Global),
+            },
+            Case {
+                // `agents_md` is the one bool the merge gates again after the
+                // ladder (on `brief`), so the local layer has to reach BOTH or
+                // the block never renders. That second gate is why the
+                // every-key drift test skips this row.
+                name: "agents_md comes through the local layer",
+                key: "sandbox.agents_md",
+                global: "",
+                local: "[sandbox]\nbrief = true\nagents_md = true\n",
+                repo: None,
+                cli: None,
+                expect: (true, ConfigLayer::Local),
+            },
+            Case {
+                // The legacy spelling folds into `gh_guard.enabled` in the
+                // `config` accessor, which IS the local accessor. If that fold
+                // were ever copied into a separate local column, this is the
+                // case that would catch the copy going stale.
+                name: "the legacy sandbox.gh_proxy spelling works from a local file",
+                key: "gh_guard.enabled",
+                global: "",
+                local: "[sandbox]\ngh_proxy = true\n",
+                repo: None,
+                cli: None,
+                expect: (true, ConfigLayer::Local),
+            },
+            Case {
                 name: "an unapproved repo proposal still does nothing",
                 key: "sandbox.allow_docker",
                 global: "",
@@ -4271,10 +4342,14 @@ mod precedence {
         }
     }
 
-    /// Anti-drift for `Config::overlay`: a boolean key the overlay forgets to
-    /// carry would silently fall back to global, which for a tightening key is
-    /// a silent grant. Every row on the ladder is exercised from the local file
-    /// alone, both ways.
+    /// Anti-drift for the ladder's LOCAL column, not for `Config::overlay` —
+    /// booleans never get their answer from the overlay, they get it from
+    /// `resolve_bool`'s `local` argument. (`overlay`'s own guard is the
+    /// exhaustive destructure at the top of that function, which is a compile
+    /// error rather than a test.) A key whose `config` accessor does not in
+    /// fact read the local struct would silently fall back to global, which for
+    /// a tightening key is a silent grant. Every row on the ladder is exercised
+    /// from the local file alone, both ways.
     #[test]
     fn every_boolean_key_reads_from_the_local_layer() {
         for row in BOOL_KEYS {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use super::error::ConfigError;
 use super::path::{config_dir, config_path, expand_tilde, resolve_config_path, resolve_repo_path};
+use super::registry::ConfigLayer;
 use super::types::{
     CliFlags, Config, EnforcementMode, GhGuardPolicy, GitGuardPolicy, LoadedConfig, Preset,
     Resolved, ResolvedPushRule, UnknownCommandPolicy,
@@ -76,6 +77,27 @@ impl Config {
         self.merge_with_no_proxy_env(cli, no_proxy_env_value())
     }
 
+    /// Merge with the per-repo user config (#340) as a layer above this one.
+    ///
+    /// The ladder is `Default/Preset < Global < Repo < Local < CLI`. Booleans
+    /// see local and global as separate layers, so the resolver can name which
+    /// one a value came from (`Resolved::bool_layer`). Scalars and lists are
+    /// overlaid first — local `Some` wins, lists union — and the rest of
+    /// `merge` reads the overlaid struct, so nothing below has to learn about
+    /// the new layer.
+    pub fn merge_with_local(
+        &self,
+        local: Option<&Config>,
+        cli: CliFlags,
+    ) -> Result<Resolved, ConfigError> {
+        match local {
+            None => self.merge_with_no_proxy_env(cli, no_proxy_env_value()),
+            Some(local) => self
+                .overlay(local)
+                .merge_inner(Some(local), cli, no_proxy_env_value()),
+        }
+    }
+
     /// Same as [`merge`](Self::merge) but with the ambient `NO_PROXY`/`no_proxy`
     /// value injected explicitly rather than read from the process environment.
     ///
@@ -89,6 +111,18 @@ impl Config {
         cli: CliFlags,
         no_proxy_env: Option<String>,
     ) -> Result<Resolved, ConfigError> {
+        self.merge_inner(None, cli, no_proxy_env)
+    }
+
+    /// The merge itself. `self` is the config to read scalars and lists from —
+    /// already overlaid with `local` when there is one — and `local` is passed
+    /// separately only so the boolean ladder can tell the two layers apart.
+    fn merge_inner(
+        &self,
+        local: Option<&Config>,
+        cli: CliFlags,
+        no_proxy_env: Option<String>,
+    ) -> Result<Resolved, ConfigError> {
         // Policy preset: sets a BASELINE spanning two axes — the five sandbox
         // toggles below AND the three safety features (gh_guard, git_guard,
         // proxy.forced). Precedence for the preset itself: CLI (--preset) wins
@@ -97,7 +131,10 @@ impl Config {
         // config values still override it (see each
         // `*.to_option().or(config).unwrap_or(baseline)` for toggles and the
         // `.resolve(config.or(...).unwrap_or(baseline))` for the guards/proxy).
-        let preset = cli.preset.or(self.sandbox.preset);
+        let preset = cli
+            .preset
+            .or_else(|| local.and_then(|l| l.sandbox.preset))
+            .or(self.sandbox.preset);
         // No preset == "standard" == cplt's hardcoded defaults (all five
         // toggles off, no guards, no forced proxy). Only `strict` turns the
         // safety features on.
@@ -106,7 +143,7 @@ impl Config {
         // Every boolean setting, resolved by the registry-driven ladder in
         // `registry.rs` (CLI flag > config > preset baseline > default). The
         // ladder is written once, there; nothing below re-implements it.
-        let bools = super::registry::ResolvedBools::resolve(&cli, self, baseline);
+        let bools = super::registry::ResolvedBools::resolve(&cli, local, self, baseline);
 
         let with_proxy = bools.with_proxy;
 
@@ -521,6 +558,7 @@ impl Config {
 
         Ok(Resolved {
             with_proxy,
+            bool_layers: bools.layers.clone(),
             repo_private_domains: Vec::new(),
             proxy_forced,
             proxy_port,
@@ -744,6 +782,29 @@ fn no_proxy_env_value() -> Option<String> {
 }
 
 impl Resolved {
+    /// Which layer supplied the resolved value of a boolean config key.
+    ///
+    /// `None` for a key that is not on the boolean ladder. This is the single
+    /// provenance source for booleans: `config show`, `cplt settings` and the
+    /// repo-proposal gate below all read it, so none of them needs a second
+    /// resolution path that can disagree with the first.
+    pub fn bool_layer(&self, section: &str, key: &str) -> Option<ConfigLayer> {
+        let index = super::registry::BOOL_KEYS
+            .iter()
+            .position(|row| row.section == section && row.key == key)?;
+        self.bool_layers.get(index).copied()
+    }
+
+    fn set_bool_layer(&mut self, section: &str, key: &str, layer: ConfigLayer) {
+        if let Some(index) = super::registry::BOOL_KEYS
+            .iter()
+            .position(|row| row.section == section && row.key == key)
+            && let Some(slot) = self.bool_layers.get_mut(index)
+        {
+            *slot = layer;
+        }
+    }
+
     /// Returns the hardening categories that are disabled by user configuration.
     pub fn disabled_hardening_categories(&self) -> Vec<HardeningCategory> {
         let mut disabled = Vec::new();
@@ -1325,10 +1386,39 @@ impl Resolved {
         let all_proposed = crate::repo_config::proposed_keys(&repo_config.propose);
 
         // Boolean proposals, driven by `PROPOSE_BOOLS` (additive: false→true only).
+        //
+        // Two gates, and they pull in opposite directions:
+        //
+        // - A tighten-only row turns a guard ON. It is `[deny]`-shaped, so it
+        //   needs no approval and no layer takes it back off — an accepted (or
+        //   merely proposed) `gh_guard = true` survives `--no-gh-guard`.
+        // - Every other row widens. It needs an approval, AND it must not
+        //   quietly undo a decision the user made themselves: a repo `true`
+        //   applies only where nothing explicit said otherwise. An explicit
+        //   `false` in global config, in the local file, or on the CLI wins,
+        //   which is what `bool_layer` is consulted for. #427, finding 6.
         for row in super::repo::PROPOSE_BOOLS {
-            if (row.propose)(&repo_config.propose) == Some(true) && is_approved(row.key) {
-                (row.apply)(self);
+            if (row.propose)(&repo_config.propose) != Some(true) {
+                continue;
             }
+            if row.tighten_only {
+                (row.apply)(self);
+                let (section, key) = row.ladder_key;
+                self.set_bool_layer(section, key, ConfigLayer::Repo);
+                continue;
+            }
+            if !is_approved(row.key) {
+                continue;
+            }
+            let (section, key) = row.ladder_key;
+            if self
+                .bool_layer(section, key)
+                .is_some_and(|l| l != ConfigLayer::Baseline)
+            {
+                continue;
+            }
+            (row.apply)(self);
+            self.set_bool_layer(section, key, ConfigLayer::Repo);
         }
 
         // Path proposals
@@ -1410,10 +1500,17 @@ impl Resolved {
             self.repo_private_domains.dedup();
         }
 
-        // Return unapproved keys for display
+        // Return unapproved keys for display. Tighten-only rows are excluded:
+        // they applied without an approval, so listing them as pending would ask
+        // the user to approve something already in force.
+        let tighten_only: Vec<&str> = super::repo::PROPOSE_BOOLS
+            .iter()
+            .filter(|row| row.tighten_only)
+            .map(|row| row.key)
+            .collect();
         all_proposed
             .into_iter()
-            .filter(|key| !is_approved(key))
+            .filter(|key| !is_approved(key) && !tighten_only.contains(key))
             .map(std::string::ToString::to_string)
             .collect()
     }
@@ -3458,7 +3555,7 @@ validate = false
 /// ladder for that key actually changed, not that a mirror of it drifted.
 #[cfg(test)]
 mod precedence {
-    use super::super::registry::{BOOL_KEYS, BOOL_KEYS_EXEMPT};
+    use super::super::registry::{BOOL_KEYS, BOOL_KEYS_EXEMPT, ConfigLayer};
     use super::super::types::{CliFlags, Config, FeatureToggle, Preset, Resolved};
     use super::super::{ConfigValueType, all_config_keys};
 
@@ -3999,6 +4096,251 @@ mod precedence {
                 info.key
             );
         }
+    }
+
+    // ── The Local column (#340) ──────────────────────────────────────
+    //
+    // A case is (global toml, local toml, repo proposal + accepted keys, CLI)
+    // → the expected value AND the expected layer. The layer is half the point:
+    // a value that comes out right from the wrong rung is a `config show` that
+    // lies about where a grant came from.
+
+    /// A `[propose]` entry to write, and the keys `cplt trust accept` approved.
+    type RepoCase = (
+        fn(&mut crate::repo_config::ProposeSection),
+        &'static [&'static str],
+    );
+
+    struct Case {
+        name: &'static str,
+        key: &'static str,
+        global: &'static str,
+        local: &'static str,
+        /// A `.cplt.toml` `[propose]` entry plus the keys the user accepted.
+        repo: Option<RepoCase>,
+        cli: Option<fn(&mut CliFlags)>,
+        expect: (bool, ConfigLayer),
+    }
+
+    fn parse_layer(toml: &str) -> Option<Config> {
+        (!toml.is_empty()).then(|| toml::from_str::<Config>(toml).expect("test config parses"))
+    }
+
+    fn run(case: &Case) -> Resolved {
+        let global = toml::from_str::<Config>(case.global).expect("global parses");
+        let local = parse_layer(case.local);
+        let mut cli = CliFlags::default();
+        if let Some(set) = case.cli {
+            set(&mut cli);
+        }
+        let mut resolved = global
+            .merge_with_local(local.as_ref(), cli)
+            .expect("test config merges");
+        if let Some((propose, accepted)) = case.repo {
+            let mut section = crate::repo_config::ProposeSection::default();
+            propose(&mut section);
+            let repo_config = crate::repo_config::RepoConfig {
+                propose: section,
+                ..Default::default()
+            };
+            resolved.apply_repo_config(
+                &repo_config,
+                std::path::Path::new("/nonexistent-repo"),
+                accepted,
+            );
+        }
+        resolved
+    }
+
+    fn cases() -> Vec<Case> {
+        vec![
+            Case {
+                name: "local beats global",
+                key: "sandbox.allow_docker",
+                global: "[sandbox]\nallow_docker = false\n",
+                local: "[sandbox]\nallow_docker = true\n",
+                repo: None,
+                cli: None,
+                expect: (true, ConfigLayer::Local),
+            },
+            Case {
+                name: "CLI beats local",
+                key: "sandbox.allow_docker",
+                global: "",
+                local: "[sandbox]\nallow_docker = true\n",
+                repo: None,
+                cli: Some(|c| c.allow_docker = FeatureToggle::ForceOff),
+                expect: (false, ConfigLayer::Cli),
+            },
+            Case {
+                name: "a missing local file changes nothing",
+                key: "sandbox.allow_docker",
+                global: "[sandbox]\nallow_docker = true\n",
+                local: "",
+                repo: None,
+                cli: None,
+                expect: (true, ConfigLayer::Global),
+            },
+            Case {
+                name: "an accepted repo proposal applies where nothing explicit said otherwise",
+                key: "sandbox.allow_docker",
+                global: "",
+                local: "",
+                repo: Some((|p| p.allow_docker = Some(true), &["allow_docker"])),
+                cli: None,
+                expect: (true, ConfigLayer::Repo),
+            },
+            Case {
+                name: "an explicit global false beats an accepted repo true",
+                key: "sandbox.allow_docker",
+                global: "[sandbox]\nallow_docker = false\n",
+                local: "",
+                repo: Some((|p| p.allow_docker = Some(true), &["allow_docker"])),
+                cli: None,
+                expect: (false, ConfigLayer::Global),
+            },
+            Case {
+                name: "an explicit local false beats an accepted repo true",
+                key: "sandbox.allow_docker",
+                global: "",
+                local: "[sandbox]\nallow_docker = false\n",
+                repo: Some((|p| p.allow_docker = Some(true), &["allow_docker"])),
+                cli: None,
+                expect: (false, ConfigLayer::Local),
+            },
+            Case {
+                name: "an unapproved repo proposal still does nothing",
+                key: "sandbox.allow_docker",
+                global: "",
+                local: "",
+                repo: Some((|p| p.allow_docker = Some(true), &[])),
+                cli: None,
+                expect: (false, ConfigLayer::Baseline),
+            },
+            Case {
+                // Tighten-only: the repo is asking for LESS permission, so no
+                // layer takes it back off. #427, finding 1.
+                name: "an accepted repo gh_guard survives --no-gh-guard",
+                key: "gh_guard.enabled",
+                global: "",
+                local: "",
+                repo: Some((|p| p.gh_guard = Some(true), &["gh_guard"])),
+                cli: Some(|c| c.gh_guard = FeatureToggle::ForceOff),
+                expect: (true, ConfigLayer::Repo),
+            },
+            Case {
+                name: "a repo gh_guard needs no acceptance",
+                key: "gh_guard.enabled",
+                global: "[gh_guard]\nenabled = false\n",
+                local: "",
+                repo: Some((|p| p.gh_guard = Some(true), &[])),
+                cli: None,
+                expect: (true, ConfigLayer::Repo),
+            },
+            Case {
+                name: "a repo git_push_prevention survives --no-git-guard",
+                key: "git_guard.enabled",
+                global: "",
+                local: "[git_guard]\nenabled = false\n",
+                repo: Some((|p| p.git_push_prevention = Some(true), &[])),
+                cli: Some(|c| c.git_push_prevention = FeatureToggle::ForceOff),
+                expect: (true, ConfigLayer::Repo),
+            },
+        ]
+    }
+
+    #[test]
+    fn the_local_layer_resolves_by_the_table() {
+        for case in cases() {
+            let resolved = run(&case);
+            let (section, key) = case.key.split_once('.').unwrap();
+            let row = super::super::registry::bool_key(section, key).expect("registry row");
+            let (want_value, want_layer) = case.expect;
+            assert_eq!(
+                (row.resolved)(&resolved),
+                want_value,
+                "value: {}",
+                case.name
+            );
+            assert_eq!(
+                resolved.bool_layer(section, key),
+                Some(want_layer),
+                "layer: {}",
+                case.name
+            );
+        }
+    }
+
+    /// Anti-drift for `Config::overlay`: a boolean key the overlay forgets to
+    /// carry would silently fall back to global, which for a tightening key is
+    /// a silent grant. Every row on the ladder is exercised from the local file
+    /// alone, both ways.
+    #[test]
+    fn every_boolean_key_reads_from_the_local_layer() {
+        for row in BOOL_KEYS {
+            if (row.section, row.key) == ("sandbox", "agents_md") {
+                // Gated on `brief` after the ladder; exercised separately.
+                continue;
+            }
+            for value in [false, true] {
+                let local: Config =
+                    toml::from_str(&toml_for(&format!("{}.{}", row.section, row.key), value))
+                        .expect("local config parses");
+                let resolved = Config::default()
+                    .merge_with_local(Some(&local), CliFlags::default())
+                    .expect("merges");
+                assert_eq!(
+                    (row.resolved)(&resolved),
+                    value,
+                    "{}.{} = {value} in the local file",
+                    row.section,
+                    row.key
+                );
+                assert_eq!(
+                    resolved.bool_layer(row.section, row.key),
+                    Some(ConfigLayer::Local),
+                    "{}.{} must report the local layer",
+                    row.section,
+                    row.key
+                );
+            }
+        }
+    }
+
+    /// Every propose row must be able to stamp its provenance, or the
+    /// explicit-false gate above silently stops gating that key.
+    #[test]
+    fn every_propose_row_names_a_ladder_key() {
+        for row in super::super::repo::PROPOSE_BOOLS {
+            let (section, key) = row.ladder_key;
+            assert!(
+                super::super::registry::bool_key(section, key).is_some(),
+                "propose {} has no ladder row for {section}.{key}",
+                row.key
+            );
+        }
+    }
+
+    /// The local file may also choose the preset, above global and below CLI.
+    #[test]
+    fn local_preset_beats_global_and_loses_to_cli() {
+        let global: Config = toml::from_str("[sandbox]\npreset = \"standard\"\n").unwrap();
+        let local: Config = toml::from_str("[sandbox]\npreset = \"strict\"\n").unwrap();
+        let r = global
+            .merge_with_local(Some(&local), CliFlags::default())
+            .unwrap();
+        assert!(r.proxy_forced, "the local preset must apply");
+
+        let r = global
+            .merge_with_local(
+                Some(&local),
+                CliFlags {
+                    preset: Some(Preset::Permissive),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(!r.proxy_forced, "--preset must beat the local preset");
     }
 
     #[test]

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -36,8 +36,9 @@ struct LocalHeader {
     /// The canonical project dir, in the clear, for listing and diagnostics.
     /// The filename is its hash; this is what makes an orphan file readable.
     /// Declared (rather than ignored) so `deny_unknown_fields` can catch a
-    /// misspelled `remote` instead of silently disarming the tripwire.
-    #[allow(dead_code)]
+    /// misspelled `remote` instead of silently disarming the tripwire, and
+    /// checked against the directory the file is keyed under in [`parse_local`]
+    /// so it is documentation rather than decoration.
     path: String,
     /// The `origin` remote as it was when the file was written. A staleness
     /// tripwire, NOT an identity — see [`remote_mismatch`].
@@ -107,15 +108,22 @@ pub fn load_local(project_dir: &Path) -> Result<Option<Config>, ConfigError> {
         path: path.clone(),
         source: e,
     })?;
-    parse_local(&raw, &path, crate::trust::canonical_remote(project_dir))
+    parse_local(
+        &raw,
+        &path,
+        crate::trust::canonical_remote(project_dir),
+        Some(&canonical_key(project_dir)),
+    )
 }
 
-/// Parse a local config file. Split out from [`load_local`] so the remote is
-/// injected rather than shelled out for: no git, no filesystem, testable.
+/// Parse a local config file. Split out from [`load_local`] so the remote and
+/// the canonical project dir are injected rather than shelled out for: no git,
+/// no filesystem, testable.
 pub(super) fn parse_local(
     raw: &str,
     path: &Path,
     current_remote: Option<String>,
+    project_key: Option<&str>,
 ) -> Result<Option<Config>, ConfigError> {
     let display = path.display().to_string();
     let mut root = raw
@@ -133,6 +141,20 @@ pub(super) fn parse_local(
         })?,
         None => LocalHeader::default(),
     };
+    // The filename is a hash of the canonical project dir, so a `[local] path`
+    // that names a different directory means the header was hand-edited or the
+    // file was copied. It is not authority — the hash already decided which
+    // checkout this file belongs to — but leaving it unchecked is what makes
+    // the field decorative. Warn and carry on.
+    if let (Some(expected), false) = (project_key, header.path.is_empty())
+        && header.path != expected
+    {
+        ui::warn(&format!(
+            "{display} is keyed to {expected}, but its [local] path says {}. \
+             The filename decides; fix the header or re-write the file.",
+            header.path
+        ));
+    }
     if let Some(recorded) = remote_mismatch(&header.remote, current_remote.as_deref()) {
         // Not `ui::info`: this warning is deliberately NOT suppressible by
         // --quiet, following #284. A grant the user cannot see is the thing the
@@ -194,8 +216,19 @@ pub(super) fn parse_local(
 ///
 /// An empty recorded remote means the file never claimed one (a repo with no
 /// origin), so there is nothing to trip.
+///
+/// Both sides are normalized before comparing. `current` already is (it comes
+/// from [`crate::trust::canonical_remote`]), but the recorded side is whatever
+/// is in the file: a hand-written `https://github.com/x/y.git` is the same
+/// remote and must not trip the wire. Normalizing at READ also means a future
+/// change to `normalize_remote_url` cannot silently disarm every file already
+/// on disk — which it would if the writer were the only normalizer.
 fn remote_mismatch<'a>(recorded: &'a str, current: Option<&str>) -> Option<&'a str> {
-    if recorded.is_empty() || current == Some(recorded) {
+    if recorded.is_empty() {
+        return None;
+    }
+    let normalized = crate::trust::normalize_remote_url(recorded);
+    if current.map(crate::trust::normalize_remote_url) == Some(normalized) {
         None
     } else {
         Some(recorded)
@@ -207,6 +240,17 @@ impl Config {
     ///
     /// `Option` fields: local when `Some`, so an unset local key falls through to
     /// global. List fields: union, as config and CLI already are.
+    ///
+    /// Two list-shaped keys are the stated exception to the union rule:
+    /// `proxy.allow_private_domains` and `proxy.upstream_no_proxy` are
+    /// `Option<Vec<String>>`, and they REPLACE. `None` (key absent) and
+    /// `Some(vec![])` (key present and empty) are distinguishable there and
+    /// mean different things, and replacing is the only semantics that lets a
+    /// local file *narrow* either list. Both narrow in the tightening
+    /// direction — fewer domains reachable without the proxy, more traffic
+    /// forced through the corporate proxy — so a union would remove the one
+    /// safe edit a per-repo file can make to them. #340's "lists union" holds
+    /// for every `Vec<T>` key; these two are `Option<Vec<T>>` and do not.
     ///
     /// Booleans do NOT get their answer from here — they run the registry ladder in
     /// `registry.rs`, which sees local and global as separate layers so it can name
@@ -227,6 +271,95 @@ impl Config {
                 } )+
             };
         }
+
+        // Anti-drift guard. Every struct `overlay` merges is destructured here
+        // without `..`, so adding a field to any of them fails to COMPILE until
+        // this function says what to do with it. A field silently dropped from
+        // the overlay would fall back to global — for a tightening key, a
+        // silent grant. The bindings are all `_`: this exists for the compiler.
+        let Config {
+            config_version: _,
+            proxy:
+                super::types::ProxyConfig {
+                    enabled: _,
+                    forced: _,
+                    port: _,
+                    blocked_domains: _,
+                    allowed_domains: _,
+                    default_allowlist: _,
+                    log_file: _,
+                    log_level: _,
+                    allow_private_domains: _,
+                    timeout: _,
+                    upstream: _,
+                    upstream_no_proxy: _,
+                    subscriptions:
+                        super::types::SubscriptionsConfig {
+                            refresh: _,
+                            blocklists: _,
+                        },
+                },
+            allow:
+                super::types::AllowConfig {
+                    read: _,
+                    write: _,
+                    exec: _,
+                    socket: _,
+                    ports: _,
+                    localhost: _,
+                },
+            deny: super::types::DenyConfig { paths: _ },
+            sandbox:
+                super::types::SandboxConfig {
+                    agent: _,
+                    preset: _,
+                    validate: _,
+                    brief: _,
+                    agents_md: _,
+                    allow_env_files: _,
+                    allow_localhost_any: _,
+                    pass_env: _,
+                    inherit_env: _,
+                    allow_lifecycle_scripts: _,
+                    allow_gpg_signing: _,
+                    deny_clipboard: _,
+                    allow_jvm_attach: _,
+                    allow_msbuild: _,
+                    gradle_init: _,
+                    allow_docker: _,
+                    allow_tmp_exec: _,
+                    allow_cache_exec: _,
+                    allow_cache_exec_any: _,
+                    allow_browser: _,
+                    keychain_substitute: _,
+                    scratch_dir: _,
+                    audit: _,
+                    use_bubblewrap: _,
+                    quiet: _,
+                    yes: _,
+                    gh_proxy: _,
+                    git_push_prevention: _,
+                },
+            gh_guard:
+                super::types::GhGuardConfig {
+                    enabled: _,
+                    mode: _,
+                    scope_check: _,
+                    block_auth_token: _,
+                    inject_token: _,
+                    unknown_command: _,
+                    allow_api_write: _,
+                },
+            git_guard:
+                super::types::GitGuardConfig {
+                    enabled: _,
+                    mode: _,
+                    prevent_push: _,
+                    prevent_force_push: _,
+                    protect_default_branch_only: _,
+                    allow_push: _,
+                },
+        } = local;
 
         let mut out = self.clone();
         take_set!(out, local, config_version);
@@ -324,7 +457,7 @@ mod tests {
     use super::*;
 
     fn parse(raw: &str) -> Result<Option<Config>, ConfigError> {
-        parse_local(raw, Path::new("/tmp/local.toml"), None)
+        parse_local(raw, Path::new("/tmp/local.toml"), None, None)
     }
 
     #[test]
@@ -389,9 +522,27 @@ mod tests {
             "[local]\nremote = \"github.com/navikt/a\"\n[sandbox]\nallow_docker = true\n",
             Path::new("/tmp/local.toml"),
             Some("github.com/navikt/b".to_string()),
+            None,
         )
         .unwrap();
         assert!(applied.is_none(), "a stale remote must apply nothing");
+    }
+
+    /// The recorded remote is normalized at READ, not trusted to have been
+    /// normalized at write: a hand-written `.git`-suffixed HTTPS URL is the
+    /// same remote and must not trip the wire.
+    #[test]
+    fn a_denormalized_recorded_remote_still_matches() {
+        let cfg = parse_local(
+            "[local]\nremote = \"https://GitHub.com/navikt/a.git\"\n\
+             [sandbox]\nallow_docker = true\n",
+            Path::new("/tmp/local.toml"),
+            Some("github.com/navikt/a".to_string()),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(cfg.sandbox.allow_docker, Some(true));
     }
 
     #[test]
@@ -400,6 +551,7 @@ mod tests {
             "[local]\nremote = \"github.com/navikt/a\"\n[sandbox]\nallow_docker = true\n",
             Path::new("/tmp/local.toml"),
             Some("github.com/navikt/a".to_string()),
+            None,
         )
         .unwrap()
         .unwrap();

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -1,0 +1,431 @@
+//! Per-repo user config (#340): the *local* layer.
+//!
+//! One file per checkout, stored OUTSIDE the repository at
+//! `~/.config/cplt/local/<sha256 hex of the canonical project dir>.toml`, so it
+//! inherits the protection the trust store already depends on: write access to
+//! `~/.config/cplt/` is denied inside the sandbox, therefore the agent cannot
+//! author its own grants here. A file inside the repository could not make that
+//! claim (see #340 §2), which is why this layer lives here and may widen.
+//!
+//! The file is the ordinary `config.toml` schema with one extra `[local]`
+//! header table (`path`, `remote`, `written_at`) that the loader strips before
+//! deserializing. Stripping is how the header stays out of the global schema:
+//! adding a `local` field to [`Config`] would make `[local]` a legal table in
+//! `~/.config/cplt/config.toml` too, and leaving it in place would make
+//! `deserialize_collecting_unknowns` warn "unknown key" on every launch.
+//!
+//! This module is the loader only. Writing the file (`config set --local`) and
+//! the `config show` / `settings` display are separate stages.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use super::error::ConfigError;
+use super::path::config_dir;
+use super::types::Config;
+use crate::ui;
+
+/// Subdirectory within the cplt config dir for local (per-repo user) configs.
+const LOCAL_DIR: &str = "local";
+
+/// The `[local]` header, stripped before the rest is parsed as a [`Config`].
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct LocalHeader {
+    /// The canonical project dir, in the clear, for listing and diagnostics.
+    /// The filename is its hash; this is what makes an orphan file readable.
+    /// Declared (rather than ignored) so `deny_unknown_fields` can catch a
+    /// misspelled `remote` instead of silently disarming the tripwire.
+    #[allow(dead_code)]
+    path: String,
+    /// The `origin` remote as it was when the file was written. A staleness
+    /// tripwire, NOT an identity — see [`remote_mismatch`].
+    remote: String,
+    /// ISO 8601 timestamp of the last write. Informational.
+    #[allow(dead_code)]
+    written_at: String,
+}
+
+/// The path-valued config keys, as `[section].key` — the only keys a relative
+/// entry is refused for.
+///
+/// Deliberately not "every string in the file": `sandbox.allow_cache_exec`
+/// entries are directory *names* under `~/Library/Caches` and `proxy.upstream`
+/// is a URL, so a blanket "must start with `/` or `~`" rule would reject both.
+fn path_valued(config: &Config) -> [(&'static str, &[String]); 5] {
+    [
+        ("allow.read", &config.allow.read),
+        ("allow.write", &config.allow.write),
+        ("allow.exec", &config.allow.exec),
+        ("allow.socket", &config.allow.socket),
+        ("deny.paths", &config.deny.paths),
+    ]
+}
+
+/// Canonical identity of a checkout: the same value the trust store binds an
+/// approval to (`src/trust.rs`), with the same fail-soft fallback when
+/// canonicalization is not possible.
+fn canonical_key(project_dir: &Path) -> String {
+    std::fs::canonicalize(project_dir).map_or_else(
+        |_| project_dir.to_string_lossy().into_owned(),
+        |p| p.to_string_lossy().into_owned(),
+    )
+}
+
+/// `~/.config/cplt/local/`, or `<parent of $CPLT_CONFIG>/local/`.
+///
+/// Derived from [`config_dir`], so a `CPLT_CONFIG` relocation moves `local/`
+/// exactly as it moves `trust/` — one resolution rule, not two.
+pub fn local_dir() -> Option<PathBuf> {
+    Some(config_dir()?.join(LOCAL_DIR))
+}
+
+/// The local config file for `project_dir`, whether or not it exists.
+pub fn local_path(project_dir: &Path) -> Option<PathBuf> {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(canonical_key(project_dir).as_bytes());
+    let name: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+    Some(local_dir()?.join(format!("{name}.toml")))
+}
+
+/// Load the local config for `project_dir`.
+///
+/// - Missing file: `Ok(None)`, silently. That is the normal case.
+/// - Recorded remote no longer matches `origin`: a loud warning and `Ok(None)`.
+/// - Malformed TOML, an unreadable file, or a relative path: `Err` — the launch
+///   fails. Skipping a bad file would silently revert a local `deny.paths` to
+///   whatever global says, which is a silent grant.
+pub fn load_local(project_dir: &Path) -> Result<Option<Config>, ConfigError> {
+    let Some(path) = local_path(project_dir) else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|e| ConfigError::FileRead {
+        path: path.clone(),
+        source: e,
+    })?;
+    parse_local(&raw, &path, crate::trust::canonical_remote(project_dir))
+}
+
+/// Parse a local config file. Split out from [`load_local`] so the remote is
+/// injected rather than shelled out for: no git, no filesystem, testable.
+pub(super) fn parse_local(
+    raw: &str,
+    path: &Path,
+    current_remote: Option<String>,
+) -> Result<Option<Config>, ConfigError> {
+    let display = path.display().to_string();
+    let mut root = raw
+        .parse::<toml::Table>()
+        .map_err(|source| ConfigError::TomlParse {
+            path: display.clone(),
+            source,
+        })?;
+
+    // Strip the header before the body is deserialized (see module docs).
+    let header: LocalHeader = match root.remove("local") {
+        Some(value) => value.try_into().map_err(|source| ConfigError::TomlParse {
+            path: display.clone(),
+            source,
+        })?,
+        None => LocalHeader::default(),
+    };
+    if let Some(recorded) = remote_mismatch(&header.remote, current_remote.as_deref()) {
+        // Not `ui::info`: this warning is deliberately NOT suppressible by
+        // --quiet, following #284. A grant the user cannot see is the thing the
+        // whole layer is trying not to be.
+        ui::warn(&format!(
+            "local config not applied: {display} was written for remote {recorded}, \
+             but origin is now {}. Re-adopt it if this is intentional.",
+            current_remote.as_deref().unwrap_or("(none)")
+        ));
+        return Ok(None);
+    }
+
+    let (config, unknown_keys) = super::validation::deserialize_collecting_unknowns(
+        &toml::to_string(&root).map_err(|_| {
+            ConfigError::Validation(format!(
+                "{display}: local config is not representable as TOML"
+            ))
+        })?,
+    )
+    .map_err(|source| ConfigError::TomlParse {
+        path: display.clone(),
+        source,
+    })?;
+
+    for key_path in &unknown_keys {
+        ui::warn(&format!(
+            "{}, ignored ({display})",
+            super::validation::describe_unknown_key(key_path)
+        ));
+    }
+
+    // Relative paths are refused before anything merges. In `config.toml` a
+    // relative path anchors to `~/.config/cplt/`, which is meaningless here;
+    // anchoring to the repo instead would reintroduce the symlink-repointing
+    // hazard `resolve_repo_allow_path` exists to close, this time repointable
+    // by the agent between sessions rather than only by a commit.
+    for (key, values) in path_valued(&config) {
+        for value in values {
+            if !(value.starts_with('/') || value.starts_with('~')) {
+                return Err(ConfigError::Validation(format!(
+                    "{display}: {key} entry {value:?} is relative — \
+                     local config accepts absolute and ~/ paths only"
+                )));
+            }
+        }
+    }
+
+    Ok(Some(config))
+}
+
+/// Whether the recorded remote disagrees with the current `origin`; returns the
+/// recorded value when it does.
+///
+/// This is a tripwire, not authentication. An attacker who controls the path
+/// can set `origin` to match too — but an attacker who controls the path
+/// already controls the user's checkout. What it catches is the honest case: a
+/// different repository now lives where the grants were made, so the grants are
+/// stale and must not apply.
+///
+/// An empty recorded remote means the file never claimed one (a repo with no
+/// origin), so there is nothing to trip.
+fn remote_mismatch<'a>(recorded: &'a str, current: Option<&str>) -> Option<&'a str> {
+    if recorded.is_empty() || current == Some(recorded) {
+        None
+    } else {
+        Some(recorded)
+    }
+}
+
+impl Config {
+    /// Take every value the local config sets, over `self`.
+    ///
+    /// `Option` fields: local when `Some`, so an unset local key falls through to
+    /// global. List fields: union, as config and CLI already are.
+    ///
+    /// Booleans do NOT get their answer from here — they run the registry ladder in
+    /// `registry.rs`, which sees local and global as separate layers so it can name
+    /// the one a value came from. Overlaying them anyway is harmless (the ladder
+    /// consults local first, so the overlaid value only shows through where local
+    /// is silent) and keeps this one function the whole story for scalars.
+    #[must_use]
+    pub(super) fn overlay(&self, local: &Config) -> Config {
+        macro_rules! take_set {
+            ($out:expr, $loc:expr, $($f:ident),+ $(,)?) => {
+                $( if $loc.$f.is_some() { $out.$f = $loc.$f.clone(); } )+
+            };
+        }
+        macro_rules! union_lists {
+            ($out:expr, $loc:expr, $($f:ident),+ $(,)?) => {
+                $( for v in &$loc.$f {
+                    if !$out.$f.contains(v) { $out.$f.push(v.clone()); }
+                } )+
+            };
+        }
+
+        let mut out = self.clone();
+        take_set!(out, local, config_version);
+        take_set!(
+            out.proxy,
+            local.proxy,
+            enabled,
+            forced,
+            port,
+            blocked_domains,
+            allowed_domains,
+            default_allowlist,
+            log_file,
+            log_level,
+            allow_private_domains,
+            timeout,
+            upstream,
+            upstream_no_proxy,
+        );
+        take_set!(out.proxy.subscriptions, local.proxy.subscriptions, refresh);
+        union_lists!(
+            out.proxy.subscriptions,
+            local.proxy.subscriptions,
+            blocklists
+        );
+        union_lists!(
+            out.allow,
+            local.allow,
+            read,
+            write,
+            exec,
+            socket,
+            ports,
+            localhost
+        );
+        union_lists!(out.deny, local.deny, paths);
+        take_set!(
+            out.sandbox,
+            local.sandbox,
+            agent,
+            preset,
+            validate,
+            brief,
+            agents_md,
+            allow_env_files,
+            allow_localhost_any,
+            inherit_env,
+            allow_lifecycle_scripts,
+            allow_gpg_signing,
+            deny_clipboard,
+            allow_jvm_attach,
+            allow_msbuild,
+            gradle_init,
+            allow_docker,
+            allow_tmp_exec,
+            allow_cache_exec_any,
+            allow_browser,
+            keychain_substitute,
+            scratch_dir,
+            audit,
+            use_bubblewrap,
+            quiet,
+            yes,
+            gh_proxy,
+            git_push_prevention,
+        );
+        union_lists!(out.sandbox, local.sandbox, pass_env, allow_cache_exec);
+        take_set!(
+            out.gh_guard,
+            local.gh_guard,
+            enabled,
+            mode,
+            scope_check,
+            block_auth_token,
+            inject_token,
+            unknown_command,
+            allow_api_write,
+        );
+        take_set!(
+            out.git_guard,
+            local.git_guard,
+            enabled,
+            mode,
+            prevent_push,
+            prevent_force_push,
+            protect_default_branch_only,
+        );
+        union_lists!(out.git_guard, local.git_guard, allow_push);
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: &str) -> Result<Option<Config>, ConfigError> {
+        parse_local(raw, Path::new("/tmp/local.toml"), None)
+    }
+
+    #[test]
+    fn header_is_stripped_and_body_parses() {
+        let cfg = parse(
+            "[local]\npath = \"/repo\"\nremote = \"\"\nwritten_at = \"now\"\n\
+             [sandbox]\nallow_docker = true\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(cfg.sandbox.allow_docker, Some(true));
+    }
+
+    #[test]
+    fn missing_header_is_fine() {
+        let cfg = parse("[sandbox]\nquiet = true\n").unwrap().unwrap();
+        assert_eq!(cfg.sandbox.quiet, Some(true));
+    }
+
+    #[test]
+    fn malformed_toml_is_an_error() {
+        assert!(parse("[sandbox\nquiet = true\n").is_err());
+    }
+
+    #[test]
+    fn relative_path_is_refused() {
+        let err = parse("[allow]\nread = [\"scratch\"]\n").unwrap_err();
+        assert!(err.to_string().contains("relative"), "{err}");
+
+        let err = parse("[deny]\npaths = [\"../secrets\"]\n").unwrap_err();
+        assert!(err.to_string().contains("relative"), "{err}");
+    }
+
+    #[test]
+    fn absolute_and_tilde_paths_are_accepted() {
+        let cfg = parse("[allow]\nread = [\"/srv/scratch\", \"~/scratch\"]\n")
+            .unwrap()
+            .unwrap();
+        assert_eq!(cfg.allow.read.len(), 2);
+    }
+
+    /// `allow_cache_exec` holds directory NAMES and `proxy.upstream` a URL —
+    /// neither is a path, so the relative-path rule must not reach them.
+    #[test]
+    fn non_path_string_keys_are_not_path_checked() {
+        let cfg = parse(
+            "[sandbox]\nallow_cache_exec = [\"ms-playwright\"]\n\
+             [proxy]\nupstream = \"http://proxy.example:8080\"\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(cfg.sandbox.allow_cache_exec, ["ms-playwright"]);
+        assert_eq!(
+            cfg.proxy.upstream.as_deref(),
+            Some("http://proxy.example:8080")
+        );
+    }
+
+    #[test]
+    fn mismatched_remote_applies_nothing() {
+        let applied = parse_local(
+            "[local]\nremote = \"github.com/navikt/a\"\n[sandbox]\nallow_docker = true\n",
+            Path::new("/tmp/local.toml"),
+            Some("github.com/navikt/b".to_string()),
+        )
+        .unwrap();
+        assert!(applied.is_none(), "a stale remote must apply nothing");
+    }
+
+    #[test]
+    fn matching_remote_applies() {
+        let cfg = parse_local(
+            "[local]\nremote = \"github.com/navikt/a\"\n[sandbox]\nallow_docker = true\n",
+            Path::new("/tmp/local.toml"),
+            Some("github.com/navikt/a".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(cfg.sandbox.allow_docker, Some(true));
+    }
+
+    #[test]
+    fn overlay_takes_local_scalars_and_unions_lists() {
+        let global: Config = toml::from_str(
+            "[proxy]\nport = 8080\n[allow]\nread = [\"/a\"]\n[sandbox]\nagent = \"claude\"\n",
+        )
+        .unwrap();
+        let local: Config =
+            toml::from_str("[proxy]\nport = 9090\n[allow]\nread = [\"/b\"]\n").unwrap();
+        let merged = global.overlay(&local);
+        assert_eq!(merged.proxy.port, Some(9090));
+        assert_eq!(merged.allow.read, ["/a", "/b"]);
+        assert_eq!(merged.sandbox.agent.as_deref(), Some("claude"));
+    }
+
+    #[test]
+    fn local_path_follows_the_config_dir() {
+        // Same input, same name: the filename is a pure function of the
+        // canonical path, like the trust store's fingerprint.
+        let a = local_path(Path::new("/definitely/not/here"));
+        let b = local_path(Path::new("/definitely/not/here"));
+        assert_eq!(a, b);
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,7 @@ mod display;
 mod editing;
 mod error;
 mod loading;
+mod local;
 mod path;
 mod registry;
 mod repo;
@@ -26,13 +27,14 @@ pub use editing::{
 pub use error::ConfigError;
 pub use loading::exec_tool_dir_warning;
 pub(crate) use path::canonicalize_deepest;
+pub use local::{load_local, local_dir, local_path};
 pub(crate) use path::lexically_normalized;
 pub use path::{
     CustomConfigVerdict, classify_custom_config, collapse_tilde, config_dir, config_path,
     default_config_contents, expand_tilde,
 };
 pub use registry::{
-    BoolKeyRow, ConfigKeyInfo, ConfigValueType, all_config_keys, bool_key, lookup_key,
+    BoolKeyRow, ConfigKeyInfo, ConfigLayer, ConfigValueType, all_config_keys, bool_key, lookup_key,
 };
 pub use repo::{
     PROPOSE_BOOLS, ProposeBoolRow, RepoKeyTarget, repo_key_rejection_reason, repo_key_target,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,8 +26,8 @@ pub use editing::{
 };
 pub use error::ConfigError;
 pub use loading::exec_tool_dir_warning;
-pub(crate) use path::canonicalize_deepest;
 pub use local::{load_local, local_dir, local_path};
+pub(crate) use path::canonicalize_deepest;
 pub(crate) use path::lexically_normalized;
 pub use path::{
     CustomConfigVerdict, classify_custom_config, collapse_tilde, config_dir, config_path,

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -628,8 +628,65 @@ pub(super) fn type_label(vt: ConfigValueType) -> &'static str {
 ///
 /// Keys with no preset baseline pass their hardcoded default as `baseline` —
 /// the bottom layer is always supplied, never omitted.
-fn resolve_bool(cli: FeatureToggle, config: Option<bool>, baseline: bool) -> bool {
-    cli.to_option().or(config).unwrap_or(baseline)
+///
+/// Returns the layer the value came from as well as the value. That is not
+/// decoration: `config show` and `cplt settings` have to say *which* file a
+/// setting came from, and a second resolution path built to answer that
+/// question is exactly the drift this table exists to prevent.
+fn resolve_bool(
+    cli: FeatureToggle,
+    local: Option<bool>,
+    config: Option<bool>,
+    baseline: bool,
+) -> (bool, ConfigLayer) {
+    if let Some(v) = cli.to_option() {
+        (v, ConfigLayer::Cli)
+    } else if let Some(v) = local {
+        (v, ConfigLayer::Local)
+    } else if let Some(v) = config {
+        (v, ConfigLayer::Global)
+    } else {
+        (baseline, ConfigLayer::Baseline)
+    }
+}
+
+/// Which layer of the precedence ladder supplied a resolved boolean.
+///
+/// Low to high: `Baseline` < `Global` < `Repo` < `Local` < `Cli`.
+///
+/// There is deliberately no `Preset` variant. A preset is not a layer — its
+/// content is chosen by another key's resolved value and it only ever moves the
+/// *baseline*, so naming it here would claim a rung the resolution does not
+/// have. `Baseline` means "nothing explicit said otherwise", preset or
+/// hardcoded default alike.
+///
+/// `Repo` is not produced by [`resolve_bool`]: an approved `.cplt.toml`
+/// proposal is applied after the merge, in `Resolved::apply_repo_config`, which
+/// stamps it there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigLayer {
+    /// Hardcoded default, or the preset baseline that moved it.
+    Baseline,
+    /// `~/.config/cplt/config.toml`.
+    Global,
+    /// An approved `[propose]` key from the repository's `.cplt.toml`.
+    Repo,
+    /// The per-repo user file under `~/.config/cplt/local/` (#340).
+    Local,
+    /// An explicit CLI flag.
+    Cli,
+}
+
+impl std::fmt::Display for ConfigLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Baseline => "default",
+            Self::Global => "global",
+            Self::Repo => "repo",
+            Self::Local => "local",
+            Self::Cli => "cli",
+        })
+    }
 }
 
 /// A registry row for a boolean config key: which key it is, and how to read
@@ -667,9 +724,11 @@ macro_rules! bool_keys {
         /// Built once per run by [`ResolvedBools::resolve`]; `Config::merge`
         /// copies the fields into [`Resolved`]. Nothing here is resolved by
         /// hand.
-        #[derive(Debug, Clone, Copy)]
+        #[derive(Debug, Clone)]
         pub struct ResolvedBools {
             $( $(#[$meta])* pub $field: bool, )*
+            /// The layer each key resolved from, in `BOOL_KEYS` order.
+            pub layers: Vec<ConfigLayer>,
         }
 
         /// Registry rows for every boolean key, in declaration order.
@@ -685,15 +744,19 @@ macro_rules! bool_keys {
             /// Resolve every boolean key through [`resolve_bool`].
             pub(super) fn resolve(
                 cli: &CliFlags,
+                local: Option<&Config>,
                 config: &Config,
                 baseline: PresetBaseline,
             ) -> Self {
+                $( let $field = resolve_bool(
+                    ($cli)(cli),
+                    local.and_then($config),
+                    ($config)(config),
+                    ($baseline)(baseline),
+                ); )*
                 Self {
-                    $( $field: resolve_bool(
-                        ($cli)(cli),
-                        ($config)(config),
-                        ($baseline)(baseline),
-                    ), )*
+                    layers: vec![ $( $field.1, )* ],
+                    $( $field: $field.0, )*
                 }
             }
         }
@@ -717,6 +780,13 @@ macro_rules! bool_keys {
 // `baseline` is `|b| b.<field>` for the nine preset-controlled keys and a
 // literal for the rest. It is a required column: a key cannot be declared
 // without stating its bottom layer.
+//
+// The LOCAL layer (#340) has no column of its own on purpose. It reads the same
+// key out of a second `Config` — the per-repo user file — so the `config`
+// accessor IS the local accessor, applied to a different struct. A duplicate
+// column would be 32 copied closures that can only ever drift; the one place it
+// would matter, `gh_guard.enabled`'s legacy `sandbox.gh_proxy` fold, is exactly
+// where a copy going stale would be a silent grant.
 bool_keys! {
     with_proxy, "proxy", "enabled",
         cli = |c: &CliFlags| c.proxy,

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -34,10 +34,25 @@ pub enum RepoKeyTarget {
 pub struct ProposeBoolRow {
     /// Name used in `[propose]` and in the trust store.
     pub key: &'static str,
-    /// The global config key this proposal corresponds to.
+    /// The global config key this proposal corresponds to. This is what
+    /// `config set --repo` writes, so for the two guard rows it stays the
+    /// legacy `sandbox.*` spelling a `.cplt.toml` already uses.
     pub config_key: (&'static str, &'static str),
+    /// The key this proposal resolves as on the boolean ladder — the same as
+    /// `config_key` except for the two legacy spellings, which fold into
+    /// `gh_guard.enabled` / `git_guard.enabled`. Provenance is stamped here.
+    pub ladder_key: (&'static str, &'static str),
     pub propose: fn(&crate::repo_config::ProposeSection) -> Option<bool>,
     pub apply: fn(&mut super::types::Resolved),
+    /// This proposal turns a GUARD ON, so it is tighten-only.
+    ///
+    /// The other rows widen the sandbox, which is why they need an approval and
+    /// why an explicit `false` from the user's own config or CLI beats them.
+    /// These two do the opposite: a repository asking for `gh_guard` or
+    /// `git_push_prevention` is asking for *less* permission, which is
+    /// `[deny]`-shaped. So they need no acceptance and no layer removes them —
+    /// including `--no-gh-guard`. See #427, finding 1.
+    pub tighten_only: bool,
 }
 
 /// Every boolean a `.cplt.toml` may propose.
@@ -45,62 +60,82 @@ pub static PROPOSE_BOOLS: &[ProposeBoolRow] = &[
     ProposeBoolRow {
         key: "allow_localhost_any",
         config_key: ("sandbox", "allow_localhost_any"),
+        ladder_key: ("sandbox", "allow_localhost_any"),
         propose: |p| p.allow_localhost_any,
         apply: |r| r.allow_localhost_any = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_jvm_attach",
         config_key: ("sandbox", "allow_jvm_attach"),
+        ladder_key: ("sandbox", "allow_jvm_attach"),
         propose: |p| p.allow_jvm_attach,
         apply: |r| r.allow_jvm_attach = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_msbuild",
         config_key: ("sandbox", "allow_msbuild"),
+        ladder_key: ("sandbox", "allow_msbuild"),
         propose: |p| p.allow_msbuild,
         apply: |r| r.allow_msbuild = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "gradle_init",
         config_key: ("sandbox", "gradle_init"),
+        ladder_key: ("sandbox", "gradle_init"),
         propose: |p| p.gradle_init,
         apply: |r| r.gradle_init = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_docker",
         config_key: ("sandbox", "allow_docker"),
+        ladder_key: ("sandbox", "allow_docker"),
         propose: |p| p.allow_docker,
         apply: |r| r.allow_docker = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_tmp_exec",
         config_key: ("sandbox", "allow_tmp_exec"),
+        ladder_key: ("sandbox", "allow_tmp_exec"),
         propose: |p| p.allow_tmp_exec,
         apply: |r| r.allow_tmp_exec = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_gpg_signing",
         config_key: ("sandbox", "allow_gpg_signing"),
+        ladder_key: ("sandbox", "allow_gpg_signing"),
         propose: |p| p.allow_gpg_signing,
         apply: |r| r.allow_gpg_signing = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_lifecycle_scripts",
         config_key: ("sandbox", "allow_lifecycle_scripts"),
+        ladder_key: ("sandbox", "allow_lifecycle_scripts"),
         propose: |p| p.allow_lifecycle_scripts,
         apply: |r| r.allow_lifecycle_scripts = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_browser",
         config_key: ("sandbox", "allow_browser"),
+        ladder_key: ("sandbox", "allow_browser"),
         propose: |p| p.allow_browser,
         apply: |r| r.allow_browser = true,
+        tighten_only: false,
     },
     ProposeBoolRow {
         key: "allow_env_files",
         config_key: ("sandbox", "allow_env_files"),
+        ladder_key: ("sandbox", "allow_env_files"),
         propose: |p| p.allow_env_files,
         apply: |r| r.allow_env_files = true,
+        tighten_only: false,
     },
     // `.cplt.toml` spells these two with the legacy `sandbox.*` config keys, so
     // `config set --repo sandbox.gh_proxy` keeps writing the name a repo file
@@ -108,14 +143,18 @@ pub static PROPOSE_BOOLS: &[ProposeBoolRow] = &[
     ProposeBoolRow {
         key: "gh_guard",
         config_key: ("sandbox", "gh_proxy"),
+        ladder_key: ("gh_guard", "enabled"),
         propose: |p| p.gh_guard,
         apply: |r| r.gh_guard.enabled = true,
+        tighten_only: true,
     },
     ProposeBoolRow {
         key: "git_push_prevention",
         config_key: ("sandbox", "git_push_prevention"),
+        ladder_key: ("git_guard", "enabled"),
         propose: |p| p.git_push_prevention,
         apply: |r| r.git_guard.enabled = true,
+        tighten_only: true,
     },
 ];
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -430,7 +430,7 @@ pub struct GitGuardConfig {
 /// security allow-rule the safe failure is to reject the key at parse. The
 /// forward-compat cost (an older binary refusing a config written for a newer
 /// one) fails *closed*, which is the correct direction for a grant.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields)]
 pub struct GitPushRule {
     /// Remote name to allow pushing to (e.g. `"fork"`, `"origin"`).
@@ -777,6 +777,9 @@ pub struct ResolvedPushRule {
 /// All paths are expanded and canonicalized.
 #[derive(Debug)]
 pub struct Resolved {
+    /// Which layer of the ladder supplied each boolean, in `BOOL_KEYS` order.
+    /// Read it with [`Resolved::bool_layer`] rather than by index.
+    pub bool_layers: Vec<crate::config::registry::ConfigLayer>,
     pub with_proxy: bool,
     /// Force all egress through the proxy (proxy mandatory, kernel egress
     /// restricted to the proxy port, fail-closed). See #53.

--- a/src/init.rs
+++ b/src/init.rs
@@ -437,11 +437,12 @@ fn merge_toml(existing_content: &str, report: &DetectionReport) -> String {
     for p in &existing.deny.paths {
         deny_paths.insert(p.as_str());
     }
-    let existing_flags = repo_config::proposed_keys(&existing.propose);
-    for key in &existing_flags {
-        // Only include boolean flags, not compound keys (allow.ports, etc.)
-        if !key.contains('.') {
-            propose_flags.insert(key);
+    // Walk `PROPOSE_BOOLS` rather than `proposed_keys`: --merge must preserve
+    // every boolean the file already sets, and `proposed_keys` deliberately
+    // omits the tighten-only rows (gh_guard, git_push_prevention).
+    for row in crate::config::PROPOSE_BOOLS {
+        if (row.propose)(&existing.propose) == Some(true) {
+            propose_flags.insert(row.key);
         }
     }
     for p in &existing.propose.allow.read {
@@ -1482,6 +1483,38 @@ allow_jvm_attach = true
         // Existing flag preserved
         assert_eq!(parsed.propose.allow_jvm_attach, Some(true));
         // New flag added
+        assert_eq!(parsed.propose.allow_docker, Some(true));
+    }
+
+    /// `proposed_keys` omits the tighten-only guard rows on purpose (they need
+    /// no approval), so --merge must NOT be driven by it — walking that list
+    /// would drop an existing `gh_guard = true` out of the regenerated file.
+    #[test]
+    fn merge_preserves_the_tighten_only_guard_flags() {
+        let existing = r"
+[propose]
+gh_guard = true
+git_push_prevention = true
+";
+        let report = DetectionReport {
+            detections: vec![],
+            suggestions: [Suggestion::Propose(SandboxFlag::AllowDocker)]
+                .into_iter()
+                .collect(),
+            diagnostics: vec![],
+            workspace_members: vec![],
+            provenance: std::collections::BTreeMap::new(),
+        };
+
+        let merged = merge_toml(existing, &report);
+        let parsed: crate::repo_config::RepoConfig =
+            toml::from_str(&merged).expect("merged TOML should be valid");
+        assert_eq!(parsed.propose.gh_guard, Some(true), "got: {merged}");
+        assert_eq!(
+            parsed.propose.git_push_prevention,
+            Some(true),
+            "got: {merged}"
+        );
         assert_eq!(parsed.propose.allow_docker, Some(true));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1575,22 +1575,40 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             &project_dir,
         ) {
             config::CustomConfigVerdict::UserConfigDir => {}
-            // Only warn for a file that is actually there: a CPLT_CONFIG naming
-            // a path that does not exist selects no config, so nothing was
-            // substituted and there is nothing to flag. (`cplt exec` promises a
-            // clean stderr, and tests point the var at a deliberate dead end to
-            // ignore the developer's real config.) The refusal below is not
-            // gated the same way — a path the repo controls is worth refusing
-            // whether or not the file exists yet.
-            config::CustomConfigVerdict::Outside(p) if p.exists() => {
-                ui::warn("CPLT_CONFIG replaces your whole cplt config, sandbox settings included:");
-                eprintln!("  {}", p.display());
-                eprintln!("  It is not under {}.", user_dir.display());
-                eprintln!(
-                    "  If you did not set it yourself, your shell did (direnv, mise, .envrc)."
-                );
+            // Only warn for a relocation that actually selects something: a
+            // CPLT_CONFIG naming a path with no file AND no sibling `local/`
+            // substitutes nothing, so there is nothing to flag. (`cplt exec`
+            // promises a clean stderr, and tests point the var at a deliberate
+            // dead end to ignore the developer's real config.) The refusal
+            // below is not gated the same way — a path the repo controls is
+            // worth refusing whether or not the file exists yet.
+            //
+            // `local/` is checked separately because it moves with the config
+            // dir, not with the file: a CPLT_CONFIG whose config.toml does not
+            // exist yet still reads per-repo grants from `<parent>/local/`, and
+            // #340 §8 requires that relocation to be named.
+            config::CustomConfigVerdict::Outside(p) => {
+                let local_dir = p.parent().map(|d| d.join("local")).filter(|d| d.is_dir());
+                if p.exists() || local_dir.is_some() {
+                    ui::warn(
+                        "CPLT_CONFIG replaces your whole cplt config, sandbox settings included:",
+                    );
+                    eprintln!("  {}", p.display());
+                    if !p.exists() {
+                        eprintln!("  (no file there yet)");
+                    }
+                    if let Some(dir) = &local_dir {
+                        eprintln!(
+                            "  Per-repo local config is being read from {}.",
+                            dir.display()
+                        );
+                    }
+                    eprintln!("  It is not under {}.", user_dir.display());
+                    eprintln!(
+                        "  If you did not set it yourself, your shell did (direnv, mise, .envrc)."
+                    );
+                }
             }
-            config::CustomConfigVerdict::Outside(_) => {}
             config::CustomConfigVerdict::InsideProject(p) => bail!(
                 "CPLT_CONFIG points inside the project directory:\n  \
                  {}\n  \
@@ -1900,6 +1918,14 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         ui::info(&format!("Home:     {}", home_dir.display()));
         if let Some(ref cp) = config_path {
             ui::info(&format!("Config:   {}", cp.display()));
+        }
+        // Only when a local file was actually APPLIED. A missing one, or one
+        // whose recorded remote no longer matches, leaves `local_cfg` None and
+        // must not claim a layer that did nothing.
+        if local_cfg.is_some()
+            && let Some(lp) = config::local_path(&project_dir)
+        {
+            ui::info(&format!("Local:    {}", lp.display()));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1618,7 +1618,14 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         Ok(None) => (config::Config::default(), None),
         Err(e) => bail!("{e}"),
     };
-    let mut resolved = match cfg.merge(config::CliFlags {
+    // Per-repo user config (#340), the layer between global config and the CLI.
+    // A malformed or relative-path file fails the launch here rather than
+    // silently falling back to global — see `config::load_local`.
+    let local_cfg = match config::load_local(&project_dir) {
+        Ok(local) => local,
+        Err(e) => bail!("{e}"),
+    };
+    let cli_flags = config::CliFlags {
         preset: cli.preset,
         proxy: config::FeatureToggle::from_pair(cli.with_proxy, cli.no_proxy),
         proxy_forced: config::FeatureToggle::from_pair(cli.proxy_forced, cli.no_proxy_forced),
@@ -1684,7 +1691,8 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
         yes: config::FeatureToggle::from_pair(cli.yes, cli.no_yes),
         gh_guard: config::FeatureToggle::from_pair(cli.gh_guard, cli.no_gh_guard),
         git_push_prevention: config::FeatureToggle::from_pair(cli.git_guard, cli.no_git_guard),
-    }) {
+    };
+    let mut resolved = match cfg.merge_with_local(local_cfg.as_ref(), cli_flags) {
         Ok(r) => r,
         Err(e) => bail!("{e}"),
     };

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -437,16 +437,22 @@ fn validate_repo_config(config: &RepoConfig) -> Result<(), String> {
     Ok(())
 }
 
-/// Collect all proposed key names from a ProposeSection.
+/// Collect the proposed key names a ProposeSection puts up for approval.
 ///
-/// Returns the list of keys that would relax the sandbox if approved.
-/// Used to show the user what a repo is requesting and to intersect
-/// with the trust store's accepted list.
+/// Returns the keys that would RELAX the sandbox if approved. Tighten-only
+/// rows (`gh_guard`, `git_push_prevention`) are deliberately absent: they turn
+/// a guard on, apply without approval and are removed by no layer, so every
+/// surface that reads this list — the untrusted-repo "wants to relax" warning,
+/// `cplt trust show`/`accept`/`revoke`, the working-tree note and the
+/// unapproved-proposal list — would otherwise describe an already-applied
+/// tightening as a pending relaxation. Filtering here fixes all of them at
+/// once. A consumer that wants "every boolean this file sets", such as
+/// `cplt init --merge`, must walk `PROPOSE_BOOLS` itself.
 pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     let mut keys = Vec::new();
 
     for row in crate::config::PROPOSE_BOOLS {
-        if (row.propose)(propose) == Some(true) {
+        if !row.tighten_only && (row.propose)(propose) == Some(true) {
             keys.push(row.key);
         }
     }
@@ -637,6 +643,28 @@ allow_network = true
         assert!(keys.contains(&"allow_jvm_attach"));
         assert!(keys.contains(&"allow.ports"));
         assert!(!keys.contains(&"allow_docker"));
+    }
+
+    /// A guard-on proposal is not a request to relax anything: it applies
+    /// without approval and no layer removes it, so every surface driven by
+    /// this list — "wants to relax", `trust show`'s pending rows, the
+    /// `trust accept <key>` hint — must not mention it. #427.
+    #[test]
+    fn proposed_keys_omits_the_tighten_only_rows() {
+        let propose = ProposeSection {
+            gh_guard: Some(true),
+            git_push_prevention: Some(true),
+            allow_docker: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(proposed_keys(&propose), vec!["allow_docker"]);
+
+        // A file proposing ONLY guards puts nothing up for approval at all.
+        let guards_only = ProposeSection {
+            gh_guard: Some(true),
+            ..Default::default()
+        };
+        assert!(proposed_keys(&guards_only).is_empty());
     }
 
     #[test]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -82,7 +82,7 @@ pub fn repo_fingerprint(project_dir: &Path) -> String {
 /// Get the canonical remote URL for the git repo at `project_dir`.
 ///
 /// Normalizes: strips `.git` suffix, lowercases host, converts SSH to HTTPS style.
-fn canonical_remote(project_dir: &Path) -> Option<String> {
+pub(crate) fn canonical_remote(project_dir: &Path) -> Option<String> {
     let output = crate::git::command(project_dir, &["remote", "get-url", "origin"])?
         .output()
         .ok()?;


### PR DESCRIPTION
The loader half of #340, built on the existing boolean ladder rather than behind a new resolution engine — see #427 and its adversarial review for why that ordering changed.

## Why it exists

Most cplt users never type the command; they reach it through nav-pilot, which dispatches agents via cplt. A CLI flag therefore cannot express a durable preference: the person who knows that this project needs a particular grant is not the one invoking the tool. There was nowhere to put such a preference except the global config, where it then applies to every session on the machine.

A file at `~/.config/cplt/local/<sha256 of the canonical project dir>.toml` carries settings that are true of one repository *as this user runs it*. It sits outside the tree, so the sandboxed agent cannot write it, which is what lets it widen freely — unlike `.cplt.toml`, which is repo-authored and needs the trust store's acceptance for anything that opens access. That split is the same one git draws with `safe.directory` and Copilot with `trustedFolders`: the tool that enforces is the tool that stores.

## Precedence

`Default → Preset → Global → Repo → Local → Cli`, with two decisions worth stating plainly.

**An explicit global `false` beats an accepted repo proposal.** Acceptance means "this repo may ask", not "this repo overrides what you decided". A proposal now applies only where nothing explicit has spoken. Nothing in the tests, docs or issues depended on the old behaviour.

**`gh_guard` and `git_push_prevention` are the exception, because they turn guards on rather than off.** They are tighten-only: applied without acceptance, removed by no layer. A repository may always make things stricter — which is what `[deny]` already meant, and the polarity of these two had made them the odd ones out. When one reverses an explicit `false`, it now says so instead of silently winning.

## Failure modes

A malformed file fails the launch rather than falling back to global, because silently skipping a local `deny.paths` would be a silent grant. A relative path is refused at load, for the path-valued keys only — `allow_cache_exec` entries are directory names, not paths. A recorded remote that no longer matches `origin` warns and applies nothing; that is a tripwire against a moved checkout, not authentication, and both sides are normalised before comparison so a `.git` suffix does not trip it. A missing file is silent and normal.

## Provenance

The boolean resolver now returns the layer it resolved from. That is what will let `config show` label a value without a second resolution path — which is how it came to disagree with the resolver in #410 in the first place. A row whose value is already true does not stamp the repo as its source.

## Found in review

An applied local file left **no trace anywhere** — not the summary, not `config show`, not `settings` — while its grants were in effect. The summary now names the file beside the global config.

The two tighten-only proposals were still listed as needing approval, so four surfaces described a guard being switched *on* as a relaxation: the untrusted-repo warning said the repo "wants to relax sandbox permissions", `trust show` listed them as pending and offered to accept them, and the working-tree note said they could not be approved — all while they were already applied.

And a regression the review did not ask about: `cplt init --merge` read the proposals list as "every boolean this file sets" rather than "what needs approval", so filtering the tighten-only rows would have made it drop an existing `gh_guard = true` from a regenerated `.cplt.toml`, writing a weaker file back to the repository.

## Not in this PR

`cplt config set --local`, the `config show` / `settings` display work, and `sandbox.repo_dirs` in this layer. The file can be hand-written, and the loader is the security-relevant half. `deny.env` remains repo-schema-only, unchanged.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings` (host and `x86_64-unknown-linux-gnu`) and the full suite pass.