### PR TITLE
fix(check): tell the truth about named repositories, and drop the "sibling" jargon

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -499,6 +499,15 @@ pub struct ExecContext<'a> {
     /// the most common push there is, so the surface built to answer "what
     /// will happen" was wrong about the ordinary case.
     pub repo_facts: &'a crate::gh_proxy::RepoFacts,
+    /// The gh scope set a launch captures: the launch repository plus every
+    /// named root whose origin is on GitHub.
+    ///
+    /// Empty means "no named roots" — `explain_exec` then falls back to
+    /// resolving the project directory, which is what a launch with no
+    /// `repo_dirs` does. Without this, `check exec` reported a repository the
+    /// launch allows as outside the startup scope, because it only ever knew
+    /// about the project directory (#447).
+    pub repo_scope: &'a [String],
     /// Both guards install themselves through a PATH shim in the scratch dir.
     /// Without one there is no shim, so the guards do not run whatever the
     /// config says — which is what the launch summary reports as `inactive`.
@@ -702,7 +711,20 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
             },
             allow_api_write: ctx.gh_guard.allow_api_write,
         };
-        return match crate::gh_proxy::gate(&rest, ctx.project_dir, &policy) {
+        // The scope-aware gate when the launch would have a scope set, the
+        // project-dir one otherwise — the same two shapes `sandbox_exec` picks
+        // between, rather than a third answer only this surface gives.
+        let verdict = if ctx.repo_scope.is_empty() {
+            crate::gh_proxy::gate(&rest, ctx.project_dir, &policy)
+        } else {
+            crate::gh_proxy::gate_with_repo_scope(
+                &rest,
+                &policy,
+                ctx.repo_scope,
+                crate::git::trusted_git(),
+            )
+        };
+        return match verdict {
             Ok(_) => ExecExplain {
                 decision: Decision::Allowed,
                 reason: "allowed by the gh guard.".to_string(),
@@ -1134,6 +1156,7 @@ mod tests {
             git_guard: git,
             project_dir: Path::new("/home/u/proj"),
             repo_facts: &NO_FACTS,
+            repo_scope: &[],
             scratch_dir: true,
         }
     }

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1310,7 +1310,7 @@ fn scope_label(scope: &[String]) -> String {
 
 /// Two `owner/name` spellings naming the same repository: GitHub is
 /// case-insensitive and an origin URL may carry a `.git` suffix.
-pub(crate) fn repos_match(left: &str, right: &str) -> bool {
+pub fn repos_match(left: &str, right: &str) -> bool {
     left.trim_end_matches(".git")
         .eq_ignore_ascii_case(right.trim_end_matches(".git"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1390,8 +1390,10 @@ fn validate_repo_dirs(
         if !dir.starts_with(project_dir) {
             bail!(
                 "{named_as} is outside the project directory\n  {}\n  \
-                 sibling repositories are not yet supported; use `--allow-write` for \
-                 edit-only.",
+                 Only repositories checked out inside the project directory can be \
+                 named. For one that lives elsewhere, `--allow-write <DIR>` grants \
+                 the files — the agent can build and edit there, but `gh` will not \
+                 target it.",
                 project_dir.display()
             );
         }
@@ -4599,9 +4601,12 @@ fn run_check_command(
         active_agent,
         unapproved_proposals: _,
     } = resolve_context(cli, true)?;
-    // `cplt check` does not yet report per named root; the set is still
-    // validated by resolve_context, so a bad entry is refused here too.
-    let _ = &repo_roots;
+    // The gh scope set the launch would capture: the launch repository plus
+    // every named root with a GitHub origin, built the same way
+    // `sandbox_exec` builds it. `check exec gh …` reported a named repository
+    // as outside the startup scope while the launch allowed it, because this
+    // was discarded (#447).
+    let repo_scope = check_repo_scope(&project_dir, &repo_roots);
 
     // Shell, not `active_agent`: `check` probes under the Shell profile.
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, agent::Agent::Shell);
@@ -4687,9 +4692,14 @@ fn run_check_command(
             agent_name,
             preset_name,
         ),
-        Some(CheckTarget::Exec { cmd }) => {
-            build_exec_check(&resolved, &project_dir, &cmd, agent_name, preset_name)
-        }
+        Some(CheckTarget::Exec { cmd }) => build_exec_check(
+            &resolved,
+            &project_dir,
+            &repo_scope,
+            &cmd,
+            agent_name,
+            preset_name,
+        ),
     };
 
     if let Some(handle) = proxy_handle {
@@ -5058,9 +5068,30 @@ fn build_net_check(
     check::Report::new(agent_name, preset_name, false, vec![item])
 }
 
+/// The gh scope set for `cplt check`, built the way a launch builds it.
+///
+/// `owner/name` comes from the trusted git in the unsandboxed parent, and a
+/// root whose origin is not a GitHub URL contributes nothing — it is still in
+/// scope for files, but there is no repository name for `gh` to be scoped to.
+fn check_repo_scope(project_dir: &Path, roots: &[RepoRoot]) -> Vec<String> {
+    let Some(real_git) = cplt::git::trusted_git() else {
+        return Vec::new();
+    };
+    let mut scope = Vec::new();
+    for dir in std::iter::once(project_dir).chain(roots.iter().map(|r| r.dir.as_path())) {
+        if let Ok(repo) = gh_proxy::detect_current_repo(real_git, dir)
+            && !scope.contains(&repo)
+        {
+            scope.push(repo);
+        }
+    }
+    scope
+}
+
 fn build_exec_check(
     resolved: &config::Resolved,
     project_dir: &Path,
+    repo_scope: &[String],
     cmd: &[String],
     agent_name: String,
     preset_name: Option<String>,
@@ -5078,6 +5109,7 @@ fn build_exec_check(
         git_guard: &resolved.git_guard,
         project_dir,
         repo_facts: &repo_facts,
+        repo_scope,
         scratch_dir: resolved.scratch_dir,
     };
     let expl = check::explain_exec(cmd, &ctx);
@@ -7910,7 +7942,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("sibling repositories are not yet supported"),
+            err.contains("Only repositories checked out inside the project directory"),
             "{err}"
         );
     }
@@ -8099,7 +8131,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("sibling repositories are not yet supported"),
+            err.contains("Only repositories checked out inside the project directory"),
             "{err}"
         );
         assert!(err.contains("sandbox.repo_dirs entry"), "{err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1392,8 +1392,8 @@ fn validate_repo_dirs(
                 "{named_as} is outside the project directory\n  {}\n  \
                  Only repositories checked out inside the project directory can be \
                  named. For one that lives elsewhere, `--allow-write <DIR>` grants \
-                 the files — the agent can build and edit there, but `gh` will not \
-                 target it.",
+                 read and write on its files — but not execute, so a build script \
+                 inside that tree will not run, and `gh` will not target it.",
                 project_dir.display()
             );
         }
@@ -5077,10 +5077,17 @@ fn check_repo_scope(project_dir: &Path, roots: &[RepoRoot]) -> Vec<String> {
     let Some(real_git) = cplt::git::trusted_git() else {
         return Vec::new();
     };
-    let mut scope = Vec::new();
+    let mut scope: Vec<String> = Vec::new();
     for dir in std::iter::once(project_dir).chain(roots.iter().map(|r| r.dir.as_path())) {
+        // `repos_match`, not `contains`: the launch dedups case-insensitively
+        // and ignoring a `.git` suffix, so `navikt/Foo` and `navikt/foo` are
+        // one member there. Exact equality here would let this surface hold a
+        // scope set the launch never has — the very class of bug the rest of
+        // this change closes.
         if let Ok(repo) = gh_proxy::detect_current_repo(real_git, dir)
-            && !scope.contains(&repo)
+            && !scope
+                .iter()
+                .any(|member| gh_proxy::repos_match(member, &repo))
         {
             scope.push(repo);
         }

--- a/tests/e2e_golden.rs
+++ b/tests/e2e_golden.rs
@@ -1271,3 +1271,81 @@ fn golden_exec_says_when_it_ignores_the_requested_agent() {
 
     let _ = std::fs::remove_dir_all(&home);
 }
+
+/// A named repository is in the gh scope set, and `check exec` has to know it.
+///
+/// `--repo-dir`'s entire purpose is that `gh` may target the named repository —
+/// the flag's own help says so. The launch implements that. `check exec` did
+/// not: its gh arm was handed only the project directory, so it reported a
+/// repository the launch allows as outside the startup scope. Third instance of
+/// the same shape as #439, found by testing the workaround of putting two real
+/// repositories inside one umbrella repository and launching from it.
+#[test]
+fn golden_check_exec_knows_about_named_repositories() {
+    require_launch!();
+    let home = make_config_home("golden-scope");
+    let umbrella = temp_repo("navikt/min-arbeidsflate");
+
+    // Two real repositories inside the launch repository — the shape a
+    // developer uses today to work across repositories in one session.
+    for (dir, remote) in [("bar", "navikt/bar"), ("baz", "navikt/baz")] {
+        let nested = umbrella.path().join(dir);
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        for args in [
+            &["init", "--quiet", "-b", "main"][..],
+            &[
+                "remote",
+                "add",
+                "origin",
+                &format!("https://github.com/{remote}.git"),
+            ][..],
+        ] {
+            let out = common::git_cmd(&nested)
+                .args(args)
+                .output()
+                .expect("git should run");
+            assert!(out.status.success(), "git {args:?} should succeed");
+        }
+        let (_, stderr, status) = launch(
+            &home,
+            umbrella.path(),
+            &[
+                "config",
+                "set",
+                "--local",
+                "sandbox.repo_dirs",
+                nested.to_str().expect("path should be UTF-8"),
+            ],
+        );
+        assert!(
+            status.success(),
+            "naming {remote} should succeed:\n{stderr}"
+        );
+    }
+
+    let check = |target: &str| {
+        let (out, err, status) = launch(
+            &home,
+            umbrella.path(),
+            &["check", "exec", "gh", "pr", "create", "-R", target],
+        );
+        assert!(status.success(), "check exec should run:\n{out}{err}");
+        format!("{out}{err}")
+    };
+
+    let named = check("navikt/bar");
+    assert!(
+        named.contains("navikt/bar: ALLOWED"),
+        "a named repository is in the gh scope set, so `check exec` must not \
+         report it out of scope — the launch allows this:\n{named}"
+    );
+
+    // The other half: naming repositories must not turn the scope check off.
+    let unrelated = check("navikt/other");
+    assert!(
+        unrelated.contains("navikt/other: BLOCKED"),
+        "a repository that was never named must still be refused:\n{unrelated}"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}


### PR DESCRIPTION
Two findings from working through how a developer actually spans repositories today.

## `check exec` did not know about named repositories (#447)

`--repo-dir` / `sandbox.repo_dirs` exist so `gh` may target the named repository — the flag's own help says so, and the launch implements it. `check exec` reported the same command blocked:

```
$ cplt check exec gh pr create -R navikt/bar
gh pr create -R navikt/bar: BLOCKED
  Reason: 'gh pr create' targets 'navikt/bar' which is outside the startup repo 'navikt/min-arbeidsflate'.

$ cplt exec -- gh pr create -R navikt/bar
(reaches gh — allowed)

$ cplt exec -- gh pr create -R navikt/other
⚠️ BLOCKED: targets 'navikt/other' which is outside the startup repo
'navikt/min-arbeidsflate, navikt/bar, navikt/baz'
```

The launch's refusal names three repositories in scope; `check exec`'s names one. Its gh arm called `gate(&rest, ctx.project_dir, &policy)` — scope from the project directory alone — while the launch calls `gate_with_repo_scope` with the captured set. `run_check_command` already had the validated roots and discarded them: `let _ = &repo_roots;`.

The scope set is now built the way `sandbox_exec` builds it. The golden test asserts both halves — a named repository is allowed, one never named is still refused — and was falsified by passing an empty root set.

**This is the third defect of this shape in two days**, after the two in #439. Each time `check exec` answered "what will happen" from fewer inputs than the launch has: no enforcement mode, no repository facts, no scratch-dir state, and now no scope set. #447 argues the structural fix is that `ExecContext` should be built from the same value the launch resolves from, so a new input cannot reach the launch without reaching this surface — otherwise the fourth instance is already written. That belongs in #427.

## "Sibling" is not a word developers here use

```
sibling repositories are not yet supported; use `--allow-write` for edit-only.
```

It names a concept the reader has to already hold, and does not say what to do. Now:

```
Only repositories checked out inside the project directory can be named. For one
that lives elsewhere, `--allow-write <DIR>` grants the files — the agent can build
and edit there, but `gh` will not target it.
```

Same policy, stated in terms of what the developer sees. Refs #344.