### PR TITLE
feat(doctor): findings first, computed from the launch's own resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ cplt auto-discovers installed tools and writes sandbox rules to match. Generally
 | Corepack | none | `COREPACK_*` | none |
 | mise | `.local/share/mise`, `.mise` | `MISE_*` | `mise` |
 
-Run `cplt doctor` to see what cplt detected on your machine.
+Run `cplt doctor` to see whether cplt will work here for your agent, and `cplt doctor --verbose` for everything it detected on your machine.
 
 ### Debugging
 
@@ -777,7 +777,7 @@ Full details, including the trust model, path expansion rules, and the complete 
 └──────────────────────────────────┘
 ```
 
-The security model is a deny-by-default filesystem with kernel enforcement. On macOS, and on Linux with kernel 6.7+ (Landlock ABI v4), the network is restricted to port 443 by default, with `--allow-port` for extras. On older Linux kernels the CONNECT proxy provides that restriction instead, which is why it is enabled by default. SSH agent access and localhost outbound are blocked in the kernel on macOS. On Linux neither is: port-based Landlock rules cannot tell localhost from a remote host, and unix socket `connect()` is not gated by Landlock below kernel 7.1, so apart from the sockets bubblewrap masks the withheld `SSH_AUTH_SOCK` is the only thing standing between the agent and your loaded keys. The profile generator discovers your environment (`cplt doctor` shows the same probe results) and emits rules only for tool directories that actually exist on disk. Fewer rules, tighter sandbox.
+The security model is a deny-by-default filesystem with kernel enforcement. On macOS, and on Linux with kernel 6.7+ (Landlock ABI v4), the network is restricted to port 443 by default, with `--allow-port` for extras. On older Linux kernels the CONNECT proxy provides that restriction instead, which is why it is enabled by default. SSH agent access and localhost outbound are blocked in the kernel on macOS. On Linux neither is: port-based Landlock rules cannot tell localhost from a remote host, and unix socket `connect()` is not gated by Landlock below kernel 7.1, so apart from the sockets bubblewrap masks the withheld `SSH_AUTH_SOCK` is the only thing standing between the agent and your loaded keys. The profile generator discovers your environment (`cplt doctor --verbose` shows the same probe results) and emits rules only for tool directories that actually exist on disk. Fewer rules, tighter sandbox.
 
 - **macOS**: a Seatbelt/SBPL profile is generated and handed to `sandbox-exec`
 - **Linux**: Landlock LSM rules plus a seccomp-BPF filter, applied via `pre_exec` (kernel 5.13+, TCP port filtering on 6.7+)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,9 @@ src/
   sandbox_exec.rs      Process execution, signal forwarding.
   sandbox_landlock.rs  Landlock LSM + seccomp-BPF (Linux).
   sandbox_bubblewrap.rs Optional Bubblewrap namespace layer + in-namespace re-entry helper (Linux).
-  discover.rs          Runtime probing (`cplt doctor`), tool/auth discovery.
+  discover.rs          Runtime probing (`cplt doctor --verbose` inventory), tool/auth discovery.
+  doctor.rs            `cplt doctor` finding rules (Pi trust lock, tracked .env, shims,
+                       bubblewrap state) and rendering; main.rs feeds it the launch's resolution.
   detect.rs            Project and machine ecosystem detectors behind `cplt init`.
   proxy.rs             CONNECT proxy, domain blocking, audit log.
   gh_proxy.rs          gh and git command guards: policy tables, gates, wrapper scripts.

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -241,6 +241,9 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// exactly the hang this function exists to remove. A detached reader blocked
 /// on a pipe costs one thread in a process that exits moments later.
 #[allow(clippy::disallowed_methods)] // runs an already-resolved discovered path; trusting it is #248, not resolution
+/// `pub`, not `pub(crate)`: the binary is a separate crate from the library,
+/// so a crate-private item here is unreachable from `main.rs`, which uses this
+/// to print agent versions.
 pub fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
     let Ok(mut child) = std::process::Command::new(path)
         .args(args)

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -241,7 +241,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// exactly the hang this function exists to remove. A detached reader blocked
 /// on a pipe costs one thread in a process that exits moments later.
 #[allow(clippy::disallowed_methods)] // runs an already-resolved discovered path; trusting it is #248, not resolution
-fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
+pub fn probe_version(path: &Path, args: &[&str]) -> VersionProbe {
     let Ok(mut child) = std::process::Command::new(path)
         .args(args)
         .stdin(Stdio::null())
@@ -322,7 +322,7 @@ pub fn discover_agents() -> Vec<AgentInfo> {
 
 // ── Tool discovery ──────────────────────────────────────────────
 
-const TOOLS_TO_CHECK: &[&str] = &[
+pub const TOOLS_TO_CHECK: &[&str] = &[
     "gh", "git", "node", "npm", "cargo", "python3", "java", "go", "gradle", "yarn",
 ];
 
@@ -335,7 +335,7 @@ const TOOLS_TO_CHECK: &[&str] = &[
 /// rest — build tools, language runtimes, the `app_dirs()` applications — are
 /// only warned about: running one starts a Windows process outside the sandbox,
 /// which is worth saying but is not a broken install.
-const WSL_CRITICAL_TOOLS: &[&str] = &["gh", "git", "node", "npm"];
+pub const WSL_CRITICAL_TOOLS: &[&str] = &["gh", "git", "node", "npm"];
 
 use crate::sandbox::app_dirs;
 use crate::sandbox::home_tool_dirs;
@@ -508,7 +508,8 @@ fn tool_lines(tools: &[ToolInfo], wsl: bool) -> (Vec<String>, bool) {
 }
 
 impl Discovery {
-    /// Print a human-readable diagnostic report. Returns true if all critical checks pass.
+    /// Print the full inventory (`cplt doctor --verbose`). Returns true if
+    /// nothing it prints is a hard failure; the verdict itself is doctor's.
     pub fn print_report(&self) -> bool {
         let mut critical_ok = true;
 
@@ -825,21 +826,6 @@ impl Discovery {
             critical_ok = false;
         }
         println!();
-
-        // Summary
-        if critical_ok {
-            println!(
-                "{}[doctor]{} All critical checks passed ✓",
-                ui::stdout_color(ui::GREEN),
-                ui::stdout_color(ui::RESET)
-            );
-        } else {
-            println!(
-                "{}[doctor]{} Critical issues found, the sandbox may not work correctly",
-                ui::stdout_color(ui::RED),
-                ui::stdout_color(ui::RESET)
-            );
-        }
 
         critical_ok
     }
@@ -1492,6 +1478,12 @@ fn find_app_contents(path: &Path) -> Option<PathBuf> {
 /// only ever *reported* or turned into a sandbox grant, never executed — except
 /// by `discover_agents`/`discover_copilot`, which run version probes for
 /// `cplt doctor` only.
+/// The PATH entry for `name` as found — a shim stays a shim. Canonicalize it
+/// yourself when you want the target.
+pub fn which_on_path(name: &str) -> Option<PathBuf> {
+    crate::sandbox::which_binary(name)
+}
+
 fn which_resolved(name: &str) -> Option<PathBuf> {
     let path = crate::sandbox::which_binary(name)?;
     Some(std::fs::canonicalize(&path).unwrap_or(path))

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -62,6 +62,21 @@ pub fn tilde(path: &Path, home: &Path) -> String {
     }
 }
 
+/// The same, for free-form text that may quote a path.
+///
+/// `tilde` needs a `Path`; an error string built elsewhere — `cplt refuses to
+/// sandbox '/Users/hans'`, a WSL tool at `/mnt/c/Users/<name>/…` — carries the
+/// username in the middle of a sentence. The default view is meant to be
+/// pasted into a public issue, so the substitution has to reach those too.
+#[must_use]
+pub fn tilde_in_text(text: &str, home: &Path) -> String {
+    let home = home.to_string_lossy();
+    if home.is_empty() || home == "/" {
+        return text.to_string();
+    }
+    text.replace(home.as_ref(), "~")
+}
+
 // ── Rule: tracked secrets vs. the .env deny ────────────────────
 
 /// A tracked secret under the `.env` deny breaks every git command that hashes
@@ -81,7 +96,11 @@ pub fn tracked_env_finding(files: &[String], allow_env_files: bool) -> Option<Fi
             if files.len() == 1 { "is" } else { "are" }
         ),
         Some(format!(
-            "git rm --cached {first} && echo {first} >> .gitignore  (or sandbox.allow_env_files = true)"
+            // `--` and quoting: a tracked path can contain spaces, and one
+            // beginning with a dash would be read as a flag. The fix line is
+            // meant to be pasted.
+            "git rm --cached -- '{first}' && echo '{first}' >> .gitignore  \
+             (or sandbox.allow_env_files = true)"
         )),
     ))
 }
@@ -354,7 +373,7 @@ mod tests {
             f.fix
                 .as_deref()
                 .unwrap()
-                .contains("git rm --cached config/.env.local")
+                .contains("git rm --cached -- 'config/.env.local'")
         );
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -64,38 +64,9 @@ pub fn tilde(path: &Path, home: &Path) -> String {
 
 // ── Rule: tracked secrets vs. the .env deny ────────────────────
 
-/// Whether a file *name* is one the `.env` deny covers.
-///
-/// Mirrors `sandbox_policy::SENSITIVE_PROJECT_PATTERNS` (`\.env$`, `\.env\..*`,
-/// and the `.pem/.key/.p12/.pfx/.jks` suffixes) without a regex engine: the
-/// list is seven fixed shapes and a test pins them together.
-#[must_use]
-pub fn is_sensitive_name(name: &str) -> bool {
-    name == ".env"
-        || name.ends_with(".env")
-        || name.contains(".env.")
-        || [".pem", ".key", ".p12", ".pfx", ".jks"]
-            .iter()
-            .any(|suffix| name.ends_with(suffix))
-}
-
-/// The tracked paths the `.env` deny applies to.
-#[must_use]
-pub fn tracked_sensitive_files<'a>(tracked: impl IntoIterator<Item = &'a str>) -> Vec<String> {
-    tracked
-        .into_iter()
-        .filter(|p| {
-            Path::new(p)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(is_sensitive_name)
-        })
-        .map(str::to_string)
-        .collect()
-}
-
 /// A tracked secret under the `.env` deny breaks every git command that hashes
-/// the index (`add`, `diff`, `stash`, `commit -a`) with `cannot hash`.
+/// the index (`add`, `diff`, `stash`, `commit -a`) with `cannot hash`. The
+/// file list comes from `cplt check`'s `tracked_sensitive_files` (#451).
 #[must_use]
 pub fn tracked_env_finding(files: &[String], allow_env_files: bool) -> Option<Finding> {
     if allow_env_files || files.is_empty() {
@@ -117,20 +88,6 @@ pub fn tracked_env_finding(files: &[String], allow_env_files: bool) -> Option<Fi
 
 // ── Rule: Pi's trust lock vs. the read-only agent root ─────────
 
-/// Newest Pi release that does not take the trust lock. Pi `main` after
-/// f53ac11 (2026-09-08) does `mkdir ~/.pi/agent/trust.json.lock` before a
-/// session exists (#449).
-const PI_LAST_LOCKLESS: &str = "0.85.1";
-
-fn version_tuple(v: &str) -> Option<Vec<u64>> {
-    v.trim_start_matches('v')
-        .split(['-', '+'])
-        .next()?
-        .split('.')
-        .map(|part| part.parse().ok())
-        .collect()
-}
-
 /// Whether the resolved policy grants `dir` itself read-only.
 fn dir_is_read_only(policy: &LandlockPolicy, dir: &Path) -> bool {
     policy
@@ -140,49 +97,21 @@ fn dir_is_read_only(policy: &LandlockPolicy, dir: &Path) -> bool {
         .is_some_and(|r| !r.access.write)
 }
 
-/// Pi creates a lock *directory* in `~/.pi/agent` to read `trust.json`, and
-/// that root is granted read-only in every regime — Landlock rule and, when
-/// bubblewrap is active, the mount too — so no bubblewrap state changes the
-/// answer. Blocking when the installed Pi is known to take the lock, a warning
-/// when its version could not be read.
+/// Pi creates a lock *directory* in `~/.pi/agent` to read `trust.json`
+/// (`withTrustFileLock` in `dist/core/trust-manager.js`, present in the
+/// released 0.85.1), and that root is granted read-only in every regime —
+/// Landlock rule and, when bubblewrap is active, the mount too. So no Pi
+/// version and no bubblewrap state changes the answer (#449).
 #[must_use]
-pub fn pi_lock_finding(
-    agent: Agent,
-    policy: &LandlockPolicy,
-    home: &Path,
-    pi_version: Option<&str>,
-) -> Option<Finding> {
-    if agent != Agent::Pi {
+pub fn pi_lock_finding(agent: Agent, policy: &LandlockPolicy, home: &Path) -> Option<Finding> {
+    if agent != Agent::Pi || !dir_is_read_only(policy, &home.join(".pi/agent")) {
         return None;
     }
-    let root = home.join(".pi/agent");
-    if !dir_is_read_only(policy, &root) {
-        return None;
-    }
-    let takes_lock = pi_version
-        .and_then(version_tuple)
-        .map(|v| v > version_tuple(PI_LAST_LOCKLESS).unwrap_or_default());
-    let fix = "run pi outside cplt until a cplt release grants the lock, or pin Pi to \
-               0.85.1 (npm i -g @earendil-works/pi-coding-agent@0.85.1)";
-    match takes_lock {
-        Some(false) => None,
-        Some(true) => Some(Finding::blocking(
-            format!(
-                "Pi will not start: ~/.pi/agent is read-only in this run, and Pi {} takes a \
-                 write lock there (trust.json.lock) before a session exists.",
-                pi_version.unwrap_or_default()
-            ),
-            fix,
-        )),
-        None => Some(Finding::warning(
-            format!(
-                "~/.pi/agent is read-only in this run; Pi newer than {PI_LAST_LOCKLESS} takes a \
-                 write lock there (trust.json.lock) and will not start. Could not read the \
-                 installed Pi's version."
-            ),
-            Some(fix.to_string()),
-        )),
-    }
+    Some(Finding::blocking(
+        "Pi will not start: ~/.pi/agent is read-only in this run, and Pi takes a write lock \
+         there (trust.json.lock) before a session exists.",
+        "run pi outside cplt for now; a cplt fix that grants the lock is in progress (#449)",
+    ))
 }
 
 // ── Rule: shims resolving outside a granted root ───────────────
@@ -408,34 +337,8 @@ mod tests {
     }
 
     #[test]
-    fn sensitive_names_track_the_policy_patterns() {
-        for hit in [
-            ".env",
-            ".env.local",
-            "prod.env",
-            "id.pem",
-            "server.key",
-            "k.p12",
-            "k.pfx",
-            "k.jks",
-        ] {
-            assert!(is_sensitive_name(hit), "{hit} should match");
-        }
-        for miss in [
-            ".envrc",
-            "env.ts",
-            "keychain.rs",
-            "README.md",
-            ".environment",
-        ] {
-            assert!(!is_sensitive_name(miss), "{miss} should not match");
-        }
-    }
-
-    #[test]
     fn tracked_env_finding_needs_a_tracked_file_and_the_deny() {
-        let files = tracked_sensitive_files(["src/main.rs", "config/.env.local", ".gitignore"]);
-        assert_eq!(files, vec!["config/.env.local".to_string()]);
+        let files = vec!["config/.env.local".to_string()];
         assert!(
             tracked_env_finding(&files, true).is_none(),
             "deny off: nothing to say"
@@ -456,30 +359,17 @@ mod tests {
     }
 
     #[test]
-    fn pi_lock_rule_is_version_gated_and_pi_only() {
+    fn pi_lock_rule_fires_for_any_pi_on_a_read_only_root() {
         let home = Path::new("/home/u");
         let ro_root = policy(vec![("/home/u/.pi/agent", false, false)]);
-        assert!(pi_lock_finding(Agent::Copilot, &ro_root, home, Some("1.0.0")).is_none());
-        assert!(
-            pi_lock_finding(Agent::Pi, &ro_root, home, Some("0.85.1")).is_none(),
-            "0.85.1 predates the lock"
-        );
-        let blocking = pi_lock_finding(Agent::Pi, &ro_root, home, Some("0.86.0")).unwrap();
+        assert!(pi_lock_finding(Agent::Copilot, &ro_root, home).is_none());
+        let blocking = pi_lock_finding(Agent::Pi, &ro_root, home).unwrap();
         assert_eq!(blocking.level, Level::Blocking);
         assert!(blocking.message.contains("trust.json.lock"));
-        let unknown = pi_lock_finding(Agent::Pi, &ro_root, home, None).unwrap();
-        assert_eq!(unknown.level, Level::Warning);
+        assert!(!blocking.fix.as_deref().unwrap().contains("0.85.1"));
         // A policy that grants the root writable has nothing to warn about.
         let rw_root = policy(vec![("/home/u/.pi/agent", true, false)]);
-        assert!(pi_lock_finding(Agent::Pi, &rw_root, home, Some("0.86.0")).is_none());
-    }
-
-    #[test]
-    fn version_tuple_ignores_prerelease_suffixes() {
-        assert_eq!(version_tuple("v0.86.0-beta.1"), Some(vec![0, 86, 0]));
-        assert!(version_tuple("0.86.0").unwrap() > version_tuple("0.85.1").unwrap());
-        assert!(version_tuple("0.85.10").unwrap() > version_tuple("0.85.1").unwrap());
-        assert_eq!(version_tuple("nope"), None);
+        assert!(pi_lock_finding(Agent::Pi, &rw_root, home).is_none());
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,535 @@
+//! `cplt doctor`: findings, not inventory.
+//!
+//! The question doctor answers is "will cplt work on this host for this
+//! agent, and if the agent just failed, which enforcement decision caused
+//! it?" — offline, without building a sandbox, so it still answers when a
+//! launch cannot. The output is written to be pasted into a public issue:
+//! paths are `~/…`, token *names* only, and the software inventory stays
+//! behind `--verbose`.
+//!
+//! The rules here are pure functions over what the launch already resolved
+//! (`Resolved`, the generated `LandlockPolicy`, the agent), so they cannot
+//! answer from fewer inputs than the launch uses (#447). `main.rs` gathers
+//! those inputs and prints; this module decides.
+
+use crate::agent::Agent;
+use crate::sandbox::LandlockPolicy;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Level {
+    /// The agent will not start, or cplt will not launch.
+    Blocking,
+    /// Something will fail mid-session, or a protection is silently off.
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub level: Level,
+    pub message: String,
+    pub fix: Option<String>,
+}
+
+impl Finding {
+    #[must_use]
+    pub fn blocking(message: impl Into<String>, fix: impl Into<String>) -> Self {
+        Self {
+            level: Level::Blocking,
+            message: message.into(),
+            fix: Some(fix.into()),
+        }
+    }
+
+    #[must_use]
+    pub fn warning(message: impl Into<String>, fix: Option<String>) -> Self {
+        Self {
+            level: Level::Warning,
+            message: message.into(),
+            fix,
+        }
+    }
+}
+
+/// `~/…` for anything under `home`, so a pasted report does not carry the
+/// username.
+#[must_use]
+pub fn tilde(path: &Path, home: &Path) -> String {
+    match path.strip_prefix(home) {
+        Ok(rest) if rest.as_os_str().is_empty() => "~".to_string(),
+        Ok(rest) => format!("~/{}", rest.display()),
+        Err(_) => path.display().to_string(),
+    }
+}
+
+// ── Rule: tracked secrets vs. the .env deny ────────────────────
+
+/// Whether a file *name* is one the `.env` deny covers.
+///
+/// Mirrors `sandbox_policy::SENSITIVE_PROJECT_PATTERNS` (`\.env$`, `\.env\..*`,
+/// and the `.pem/.key/.p12/.pfx/.jks` suffixes) without a regex engine: the
+/// list is seven fixed shapes and a test pins them together.
+#[must_use]
+pub fn is_sensitive_name(name: &str) -> bool {
+    name == ".env"
+        || name.ends_with(".env")
+        || name.contains(".env.")
+        || [".pem", ".key", ".p12", ".pfx", ".jks"]
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
+}
+
+/// The tracked paths the `.env` deny applies to.
+#[must_use]
+pub fn tracked_sensitive_files<'a>(tracked: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    tracked
+        .into_iter()
+        .filter(|p| {
+            Path::new(p)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(is_sensitive_name)
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+/// A tracked secret under the `.env` deny breaks every git command that hashes
+/// the index (`add`, `diff`, `stash`, `commit -a`) with `cannot hash`.
+#[must_use]
+pub fn tracked_env_finding(files: &[String], allow_env_files: bool) -> Option<Finding> {
+    if allow_env_files || files.is_empty() {
+        return None;
+    }
+    let list = files.join(", ");
+    let first = &files[0];
+    Some(Finding::warning(
+        format!(
+            "{list} {} tracked in git and allow_env_files is off: git add/diff/stash/commit -a \
+             will fail with `cannot hash`.",
+            if files.len() == 1 { "is" } else { "are" }
+        ),
+        Some(format!(
+            "git rm --cached {first} && echo {first} >> .gitignore  (or sandbox.allow_env_files = true)"
+        )),
+    ))
+}
+
+// ── Rule: Pi's trust lock vs. the read-only agent root ─────────
+
+/// Newest Pi release that does not take the trust lock. Pi `main` after
+/// f53ac11 (2026-09-08) does `mkdir ~/.pi/agent/trust.json.lock` before a
+/// session exists (#449).
+const PI_LAST_LOCKLESS: &str = "0.85.1";
+
+fn version_tuple(v: &str) -> Option<Vec<u64>> {
+    v.trim_start_matches('v')
+        .split(['-', '+'])
+        .next()?
+        .split('.')
+        .map(|part| part.parse().ok())
+        .collect()
+}
+
+/// Whether the resolved policy grants `dir` itself read-only.
+fn dir_is_read_only(policy: &LandlockPolicy, dir: &Path) -> bool {
+    policy
+        .fs_rules
+        .iter()
+        .find(|r| r.path == dir)
+        .is_some_and(|r| !r.access.write)
+}
+
+/// Pi creates a lock *directory* in `~/.pi/agent` to read `trust.json`, and
+/// that root is granted read-only in every regime — Landlock rule and, when
+/// bubblewrap is active, the mount too — so no bubblewrap state changes the
+/// answer. Blocking when the installed Pi is known to take the lock, a warning
+/// when its version could not be read.
+#[must_use]
+pub fn pi_lock_finding(
+    agent: Agent,
+    policy: &LandlockPolicy,
+    home: &Path,
+    pi_version: Option<&str>,
+) -> Option<Finding> {
+    if agent != Agent::Pi {
+        return None;
+    }
+    let root = home.join(".pi/agent");
+    if !dir_is_read_only(policy, &root) {
+        return None;
+    }
+    let takes_lock = pi_version
+        .and_then(version_tuple)
+        .map(|v| v > version_tuple(PI_LAST_LOCKLESS).unwrap_or_default());
+    let fix = "run pi outside cplt until a cplt release grants the lock, or pin Pi to \
+               0.85.1 (npm i -g @earendil-works/pi-coding-agent@0.85.1)";
+    match takes_lock {
+        Some(false) => None,
+        Some(true) => Some(Finding::blocking(
+            format!(
+                "Pi will not start: ~/.pi/agent is read-only in this run, and Pi {} takes a \
+                 write lock there (trust.json.lock) before a session exists.",
+                pi_version.unwrap_or_default()
+            ),
+            fix,
+        )),
+        None => Some(Finding::warning(
+            format!(
+                "~/.pi/agent is read-only in this run; Pi newer than {PI_LAST_LOCKLESS} takes a \
+                 write lock there (trust.json.lock) and will not start. Could not read the \
+                 installed Pi's version."
+            ),
+            Some(fix.to_string()),
+        )),
+    }
+}
+
+// ── Rule: shims resolving outside a granted root ───────────────
+
+/// A `(name, path-as-found-on-PATH)` pair; the path must be the PATH entry,
+/// not its canonical target, or there is no shim left to inspect.
+pub type ToolOnPath<'a> = (&'a str, &'a Path);
+
+/// One warning per tool whose symlink target the policy does not grant
+/// execute on. Same predicate the launch warns with (#390).
+#[must_use]
+pub fn shim_findings(
+    policy: &LandlockPolicy,
+    tools: &[ToolOnPath<'_>],
+    home: &Path,
+) -> Vec<Finding> {
+    tools
+        .iter()
+        .filter_map(|(name, path)| {
+            let target = crate::check::shim_target_without_exec(policy, path)?;
+            let dir = target.parent().unwrap_or(&target).to_path_buf();
+            Some(Finding::warning(
+                format!(
+                    "{name} is a shim resolving to {}, which this run does not grant execute on: \
+                     running it fails with exit 126 and no message.",
+                    tilde(&target, home)
+                ),
+                Some(format!(
+                    "--allow-exec {} (or [sandbox] allow.exec)",
+                    tilde(&dir, home)
+                )),
+            ))
+        })
+        .collect()
+}
+
+// ── Bubblewrap: three states, not a PATH lookup ────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Bubblewrap {
+    /// Present and able to create the namespaces the launch needs.
+    Usable(PathBuf),
+    /// On disk, but the probe the launch runs fails (no user namespaces, a
+    /// hardened kernel, some WSL configs). Auto-detect falls back silently.
+    Unusable { path: PathBuf, reason: String },
+    /// Not in any trusted directory.
+    NotInstalled,
+    /// `use_bubblewrap = false` / `--no-bubblewrap`.
+    Disabled,
+    /// Not a Linux host.
+    NotApplicable,
+}
+
+impl Bubblewrap {
+    #[must_use]
+    pub fn active(&self) -> bool {
+        matches!(self, Self::Usable(_))
+    }
+
+    /// The `bubblewrap:` fragment of the enforcement line.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Usable(_) => "bubblewrap: active".to_string(),
+            Self::Unusable { reason, .. } => format!("bubblewrap: installed, {reason}"),
+            Self::NotInstalled => "bubblewrap: not installed".to_string(),
+            Self::Disabled => "bubblewrap: disabled by config".to_string(),
+            Self::NotApplicable => String::new(),
+        }
+    }
+}
+
+/// What the launch's own `bubblewrap::resolve` would conclude, minus the
+/// wrapper: the same trusted-directory lookup and the same `bwrap … /bin/true`
+/// namespace probe, run against an empty rule set.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn bubblewrap_state(use_bubblewrap: Option<bool>) -> Bubblewrap {
+    use crate::sandbox::bubblewrap_probe;
+    if use_bubblewrap == Some(false) {
+        return Bubblewrap::Disabled;
+    }
+    let Some(path) = bubblewrap_probe::check_availability() else {
+        return Bubblewrap::NotInstalled;
+    };
+    match bubblewrap_probe::test_empty(&path) {
+        Ok(()) => Bubblewrap::Usable(path),
+        Err(reason) => Bubblewrap::Unusable {
+            path,
+            reason: first_line(&reason),
+        },
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[must_use]
+pub fn bubblewrap_state(_use_bubblewrap: Option<bool>) -> Bubblewrap {
+    Bubblewrap::NotApplicable
+}
+
+#[cfg(target_os = "linux")]
+fn first_line(s: &str) -> String {
+    s.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("probe failed")
+        .to_string()
+}
+
+// ── Rendering ──────────────────────────────────────────────────
+
+/// The findings block plus the summary line. `ok` is the one-line "what is
+/// fine" roll-up; `header` is printed by the caller, which owns the inputs.
+#[must_use]
+pub fn render(findings: &[Finding], ok: &[String], verbose_hint: bool) -> String {
+    use crate::ui::{GREEN, RED, RESET, YELLOW, stdout_color};
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let blocking = findings
+        .iter()
+        .filter(|f| f.level == Level::Blocking)
+        .count();
+    let warnings = findings.len() - blocking;
+
+    for f in findings {
+        let (sym, color) = match f.level {
+            Level::Blocking => ("✗", RED),
+            Level::Warning => ("⚠", YELLOW),
+        };
+        let _ = writeln!(
+            out,
+            "{}{sym}{} {}",
+            stdout_color(color),
+            stdout_color(RESET),
+            f.message
+        );
+        if let Some(fix) = &f.fix {
+            let _ = writeln!(out, "  fix: {fix}");
+        }
+    }
+    if !ok.is_empty() {
+        let joined = ok
+            .iter()
+            .map(|s| format!("{}✓{} {s}", stdout_color(GREEN), stdout_color(RESET)))
+            .collect::<Vec<_>>()
+            .join(" · ");
+        let _ = writeln!(out, "{joined}");
+    }
+    let _ = writeln!(out);
+    let verdict = if blocking > 0 {
+        format!(
+            "{}{blocking} blocking, {warnings} warning{}.{}",
+            stdout_color(RED),
+            if warnings == 1 { "" } else { "s" },
+            stdout_color(RESET)
+        )
+    } else if warnings > 0 {
+        format!(
+            "{}0 blocking, {warnings} warning{}.{}",
+            stdout_color(YELLOW),
+            if warnings == 1 { "" } else { "s" },
+            stdout_color(RESET)
+        )
+    } else {
+        format!(
+            "{}No problems found.{}",
+            stdout_color(GREEN),
+            stdout_color(RESET)
+        )
+    };
+    let hint = if verbose_hint {
+        " `cplt doctor --verbose` for the inventory, `cplt check` to probe enforcement."
+    } else {
+        " `cplt check` to probe enforcement."
+    };
+    let _ = writeln!(out, "{verdict}{hint}");
+    out
+}
+
+/// Exit non-zero iff something is blocking — the contract the old doctor had
+/// for its "critical" checks.
+#[must_use]
+pub fn exit_nonzero(findings: &[Finding]) -> bool {
+    findings.iter().any(|f| f.level == Level::Blocking)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::{FsAccess, FsRule};
+
+    fn policy(rules: Vec<(&str, bool, bool)>) -> LandlockPolicy {
+        LandlockPolicy {
+            fs_rules: rules
+                .into_iter()
+                .map(|(p, write, execute)| FsRule {
+                    path: PathBuf::from(p),
+                    access: FsAccess {
+                        read: true,
+                        write,
+                        execute,
+                        ioctl: false,
+                    },
+                })
+                .collect(),
+            net_rules: vec![],
+            restrict_net_connect: false,
+            proxy_forced: false,
+            home_dir: PathBuf::from("/home/u"),
+            precreate_dirs: vec![],
+        }
+    }
+
+    #[test]
+    fn tilde_hides_the_username() {
+        let home = Path::new("/Users/hans");
+        assert_eq!(
+            tilde(Path::new("/Users/hans/.pi/agent"), home),
+            "~/.pi/agent"
+        );
+        assert_eq!(tilde(home, home), "~");
+        assert_eq!(tilde(Path::new("/usr/bin/git"), home), "/usr/bin/git");
+    }
+
+    #[test]
+    fn sensitive_names_track_the_policy_patterns() {
+        for hit in [
+            ".env",
+            ".env.local",
+            "prod.env",
+            "id.pem",
+            "server.key",
+            "k.p12",
+            "k.pfx",
+            "k.jks",
+        ] {
+            assert!(is_sensitive_name(hit), "{hit} should match");
+        }
+        for miss in [
+            ".envrc",
+            "env.ts",
+            "keychain.rs",
+            "README.md",
+            ".environment",
+        ] {
+            assert!(!is_sensitive_name(miss), "{miss} should not match");
+        }
+    }
+
+    #[test]
+    fn tracked_env_finding_needs_a_tracked_file_and_the_deny() {
+        let files = tracked_sensitive_files(["src/main.rs", "config/.env.local", ".gitignore"]);
+        assert_eq!(files, vec!["config/.env.local".to_string()]);
+        assert!(
+            tracked_env_finding(&files, true).is_none(),
+            "deny off: nothing to say"
+        );
+        assert!(
+            tracked_env_finding(&[], false).is_none(),
+            "nothing tracked: nothing to say"
+        );
+        let f = tracked_env_finding(&files, false).expect("finding");
+        assert_eq!(f.level, Level::Warning);
+        assert!(f.message.contains("cannot hash"));
+        assert!(
+            f.fix
+                .as_deref()
+                .unwrap()
+                .contains("git rm --cached config/.env.local")
+        );
+    }
+
+    #[test]
+    fn pi_lock_rule_is_version_gated_and_pi_only() {
+        let home = Path::new("/home/u");
+        let ro_root = policy(vec![("/home/u/.pi/agent", false, false)]);
+        assert!(pi_lock_finding(Agent::Copilot, &ro_root, home, Some("1.0.0")).is_none());
+        assert!(
+            pi_lock_finding(Agent::Pi, &ro_root, home, Some("0.85.1")).is_none(),
+            "0.85.1 predates the lock"
+        );
+        let blocking = pi_lock_finding(Agent::Pi, &ro_root, home, Some("0.86.0")).unwrap();
+        assert_eq!(blocking.level, Level::Blocking);
+        assert!(blocking.message.contains("trust.json.lock"));
+        let unknown = pi_lock_finding(Agent::Pi, &ro_root, home, None).unwrap();
+        assert_eq!(unknown.level, Level::Warning);
+        // A policy that grants the root writable has nothing to warn about.
+        let rw_root = policy(vec![("/home/u/.pi/agent", true, false)]);
+        assert!(pi_lock_finding(Agent::Pi, &rw_root, home, Some("0.86.0")).is_none());
+    }
+
+    #[test]
+    fn version_tuple_ignores_prerelease_suffixes() {
+        assert_eq!(version_tuple("v0.86.0-beta.1"), Some(vec![0, 86, 0]));
+        assert!(version_tuple("0.86.0").unwrap() > version_tuple("0.85.1").unwrap());
+        assert!(version_tuple("0.85.10").unwrap() > version_tuple("0.85.1").unwrap());
+        assert_eq!(version_tuple("nope"), None);
+    }
+
+    #[test]
+    fn shim_findings_use_the_launch_predicate() {
+        // A real symlink whose target is outside every exec grant.
+        let tmp = std::env::temp_dir().join(format!("cplt-doctor-shim-{}", std::process::id()));
+        let granted = tmp.join("granted");
+        let outside = tmp.join("outside");
+        std::fs::create_dir_all(&granted).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let target = outside.join("real");
+        std::fs::write(&target, "").unwrap();
+        // The shim is named by its canonical directory, as a PATH entry the
+        // launch canonicalized would be; the predicate compares paths textually.
+        let granted_c = std::fs::canonicalize(&granted).unwrap();
+        let shim = granted_c.join("node");
+        std::os::unix::fs::symlink(&target, &shim).unwrap();
+        let p = policy(vec![(granted_c.to_str().unwrap(), false, true)]);
+
+        let found = shim_findings(&p, &[("node", shim.as_path())], &tmp);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].message.starts_with("node is a shim"));
+        assert!(found[0].fix.as_deref().unwrap().contains("--allow-exec"));
+
+        // The target granted too: not a shim problem.
+        let outside_c = std::fs::canonicalize(&outside).unwrap();
+        let p2 = policy(vec![
+            (granted_c.to_str().unwrap(), false, true),
+            (outside_c.to_str().unwrap(), false, true),
+        ]);
+        assert!(shim_findings(&p2, &[("node", shim.as_path())], &tmp).is_empty());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn render_puts_the_verdict_last_and_counts_levels() {
+        let findings = vec![
+            Finding::blocking("Pi will not start", "run outside"),
+            Finding::warning("x is tracked", None),
+        ];
+        let out = render(&findings, &["auth: gh CLI".to_string()], true);
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].contains("Pi will not start"));
+        assert_eq!(lines[1].trim(), "fix: run outside");
+        assert!(lines[2].contains("x is tracked"));
+        assert!(lines[3].contains("auth: gh CLI"));
+        assert!(lines.last().unwrap().starts_with("1 blocking, 1 warning."));
+        assert!(lines.last().unwrap().contains("--verbose"));
+        assert!(exit_nonzero(&findings));
+        assert!(!exit_nonzero(&findings[1..]));
+        assert!(render(&[], &[], false).contains("No problems found."));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod check;
 pub mod config;
 pub mod detect;
 pub mod discover;
+pub mod doctor;
 pub mod gh_proxy;
 pub mod git;
 pub mod gradle_init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -778,11 +778,18 @@ QUICK START:
         global: bool,
     },
 
-    /// Run environment diagnostics.
+    /// Will cplt work on this host for this agent? Offline; builds no sandbox.
     ///
-    /// Checks auth mechanisms, agent install, tool availability,
-    /// and sandbox-critical paths. Exits 0 if all critical checks pass.
-    Doctor,
+    /// Prints the resolved agent, config sources and enforcement regime, then
+    /// only what will fail and how to fix it. Paths are shown as `~/…` so the
+    /// output can be pasted into an issue. Exits 0 unless something blocks the
+    /// launch.
+    Doctor {
+        /// Also print the full inventory: tools, tool dirs, protected paths,
+        /// agents found on PATH, project ecosystems. Absolute paths.
+        #[arg(long)]
+        verbose: bool,
+    },
 
     /// Verify & explain sandbox enforcement.
     ///
@@ -2899,6 +2906,18 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         }
     }
 
+    // `cplt doctor` borrows &cli through resolve_context, like check above.
+    #[allow(clippy::collapsible_if)]
+    if matches!(&cli.command, Some(Command::Doctor { .. })) {
+        if let Some(Command::Doctor { verbose }) = cli.command.take() {
+            // Doctor prints its own header; resolve_context's summary lines
+            // and "no agent" default (see `cli.doctor` there) are for it.
+            cli.quiet = true;
+            cli.doctor = true;
+            return Ok(run_doctor(&cli, verbose));
+        }
+    }
+
     // Handle subcommands (these don't need macOS or sandbox)
     if let Some(command) = cli.command {
         return Ok(match command {
@@ -2926,7 +2945,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
                     run_init_command(write, force, merge, quiet)
                 }
             }
-            Command::Doctor => run_doctor(),
+            Command::Doctor { .. } => unreachable!("Command::Doctor handled before this match"),
             Command::GhGate {
                 real_gh,
                 repo_scope,
@@ -3010,7 +3029,8 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     // DEPRECATED: use `cplt doctor` subcommand instead
     if cli.doctor {
         ui::warn("--doctor is deprecated, use `cplt doctor` instead");
-        return Ok(run_doctor());
+        cli.quiet = true;
+        return Ok(run_doctor(&cli, false));
     }
 
     // Resolve config, paths, and agent
@@ -3893,7 +3913,6 @@ fn assemble_sandbox(
     opts: AssemblyOptions<'_>,
 ) -> anyhow::Result<AssembledSandbox> {
     let home_dir = probe.home_dir.as_path();
-    let project_dir = probe.project_dir.as_path();
     let active_agent = opts.agent;
 
     // Create per-session scratch directory if enabled
@@ -3992,48 +4011,21 @@ fn assemble_sandbox(
         resolved.keychain_substitute,
     );
 
-    let sandbox_config = sandbox::SandboxConfig {
-        project_dir,
-        home_dir,
-        extra_read: &resolved.allow_read,
-        extra_write: &resolved.allow_write,
-        extra_exec: &resolved.allow_exec,
-        extra_socket: &resolved.allow_socket,
-        extra_deny: &resolved.deny_paths,
-        existing_home_tool_dirs: Some(&probe.existing_home_tool_dirs),
-        existing_app_dirs: Some(&probe.existing_app_dirs),
-        extra_ports: &resolved.allow_ports,
-        localhost_ports: &resolved.allow_localhost,
-        proxy_port: proxy_port_for_profile,
-        proxy_forced: resolved.proxy_forced,
-        allow_env_files: resolved.allow_env_files,
-        allow_localhost_any: resolved.allow_localhost_any,
-        scratch_dir: scratch_path,
-        playwright_socket_dir: playwright_socket_path,
-        allow_tmp_exec: resolved.allow_tmp_exec,
-        copilot_install_dir: opts.copilot_install_dir,
-        java_home: probe.java_home.as_deref(),
-        dotnet_root: probe.dotnet_root.as_deref(),
-        git_hooks_path: probe.git_hooks_path.as_deref(),
-        git_common_dir: probe.git_common_dir.as_deref(),
-        allow_gpg_signing: resolved.allow_gpg_signing,
-        deny_clipboard: resolved.deny_clipboard,
-        allow_jvm_attach: resolved.allow_jvm_attach,
-        allow_msbuild: resolved.allow_msbuild,
-        allow_docker: resolved.allow_docker,
-        electron_app_dir: opts.electron_app_dir,
-        agent: active_agent,
-        agent_dirs: &agent_dirs,
-        allow_cache_exec: &resolved.allow_cache_exec,
-        allow_cache_exec_any: resolved.allow_cache_exec_any,
-        allow_browser: resolved.allow_browser,
+    let sandbox_config = build_sandbox_config(
+        resolved,
+        probe,
+        active_agent,
+        &agent_dirs,
+        SessionPaths {
+            proxy_port: proxy_port_for_profile,
+            scratch_dir: scratch_path,
+            playwright_socket_dir: playwright_socket_path,
+            copilot_install_dir: opts.copilot_install_dir,
+            electron_app_dir: opts.electron_app_dir,
+        },
         keychain_substitute,
-        use_bubblewrap: resolved.use_bubblewrap,
-    };
+    );
 
-    // The structured Landlock model of the fs policy — used by the check
-    // explain layer. It faithfully mirrors the enforced allow-list on both
-    // platforms (the live probe remains authoritative where they differ).
     let policy = sandbox::generate_policy(&sandbox_config);
     // Path validation (SBPL injection checks on macOS) is handled internally by
     // prepare(), so callers don't need to know about backend-specific risks.
@@ -4052,6 +4044,68 @@ fn assemble_sandbox(
 /// Build the resolved Shell sandbox, shared by `cplt exec` and `cplt check` so
 /// their probes run under byte-for-byte the same policy as each other — and, via
 /// [`assemble_sandbox`], as the agent launch.
+/// The inputs to a `SandboxConfig` that exist only once a session is being
+/// set up. `cplt doctor` builds the policy with all of them absent.
+#[derive(Default)]
+struct SessionPaths<'a> {
+    proxy_port: Option<u16>,
+    scratch_dir: Option<&'a Path>,
+    playwright_socket_dir: Option<&'a Path>,
+    copilot_install_dir: Option<&'a Path>,
+    electron_app_dir: Option<&'a Path>,
+}
+
+/// The one place a `SandboxConfig` is assembled from the resolved config and
+/// the host probe. The launch, `exec`, `check` and `doctor` all go through it,
+/// so a new input reaches every surface or none (#447).
+fn build_sandbox_config<'a>(
+    resolved: &'a config::Resolved,
+    probe: &'a HostProbe,
+    agent: agent::Agent,
+    agent_dirs: &'a [agent::AgentDir],
+    session: SessionPaths<'a>,
+    keychain_substitute: Option<agent::KeychainSubstitute>,
+) -> sandbox::SandboxConfig<'a> {
+    sandbox::SandboxConfig {
+        project_dir: probe.project_dir.as_path(),
+        home_dir: probe.home_dir.as_path(),
+        extra_read: &resolved.allow_read,
+        extra_write: &resolved.allow_write,
+        extra_exec: &resolved.allow_exec,
+        extra_socket: &resolved.allow_socket,
+        extra_deny: &resolved.deny_paths,
+        existing_home_tool_dirs: Some(&probe.existing_home_tool_dirs),
+        existing_app_dirs: Some(&probe.existing_app_dirs),
+        extra_ports: &resolved.allow_ports,
+        localhost_ports: &resolved.allow_localhost,
+        proxy_port: session.proxy_port,
+        proxy_forced: resolved.proxy_forced,
+        allow_env_files: resolved.allow_env_files,
+        allow_localhost_any: resolved.allow_localhost_any,
+        scratch_dir: session.scratch_dir,
+        playwright_socket_dir: session.playwright_socket_dir,
+        allow_tmp_exec: resolved.allow_tmp_exec,
+        copilot_install_dir: session.copilot_install_dir,
+        java_home: probe.java_home.as_deref(),
+        dotnet_root: probe.dotnet_root.as_deref(),
+        git_hooks_path: probe.git_hooks_path.as_deref(),
+        git_common_dir: probe.git_common_dir.as_deref(),
+        allow_gpg_signing: resolved.allow_gpg_signing,
+        deny_clipboard: resolved.deny_clipboard,
+        allow_jvm_attach: resolved.allow_jvm_attach,
+        allow_msbuild: resolved.allow_msbuild,
+        allow_docker: resolved.allow_docker,
+        electron_app_dir: session.electron_app_dir,
+        agent,
+        agent_dirs,
+        allow_cache_exec: &resolved.allow_cache_exec,
+        allow_cache_exec_any: resolved.allow_cache_exec_any,
+        allow_browser: resolved.allow_browser,
+        keychain_substitute,
+        use_bubblewrap: resolved.use_bubblewrap,
+    }
+}
+
 fn prepare_shell_sandbox(
     cli: &Cli,
     resolved: &mut config::Resolved,
@@ -5186,139 +5240,444 @@ fn build_exec_check(
     check::Report::new(agent_name, preset_name, false, vec![item])
 }
 
-fn run_doctor() -> ExitCode {
-    let home_dir = if let Ok(h) = std::env::var("HOME") {
-        match std::fs::canonicalize(&h) {
-            Ok(p) => p,
+/// The kernel release, from `uname(2)`: no spawn, and the same string on
+/// both platforms (`6.6.87.2-microsoft-standard-WSL2`, `25.6.0`).
+fn kernel_release() -> String {
+    // SAFETY: utsname is plain-old-data; uname fills it or fails.
+    let mut u: libc::utsname = unsafe { std::mem::zeroed() };
+    if unsafe { libc::uname(&raw mut u) } != 0 {
+        return "unknown".to_string();
+    }
+    // SAFETY: uname NUL-terminates every field it fills.
+    unsafe { std::ffi::CStr::from_ptr(u.release.as_ptr()) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// `cplt doctor`. Findings first; the inventory only under `--verbose`.
+///
+/// Built from the launch's own resolution (`resolve_context`, `HostProbe`,
+/// `build_sandbox_config`, `generate_policy`) rather than a parallel
+/// discovery, so what it reports about the agent, the config layers and the
+/// grants is what a launch would use — the old doctor auto-detected only
+/// Copilot/OpenCode/Antigravity and ignored `--agent` and `sandbox.agent`
+/// entirely, so it could not name the agent that had just failed (#449).
+///
+/// Degrades rather than errors: when the launch cannot even resolve (bad
+/// config, unsafe root), that is the one blocking finding and the header
+/// still prints.
+fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
+    use cplt::doctor::{self, Finding, Level};
+
+    let wsl = cfg!(target_os = "linux") && agent::is_wsl();
+    let mut headline = format!(
+        "cplt {LONG_VERSION} · {} {} · kernel {}",
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        kernel_release()
+    );
+    if wsl {
+        headline.push_str(" (WSL)");
+    }
+    if std::env::var_os("__CPLT_WRAPPED").is_some() {
+        headline.push_str(" · inside a cplt sandbox");
+    }
+    println!("{headline}");
+
+    let ctx = match resolve_context(cli, false) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            println!();
+            let findings = [Finding {
+                level: Level::Blocking,
+                message: format!("cplt cannot resolve this launch: {e}"),
+                fix: None,
+            }];
+            print!("{}", doctor::render(&findings, &[], false));
+            return ExitCode::FAILURE;
+        }
+    };
+    let ResolvedContext {
+        mut resolved,
+        config_path,
+        home_dir,
+        project_dir,
+        repo_roots: _,
+        active_agent,
+        unapproved_proposals,
+    } = ctx;
+    let tilde = |p: &Path| doctor::tilde(p, &home_dir);
+    let mut findings: Vec<Finding> = Vec::new();
+    let mut ok: Vec<String> = Vec::new();
+
+    // ── agent: which one, and why ──
+    let agent_source = if cli.agent.is_some() {
+        Some("--agent".to_string())
+    } else if resolved.agent.is_some() {
+        let file = config::load_local(&project_dir)
+            .ok()
+            .flatten()
+            .filter(|l| l.config.sandbox.agent.is_some())
+            .map(|l| l.path)
+            .or_else(|| config_path.clone());
+        Some(match file {
+            Some(f) => format!("sandbox.agent in {}", tilde(&f)),
+            None => "sandbox.agent".to_string(),
+        })
+    } else if agent::Agent::auto_detect().is_some() {
+        Some("auto-detected from PATH".to_string())
+    } else {
+        None
+    };
+    let mut agent_version: Option<String> = None;
+    let mut agent_runnable = false;
+    match &agent_source {
+        None => {
+            println!("agent:       none (nothing on PATH, no --agent, no sandbox.agent)");
+            findings.push(Finding::blocking(
+                "No supported agent found: cplt will refuse to launch.",
+                "install one (copilot, opencode, antigravity, pi, claude, goose) or pass \
+                 --agent <name> / set sandbox.agent",
+            ));
+        }
+        Some(source) => match active_agent.resolve_binary() {
+            Ok(bin) => {
+                agent_runnable = true;
+                let shown = match discover::probe_version(&bin, &["--version"]) {
+                    discover::VersionProbe::Version(v) => {
+                        agent_version = Some(v.clone());
+                        v
+                    }
+                    discover::VersionProbe::Unknown => "(version unknown)".to_string(),
+                    discover::VersionProbe::TimedOut => {
+                        findings.push(Finding::warning(
+                            format!(
+                                "{} --version did not answer within 5s and was killed; the \
+                                 binary is installed but may be wedged.",
+                                active_agent.binary_name()
+                            ),
+                            None,
+                        ));
+                        "(version probe timed out)".to_string()
+                    }
+                };
+                println!(
+                    "agent:       {} {shown}  ({source})",
+                    active_agent.display_name()
+                );
+            }
             Err(e) => {
-                ui::error(&format!("Cannot resolve $HOME ({h}): {e}"));
-                return ExitCode::FAILURE;
+                println!(
+                    "agent:       {} — not runnable  ({source})",
+                    active_agent.display_name()
+                );
+                findings.push(Finding {
+                    level: Level::Blocking,
+                    message: e,
+                    fix: None,
+                });
             }
-        }
-    } else {
-        ui::error("$HOME not set");
-        return ExitCode::FAILURE;
-    };
-
-    let project_dir = if let Some(root) = detect_project_root() {
-        std::fs::canonicalize(&root).unwrap_or(root)
-    } else {
-        std::env::current_dir()
-            .and_then(std::fs::canonicalize)
-            .unwrap_or_else(|_| PathBuf::from("."))
-    };
-
-    println!(
-        "{}[cplt]{} cplt:     {}",
-        ui::stdout_color(ui::BLUE),
-        ui::stdout_color(ui::RESET),
-        LONG_VERSION
-    );
-    println!(
-        "{}[cplt]{} Project:  {}",
-        ui::stdout_color(ui::BLUE),
-        ui::stdout_color(ui::RESET),
-        project_dir.display()
-    );
-    println!(
-        "{}[cplt]{} Home:     {}",
-        ui::stdout_color(ui::BLUE),
-        ui::stdout_color(ui::RESET),
-        home_dir.display()
-    );
-    println!();
-
-    let discovery = discover::discover_all(&home_dir, &project_dir);
-    let ok = discovery.print_report();
-
-    // Show project ecosystem detection summary
-    let report = cplt::detect::detect_project_recursive(&project_dir);
-    if !report.detections.is_empty() || !report.workspace_members.is_empty() {
-        println!();
-        println!(
-            "{}{}[doctor]{} {}Project ecosystems{}",
-            ui::stdout_color(ui::BOLD),
-            ui::stdout_color(ui::BLUE),
-            ui::stdout_color(ui::RESET),
-            ui::stdout_color(ui::BOLD),
-            ui::stdout_color(ui::RESET)
-        );
-        for d in &report.detections {
-            println!(
-                "  {}✓{} {}",
-                ui::stdout_color(ui::GREEN),
-                ui::stdout_color(ui::RESET),
-                d.name
-            );
-        }
-
-        // Show workspace member ecosystems
-        if !report.workspace_members.is_empty() {
-            // Collect unique sources for the header
-            let sources: BTreeSet<String> = report
-                .workspace_members
-                .iter()
-                .map(|m| m.source.to_string())
-                .collect();
-            let source_label = sources.into_iter().collect::<Vec<_>>().join(", ");
-
-            println!();
-            println!(
-                "  {}Workspace members ({}){}",
-                ui::stdout_color(ui::BOLD),
-                source_label,
-                ui::stdout_color(ui::RESET),
-            );
-            for member in &report.workspace_members {
-                let ecosystems: Vec<&str> = member.detections.iter().map(|d| d.name).collect();
-                if ecosystems.is_empty() {
-                    println!(
-                        "    {}•{} {}",
-                        ui::stdout_color(ui::DIM),
-                        ui::stdout_color(ui::RESET),
-                        member.relative_path
-                    );
-                } else {
-                    println!(
-                        "    {}✓{} {}: {}",
-                        ui::stdout_color(ui::GREEN),
-                        ui::stdout_color(ui::RESET),
-                        member.relative_path,
-                        ecosystems.join(", ")
-                    );
-                }
-            }
-        }
-
-        // Detector diagnostics carry the remedy; the ecosystem name alone does
-        // not. `cplt doctor` is what a developer runs after a refusal, so the
-        // explanation has to reach this surface and not only `cplt init`.
-        for diag in &report.diagnostics {
-            println!();
-            println!(
-                "  {}!{} [{}] {}",
-                ui::stdout_color(ui::YELLOW),
-                ui::stdout_color(ui::RESET),
-                diag.detector,
-                diag.message
-            );
-        }
-
-        let has_repo_config = project_dir.join(".cplt.toml").exists();
-        if !has_repo_config {
-            println!();
-            println!(
-                "  {}→{} Run `cplt init` to generate .cplt.toml",
-                ui::stdout_color(ui::BLUE),
-                ui::stdout_color(ui::RESET),
-            );
-        }
+        },
     }
 
-    if ok {
-        ExitCode::SUCCESS
-    } else {
+    // ── config: which layers loaded ──
+    let mut layers = vec![match &config_path {
+        Some(p) => format!("user {}", tilde(p)),
+        None => "user: none".to_string(),
+    }];
+    if let Some(lp) = config::local_path(&project_dir).filter(|p| p.exists()) {
+        layers.push(format!("local {}", tilde(&lp)));
+    }
+    match repo_config::load_repo_config(&project_dir) {
+        Ok(Some(loaded)) => layers.push(format!(
+            "repo .cplt.toml ({})",
+            match loaded.source {
+                repo_config::RepoConfigSource::GitHead => "committed",
+                repo_config::RepoConfigSource::WorkingTree => "working tree, not committed",
+                _ => "unknown source",
+            }
+        )),
+        Ok(None) => {}
+        Err(_) => layers.push("repo .cplt.toml (unreadable)".to_string()),
+    }
+    layers.push(format!(
+        "preset: {}",
+        resolved.preset.map_or("none", preset_label)
+    ));
+    println!("config:      {}", layers.join(" · "));
+    if !unapproved_proposals.is_empty() {
+        findings.push(Finding::warning(
+            format!(
+                ".cplt.toml has {} unapproved permission(s) ({}): the launch applies none of them.",
+                unapproved_proposals.len(),
+                unapproved_proposals.join(", ")
+            ),
+            Some("review with `cplt trust`, then `cplt trust accept --all`".to_string()),
+        ));
+    }
+
+    // ── enforcement: the regime, and why ──
+    let bubblewrap = doctor::bubblewrap_state(resolved.use_bubblewrap);
+    #[cfg(target_os = "macos")]
+    {
+        if Path::new("/usr/bin/sandbox-exec").exists() {
+            println!("enforcement: Seatbelt (sandbox-exec)");
+        } else {
+            println!("enforcement: none — /usr/bin/sandbox-exec missing");
+            findings.push(Finding {
+                level: Level::Blocking,
+                message: "Seatbelt is unavailable: /usr/bin/sandbox-exec is missing, so cplt \
+                          cannot sandbox anything on this host."
+                    .to_string(),
+                fix: None,
+            });
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let landlock = match sandbox::available_abi_version() {
+            Some(abi) if abi < 4 => format!("Landlock ABI {abi} (no TCP port rules: proxy only)"),
+            Some(abi) => format!("Landlock ABI {abi}"),
+            None => {
+                findings.push(Finding::blocking(
+                    "Landlock is unavailable: cplt cannot sandbox anything on this kernel.",
+                    "Linux 5.13+ with landlock in the LSM list (cat /sys/kernel/security/lsm); \
+                     on WSL, check .wslconfig for a kernelCommandLine lsm= that omits it",
+                ));
+                "Landlock: unavailable".to_string()
+            }
+        };
+        println!(
+            "enforcement: {landlock} + seccomp · {}",
+            bubblewrap.describe()
+        );
+        if !bubblewrap.active() {
+            println!(
+                "             → mount-level protections OFF (.git/hooks, agent host files, mise \
+                 shims, Pi bin/, unix-socket masks)"
+            );
+        }
+        if resolved.use_bubblewrap == Some(true) && !bubblewrap.active() {
+            findings.push(Finding::blocking(
+                format!(
+                    "use_bubblewrap = true but {}: the launch refuses to start.",
+                    bubblewrap.describe()
+                ),
+                "install bubblewrap into /usr/bin, enable user namespaces \
+                 (sysctl kernel.unprivileged_userns_clone=1), or drop use_bubblewrap",
+            ));
+        }
+    }
+    let _ = &bubblewrap;
+    println!();
+
+    // ── the policy a launch would build, for the rules below ──
+    let probe = HostProbe::probe(&mut resolved, &home_dir, &project_dir);
+    let mut agent_dirs = active_agent.config_dirs(&home_dir);
+    agent::canonicalize_agent_dirs(&mut agent_dirs);
+    let keychain_substitute = active_agent.credential_outside_keychain(
+        &home_dir,
+        &resolved.deny_env,
+        resolved.keychain_substitute,
+    );
+    let sandbox_config = build_sandbox_config(
+        &resolved,
+        &probe,
+        active_agent,
+        &agent_dirs,
+        SessionPaths::default(),
+        keychain_substitute,
+    );
+    let policy = sandbox::generate_policy(&sandbox_config);
+
+    // Only for an agent that can run: "Pi will not start" under "Pi is not
+    // installed" is noise.
+    if agent_runnable {
+        findings.extend(doctor::pi_lock_finding(
+            active_agent,
+            &policy,
+            &home_dir,
+            agent_version.as_deref(),
+        ));
+    }
+
+    // Tracked secrets under the .env deny. `ls-files` reads the index, not
+    // content; `git::command` still refuses it in a repo that defines a
+    // content filter, and this rule then says nothing rather than guessing.
+    let tracked = cplt::git::command(&project_dir, &["ls-files", "-z"])
+        .and_then(|mut c| c.output().ok())
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+        .unwrap_or_default();
+    let sensitive = doctor::tracked_sensitive_files(tracked.split('\0').filter(|p| !p.is_empty()));
+    findings.extend(doctor::tracked_env_finding(
+        &sensitive,
+        resolved.allow_env_files,
+    ));
+
+    // Tools as found on PATH — the shim, not its target.
+    let tools: Vec<(&str, PathBuf)> = discover::TOOLS_TO_CHECK
+        .iter()
+        .filter_map(|name| discover::which_on_path(name).map(|p| (*name, p)))
+        .collect();
+    let mut tool_names: Vec<&str> = Vec::new();
+    for (name, path) in &tools {
+        let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        if agent::is_wsl_interop_binary(&canon, wsl) {
+            let critical = discover::WSL_CRITICAL_TOOLS.contains(name);
+            let msg = format!(
+                "{name} resolves to {}, a Windows install reached through WSL interop{}",
+                canon.display(),
+                if critical {
+                    ", which cannot run in the Linux sandbox."
+                } else {
+                    "; running it starts a Windows process outside the sandbox."
+                }
+            );
+            findings.push(if critical {
+                Finding::blocking(msg, format!("install {name} inside the WSL distro"))
+            } else {
+                Finding::warning(msg, None)
+            });
+            continue;
+        }
+        tool_names.push(name);
+    }
+    // Linux only: the LandlockPolicy IS the enforcement there. On macOS it is
+    // a model of the SBPL profile that lacks the Homebrew exec grants, so a
+    // mise shim into /opt/homebrew/Cellar reads as denied while the real
+    // sandbox runs it (`cplt check path` shows the same model/probe gap).
+    if cfg!(target_os = "linux") {
+        let shim_inputs: Vec<doctor::ToolOnPath<'_>> =
+            tools.iter().map(|(n, p)| (*n, p.as_path())).collect();
+        findings.extend(doctor::shim_findings(&policy, &shim_inputs, &home_dir));
+    }
+    if !tool_names.contains(&"git") {
+        findings.push(Finding::warning(
+            "git not found on PATH: the git guard, the session audit and repo config trust \
+             all need it."
+                .to_string(),
+            None,
+        ));
+    }
+
+    // Detector diagnostics carry their own remedy (#434); they are findings,
+    // the ecosystem list itself is `cplt init`'s business.
+    for diag in cplt::detect::detect_project_recursive(&project_dir).diagnostics {
+        findings.push(Finding::warning(
+            format!("[{}] {}", diag.detector, diag.message),
+            None,
+        ));
+    }
+
+    // Auth matters to Copilot; the others log in on disk or via --pass-env.
+    let auth = discover::discover_auth(&home_dir);
+    if auth.gh_cli_auth {
+        ok.push("auth: gh CLI".to_string());
+    } else if let Some(var) = auth.env_tokens.first() {
+        ok.push(format!("auth: {var}"));
+    } else if active_agent == agent::Agent::Copilot && !auth.any_auth_available() {
+        findings.push(Finding::blocking(
+            "No auth for Copilot: gh is not logged in and none of COPILOT_GITHUB_TOKEN, \
+             GH_TOKEN, GITHUB_TOKEN is set.",
+            "gh auth login",
+        ));
+    }
+    let agents_on_path: Vec<&str> = agent::Agent::ALL
+        .iter()
+        .filter(|a| **a != agent::Agent::Shell)
+        .map(agent::Agent::binary_name)
+        .filter(|b| discover::which_on_path(b).is_some())
+        .collect();
+    if !agents_on_path.is_empty() {
+        ok.push(format!("agents on PATH: {}", agents_on_path.join(", ")));
+    }
+    if !tool_names.is_empty() {
+        ok.push(format!("tools: {}", tool_names.join(" ")));
+    }
+
+    print!("{}", doctor::render(&findings, &ok, !verbose));
+
+    if verbose {
+        println!();
+        println!("── inventory ──");
+        println!("project:  {}", project_dir.display());
+        println!("home:     {}", home_dir.display());
+        println!();
+        discover::discover_all(&home_dir, &project_dir).print_report();
+        print_project_ecosystems(&project_dir);
+    }
+
+    if doctor::exit_nonzero(&findings) {
         ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+/// The `Project ecosystems` block of `cplt doctor --verbose`.
+fn print_project_ecosystems(project_dir: &Path) {
+    let report = cplt::detect::detect_project_recursive(project_dir);
+    if report.detections.is_empty() && report.workspace_members.is_empty() {
+        return;
+    }
+    println!(
+        "{}{}[doctor]{} {}Project ecosystems{}",
+        ui::stdout_color(ui::BOLD),
+        ui::stdout_color(ui::BLUE),
+        ui::stdout_color(ui::RESET),
+        ui::stdout_color(ui::BOLD),
+        ui::stdout_color(ui::RESET)
+    );
+    for d in &report.detections {
+        println!(
+            "  {}✓{} {}",
+            ui::stdout_color(ui::GREEN),
+            ui::stdout_color(ui::RESET),
+            d.name
+        );
+    }
+    if !report.workspace_members.is_empty() {
+        let sources: BTreeSet<String> = report
+            .workspace_members
+            .iter()
+            .map(|m| m.source.to_string())
+            .collect();
+        let source_label = sources.into_iter().collect::<Vec<_>>().join(", ");
+        println!();
+        println!(
+            "  {}Workspace members ({}){}",
+            ui::stdout_color(ui::BOLD),
+            source_label,
+            ui::stdout_color(ui::RESET),
+        );
+        for member in &report.workspace_members {
+            let ecosystems: Vec<&str> = member.detections.iter().map(|d| d.name).collect();
+            if ecosystems.is_empty() {
+                println!(
+                    "    {}•{} {}",
+                    ui::stdout_color(ui::DIM),
+                    ui::stdout_color(ui::RESET),
+                    member.relative_path
+                );
+            } else {
+                println!(
+                    "    {}✓{} {}: {}",
+                    ui::stdout_color(ui::GREEN),
+                    ui::stdout_color(ui::RESET),
+                    member.relative_path,
+                    ecosystems.join(", ")
+                );
+            }
+        }
+    }
+    if !project_dir.join(".cplt.toml").exists() {
+        println!();
+        println!(
+            "  {}→{} Run `cplt init` to generate .cplt.toml",
+            ui::stdout_color(ui::BLUE),
+            ui::stdout_color(ui::RESET),
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5290,7 +5290,16 @@ fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
             println!();
             let findings = [Finding {
                 level: Level::Blocking,
-                message: format!("cplt cannot resolve this launch: {e}"),
+                // The error text can quote an absolute path — "cplt refuses
+                // to sandbox '/Users/hans'" — and this view gets pasted into
+                // public issues.
+                message: doctor::tilde_in_text(
+                    &format!("cplt cannot resolve this launch: {e}"),
+                    &std::env::var("HOME").map_or_else(
+                        |_| std::path::PathBuf::from("/nonexistent"),
+                        std::path::PathBuf::from,
+                    ),
+                ),
                 fix: None,
             }];
             print!("{}", doctor::render(&findings, &[], false));

--- a/src/main.rs
+++ b/src/main.rs
@@ -5329,7 +5329,6 @@ fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
     } else {
         None
     };
-    let mut agent_version: Option<String> = None;
     let mut agent_runnable = false;
     match &agent_source {
         None => {
@@ -5344,10 +5343,7 @@ fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
             Ok(bin) => {
                 agent_runnable = true;
                 let shown = match discover::probe_version(&bin, &["--version"]) {
-                    discover::VersionProbe::Version(v) => {
-                        agent_version = Some(v.clone());
-                        v
-                    }
+                    discover::VersionProbe::Version(v) => v,
                     discover::VersionProbe::Unknown => "(version unknown)".to_string(),
                     discover::VersionProbe::TimedOut => {
                         findings.push(Finding::warning(
@@ -5493,23 +5489,12 @@ fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
     // Only for an agent that can run: "Pi will not start" under "Pi is not
     // installed" is noise.
     if agent_runnable {
-        findings.extend(doctor::pi_lock_finding(
-            active_agent,
-            &policy,
-            &home_dir,
-            agent_version.as_deref(),
-        ));
+        findings.extend(doctor::pi_lock_finding(active_agent, &policy, &home_dir));
     }
 
-    // Tracked secrets under the .env deny. `ls-files` reads the index, not
-    // content; `git::command` still refuses it in a repo that defines a
-    // content filter, and this rule then says nothing rather than guessing.
-    let tracked = cplt::git::command(&project_dir, &["ls-files", "-z"])
-        .and_then(|mut c| c.output().ok())
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default();
-    let sensitive = doctor::tracked_sensitive_files(tracked.split('\0').filter(|p| !p.is_empty()));
+    // Tracked secrets under the .env deny — the same set `cplt check` reports
+    // (#451), from the same function.
+    let sensitive = tracked_sensitive_files(&project_dir);
     findings.extend(doctor::tracked_env_finding(
         &sensitive,
         resolved.allow_env_files,

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -36,6 +36,23 @@ use crate::ui;
 mod bubblewrap;
 #[path = "sandbox_env.rs"]
 mod env;
+
+/// The two bubblewrap probes `cplt doctor` reports from — the same trusted
+/// lookup and the same `bwrap … /bin/true` the launch runs, against an empty
+/// rule set, so "installed" and "usable" stay two different answers.
+#[cfg(target_os = "linux")]
+pub(crate) mod bubblewrap_probe {
+    pub(crate) use super::bubblewrap::check_availability;
+
+    pub(crate) fn test_empty(bwrap: &std::path::Path) -> Result<(), String> {
+        super::bubblewrap::test_functionality(
+            bwrap,
+            &[],
+            super::bubblewrap::Overlays::default(),
+            &super::bubblewrap::DenyMasks::default(),
+        )
+    }
+}
 #[path = "sandbox_exec.rs"]
 mod exec;
 #[path = "sandbox_landlock.rs"]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -702,7 +702,7 @@ mod e2e_tests {
             "a tracked .env under the deny is a finding.\nstdout: {stdout}"
         );
         assert!(
-            stdout.contains("git rm --cached .env.local"),
+            stdout.contains("git rm --cached -- '.env.local'"),
             "the finding carries its fix.\nstdout: {stdout}"
         );
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -514,6 +514,10 @@ mod e2e_tests {
     // ============================================================
     // Doctor command tests
     // ============================================================
+    //
+    // Doctor is findings-first: a header a maintainer can trust (version, OS,
+    // agent and where the choice came from, config layers, enforcement), then
+    // only what will fail, then the verdict. The inventory is `--verbose`.
 
     #[test]
     fn e2e_doctor_exits_successfully() {
@@ -533,46 +537,95 @@ mod e2e_tests {
     }
 
     #[test]
-    fn e2e_doctor_reports_auth_section() {
-        // No require_copilot!: doctor always prints the Auth section header
-        // regardless of whether Copilot is installed, so this runs in CI.
+    fn e2e_doctor_header_names_agent_config_and_enforcement() {
+        // No require_copilot!: the header prints whatever is installed, and
+        // `--agent shell` needs no agent binary at all.
         let output = cplt_cmd()
-            .args(["--doctor"])
+            .args(["--agent", "shell", "doctor"])
             .current_dir(project_dir())
             .output()
             .expect("binary should run");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
+        let first = stdout.lines().next().unwrap_or_default();
 
         assert!(
-            stdout.contains("[doctor]") && stdout.contains("Auth"),
-            "--doctor should print Auth section.\nstdout: {stdout}"
+            first.starts_with("cplt ") && first.contains("kernel"),
+            "first line is version · os · kernel.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("agent:       Shell") && stdout.contains("(--agent)"),
+            "the agent line names the resolved agent and where the choice came from.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("config:      user") && stdout.contains("preset:"),
+            "the config line lists the layers loaded.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("enforcement: "),
+            "the enforcement line names the regime.\nstdout: {stdout}"
         );
     }
 
     #[test]
-    fn e2e_doctor_reports_copilot_section() {
-        require_copilot!();
+    fn e2e_doctor_default_view_is_short_and_ends_with_the_verdict() {
         let output = cplt_cmd()
-            .args(["--doctor"])
+            .args(["--agent", "shell", "doctor"])
             .current_dir(project_dir())
             .output()
             .expect("binary should run");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
+        let last = stdout.lines().last().unwrap_or_default();
 
         assert!(
-            stdout.contains("Agents") && stdout.contains("Copilot"),
-            "--doctor should show Agents section with Copilot.\nstdout: {stdout}"
+            last.contains("blocking") || last.contains("No problems found"),
+            "the verdict is the last line.\nstdout: {stdout}"
+        );
+        assert!(
+            last.contains("`cplt check`"),
+            "the verdict points at the enforcement probe.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.lines().count() <= 25,
+            "default view stays short (the inventory is --verbose).\nstdout: {stdout}"
+        );
+        // Inventory sections stay out of the default view.
+        for cut in [
+            "Tool dirs",
+            "Not found (skippable)",
+            "Protected (",
+            "Project ecosystems",
+        ] {
+            assert!(
+                !stdout.contains(cut),
+                "{cut:?} is inventory and belongs to --verbose.\nstdout: {stdout}"
+            );
+        }
+    }
+
+    #[test]
+    fn e2e_doctor_hides_the_home_directory() {
+        let output = cplt_cmd()
+            .args(["--agent", "shell", "doctor"])
+            .current_dir(project_dir())
+            .output()
+            .expect("binary should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let home = std::env::var("HOME").expect("HOME");
+        // Paths under HOME print as ~/… so the output can be pasted publicly.
+        // Findings may legitimately name absolute paths outside HOME.
+        assert!(
+            !stdout.contains(&home),
+            "default view must not print the home directory.\nstdout: {stdout}"
         );
     }
 
     #[test]
-    fn e2e_doctor_reports_tools_section() {
-        // No require_copilot!: doctor always prints the Tools section (git is
-        // present on the runner) regardless of Copilot, so this runs in CI.
+    fn e2e_doctor_verbose_prints_the_inventory() {
         let output = cplt_cmd()
-            .args(["--doctor"])
+            .args(["--agent", "shell", "doctor", "--verbose"])
             .current_dir(project_dir())
             .output()
             .expect("binary should run");
@@ -580,16 +633,28 @@ mod e2e_tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         assert!(
-            stdout.contains("Tools") && stdout.contains("git"),
-            "--doctor should show Tools section with git.\nstdout: {stdout}"
+            stdout.contains("── inventory ──")
+                && stdout.contains("[doctor]")
+                && stdout.contains("Tools")
+                && stdout.contains("git"),
+            "--verbose appends the old inventory (Tools section with git).\nstdout: {stdout}"
         );
     }
 
     #[test]
-    fn e2e_doctor_reports_sandbox_paths() {
-        require_copilot!();
+    fn e2e_doctor_reports_a_missing_agent_as_blocking() {
+        // `--agent pi` on a host without pi: the header still prints, the
+        // missing binary is the one blocking finding, and exit is non-zero.
+        if Command::new("which")
+            .arg("pi")
+            .output()
+            .is_ok_and(|o| o.status.success())
+        {
+            eprintln!("SKIPPED: pi is installed here");
+            return;
+        }
         let output = cplt_cmd()
-            .args(["--doctor"])
+            .args(["--agent", "pi", "doctor"])
             .current_dir(project_dir())
             .output()
             .expect("binary should run");
@@ -597,8 +662,60 @@ mod e2e_tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         assert!(
-            stdout.contains("Sandbox paths") && stdout.contains("Protected"),
-            "--doctor should show Sandbox paths with protected dirs.\nstdout: {stdout}"
+            !output.status.success(),
+            "a blocking finding exits non-zero"
+        );
+        assert!(
+            stdout.contains("agent:       Pi") && stdout.contains("not runnable"),
+            "the agent line says Pi could not be resolved.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("✗ Pi not found in PATH"),
+            "the finding names the cause and the install command.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("1 blocking"),
+            "the verdict counts it.\nstdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn e2e_doctor_flags_a_tracked_env_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        assert!(git_ok(repo, &["init", "-q", "."]));
+        assert!(git_ok(repo, &["config", "user.email", "t@t"]));
+        assert!(git_ok(repo, &["config", "user.name", "t"]));
+        std::fs::write(repo.join(".env.local"), "SECRET=x\n").unwrap();
+        std::fs::write(repo.join("README.md"), "ok\n").unwrap();
+        assert!(git_ok(repo, &["add", "-A"]));
+        assert!(git_ok(repo, &["commit", "-q", "-m", "init"]));
+
+        let output = cplt_cmd()
+            .args(["--agent", "shell", "doctor"])
+            .current_dir(repo)
+            .output()
+            .expect("binary should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(".env.local is tracked in git") && stdout.contains("cannot hash"),
+            "a tracked .env under the deny is a finding.\nstdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("git rm --cached .env.local"),
+            "the finding carries its fix.\nstdout: {stdout}"
+        );
+
+        // With the deny lifted there is nothing to say.
+        let output = cplt_cmd()
+            .args(["--agent", "shell", "--allow-env-files", "doctor"])
+            .current_dir(repo)
+            .output()
+            .expect("binary should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("cannot hash"),
+            "allow_env_files on: no finding.\nstdout: {stdout}"
         );
     }
 
@@ -619,8 +736,8 @@ mod e2e_tests {
             "cplt doctor should exit 0.\nstderr: {stderr}"
         );
         assert!(
-            stdout.contains("[doctor]"),
-            "should have doctor output.\nstdout: {stdout}"
+            stdout.contains("agent:       Copilot"),
+            "should name the auto-detected agent.\nstdout: {stdout}"
         );
         // No deprecation warning for subcommand form
         assert!(
@@ -651,7 +768,7 @@ mod e2e_tests {
     }
 
     #[test]
-    fn e2e_doctor_shows_project_ecosystems() {
+    fn e2e_doctor_verbose_shows_project_ecosystems() {
         // Create a project with a Cargo.toml so ecosystems are detected
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -661,15 +778,15 @@ mod e2e_tests {
         .unwrap();
 
         let output = cplt_cmd()
-            .args(["doctor"])
+            .args(["doctor", "--verbose"])
             .current_dir(dir.path())
             .output()
             .expect("binary should run");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        // Doctor may exit non-zero if no agent/auth is found (CI), but it
-        // should still print ecosystem detection results regardless.
+        // Doctor may exit non-zero if no agent is found (CI), but the
+        // inventory prints regardless.
         assert!(
             stdout.contains("Project ecosystems") && stdout.contains("Rust"),
             "should detect Rust ecosystem.\nstdout: {stdout}"
@@ -4817,8 +4934,9 @@ paths = [
         )
         .unwrap();
 
+        // Workspace members are inventory, so they live under --verbose.
         let output = cplt_cmd()
-            .args(["doctor"])
+            .args(["doctor", "--verbose"])
             .current_dir(dir.path())
             .output()
             .expect("should run");
@@ -4829,7 +4947,7 @@ paths = [
         let combined = format!("{stdout}{stderr}");
         assert!(
             combined.contains("apps/web"),
-            "doctor should show workspace member: {combined}"
+            "doctor --verbose should show workspace member: {combined}"
         );
     }
 


### PR DESCRIPTION
`doctor` was a 52-line inventory that reasoned about almost nothing, built from **different inputs than a launch uses** — so it could be confidently wrong about the two facts a bug report needs most: which agent, and which enforcement regime.

#449 is the evidence. Diagnosing it needed two things doctor did not report, and the regime ended up being inferred from an errno in a Node stack trace.

## Now

```
cplt 0.0.0 · macos aarch64 · kernel 25.6.0
agent:       Copilot 1.0.84-1  (auto-detected from PATH)
config:      user ~/.config/cplt/config.toml · repo .cplt.toml (committed) · preset: none
enforcement: Seatbelt (sandbox-exec)

⚠ .cplt.toml has 3 unapproved permission(s): the launch applies none of them.
  fix: review with `cplt trust`, then `cplt trust accept --all`
✓ auth: gh CLI · ✓ agents on PATH: copilot, opencode, claude · ✓ tools: gh git node npm …

0 blocking, 1 warning. `cplt doctor --verbose` for the inventory, `cplt check` to probe enforcement.
```

**Built from `resolve_context`**, so `--agent`, `sandbox.agent` and auto-detect resolve with the launch's own precedence, and the policy comes from the same `SandboxConfig` the launch builds. Previously `run_doctor` took no `cli` at all and `auto_detect()` could only ever return Copilot, OpenCode or Antigravity — never Pi, Claude or Goose. That is the same defect class as #447.

**Findings, not inventory.** Tools, tool dirs, the "not found (skippable)" list, the protected-path inventory, per-agent paths and versions, and project ecosystems all move behind `--verbose`. Default view is paths as `~/…` — the output is meant to be pasted into public issues, and it used to leak the username and enumerate which credential stores exist.

**Rules that reason** rather than list: Pi's trust lock; a tracked `.env*` under the env deny (reusing #451's matcher); shim targets outside an exec grant; bubblewrap **three-valued** — usable / installed-but-unusable / disabled by config, using the same functionality probe the launch runs, because a PATH lookup alone repeats the "configured is not active" trap that caused #449's misdiagnosis.

## Two corrections made during review

The first draft gated the Pi finding on `version > 0.85.1`, reasoning that the linked commit is 27 commits ahead of the latest tag. I checked the published artefact instead: npm `latest` **is** 0.85.1, it depends on `proper-lockfile` 4.1.2, and its `getEntry` — the read path — wraps in `withTrustFileLock`. The gate would have silenced the finding for exactly the person who filed #449.

The draft also had the rule as "Pi × no bubblewrap". That is wrong and would have baked #449's original misdiagnosis into the diagnostic tool: the root is `write: false`, so `mkdir` fails under Landlock *and* under bubblewrap's mounts. Bubblewrap state does not change the answer.

## Depends on #455 — merge that first

#455 adds a create-only directory grant so Pi's lock works. After it lands, `~/.pi/agent` is `write: false` **with** `create_dirs: true`, and this PR's `dir_is_read_only` predicate keys only on `!access.write` — so it would report "Pi will not start" for every Pi user when Pi now starts fine, and exit non-zero.

Merge #455 first; I will rebase this and change the predicate to "read-only **and** cannot create directories", with the finding's text updated to match. Flagging rather than fixing blind, because the field does not exist on main yet.

Refs #449.