### PR TITLE
docs(readme): the guard blocks pushes to main, not every push

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cplt gives you kernel-level enforcement with team-configurable policy:
 
 - Per-repo policy in `.cplt.toml`, committed to version control, so it is tamper-proof and auditable
 - Deny by default for credentials, secrets, and sensitive files
-- Command-level git and gh interception that blocks pushes, merges, and releases
+- Command-level git and gh interception: pushes to the default branch, force pushes, merges, and releases are blocked, feature branches stay open
 - Outbound network filtering with an audit log
 - No Docker, no VMs. One binary that runs on a locked-down laptop
 - Zero-config start for developers, with escape hatches when a build genuinely needs one


### PR DESCRIPTION
The feature bullet in "Why cplt?" said the git guard "blocks pushes, merges, and releases", which reads as every push. Since #387, `protect_default_branch_only` is on in the standard preset: pushes to the default branch and force pushes are blocked, feature branches stay open, and the review gate is the pull request.

The table under "What it blocks" already stated this correctly. The bullet a reader sees first did not, and it is the claim most likely to be tested by someone who just installed it.

One line, no behaviour change.