### PR TITLE
fix(check): report what will actually happen, not what the policy objects to

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -490,6 +490,19 @@ pub struct ExecContext<'a> {
     pub gh_guard: &'a crate::config::GhGuardPolicy,
     pub git_guard: &'a crate::config::GitGuardPolicy,
     pub project_dir: &'a Path,
+    /// The repository facts the launch bakes in, captured the same way and from
+    /// the same trusted git.
+    ///
+    /// Without them `protect_default_branch_only` has no default branch to
+    /// compare against, so `gate_git` fails closed and every push reads as
+    /// blocked — including a feature-branch push the launch allows. That is
+    /// the most common push there is, so the surface built to answer "what
+    /// will happen" was wrong about the ordinary case.
+    pub repo_facts: &'a crate::gh_proxy::RepoFacts,
+    /// Both guards install themselves through a PATH shim in the scratch dir.
+    /// Without one there is no shim, so the guards do not run whatever the
+    /// config says — which is what the launch summary reports as `inactive`.
+    pub scratch_dir: bool,
 }
 
 /// Static explanation of whether a command would run under the resolved policy.
@@ -509,14 +522,6 @@ fn command_basename(cmd: &str) -> String {
         .unwrap_or_default()
 }
 
-/// Explain whether `argv` would run, is guard-blocked, or needs an `allow_*`.
-///
-/// Reuses the gh/git guard classifiers ([`crate::gh_proxy::gate`],
-/// [`crate::gh_proxy::gate_git`]) so the verdict matches what the in-sandbox
-/// wrappers enforce, and the `allow_docker` / `allow_tmp_exec` gates for the
-/// other high-frequency cases. Unrecognized commands get an honest generic
-/// answer (they run, subject to the fs/net policy).
-#[must_use]
 /// What a guard refusal means for `check exec`, given the mode that guard runs in.
 ///
 /// `gate_git` and `gate` answer one question — does the policy object? — and
@@ -567,6 +572,14 @@ fn refusal_decision(
     }
 }
 
+/// Explain whether `argv` would run, is guard-blocked, or needs an `allow_*`.
+///
+/// Reuses the gh/git guard classifiers ([`crate::gh_proxy::gate`],
+/// [`crate::gh_proxy::gate_git`]) so the verdict matches what the in-sandbox
+/// wrappers enforce, and the `allow_docker` / `allow_tmp_exec` gates for the
+/// other high-frequency cases. Unrecognized commands get an honest generic
+/// answer (they run, subject to the fs/net policy).
+#[must_use]
 pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
     let Some(first) = argv.first() else {
         return ExecExplain {
@@ -613,17 +626,27 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 fix: None,
             };
         }
+        if !ctx.scratch_dir {
+            return ExecExplain {
+                decision: Decision::Allowed,
+                reason: "git runs unguarded: the git guard needs a scratch dir for its \
+                         PATH shim, and this run has none, so the guard is inactive \
+                         however it is configured."
+                    .to_string(),
+                fix: Some("remove `sandbox.scratch_dir = false` to let the guard run.".to_string()),
+            };
+        }
         return match crate::gh_proxy::gate_git(
             &rest,
             ctx.git_guard.prevent_push,
             ctx.git_guard.prevent_force_push,
             ctx.git_guard.protect_default_branch_only,
             &ctx.git_guard.allow_push,
-            None,
-            // `cplt check exec` explains policy without a repository probe; with
-            // no baked facts the default-branch arm fails closed, matching what
-            // a launch that captured nothing would do.
-            &crate::gh_proxy::RepoFacts::default(),
+            // The launch hands the gate a real git so it can resolve which
+            // branches a push actually targets; without one no push is ever
+            // provably feature-only and the default-branch arm fails closed.
+            crate::git::trusted_git(),
+            ctx.repo_facts,
         ) {
             Ok(()) => ExecExplain {
                 decision: Decision::Allowed,
@@ -647,6 +670,16 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 decision: Decision::Allowed,
                 reason: "gh runs; the gh guard is not enabled for this run.".to_string(),
                 fix: None,
+            };
+        }
+        if !ctx.scratch_dir {
+            return ExecExplain {
+                decision: Decision::Allowed,
+                reason: "gh runs unguarded: the gh guard needs a scratch dir for its \
+                         PATH shim, and this run has none, so the guard is inactive \
+                         however it is configured."
+                    .to_string(),
+                fix: Some("remove `sandbox.scratch_dir = false` to let the guard run.".to_string()),
             };
         }
         let policy = crate::gh_proxy::GatePolicy {
@@ -1074,6 +1107,15 @@ mod tests {
 
     // ── explain_exec ──
 
+    /// Facts for the unit tests: a scratch dir, and no captured repository.
+    ///
+    /// Empty facts is the honest default here — these tests assert on policy
+    /// shape, not on a checkout — and it is also the case the guard fails
+    /// closed on, so `git push` reads as blocked exactly as it did before
+    /// `ExecContext` grew these fields.
+    static NO_FACTS: std::sync::LazyLock<crate::gh_proxy::RepoFacts> =
+        std::sync::LazyLock::new(crate::gh_proxy::RepoFacts::default);
+
     fn exec_ctx<'a>(
         gh: &'a GhGuardPolicy,
         git: &'a GitGuardPolicy,
@@ -1085,6 +1127,8 @@ mod tests {
             gh_guard: gh,
             git_guard: git,
             project_dir: Path::new("/home/u/proj"),
+            repo_facts: &NO_FACTS,
+            scratch_dir: true,
         }
     }
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -548,27 +548,33 @@ fn refusal_decision(
         // The command runs. Saying "allowed" alone would hide that the policy
         // objected, so the reason carries the objection and the fix says how to
         // make it bite.
-        EnforcementMode::Warn | EnforcementMode::Audit => ExecExplain {
-            decision: Decision::Allowed,
-            reason: format!(
-                "the {guard} guard objects, but it runs in {} mode, so the command runs. {}",
-                match mode {
-                    EnforcementMode::Warn => "warn",
-                    _ => "audit",
-                },
-                // The policy message is written for block mode and leads with
-                // "BLOCKED by sandbox"; stacking that inside a line that says
-                // ALLOWED is the contradiction this fix exists to remove. The
-                // launch strips the same prefix for the same reason.
-                first_line(msg)
-                    .strip_prefix("⚠️ BLOCKED by sandbox:")
-                    .unwrap_or(&first_line(msg))
-                    .trim()
-            ),
-            fix: Some(format!(
-                "set {guard}_guard.mode = \"block\" to enforce this."
-            )),
-        },
+        EnforcementMode::Warn | EnforcementMode::Audit => {
+            // The policy message is written for block mode and leads with
+            // "BLOCKED by sandbox"; stacking that inside a line that says
+            // ALLOWED is the contradiction this fix exists to remove. The
+            // launch strips the same prefix for the same reason. Bound once:
+            // `first_line` allocates, and calling it inside the format to
+            // strip a prefix off its own temporary reads as a puzzle.
+            let line = first_line(msg);
+            let objection = line
+                .strip_prefix("⚠️ BLOCKED by sandbox:")
+                .unwrap_or(&line)
+                .trim();
+            let mode_name = match mode {
+                EnforcementMode::Warn => "warn",
+                _ => "audit",
+            };
+            ExecExplain {
+                decision: Decision::Allowed,
+                reason: format!(
+                    "the {guard} guard objects, but it runs in {mode_name} mode, so the \
+                 command runs. {objection}"
+                ),
+                fix: Some(format!(
+                    "set {guard}_guard.mode = \"block\" to enforce this."
+                )),
+            }
+        }
     }
 }
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -517,6 +517,56 @@ fn command_basename(cmd: &str) -> String {
 /// other high-frequency cases. Unrecognized commands get an honest generic
 /// answer (they run, subject to the fs/net policy).
 #[must_use]
+/// What a guard refusal means for `check exec`, given the mode that guard runs in.
+///
+/// `gate_git` and `gate` answer one question — does the policy object? — and
+/// return `Err` when it does. Whether that objection *stops* the command is a
+/// separate decision the launch makes from the enforcement mode, and
+/// `check exec` used to skip it: every refusal was reported `BLOCKED`, so a
+/// developer in warn mode was told a push would be blocked while the launch
+/// printed a warning and pushed. `check exec` exists to answer "what will
+/// happen", which makes it the one surface where that drift is the whole
+/// defect (#431).
+fn refusal_decision(
+    mode: crate::config::EnforcementMode,
+    msg: &str,
+    blocked_fix: &str,
+    guard: &str,
+) -> ExecExplain {
+    use crate::config::EnforcementMode;
+    match mode {
+        EnforcementMode::Block => ExecExplain {
+            decision: Decision::Blocked,
+            reason: first_line(msg),
+            fix: Some(blocked_fix.to_string()),
+        },
+        // The command runs. Saying "allowed" alone would hide that the policy
+        // objected, so the reason carries the objection and the fix says how to
+        // make it bite.
+        EnforcementMode::Warn | EnforcementMode::Audit => ExecExplain {
+            decision: Decision::Allowed,
+            reason: format!(
+                "the {guard} guard objects, but it runs in {} mode, so the command runs. {}",
+                match mode {
+                    EnforcementMode::Warn => "warn",
+                    _ => "audit",
+                },
+                // The policy message is written for block mode and leads with
+                // "BLOCKED by sandbox"; stacking that inside a line that says
+                // ALLOWED is the contradiction this fix exists to remove. The
+                // launch strips the same prefix for the same reason.
+                first_line(msg)
+                    .strip_prefix("⚠️ BLOCKED by sandbox:")
+                    .unwrap_or(&first_line(msg))
+                    .trim()
+            ),
+            fix: Some(format!(
+                "set {guard}_guard.mode = \"block\" to enforce this."
+            )),
+        },
+    }
+}
+
 pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
     let Some(first) = argv.first() else {
         return ExecExplain {
@@ -580,15 +630,13 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 reason: "allowed by the git guard.".to_string(),
                 fix: None,
             },
-            Err(msg) => ExecExplain {
-                decision: Decision::Blocked,
-                reason: first_line(&msg),
-                fix: Some(
-                    "push to an allowed branch/remote, configure [git] allow_push, \
-                     or disable with git_push_prevention = false."
-                        .to_string(),
-                ),
-            },
+            Err(msg) => refusal_decision(
+                ctx.git_guard.mode,
+                &msg,
+                "push to an allowed branch/remote, configure [git] allow_push, \
+                 or disable with git_push_prevention = false.",
+                "git",
+            ),
         };
     }
 
@@ -621,16 +669,14 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 reason: "allowed by the gh guard.".to_string(),
                 fix: None,
             },
-            Err(msg) => ExecExplain {
-                decision: Decision::Blocked,
-                reason: first_line(&msg),
-                fix: Some(
-                    "use a read-only / in-scope gh command, run it from the startup \
-                     repository's checkout, or relax the gh guard (e.g. [sandbox] \
-                     gh_proxy settings)."
-                        .to_string(),
-                ),
-            },
+            Err(msg) => refusal_decision(
+                ctx.gh_guard.mode,
+                &msg,
+                "use a read-only / in-scope gh command, run it from the startup \
+                 repository's checkout, or relax the gh guard (e.g. [sandbox] \
+                 gh_proxy settings).",
+                "gh",
+            ),
         };
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4149,6 +4149,22 @@ fn run_exec_command(
     // Always use the Shell sandbox policy
     let active_agent = agent::Agent::Shell;
 
+    // ...but say so when the operator asked for something else. The profiles
+    // genuinely differ — Shell has no Keychain grant, so `gh` finds no token,
+    // while copilot, claude, antigravity and goose do — so someone running
+    // `--agent copilot exec` to find out what Copilot may do gets a truthful
+    // answer about a different sandbox. Dropping the flag in silence cost a
+    // real debugging session (#411).
+    if let Some(requested) = cli.agent.as_deref()
+        && !requested.eq_ignore_ascii_case("shell")
+    {
+        ui::warn(&format!(
+            "exec: --agent {requested} is ignored. `cplt exec` always builds the Shell \
+             profile, which grants less (no Keychain, so `gh` finds no token here). To \
+             probe what {requested} may do, run `cplt --agent {requested} check`."
+        ));
+    }
+
     // Shell, not the agent `resolve_context` detected: exec builds the Shell
     // profile, so a warning about another agent's directories would name an
     // effect this session cannot have (#343).

--- a/src/main.rs
+++ b/src/main.rs
@@ -5065,12 +5065,20 @@ fn build_exec_check(
     agent_name: String,
     preset_name: Option<String>,
 ) -> check::Report {
+    // The same capture the launch does, from the same trusted git (see
+    // `sandbox_exec.rs`, "baked at launch"): without it every push reads as
+    // blocked, feature branches included.
+    let repo_facts = crate::git::trusted_git()
+        .map(|git| gh_proxy::capture_repo_facts(git, project_dir))
+        .unwrap_or_default();
     let ctx = check::ExecContext {
         allow_docker: resolved.allow_docker,
         allow_tmp_exec: resolved.allow_tmp_exec,
         gh_guard: &resolved.gh_guard,
         git_guard: &resolved.git_guard,
         project_dir,
+        repo_facts: &repo_facts,
+        scratch_dir: resolved.scratch_dir,
     };
     let expl = check::explain_exec(cmd, &ctx);
     let item = check::CheckItem {

--- a/tests/e2e_golden.rs
+++ b/tests/e2e_golden.rs
@@ -896,17 +896,43 @@ fn golden_check_exec_agrees_with_the_launch_in_both_modes() {
     let check = format!("{check_out}{check_err}");
     assert!(status.success(), "check exec should run:\n{check}");
     assert!(
-        check.contains("BLOCKED"),
-        "in block mode `check exec` must say the push is blocked:\n{check}"
+        check.contains("origin main: BLOCKED"),
+        "in block mode `check exec` must say the push is blocked. Asserted on the \
+         verdict line, not on the word: the reason quotes the guard's own message, \
+         which carries `BLOCKED by sandbox` whatever the verdict says:\n{check}"
     );
 
     let before = head();
     let (_, stderr, push_status) = push();
-    assert!(
-        !push_status.success(),
-        "the launch must agree with `check exec` and refuse:\n{stderr}"
-    );
+    common::assert_refused(&stderr, push_status.success(), "Push prevention is enabled");
     assert_eq!(before, head(), "a blocked push must not move the remote");
+
+    // ── a feature-branch push: allowed by the default policy, and `check exec`
+    //    has to know that. It did not: with no baked repository facts and no
+    //    real git to resolve push targets, `protect_default_branch_only` could
+    //    not tell a feature branch from the protected one, so every push read
+    //    as blocked — the most common push there is, on the default config.
+    run(&["checkout", "--quiet", "-b", "feature/golden-check"]);
+    let (check_out, check_err, status) = launch(
+        &home,
+        &work,
+        &[
+            "check",
+            "exec",
+            "git",
+            "push",
+            "origin",
+            "feature/golden-check",
+        ],
+    );
+    let check = format!("{check_out}{check_err}");
+    assert!(status.success(), "check exec should run:\n{check}");
+    assert!(
+        check.contains("feature/golden-check: ALLOWED"),
+        "the default policy protects the default branch only, so `check exec` must \
+         say a feature-branch push is allowed:\n{check}"
+    );
+    run(&["checkout", "--quiet", "main"]);
 
     // ── warn mode: the launch runs the push, so check must not say BLOCKED ──
     let (_, stderr, status) = launch(
@@ -946,12 +972,74 @@ fn golden_check_exec_agrees_with_the_launch_in_both_modes() {
         push_status.success(),
         "warn mode must let the push through, matching what `check exec` said:\n{stderr}"
     );
+    // Running it is not the same as running it silently. Warn mode's whole
+    // value is the notice; without this a mutation that drops it passes.
+    assert!(
+        stderr.contains("would block"),
+        "warn mode must still tell the operator what it declined to enforce:\n{stderr}"
+    );
     assert_ne!(
         before,
         head(),
         "warn mode does not enforce, so the push must have reached the remote — \
          if it did not, `check exec` is now wrong in the other direction:\n{stderr}"
     );
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// Both guards install themselves through a PATH shim in the scratch dir, so
+/// `sandbox.scratch_dir = false` turns them off however they are configured —
+/// which the launch summary reports as `inactive`. `check exec` read only
+/// `enabled` and answered BLOCKED for a command that would run unguarded: the
+/// most dangerous direction for this surface to be wrong in, because it tells
+/// an operator they are protected when they are not.
+#[test]
+fn golden_check_exec_knows_the_guards_need_a_scratch_dir() {
+    require_launch!();
+    let home = make_config_home("golden-noscratch");
+    let repo = temp_repo("navikt/spleis");
+
+    let (_, stderr, status) = launch(
+        &home,
+        repo.path(),
+        &["config", "set", "sandbox.scratch_dir", "false", "--force"],
+    );
+    assert!(
+        status.success(),
+        "setting scratch_dir should succeed:\n{stderr}"
+    );
+
+    // What the launch says.
+    let (_, stderr, ok) = launch_agent(&home, repo.path());
+    assert!(
+        ok,
+        "a launch without a scratch dir must still work:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("git guard:     inactive") && stderr.contains("gh guard:      inactive"),
+        "without a scratch dir there is no shim, so the summary must say inactive:\n{stderr}"
+    );
+
+    // What `check exec` must say about the same run.
+    for cmd in [
+        &["check", "exec", "git", "push", "origin", "main"][..],
+        &["check", "exec", "gh", "pr", "merge", "1"][..],
+    ] {
+        let (out, err, status) = launch(&home, repo.path(), cmd);
+        let check = format!("{out}{err}");
+        assert!(status.success(), "check exec should run:\n{check}");
+        assert!(
+            check.contains("ALLOWED"),
+            "the guard cannot run without a scratch dir, so `check exec` must not \
+             claim it blocks anything — telling an operator they are protected when \
+             they are not is the worst way for this surface to be wrong:\n{check}"
+        );
+        assert!(
+            check.contains("scratch dir"),
+            "and must say why, so the operator can put the guard back:\n{check}"
+        );
+    }
 
     let _ = std::fs::remove_dir_all(&home);
 }

--- a/tests/e2e_golden.rs
+++ b/tests/e2e_golden.rs
@@ -820,3 +820,314 @@ fn golden_env_denial_names_the_nais_bootstrap_it_detected() {
     let _ = std::fs::remove_dir_all(&home);
     let _ = std::fs::remove_dir_all(&plain_home);
 }
+
+// ════════════════════════════════════════════════════════════════════
+// Path 5 — `check exec` answers the question the launch answers
+// ════════════════════════════════════════════════════════════════════
+
+/// `cplt check exec <cmd>` exists so a developer can ask what will happen
+/// without launching an agent. It is therefore the one surface where telling
+/// the truth about the guards *is* the feature.
+///
+/// It got warn mode wrong: `gate_git` and `gate` answer "does the policy
+/// object", and `check exec` mapped every objection to BLOCKED — while the
+/// launch consults the enforcement mode, prints a warning and runs the command.
+/// A developer in warn mode was told a push would be blocked; the push went
+/// through and the remote moved.
+#[test]
+fn golden_check_exec_agrees_with_the_launch_in_both_modes() {
+    require_launch!();
+    let home = make_config_home("golden-check");
+    let (_tmp, work, origin) = bare_origin_repo(Path::new(env!("CARGO_MANIFEST_DIR")));
+
+    let run = |args: &[&str]| {
+        let out = common::git_cmd(&work)
+            .args(args)
+            .output()
+            .expect("git should run");
+        assert!(
+            out.status.success(),
+            "git {args:?} should succeed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    run(&["push", "--quiet", "origin", "main"]);
+    run(&[
+        "symbolic-ref",
+        "refs/remotes/origin/HEAD",
+        "refs/remotes/origin/main",
+    ]);
+    run(&["commit", "--quiet", "--allow-empty", "-m", "work"]);
+
+    let allow = origin.to_string_lossy().into_owned();
+    let push = || {
+        let args = vec![
+            "--yes",
+            "--no-validate",
+            "--allow-write",
+            &allow,
+            "exec",
+            "--",
+            "git",
+            "push",
+            "origin",
+            "main",
+        ];
+        launch(&home, &work, &args)
+    };
+    let head = || {
+        String::from_utf8_lossy(
+            &common::git_cmd(&origin)
+                .args(["rev-parse", "refs/heads/main"])
+                .output()
+                .expect("git should run")
+                .stdout,
+        )
+        .trim()
+        .to_string()
+    };
+
+    // ── block mode: check says BLOCKED, and the push really is blocked ──
+    let (check_out, check_err, status) = launch(
+        &home,
+        &work,
+        &["check", "exec", "git", "push", "origin", "main"],
+    );
+    let check = format!("{check_out}{check_err}");
+    assert!(status.success(), "check exec should run:\n{check}");
+    assert!(
+        check.contains("BLOCKED"),
+        "in block mode `check exec` must say the push is blocked:\n{check}"
+    );
+
+    let before = head();
+    let (_, stderr, push_status) = push();
+    assert!(
+        !push_status.success(),
+        "the launch must agree with `check exec` and refuse:\n{stderr}"
+    );
+    assert_eq!(before, head(), "a blocked push must not move the remote");
+
+    // ── warn mode: the launch runs the push, so check must not say BLOCKED ──
+    let (_, stderr, status) = launch(
+        &home,
+        &work,
+        &["config", "set", "git_guard.mode", "warn", "--force"],
+    );
+    assert!(
+        status.success(),
+        "setting warn mode should succeed:\n{stderr}"
+    );
+
+    let (check_out, check_err, status) = launch(
+        &home,
+        &work,
+        &["check", "exec", "git", "push", "origin", "main"],
+    );
+    let check = format!("{check_out}{check_err}");
+    assert!(
+        status.success(),
+        "check exec should run in warn mode:\n{check}"
+    );
+    assert!(
+        check.contains("ALLOWED"),
+        "warn mode lets the command run, so `check exec` must not report it \
+         blocked — this is the drift the surface exists to prevent:\n{check}"
+    );
+    // Allowed, but not silently: the objection is still the operator's business.
+    assert!(
+        check.contains("warn mode"),
+        "`check exec` must say why a command the guard objects to is allowed:\n{check}"
+    );
+
+    let before = head();
+    let (_, stderr, push_status) = push();
+    assert!(
+        push_status.success(),
+        "warn mode must let the push through, matching what `check exec` said:\n{stderr}"
+    );
+    assert_ne!(
+        before,
+        head(),
+        "warn mode does not enforce, so the push must have reached the remote — \
+         if it did not, `check exec` is now wrong in the other direction:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Path 6 — an untrusted `.cplt.toml` is announced, inert, then in force
+// ════════════════════════════════════════════════════════════════════
+
+/// The repo layer's whole security model is that `[propose]` does nothing until
+/// a human approves it on this machine. Two failures are equally bad: a
+/// proposal that applies before approval, and a summary that stays silent about
+/// one waiting. Both are invisible to every test that only asserts on the
+/// agent's view.
+#[test]
+fn golden_untrusted_repo_config_is_announced_inert_then_applied() {
+    require_launch!();
+    let home = make_config_home("golden-trust");
+    let repo = temp_repo("navikt/spleis");
+
+    // From git HEAD, not the working tree — so it has to be committed.
+    std::fs::write(
+        repo.path().join(".cplt.toml"),
+        "[propose]\nallow_localhost_any = true\n",
+    )
+    .expect("write .cplt.toml");
+    for args in [
+        &["add", ".cplt.toml"][..],
+        &["commit", "--quiet", "-m", "add cplt config"][..],
+    ] {
+        let out = common::git_cmd(repo.path())
+            .args(args)
+            .output()
+            .expect("git should run");
+        assert!(out.status.success(), "git {args:?} should succeed");
+    }
+
+    // 1. Announced, and not yet in force.
+    let (_, stderr, ok) = launch_agent(&home, repo.path());
+    assert!(
+        ok,
+        "an unapproved proposal must not stop the launch:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Untrusted .cplt.toml"),
+        "the summary must say a repo config is waiting for approval:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("cplt trust"),
+        "and must name the command that shows it:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Localhost:     blocked"),
+        "an unapproved proposal must not be in force — this is the whole trust \
+         model:\n{stderr}"
+    );
+
+    // 2. `cplt trust` shows it as pending rather than applied.
+    let (stdout, stderr, status) = launch(&home, repo.path(), &["trust"]);
+    let trust = format!("{stdout}{stderr}");
+    assert!(status.success(), "cplt trust should succeed:\n{trust}");
+    assert!(
+        trust.contains("allow_localhost_any") && trust.contains("pending"),
+        "`cplt trust` must list the proposal as pending:\n{trust}"
+    );
+
+    // 3. Approved, and now in force.
+    let (stdout, stderr, status) = launch(&home, repo.path(), &["trust", "accept", "--all"]);
+    assert!(
+        status.success(),
+        "trust accept should succeed:\n{stdout}{stderr}"
+    );
+
+    let (_, stderr, ok) = launch_agent(&home, repo.path());
+    assert!(ok, "an approved launch must succeed:\n{stderr}");
+    assert!(
+        !stderr.contains("Untrusted .cplt.toml"),
+        "an approved config must stop being announced as untrusted:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Localhost:     all ports"),
+        "after approval the proposal must actually apply:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Path 7 — the awkward repository states still launch, and say something true
+// ════════════════════════════════════════════════════════════════════
+
+/// A repository with no remote, a detached HEAD, or uncommitted changes is an
+/// ordinary Tuesday, and none of the three was covered anywhere. The guards
+/// read the remote's default branch, so "there isn't one" is a real input, and
+/// the failure mode to avoid is a launch that dies on it or reports guards it
+/// is not running.
+#[test]
+fn golden_awkward_repository_states_still_launch() {
+    require_launch!();
+
+    let commit = |dir: &Path, args: &[&str]| {
+        let out = common::git_cmd(dir)
+            .args(args)
+            .output()
+            .expect("git should run");
+        assert!(
+            out.status.success(),
+            "git {args:?} should succeed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    // ── no remote at all ──
+    let bare = tempfile::tempdir().expect("tempdir");
+    commit(bare.path(), &["init", "--quiet", "-b", "main"]);
+    commit(
+        bare.path(),
+        &["commit", "--quiet", "--allow-empty", "-m", "init"],
+    );
+
+    let home = make_config_home("golden-noremote");
+    let (_, stderr, ok) = launch_agent(&home, bare.path());
+    assert!(
+        ok,
+        "a repository with no remote must still launch — the guards read the \
+         remote's default branch, and not having one is not an error:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("git guard:     on"),
+        "the guards still run with no remote, so the summary must still say so:\n{stderr}"
+    );
+
+    // ── detached HEAD ──
+    let detached = temp_repo("navikt/spleis");
+    commit(
+        detached.path(),
+        &["commit", "--quiet", "--allow-empty", "-m", "one"],
+    );
+    commit(
+        detached.path(),
+        &["commit", "--quiet", "--allow-empty", "-m", "two"],
+    );
+    commit(
+        detached.path(),
+        &["checkout", "--quiet", "--detach", "HEAD"],
+    );
+
+    let detached_home = make_config_home("golden-detached");
+    let (_, stderr, ok) = launch_agent(&detached_home, detached.path());
+    assert!(
+        ok,
+        "a detached HEAD must still launch — there is no current branch to \
+         compare against the protected one:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("git guard:     on"),
+        "the git guard must still be reported on a detached HEAD:\n{stderr}"
+    );
+
+    // ── uncommitted changes ──
+    let dirty = temp_repo("navikt/spleis");
+    commit(
+        dirty.path(),
+        &["commit", "--quiet", "--allow-empty", "-m", "init"],
+    );
+    std::fs::write(dirty.path().join("notes.txt"), "work in progress\n")
+        .expect("write a dirty file");
+
+    let dirty_home = make_config_home("golden-dirty");
+    let (_, stderr, ok) = launch_agent(&dirty_home, dirty.path());
+    assert!(
+        ok,
+        "uncommitted changes must not stop a launch — that is the state an \
+         agent is usually asked to work in:\n{stderr}"
+    );
+
+    for h in [&home, &detached_home, &dirty_home] {
+        let _ = std::fs::remove_dir_all(h);
+    }
+}

--- a/tests/e2e_golden.rs
+++ b/tests/e2e_golden.rs
@@ -1131,3 +1131,55 @@ fn golden_awkward_repository_states_still_launch() {
         let _ = std::fs::remove_dir_all(h);
     }
 }
+
+/// `cplt exec` always builds the Shell profile, whatever `--agent` says. That
+/// is deliberate (#343) — but the flag was accepted and dropped in silence, so
+/// `--agent copilot exec` answered questions about a different sandbox than the
+/// operator believed they were probing. The profiles differ where it matters:
+/// Shell has no Keychain grant, so `gh` finds no token.
+///
+/// The two sibling warnings beside this one (`--allow-docker`, `--allow-tmp-exec`)
+/// have no test either; this is the shape of that gap, not just one message.
+#[test]
+fn golden_exec_says_when_it_ignores_the_requested_agent() {
+    require_launch!();
+    let home = make_config_home("golden-agent");
+    let repo = temp_repo("navikt/spleis");
+
+    let exec_with = |args: &[&str]| {
+        let mut all = args.to_vec();
+        all.extend_from_slice(&["--yes", "--no-validate", "exec", "--", TRUE_BIN]);
+        launch(&home, repo.path(), &all)
+    };
+
+    let (_, stderr, status) = exec_with(&["--agent", "copilot"]);
+    assert!(status.success(), "exec should still run:\n{stderr}");
+    assert!(
+        stderr.contains("--agent copilot is ignored"),
+        "exec must say it is not building the profile that was asked for:\n{stderr}"
+    );
+    // A warning that only says "ignored" leaves the operator where they were.
+    assert!(
+        stderr.contains("check"),
+        "and must name the command that does answer the question:\n{stderr}"
+    );
+
+    // Not suppressed by --quiet: the whole failure is the operator believing
+    // something untrue about the sandbox they are looking at.
+    let (_, stderr, _) = exec_with(&["--agent", "copilot", "--quiet"]);
+    assert!(
+        stderr.contains("--agent copilot is ignored"),
+        "--quiet must not hide it:\n{stderr}"
+    );
+
+    // No flag, and the flag that matches what exec actually builds, stay quiet.
+    for args in [&[][..], &["--agent", "shell"][..]] {
+        let (_, stderr, _) = exec_with(args);
+        assert!(
+            !stderr.contains("is ignored"),
+            "no warning is owed for {args:?}:\n{stderr}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&home);
+}


### PR DESCRIPTION
## The defect

`cplt check exec <cmd>` exists so a developer can ask what will happen without launching an agent. That makes it the one surface where telling the truth about the guards *is* the feature. It got warn mode backwards.

`gate_git` and `gate` answer one question — does the policy object? — and return `Err` when it does. Whether that objection *stops* the command is a separate decision the launch makes from the enforcement mode, and `check exec` skipped it. Every objection was reported `BLOCKED`.

Observed, with `git_guard.mode = "warn"`:

```
$ cplt check exec git push origin main
git push origin main: BLOCKED

$ cplt exec -- git push origin main
⚠️  WARNING (would block): ...
   751c4c3..92e9978  main -> main      # the push ran, the remote moved
```

Both guards had it: the gh arm builds a `GatePolicy` carrying the mode, but `gate` refuses without consulting it — the mode is applied later, by `decide_gh_gate`.

Warn and audit now report the command allowed, with the objection in the reason and the fix naming how to make it bite. The block-mode message is stripped of its `BLOCKED by sandbox` prefix on that path, for the same reason `warn_mode_message` already strips it in the launch: a line that says `ALLOWED` must not have `BLOCKED` nested inside it.

```
git push origin main: ALLOWED
  Reason: the git guard objects, but it runs in warn mode, so the command runs. 'git push origin' is not allowed while push prevention is active.
  Fix: set git_guard.mode = "block" to enforce this.
```

## Golden paths 5–7 of #431

Each falsified before being trusted.

**Path 5** pins the above end to end: `check exec` and a real push against a bare origin, in both modes, required to agree twice over — blocked with the ref unmoved, then allowed with the ref moved. Restoring `Decision::Blocked` fails it.

**Path 6** is the repo layer's trust model: an untrusted `.cplt.toml` must be announced in the summary, inert until approved, listed pending by `cplt trust`, and in force after `trust accept --all`. Making the approval check pass unconditionally fails it.

Worth recording: my first falsification of path 6 mutated `trust::is_key_approved` and the test stayed green. That function is short-circuited by `is_some_and` when no trust file exists, so the mutation never ran — the test was fine, the falsification was aimed at the wrong function. The gate that decides is the `is_approved` closure in `apply_repo_config`. A falsification that silently tests nothing is how a dead test gets trusted, so it seemed worth naming rather than quietly redoing.

**Path 7** covers three ordinary repository states that were untested anywhere: no remote, detached HEAD, uncommitted changes. Each must launch and still report the guards. The guards read the remote's default branch, so "there isn't one" is a real input rather than an error.

Closes the #431 ranked list. Follow-up noticed while testing, not fixed here: with no remote at all the git guard fails closed and blocks every push, while the summary row still says "blocks git push to the default branch" — the same overstatement fixed in #436, in the other direction.