### PR TITLE
refactor(check): derive the exec context instead of assembling it

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -485,33 +485,77 @@ pub fn explain_domain(
 
 /// The exec-relevant slice of the resolved policy, for [`explain_exec`].
 pub struct ExecContext<'a> {
-    pub allow_docker: bool,
-    pub allow_tmp_exec: bool,
-    pub gh_guard: &'a crate::config::GhGuardPolicy,
-    pub git_guard: &'a crate::config::GitGuardPolicy,
-    pub project_dir: &'a Path,
+    allow_docker: bool,
+    allow_tmp_exec: bool,
+    gh_guard: &'a crate::config::GhGuardPolicy,
+    git_guard: &'a crate::config::GitGuardPolicy,
+    project_dir: &'a Path,
     /// The repository facts the launch bakes in, captured the same way and from
     /// the same trusted git.
-    ///
-    /// Without them `protect_default_branch_only` has no default branch to
-    /// compare against, so `gate_git` fails closed and every push reads as
-    /// blocked — including a feature-branch push the launch allows. That is
-    /// the most common push there is, so the surface built to answer "what
-    /// will happen" was wrong about the ordinary case.
-    pub repo_facts: &'a crate::gh_proxy::RepoFacts,
+    repo_facts: crate::gh_proxy::RepoFacts,
     /// The gh scope set a launch captures: the launch repository plus every
     /// named root whose origin is on GitHub.
-    ///
-    /// Empty means "no named roots" — `explain_exec` then falls back to
-    /// resolving the project directory, which is what a launch with no
-    /// `repo_dirs` does. Without this, `check exec` reported a repository the
-    /// launch allows as outside the startup scope, because it only ever knew
-    /// about the project directory (#447).
-    pub repo_scope: &'a [String],
+    repo_scope: Vec<String>,
     /// Both guards install themselves through a PATH shim in the scratch dir.
     /// Without one there is no shim, so the guards do not run whatever the
     /// config says — which is what the launch summary reports as `inactive`.
-    pub scratch_dir: bool,
+    scratch_dir: bool,
+}
+
+impl<'a> ExecContext<'a> {
+    /// Build the context from the same values a launch resolves from.
+    ///
+    /// The fields above are private and this is the only constructor, which is
+    /// the point. `check exec` answers "what will happen if I run this", and it
+    /// got that wrong five times in two days — reporting a block under
+    /// `mode = "warn"` while the launch ran the command and moved the remote;
+    /// reporting a block with no scratch dir, where no guard runs at all;
+    /// reporting a feature-branch push blocked on the default config; reporting
+    /// a named repository outside the gh scope; and still reporting
+    /// `gh auth token` blocked while the launch serves it from cache (#440).
+    ///
+    /// Every one had the same cause. The context was assembled by hand from
+    /// whatever the author remembered, so each input the launch gained had to
+    /// be added in two places, and the second was missed. Deriving it here from
+    /// `Resolved` plus the two things a launch knows that config does not — the
+    /// project directory and the named roots — means a new input reaches this
+    /// surface or it reaches neither (#447).
+    #[must_use]
+    pub fn for_launch(
+        resolved: &'a crate::config::Resolved,
+        project_dir: &'a Path,
+        named_roots: &[&Path],
+    ) -> Self {
+        let real_git = crate::git::trusted_git();
+        let repo_facts = real_git
+            .map(|git| crate::gh_proxy::capture_repo_facts(git, project_dir))
+            .unwrap_or_default();
+        // `repos_match`, not `contains`: the launch dedups case-insensitively
+        // and ignoring a `.git` suffix, so holding an exact-match set here
+        // would be a scope set the launch never has.
+        let mut repo_scope: Vec<String> = Vec::new();
+        if let Some(git) = real_git {
+            for dir in std::iter::once(project_dir).chain(named_roots.iter().copied()) {
+                if let Ok(repo) = crate::gh_proxy::detect_current_repo(git, dir)
+                    && !repo_scope
+                        .iter()
+                        .any(|member| crate::gh_proxy::repos_match(member, &repo))
+                {
+                    repo_scope.push(repo);
+                }
+            }
+        }
+        Self {
+            allow_docker: resolved.allow_docker,
+            allow_tmp_exec: resolved.allow_tmp_exec,
+            gh_guard: &resolved.gh_guard,
+            git_guard: &resolved.git_guard,
+            project_dir,
+            repo_facts,
+            repo_scope,
+            scratch_dir: resolved.scratch_dir,
+        }
+    }
 }
 
 /// Static explanation of whether a command would run under the resolved policy.
@@ -661,7 +705,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
             // branches a push actually targets; without one no push is ever
             // provably feature-only and the default-branch arm fails closed.
             crate::git::trusted_git(),
-            ctx.repo_facts,
+            &ctx.repo_facts,
         ) {
             Ok(()) => ExecExplain {
                 decision: Decision::Allowed,
@@ -720,7 +764,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
             crate::gh_proxy::gate_with_repo_scope(
                 &rest,
                 &policy,
-                ctx.repo_scope,
+                &ctx.repo_scope,
                 crate::git::trusted_git(),
             )
         };
@@ -1135,28 +1179,22 @@ mod tests {
 
     // ── explain_exec ──
 
-    /// Facts for the unit tests: a scratch dir, and no captured repository.
-    ///
-    /// Empty facts is the honest default here — these tests assert on policy
-    /// shape, not on a checkout — and it is also the case the guard fails
-    /// closed on, so `git push` reads as blocked exactly as it did before
-    /// `ExecContext` grew these fields.
-    static NO_FACTS: std::sync::LazyLock<crate::gh_proxy::RepoFacts> =
-        std::sync::LazyLock::new(crate::gh_proxy::RepoFacts::default);
-
     fn exec_ctx<'a>(
         gh: &'a GhGuardPolicy,
         git: &'a GitGuardPolicy,
         allow_docker: bool,
     ) -> ExecContext<'a> {
+        // The tests construct directly because they assert on policy shape
+        // rather than on a checkout — but they are inside this module, which is
+        // what keeps `for_launch` the only way in from anywhere else.
         ExecContext {
             allow_docker,
             allow_tmp_exec: false,
             gh_guard: gh,
             git_guard: git,
             project_dir: Path::new("/home/u/proj"),
-            repo_facts: &NO_FACTS,
-            repo_scope: &[],
+            repo_facts: crate::gh_proxy::RepoFacts::default(),
+            repo_scope: Vec::new(),
             scratch_dir: true,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4601,11 +4601,10 @@ fn run_check_command(
         active_agent,
         unapproved_proposals: _,
     } = resolve_context(cli, true)?;
-    // The gh scope set the launch would capture: the launch repository plus
-    // every named root with a GitHub origin, built the same way
-    // `sandbox_exec` builds it. `check exec gh …` reported a named repository
-    // as outside the startup scope while the launch allowed it, because this
-    // was discarded (#447).
+    // The named roots, which `ExecContext::for_launch` turns into the gh scope
+    // set. `check exec gh …` reported a named repository as outside the startup
+    // scope while the launch allowed it, because these were discarded here with
+    // `let _ = &repo_roots` (#447).
     let named_roots: Vec<&Path> = repo_roots.iter().map(|r| r.dir.as_path()).collect();
 
     // Shell, not `active_agent`: `check` probes under the Shell profile.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4606,7 +4606,7 @@ fn run_check_command(
     // `sandbox_exec` builds it. `check exec gh …` reported a named repository
     // as outside the startup scope while the launch allowed it, because this
     // was discarded (#447).
-    let repo_scope = check_repo_scope(&project_dir, &repo_roots);
+    let named_roots: Vec<&Path> = repo_roots.iter().map(|r| r.dir.as_path()).collect();
 
     // Shell, not `active_agent`: `check` probes under the Shell profile.
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, agent::Agent::Shell);
@@ -4695,7 +4695,7 @@ fn run_check_command(
         Some(CheckTarget::Exec { cmd }) => build_exec_check(
             &resolved,
             &project_dir,
-            &repo_scope,
+            &named_roots,
             &cmd,
             agent_name,
             preset_name,
@@ -5068,57 +5068,18 @@ fn build_net_check(
     check::Report::new(agent_name, preset_name, false, vec![item])
 }
 
-/// The gh scope set for `cplt check`, built the way a launch builds it.
-///
-/// `owner/name` comes from the trusted git in the unsandboxed parent, and a
-/// root whose origin is not a GitHub URL contributes nothing — it is still in
-/// scope for files, but there is no repository name for `gh` to be scoped to.
-fn check_repo_scope(project_dir: &Path, roots: &[RepoRoot]) -> Vec<String> {
-    let Some(real_git) = cplt::git::trusted_git() else {
-        return Vec::new();
-    };
-    let mut scope: Vec<String> = Vec::new();
-    for dir in std::iter::once(project_dir).chain(roots.iter().map(|r| r.dir.as_path())) {
-        // `repos_match`, not `contains`: the launch dedups case-insensitively
-        // and ignoring a `.git` suffix, so `navikt/Foo` and `navikt/foo` are
-        // one member there. Exact equality here would let this surface hold a
-        // scope set the launch never has — the very class of bug the rest of
-        // this change closes.
-        if let Ok(repo) = gh_proxy::detect_current_repo(real_git, dir)
-            && !scope
-                .iter()
-                .any(|member| gh_proxy::repos_match(member, &repo))
-        {
-            scope.push(repo);
-        }
-    }
-    scope
-}
-
 fn build_exec_check(
     resolved: &config::Resolved,
     project_dir: &Path,
-    repo_scope: &[String],
+    named_roots: &[&Path],
     cmd: &[String],
     agent_name: String,
     preset_name: Option<String>,
 ) -> check::Report {
-    // The same capture the launch does, from the same trusted git (see
-    // `sandbox_exec.rs`, "baked at launch"): without it every push reads as
-    // blocked, feature branches included.
-    let repo_facts = crate::git::trusted_git()
-        .map(|git| gh_proxy::capture_repo_facts(git, project_dir))
-        .unwrap_or_default();
-    let ctx = check::ExecContext {
-        allow_docker: resolved.allow_docker,
-        allow_tmp_exec: resolved.allow_tmp_exec,
-        gh_guard: &resolved.gh_guard,
-        git_guard: &resolved.git_guard,
-        project_dir,
-        repo_facts: &repo_facts,
-        repo_scope,
-        scratch_dir: resolved.scratch_dir,
-    };
+    // One constructor, deriving everything from the same values the launch
+    // resolves from. See `ExecContext::for_launch` for why this is not
+    // assembled field by field any more (#447).
+    let ctx = check::ExecContext::for_launch(resolved, project_dir, named_roots);
     let expl = check::explain_exec(cmd, &ctx);
     let item = check::CheckItem {
         name: "exec".to_string(),


### PR DESCRIPTION
`check exec` answers "what will happen if I run this", and it got that wrong five times in two days:

- a block reported under `mode = "warn"` while the launch ran the command and moved the remote (#439)
- a block reported with no scratch dir, where no guard runs at all (#439)
- a feature-branch push reported blocked on the default config (#439)
- a named repository reported outside the gh scope (#447)
- `gh auth token` reported blocked while the launch serves it from cache (#440, still open)

Every one had the same cause rather than five causes. `ExecContext` was assembled field by field at the call site from whatever the author remembered, so each input the launch gained had to be added in two places, and the second was missed. Fixing the instances one at a time is what guarantees a sixth.

The fields are now private and `ExecContext::for_launch` is the only constructor. It takes `Resolved` plus the two things a launch knows that config does not — the project directory and the named roots — and derives the rest, including the repository facts and the gh scope set the caller used to build. A new input reaches this surface or it reaches neither.

No behaviour change: the same values from the same sources, and the golden tests pinning each fixed defect still pass. The unit tests construct the struct directly because they assert on policy shape rather than on a checkout, and they sit inside the module — which is what keeps `for_launch` the only way in from anywhere else.

Refs #447. #427 should keep this property rather than rebuild the hand-assembly.