### PR TITLE
feat(doctor): report which sandbox mechanism is actually enforcing

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1016,6 +1016,30 @@ fn print_sandbox_mechanism_status() -> bool {
             ui::stdout_color(ui::GREEN),
             ui::stdout_color(ui::RESET)
         );
+        // Whether bubblewrap is available decides what is actually enforced on
+        // this host, and nothing reported it. Several protections exist ONLY
+        // under bwrap — `.git/hooks`, the agent host-persistence files, mise's
+        // shims, Copilot's package dirs — because Landlock cannot subtract a
+        // deny from inside an allowed tree. Without this line an operator
+        // cannot tell which regime they are in, and neither can a bug report:
+        // #449 was diagnosed from a Node errno because this fact was missing.
+        if crate::sandbox::bwrap_available() {
+            println!(
+                "  {}✓{} Bubblewrap: available — mount-level protections active",
+                ui::stdout_color(ui::GREEN),
+                ui::stdout_color(ui::RESET)
+            );
+        } else {
+            println!(
+                "  {}⚠{} Bubblewrap: not found (looked on PATH)",
+                ui::stdout_color(ui::YELLOW),
+                ui::stdout_color(ui::RESET)
+            );
+            println!("      Landlock-only. It cannot deny a path inside a tree it has granted,");
+            println!("      so these are NOT enforced: .git/hooks, the agent config files that");
+            println!("      auto-execute on the host, mise shims, and package dirs. Install");
+            println!("      bubblewrap (apt install bubblewrap) to close them.");
+        }
         ok
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5176,7 +5176,56 @@ fn run_doctor() -> ExitCode {
     println!();
 
     let discovery = discover::discover_all(&home_dir, &project_dir);
+
     let ok = discovery.print_report();
+
+    // The agent's own grants. A report of "the agent cannot write X" is
+    // unanswerable without them, and #449 was exactly that: `~/.pi/agent` is
+    // granted read-only with write carved back per subdirectory, which explains
+    // the failure in one line and was visible nowhere.
+    //
+    // The agent a launch here would pick, so the grants shown are the ones that
+    // would apply — falling back the way the launch path does when nothing is
+    // installed.
+    let agent = agent::Agent::auto_detect().unwrap_or(agent::Agent::Copilot);
+    let dirs = agent.config_dirs(&home_dir);
+    if !dirs.is_empty() {
+        println!();
+        println!(
+            "{}{}[doctor]{} {}Agent grants{} ({})",
+            ui::stdout_color(ui::BOLD),
+            ui::stdout_color(ui::BLUE),
+            ui::stdout_color(ui::RESET),
+            ui::stdout_color(ui::BOLD),
+            ui::stdout_color(ui::RESET),
+            agent.display_name()
+        );
+        for dir in &dirs {
+            let access = if dir.write { "read/write" } else { "read-only" };
+            let exec = if dir.process_exec { ", execute" } else { "" };
+            println!(
+                "  {}{}{} {access}{exec}  {}",
+                ui::stdout_color(if dir.path.exists() {
+                    ui::GREEN
+                } else {
+                    ui::DIM
+                }),
+                if dir.path.exists() { "✓" } else { "·" },
+                ui::stdout_color(ui::RESET),
+                dir.path.display()
+            );
+        }
+        // Linux-only caveat: on macOS the profile denies by path and does not
+        // care whether it exists, so a missing path is not a missing rule.
+        if cfg!(target_os = "linux") {
+            println!(
+                "  {}·{} a path that does not exist is not bound by bubblewrap, so a \
+                 read-only re-bind over it is skipped",
+                ui::stdout_color(ui::DIM),
+                ui::stdout_color(ui::RESET)
+            );
+        }
+    }
 
     // Show project ecosystem detection summary
     let report = cplt::detect::detect_project_recursive(&project_dir);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -718,6 +718,25 @@ fn pin_paths(config: &SandboxConfig, extra_git_dirs: &[PathBuf]) -> Vec<PathBuf>
     pins
 }
 
+/// Whether the bubblewrap read-only overlay is available on this host.
+///
+/// Availability, not configuration: `use_bubblewrap` says what the operator
+/// asked for, and auto-detect falls back to Landlock-only when bwrap is not
+/// installed. The difference decides what is actually enforced, because several
+/// protections exist only under the mount overlay — Landlock cannot deny a path
+/// inside a tree it has granted.
+#[must_use]
+pub fn bwrap_available() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        bubblewrap::check_availability().is_some()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn ro_protect_paths(config: &SandboxConfig, extra_git_dirs: &[PathBuf]) -> Vec<PathBuf> {
     // Finding 1: Landlock cannot deny subpaths inside the writable project tree,


### PR DESCRIPTION
#449 could not be diagnosed from anything cplt prints, and that is the actual finding.

The reporter said bubblewrap was "enabled" — meaning configured. Whether it was **active** decides what is enforced, and nothing reports that. I had to infer the regime from a Node errno in their traceback (`EACCES` is Landlock's denial; a read-only bind mount would have given `EROFS`), concluded bubblewrap probably was not running, and only then realised the fix I had proposed might not help the person who reported the bug.

On Linux the protections are split across two mechanisms, and several exist **only** under the mount overlay, because Landlock cannot deny a path inside a tree it has granted:

- `.git/hooks` and the rest of the git-persistence set
- the agent config files that auto-execute on the host next time it runs outside cplt
- mise's `shims/` and `installs/`
- Copilot's package dirs
- Pi's managed `fd`/`rg`

`doctor` reported the Landlock ABI and mentioned bubblewrap only inside a conditional caveat about escape sockets. So an operator on a host without it — WSL2 restricting user namespaces, a container, a minimal image — was told nothing about the protections they do not have.

It now says whether bubblewrap was found, and when it was not, names what is consequently unenforced and how to close it. **Availability, not configuration**: auto-detect falls back silently, and the fallback is precisely the case worth reporting.

## Agent grants

Second gap from the same report: nothing printed the agent's own grants.

```
[doctor] Agent grants (Copilot)
  ✓ read/write, execute  /Users/hans/.copilot
```

"The agent cannot write X" is unanswerable without them. For Pi the answer is one line — `~/.pi/agent` read-only with write carved back per subdirectory — and it was visible nowhere. Each entry shows access and whether it exists, because on Linux a path that does not exist gets no read-only re-bind, which turns a protection into a no-op silently.

Reporting only, no behaviour change. This is the prerequisite for asking the reporter anything useful, and for the next report of this shape being answerable from one command.