### PR TITLE
fix(check): report a tracked file the sandbox will not let git read

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -25,6 +25,39 @@ cplt config set sandbox.allow_env_files true
 
 Or for a single run: `cplt --allow-env-files -- -p "start the dev server"`
 
+### A tracked protected file breaks git
+
+The table above lists reading. There is a second effect that looks like a git
+bug rather than a sandbox decision: if one of these files is **tracked by git**
+and has been modified, git commands that hash the worktree fail outright.
+
+```
+error: open(".env.local"): Operation not permitted
+fatal: cannot hash .env.local
+```
+
+`git diff`, `git add`, `git stash` and `git commit -a` all abort — not skip the
+file, abort — because git hashes worktree files and the read is denied.
+`git status` still works, since it only stats. An **untracked** file affects
+only `git add -A`, and a **gitignored** one affects nothing, because git never
+hashes it.
+
+The fix is to stop tracking it, which is worth doing on its own — a file
+matching these patterns is secret-shaped, and it is in the repository:
+
+```bash
+git rm --cached .env.local
+echo ".env.local" >> .gitignore
+```
+
+`--allow-env-files` also works, but it unblocks every `.env*`, `.pem`, `.key`,
+`.p12`, `.pfx` and `.jks` in the project rather than the one file. A targeted
+`allow.read` on the path does **not** lift the deny; there is no per-file
+exemption.
+
+`cplt check` reports any tracked file matching these patterns, so you can find
+out before an agent session does.
+
 ## Relative paths in `.cplt.toml` now bite (behaviour change)
 
 A relative path in a repo `.cplt.toml`, say `deny.paths = ["target"]` or `propose.allow.read = ["vendor"]`, used to be **silently unenforced**. macOS compiled it into the profile as a rule that matched nothing, and Linux dropped it. It is now resolved against the repository root and enforced for real.
@@ -348,7 +381,7 @@ Some git operations are blocked to prevent persistence attacks that would surviv
 
 | Operation                          | Impact      | Why                                                               |
 | ---------------------------------- | ----------- | ----------------------------------------------------------------- |
-| `git add/commit/status/diff/log`   | ✅ Works     | Local operations, no writes to protected paths                    |
+| `git add/commit/status/diff/log`   | ✅ Works, unless a protected file is tracked | Local operations, no writes to protected paths — but git hashes worktree files, so a **tracked** `.env*`/`.pem`/`.key` that has been modified aborts `add`, `diff`, `stash` and `commit -a`. See [A tracked protected file breaks git](#a-tracked-protected-file-breaks-git) |
 | `git checkout/merge/rebase/branch` | ✅ Works     | Branch operations work normally                                   |
 | `git fetch/pull/push` (HTTPS)      | ✅ Works, except a default-branch push | Port 443 allowed, `gh auth git-credential` provides credentials. The git guard refuses pushes to `main`/`master` and every force push, see [Git workflow](#git-workflow-commit--push) |
 | `git fetch/pull/push` (SSH)        | ❌ Blocked on macOS | SSH agent socket denied, use HTTPS. On Linux only `SSH_AUTH_SOCK` is withheld |

--- a/src/main.rs
+++ b/src/main.rs
@@ -4718,6 +4718,53 @@ fn run_check_command(
     }
 }
 
+/// Files git tracks in `project_dir` that the sandbox denies reading.
+///
+/// Asks git rather than walking the tree: an ignored or untracked `.env` is
+/// harmless here — git never hashes it — so the tracked set is exactly the one
+/// that breaks commands, and it is also exactly the set that represents a
+/// secret committed to the repository.
+///
+/// Silent on any git failure: this is an advisory check, and a repository
+/// without a commit yet, or no git at all, is not something to report as a
+/// finding.
+#[allow(clippy::disallowed_methods)] // `git` is a git::trusted_git() path, resolved immediately above
+fn tracked_sensitive_files(project_dir: &Path) -> Vec<String> {
+    let Some(git) = cplt::git::trusted_git() else {
+        return Vec::new();
+    };
+    let Ok(out) = std::process::Command::new(git)
+        .args(["-C", &project_dir.to_string_lossy(), "ls-files", "-z"])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .split('\0')
+        .filter(|name| !name.is_empty())
+        .filter(|name| is_sensitive_basename(name.rsplit('/').next().unwrap_or(name)))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether a file name matches [`sandbox::SENSITIVE_PROJECT_PATTERNS`].
+///
+/// Hand-matched rather than compiled: those patterns are SBPL regex source for
+/// the macOS profile, and cplt has no regex engine linked. The list is seven
+/// fixed shapes, so a `ends_with` each is the whole implementation — and
+/// `sensitive_basename_matches_the_profile_patterns` fails if the constant
+/// grows, so a new pattern cannot be silently unmatched here.
+fn is_sensitive_basename(base: &str) -> bool {
+    base == ".env"
+        || base.starts_with(".env.")
+        || [".pem", ".key", ".p12", ".pfx", ".jks"]
+            .iter()
+            .any(|ext| base.ends_with(ext))
+}
+
 /// Resolve a user-supplied check path to an absolute path without requiring it
 /// to exist (canonicalize the existing ancestor, then re-append the tail).
 fn canonicalize_check_path(path: &Path) -> PathBuf {
@@ -4749,6 +4796,48 @@ fn build_battery(
     preset_name: Option<String>,
 ) -> check::Report {
     let mut items = Vec::new();
+
+    // A tracked file the sandbox denies breaks git itself, and the failure
+    // names the sandbox rather than the cause: `fatal: cannot hash .env.local`
+    // from `git diff`, `git add`, `git stash` and `git commit -a`, because git
+    // hashes worktree files and the read deny aborts it. Worth checking for
+    // two reasons at once — it is a git-hostile configuration *and* a secret
+    // committed to the repository (#401).
+    for tracked in tracked_sensitive_files(project_dir) {
+        items.push(check::CheckItem {
+            name: "tracked secret-shaped file".to_string(),
+            category: "filesystem".to_string(),
+            target: tracked.clone(),
+            decision: if resolved.allow_env_files {
+                check::Decision::Allowed
+            } else {
+                check::Decision::Blocked
+            },
+            expected: None,
+            reason: if resolved.allow_env_files {
+                format!(
+                    "{tracked} is tracked by git and matches the protected patterns, but \
+                     allow_env_files is on, so git can read it. It is still a secret-shaped \
+                     file committed to the repository."
+                )
+            } else {
+                format!(
+                    "{tracked} is tracked by git and the sandbox denies reading it, so \
+                     `git add`, `git diff`, `git stash` and `git commit -a` fail with \
+                     \"cannot hash\" whenever it is modified. git hashes worktree files, and \
+                     the read deny aborts the whole command rather than skipping the file."
+                )
+            },
+            fix: Some(
+                "Untrack it (`git rm --cached <FILE>`) and add it to .gitignore — an ignored \
+                 file is never hashed, and a secret-shaped file does not belong in the \
+                 repository. `--allow-env-files` also works but unblocks every .env, .pem, \
+                 .key, .p12, .pfx and .jks in the project."
+                    .to_string(),
+            ),
+            note: None,
+        });
+    }
 
     // ── Filesystem ──
     // Sanity: reading & writing the project dir must be ALLOWED.
@@ -6926,6 +7015,44 @@ fn start_denial_stream() -> Option<std::process::Child> {
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)] // test code: no unsandboxed parent to protect (#239)
 mod tests {
+    /// The hand-written matcher must cover every pattern the profile denies.
+    /// It cannot be derived from them — they are SBPL regex source and there is
+    /// no regex engine linked — so this is the thing that stops the two
+    /// drifting when someone adds a pattern (#401).
+    #[test]
+    fn sensitive_basename_matches_the_profile_patterns() {
+        assert_eq!(
+            sandbox::SENSITIVE_PROJECT_PATTERNS.len(),
+            7,
+            "a pattern was added or removed; teach `is_sensitive_basename` about it \
+             and update this count"
+        );
+        for name in [
+            ".env",
+            ".env.local",
+            ".env.production",
+            "server.pem",
+            "id.key",
+            "cert.p12",
+            "cert.pfx",
+            "keystore.jks",
+        ] {
+            assert!(is_sensitive_basename(name), "{name} should be sensitive");
+        }
+        for name in [
+            "env",
+            "environment.md",
+            ".envrc",
+            "README.md",
+            "monkey.jks.bak",
+        ] {
+            assert!(
+                !is_sensitive_basename(name),
+                "{name} should not be treated as sensitive"
+            );
+        }
+    }
+
     use super::*;
     use clap::Parser;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4734,7 +4734,11 @@ fn tracked_sensitive_files(project_dir: &Path) -> Vec<String> {
         return Vec::new();
     };
     let Ok(out) = std::process::Command::new(git)
-        .args(["-C", &project_dir.to_string_lossy(), "ls-files", "-z"])
+        .arg("-C")
+        // The path itself, not a lossy string: a non-UTF-8 byte would be
+        // replaced and point git at a different directory, or none.
+        .arg(project_dir)
+        .args(["ls-files", "-z"])
         .output()
     else {
         return Vec::new();

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -55,12 +55,13 @@ pub use policy::{
     HardeningCategory, HardeningEnvVar, HomeToolDir, LinuxCoverage,
     PLAYWRIGHT_SOCKET_BASE_MAX_BYTES, PLAYWRIGHT_SOCKET_DIR_PREFIX, PLAYWRIGHT_SOCKET_PATH_LIMIT,
     PLAYWRIGHT_SOCKET_ROOT, PLAYWRIGHT_SOCKET_WORST_CASE_SUFFIX, PROTECTED_IN_GITDIR,
-    PROTECTED_IN_ROOT, PathBinDir, Protected, ResolvedToolDir, TOOL_PATH_ENV_VARS, ToolPathEnvVar,
-    ToolPathOverride, ToolRoot, active_tool_dirs, app_dirs, copilot_ro_protect_paths, current_uid,
-    home_tool_dirs, linux_docker_socket_paths, linux_runtime_dirs, mise_ro_protect_paths,
-    nested_alternation, path_bin_dirs, playwright_runtime_intent, relocatable_tool_prefix,
-    socket_mask_paths, tool_override_path_is_safe, tool_path_env_overrides,
-    validate_playwright_socket_dir, validate_sbpl_path, xdg_runtime_dir_env,
+    PROTECTED_IN_ROOT, PathBinDir, Protected, ResolvedToolDir, SENSITIVE_PROJECT_PATTERNS,
+    TOOL_PATH_ENV_VARS, ToolPathEnvVar, ToolPathOverride, ToolRoot, active_tool_dirs, app_dirs,
+    copilot_ro_protect_paths, current_uid, home_tool_dirs, linux_docker_socket_paths,
+    linux_runtime_dirs, mise_ro_protect_paths, nested_alternation, path_bin_dirs,
+    playwright_runtime_intent, relocatable_tool_prefix, socket_mask_paths,
+    tool_override_path_is_safe, tool_path_env_overrides, validate_playwright_socket_dir,
+    validate_sbpl_path, xdg_runtime_dir_env,
 };
 
 // SBPL profile generation — kept public for unit tests.

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -328,7 +328,7 @@ pub fn linux_docker_socket_paths(
 /// These often contain secrets (API keys, database passwords, private keys).
 /// A rogue agent could read and exfiltrate these via HTTPS.
 /// Override with `--allow-env-files` if Copilot genuinely needs them.
-pub(super) const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
+pub const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
     // .env files — the #1 source of leaked secrets in project dirs
     r"\.env$",
     r"\.env\..*",


### PR DESCRIPTION
A tracked `.env*` in the worktree does not degrade git, it stops it. Reproduced before fixing:

```
$ cplt exec -- git diff --stat
error: open(".env.local"): Operation not permitted
fatal: cannot hash .env.local

$ cplt exec -- git add -A
error: unable to index file '.env.local'
fatal: updating files failed
```

`git diff`, `git add`, `git stash` and `git commit -a` all **abort** — not skip the file — because git hashes worktree files and the read is denied. `git status` survives, since it only stats. An untracked file affects only `git add -A`; a gitignored one affects nothing.

Nothing anticipated it: the agent brief says `.env*` is denied but says nothing about git, `cplt check` had no `.env` logic, and `known-impacts.md` said the opposite in a table — *"git add/commit/status/diff/log — ✅ Works"*.

## The check

`cplt check` now reports any tracked file matching the protected patterns:

```
· tracked secret-shaped file → BLOCKED
```

It earns its place twice over: the configuration breaks git, **and** a file of that shape is a secret sitting in the repository. So the remedy leads with untracking rather than with the flag:

```bash
git rm --cached .env.local
echo ".env.local" >> .gitignore
```

That fixes both problems. `--allow-env-files` fixes one and unblocks every `.env*`, `.pem`, `.key`, `.p12`, `.pfx` and `.jks` in the project to do it. A targeted `allow.read` on the path does not lift the deny at all, so there is no narrower grant to suggest.

The check asks git for the tracked set rather than walking the tree — that is exactly the set that breaks commands — and stays silent on any git failure, since an advisory check should not report a finding for a repository with no commits yet.

## The matcher

Hand-written, deliberately. `SENSITIVE_PROJECT_PATTERNS` is SBPL regex source for the macOS profile and cplt links no regex engine, so pulling in `regex` to match seven fixed shapes would be the wrong trade. Seven `ends_with` calls are the whole implementation, with a test that fails if the constant changes size so a new pattern cannot go silently unmatched. `.envrc` is correctly excluded — direnv's config is not a secret, and the profile's `\.env\..*` does not match it either.

Docs corrected: the table row now says what actually happens, and a new section explains the tracked/untracked/ignored distinction and the remedy.

Closes #401.