### PR TITLE
fix: make four refusals say something the reader can act on

### DIFF
--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -49,9 +49,16 @@ pub fn explain_key(
     if key_info.dangerous {
         println!("  {yellow}Requires --force to enable{nc}");
     }
+    // The layer this key actually accepts, not a generic invocation: for a
+    // local- or repo-only key the plain form is refused, so printing it sent
+    // the reader to a dead end (#438).
     println!(
-        "  {blue}Set:{nc}  cplt config set {}.{} <value>",
-        key_info.section, key_info.key
+        "  {blue}Set:{nc}  cplt config set {}{}.{} <value>",
+        super::registry::layer_only_flag(key_info)
+            .map(|flag| format!("{flag} "))
+            .unwrap_or_default(),
+        key_info.section,
+        key_info.key
     );
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,7 +37,8 @@ pub use path::{
     default_config_contents, expand_tilde,
 };
 pub use registry::{
-    BoolKeyRow, ConfigKeyInfo, ConfigLayer, ConfigValueType, all_config_keys, bool_key, lookup_key,
+    BoolKeyRow, ConfigKeyInfo, ConfigLayer, ConfigValueType, all_config_keys, bool_key,
+    layer_only_flag, lookup_key,
 };
 pub use repo::{
     PROPOSE_BOOLS, ProposeBoolRow, RepoKeyTarget, repo_key_rejection_reason, repo_key_target,

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -548,6 +548,25 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
     },
 ];
 
+/// The only layer that can set this key, when it is not settable everywhere.
+///
+/// One rule, two readers: `config set` refuses the wrong layer with it, and
+/// `config explain` builds its `Set:` line from it. They disagreed — `explain`
+/// printed `cplt config set sandbox.repo_dirs <value>` for a key whose only
+/// outcome globally is a refusal, contradicting its own description two lines
+/// above (#438). Generated from the key rather than special-cased, so a new
+/// layer-restricted key cannot print advice that cannot work.
+#[must_use]
+pub fn layer_only_flag(key_info: &ConfigKeyInfo) -> Option<&'static str> {
+    match (key_info.section, key_info.key) {
+        // A repository list in the global config would attach to every session.
+        ("sandbox", "repo_dirs") => Some("--local"),
+        // Not in the global file's schema at all; it lives in `.cplt.toml`.
+        ("deny", "env") => Some("--repo"),
+        _ => None,
+    }
+}
+
 /// Sections removed from the registry, with the message shown when one is
 /// still named — by `cplt config set/get` or by a config file left on disk.
 ///
@@ -1057,6 +1076,33 @@ pub(super) const BOOL_KEYS_EXEMPT: &[(&str, &str, &str)] = &[
 
 #[cfg(test)]
 mod tests {
+    /// #438: `explain` printed a `Set:` line the key would refuse, so the
+    /// advice and the description two lines above contradicted each other.
+    /// Both readers take the flag from here now, so they cannot disagree.
+    #[test]
+    fn layer_only_keys_are_the_ones_config_set_refuses_globally() {
+        let repo_dirs = lookup_key("sandbox.repo_dirs").expect("key should exist");
+        assert_eq!(layer_only_flag(repo_dirs), Some("--local"));
+
+        let deny_env = lookup_key("deny.env").expect("key should exist");
+        assert_eq!(layer_only_flag(deny_env), Some("--repo"));
+
+        // Everything else is settable globally, which is what the plain
+        // `cplt config set <key>` form in `explain` promises.
+        for key in all_config_keys() {
+            let dotted = format!("{}.{}", key.section, key.key);
+            if dotted == "sandbox.repo_dirs" || dotted == "deny.env" {
+                continue;
+            }
+            assert_eq!(
+                layer_only_flag(key),
+                None,
+                "{dotted} is restricted to a layer but `explain` would still print the \
+                 plain form; add it here so both readers agree"
+            );
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -206,7 +206,17 @@ pub fn repo_key_rejection_reason(key_info: &ConfigKeyInfo) -> &'static str {
         ("sandbox", "inherit_env") => {
             "too dangerous for repo config, it would affect all team members"
         }
-        ("sandbox", "pass_env") => "environment variables are machine-specific, not project policy",
+        // Not "environment variables are machine-specific" — plenty are the
+        // application's (NODE_ENV, TZ, SPRING_PROFILES_ACTIVE) and are not
+        // sensitive at all, so that premise loses an argument it should win
+        // (#443). The hazard is the direction of the read: `pass_env` names a
+        // variable in the *parent's* environment, so a committed entry pulls
+        // whatever this machine happens to have under that name.
+        ("sandbox", "pass_env") => {
+            "names a variable to copy from whoever launched the agent, so a committed entry \
+             would pull whatever each machine happens to have under that name — including a \
+             credential a repo must not be able to ask for by spelling"
+        }
         ("sandbox", "repo_dirs") => {
             "naming other trees as project-grade roots is a path grant, and repo config \
              cannot grant paths. It is a per-checkout user setting: \

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1944,9 +1944,21 @@ fn gate_with_scope_resolver(
                     "Run it from the startup repository's checkout.",
                 ))
             } else {
+                // Two ways forward exist and the message named neither, so a
+                // session that hit this concluded it was blocked when a
+                // supported command would have worked (#403). The higher-level
+                // read commands really are allowed cross-repo with an explicit
+                // `-R`, and a repository checked out inside the project can be
+                // named into the scope set.
                 Err(format!(
                     "⚠️ BLOCKED by sandbox: 'gh {}{}' targets '{}' which is outside the startup repo '{}'.\n\
                      Reason: {}\n\
+                     Ways forward: read-only commands take an explicit repository — \
+                     `gh pr view -R <owner>/<repo>`, `gh pr diff -R …`, `gh issue view -R …` — \
+                     and are allowed against any repository. Raw `gh api` is not. If the agent \
+                     works in that repository too and it is checked out inside this one, name it \
+                     with `cplt config set --local sandbox.repo_dirs <DIR>` and it joins the \
+                     scope set. Otherwise relaunch cplt against that repository.\n\
                      This operation is restricted by the cplt sandbox environment.\n\
                     Please make a note of this for the human operator and continue with your remaining work.",
                     cmd.command,

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1954,8 +1954,9 @@ fn gate_with_scope_resolver(
                     "⚠️ BLOCKED by sandbox: 'gh {}{}' targets '{}' which is outside the startup repo '{}'.\n\
                      Reason: {}\n\
                      Ways forward: read-only commands take an explicit repository — \
-                     `gh pr view -R <owner>/<repo>`, `gh pr diff -R …`, `gh issue view -R …` — \
-                     and are allowed against any repository. Raw `gh api` is not. If the agent \
+                     `gh pr view -R <owner>/<repo> <number>`, `gh pr diff -R <owner>/<repo> \
+                     <number>`, `gh issue view -R <owner>/<repo> <number>` — and are allowed \
+                     against any repository. Raw `gh api` is not. If the agent \
                      works in that repository too and it is checked out inside this one, name it \
                      with `cplt config set --local sandbox.repo_dirs <DIR>` and it joins the \
                      scope set. Otherwise relaunch cplt against that repository.\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -5646,7 +5646,7 @@ fn run_config_set(
     // `sandbox.repo_dirs` is local-layer only. Writing it globally would produce
     // a file the next launch warns about and ignores; refuse here instead, and
     // name the flag that makes it work.
-    if !local && key_info.section == "sandbox" && key_info.key == "repo_dirs" {
+    if !local && config::layer_only_flag(key_info) == Some("--local") {
         ui::error(&format!(
             "sandbox.repo_dirs is per-project, not machine-wide: a repository list in \
              your global config would attach to every session.\n  \
@@ -5660,7 +5660,7 @@ fn run_config_set(
     // ── Global mode (default) ───────────────────────────────────────
 
     // deny.env is repo-local only (not in global config file schema)
-    if key_info.section == "deny" && key_info.key == "env" {
+    if config::layer_only_flag(key_info) == Some("--repo") {
         ui::error(
             "deny.env is only supported in repo-local config (.cplt.toml).\n  Use: cplt config set --repo deny.env <VALUE>",
         );

--- a/src/sandbox_landlock.rs
+++ b/src/sandbox_landlock.rs
@@ -1027,11 +1027,25 @@ pub fn generate_policy(config: &super::SandboxConfig) -> LandlockPolicy {
                         safe.join(" or ")
                     )
                 };
+                // The consequence is Landlock's, not Seatbelt's: on macOS
+                // `process-exec` is granted profile-wide, so the wrapper
+                // re-enters whether or not this rule was emitted, and nothing
+                // fails. This function still runs there — `cplt check` builds
+                // its explanation from it — so the unconditional claim told
+                // macOS users their guards were about to break, and then
+                // nothing broke. A guard that cries wolf about itself teaches
+                // people to ignore it (#400).
+                let consequence = if cfg!(target_os = "linux") {
+                    "so the gh and git guard wrappers cannot re-execute cplt — every guarded \
+                     command will fail with \"Permission denied\""
+                } else {
+                    "so the rule is skipped. On this platform the wrappers still re-enter, \
+                     because the profile grants process-exec generally — but the binary staying \
+                     agent-writable is the hazard on its own"
+                };
                 crate::ui::warn(&format!(
                     "the cplt binary at {} sits under {}, which the sandbox makes writable. \
-                     Granting it execute would let the agent overwrite cplt and run it, so the \
-                     grant is skipped and the gh and git guard wrappers cannot re-execute cplt \
-                     — every guarded command will fail with \"Permission denied\". {advice}",
+                     Granting it execute would let the agent overwrite cplt and run it, {consequence}. {advice}",
                     cplt_bin.display(),
                     tree.path.display()
                 ));


### PR DESCRIPTION
Four messages that were wrong, absolute, or dead ends — the same defect in different words. A block that does not say how to proceed is how "cplt broke my build" reports get filed.

## The cross-repo `gh` refusal named no way forward (#403)

Two exist. Read-only commands take an explicit `-R owner/repo` and are allowed against any repository; raw `gh api` is not. And a repository checked out inside the project can be named into the scope set. Both verified before being written down:

```
gh pr view -R navikt/other 828                     → ALLOWED
gh api repos/navikt/other/pulls/1/comments         → BLOCKED
```

The session that prompted the issue concluded it was blocked when the first would have worked. Note the issue's own write-up predates `--repo-dir` and says no multi-repo configuration exists — that is now stale, so the message names both routes.

## `pass_env`'s stated reason was wrong (#443)

> environment variables are machine-specific, not project policy

Wrong often enough to lose the argument: `NODE_ENV`, `TZ`, `SPRING_PROFILES_ACTIVE` are the application's, and none is sensitive. The real hazard is the **direction of the read** — `pass_env` names a variable in the *parent's* environment, so a committed entry pulls whatever each machine happens to have under that name, including a credential a repo must not be able to request by spelling. The refusal now says that. Whether the key should be allowed under `[propose]` stays open in #443.

## The exec-grant warning cried wolf on macOS (#400)

It claimed every guarded command was about to fail with `Permission denied`. True on Linux, where Landlock checks the exec target; false on macOS, where the profile grants `process-exec` generally and the wrappers re-enter regardless. The function runs on macOS anyway — `cplt check` builds its explanation from it — so those users were told their guards had stopped working, and then nothing failed. Now platform-specific, with the macOS branch still naming the real hazard: the binary staying agent-writable.

## `explain` printed a command that can only be refused (#438)

```
sandbox.repo_dirs
  Additional repositories this project spans (local config only: cplt config set --local). …
  Set:  cplt config set sandbox.repo_dirs <value>     ← refused
```

The `Set:` line contradicted the description two lines above it. Rather than special-casing the key, the layer restriction is now one function both readers consult — the `set` refusals and the `explain` line. A test asserts the set of layer-restricted keys is exactly the set `config set` refuses globally, so a new one cannot print advice that cannot work.

```
  Set:  cplt config set --local sandbox.repo_dirs <value>
  Set:  cplt config set --repo deny.env <value>
  Set:  cplt config set proxy.port <value>
```

Closes #400, #403, #438. Refs #443.