### PR TITLE
fix(check): carry the guard's own remedy, and know about the cached token

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -1316,10 +1316,15 @@ mod tests {
 
         let e = explain_exec(&["gh".into(), "auth".into(), "token".into()], &ctx);
         assert_eq!(e.decision, Decision::Allowed);
+        // The message does not interpolate `e.reason`: CodeQL traces this
+        // branch's string back through the guard plumbing and reports it as
+        // cleartext logging of sensitive information. It is a fixed
+        // explanation, not a token, so the alert is wrong — but the assertion
+        // reads fine without it, and arguing with the scanner is worth less
+        // than the two words of diagnostic it costs.
         assert!(
             e.reason.contains("served from the token file"),
-            "and says where it comes from: {}",
-            e.reason
+            "the explanation must say where the token comes from"
         );
 
         // Another `gh auth` subcommand is not the intercepted one.

--- a/src/check.rs
+++ b/src/check.rs
@@ -837,11 +837,11 @@ fn looks_like_tmp_path(cmd: &str) -> bool {
 /// the human operator") and the escape hatch, neither of which belongs in a
 /// `Fix:` line an operator reads — so this takes the guidance and leaves those.
 fn guidance(msg: &str) -> Option<String> {
-    const NOISE: &[&str] = &[
-        "This operation is restricted",
-        "Please make a note",
-        "Reason:",
-    ];
+    // `Reason:` stays. It looked like boilerplate, but some guards put the
+    // remedy there and nowhere else — the token-exfiltration refusal's "Use the
+    // GH_TOKEN env var instead" is on that line — so dropping it threw away
+    // exactly what this function exists to keep.
+    const NOISE: &[&str] = &["This operation is restricted", "Please make a note"];
     let lines: Vec<&str> = msg
         .lines()
         .skip(1)
@@ -1294,6 +1294,64 @@ mod tests {
         let ctx = exec_ctx(&gh, &git, false);
         let e = explain_exec(&["node".into(), "app.js".into()], &ctx);
         assert_eq!(e.decision, Decision::Allowed);
+    }
+
+    /// The launch serves `gh auth token` from the file cplt wrote at startup
+    /// rather than running the real `gh`, so reporting the block the policy
+    /// would otherwise imply is wrong (#440).
+    #[test]
+    fn gh_auth_token_is_served_not_blocked() {
+        // The interception only exists when the guard runs: with it off there
+        // is no shim, and the real `gh` handles the command.
+        let gh = GhGuardPolicy {
+            enabled: true,
+            ..GhGuardPolicy::default()
+        };
+        let git = GitGuardPolicy::default();
+        assert!(
+            gh.block_auth_token,
+            "the interception is on by default; this test means nothing otherwise"
+        );
+        let ctx = exec_ctx(&gh, &git, false);
+
+        let e = explain_exec(&["gh".into(), "auth".into(), "token".into()], &ctx);
+        assert_eq!(e.decision, Decision::Allowed);
+        assert!(
+            e.reason.contains("served from the token file"),
+            "and says where it comes from: {}",
+            e.reason
+        );
+
+        // Another `gh auth` subcommand is not the intercepted one.
+        let other = explain_exec(&["gh".into(), "auth".into(), "status".into()], &ctx);
+        assert_ne!(
+            other.reason, e.reason,
+            "only `auth token` is served from the file"
+        );
+    }
+
+    /// A guard that writes its own remedy must have it reach the reader. The
+    /// generic fix is the fallback, not the default — `check exec` used to show
+    /// only the first line and drop everything the guard said after it.
+    #[test]
+    fn a_refusal_carries_the_guards_own_guidance() {
+        let msg = "⚠️ BLOCKED by sandbox: 'gh api' targets 'other/repo'.\n\
+                   Reason: token exfiltration prevention. Use the GH_TOKEN env var instead.\n\
+                   This operation is restricted by the cplt sandbox environment.\n\
+                   Please make a note of this for the human operator.";
+        let out = guidance(msg).expect("the message carries guidance");
+        assert!(
+            out.contains("Use the GH_TOKEN env var"),
+            "the remedy on the Reason line must survive: {out}"
+        );
+        assert!(
+            !out.contains("make a note") && !out.contains("This operation is restricted"),
+            "but the lines addressed to the agent must not: {out}"
+        );
+        assert!(
+            guidance("⚠️ BLOCKED by sandbox: no further detail.").is_none(),
+            "a message with nothing after the headline falls back to the generic fix"
+        );
     }
 
     // ── Report verdict & JSON ──

--- a/src/check.rs
+++ b/src/check.rs
@@ -596,7 +596,13 @@ fn refusal_decision(
         EnforcementMode::Block => ExecExplain {
             decision: Decision::Blocked,
             reason: first_line(msg),
-            fix: Some(blocked_fix.to_string()),
+            // The guard's own guidance when it carries some, the generic line
+            // otherwise. The guards write remedies specific to the command that
+            // was refused — which repository to name, which spelling is allowed
+            // — and `first_line` was dropping all of it, so `check exec` told
+            // the reader less than the launch would have. It is the surface
+            // someone consults deliberately; it should not be the poorer one.
+            fix: Some(guidance(msg).unwrap_or_else(|| blocked_fix.to_string())),
         },
         // The command runs. Saying "allowed" alone would hide that the policy
         // objected, so the reason carries the objection and the fix says how to
@@ -731,6 +737,19 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 fix: None,
             };
         }
+        // The launch serves this from the cached token file rather than
+        // running the real `gh`, so reporting the policy's block would be
+        // wrong (#440).
+        if ctx.gh_guard.block_auth_token && crate::gh_proxy::is_auth_token_request(&rest) {
+            return ExecExplain {
+                decision: Decision::Allowed,
+                reason: "gh auth token is served from the token file cplt wrote at startup, \
+                         not by running gh — so the agent can authenticate without the token \
+                         being an environment variable every child process can read."
+                    .to_string(),
+                fix: None,
+            };
+        }
         if !ctx.scratch_dir {
             return ExecExplain {
                 decision: Decision::Allowed,
@@ -809,6 +828,28 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
 
 fn looks_like_tmp_path(cmd: &str) -> bool {
     cmd.starts_with("/tmp/") || cmd.starts_with("/private/tmp/") || cmd.starts_with("/var/tmp/")
+}
+
+/// The guard's own "way forward" lines, if its message carries any.
+///
+/// Both guards put the headline on the first line and the remedy below it. The
+/// tail also holds boilerplate addressed to the agent ("make a note of this for
+/// the human operator") and the escape hatch, neither of which belongs in a
+/// `Fix:` line an operator reads — so this takes the guidance and leaves those.
+fn guidance(msg: &str) -> Option<String> {
+    const NOISE: &[&str] = &[
+        "This operation is restricted",
+        "Please make a note",
+        "Reason:",
+    ];
+    let lines: Vec<&str> = msg
+        .lines()
+        .skip(1)
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter(|l| !NOISE.iter().any(|n| l.starts_with(n)))
+        .collect();
+    (!lines.is_empty()).then(|| lines.join(" "))
 }
 
 fn first_line(s: &str) -> String {

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1310,6 +1310,19 @@ fn scope_label(scope: &[String]) -> String {
 
 /// Two `owner/name` spellings naming the same repository: GitHub is
 /// case-insensitive and an origin URL may carry a `.git` suffix.
+/// Whether this argv is `gh auth token`.
+///
+/// One rule, two readers: the gate serves the cached token for it instead of
+/// running the real `gh`, and `check exec` has to report that rather than the
+/// block the policy would otherwise imply (#440). It lived only in `main.rs`,
+/// so the library surface could not see it — the same shape as the other four
+/// cases where `check exec` answered from fewer inputs than the launch has.
+#[must_use]
+pub fn is_auth_token_request(args: &[&str]) -> bool {
+    let mut positional = args.iter().copied().filter(|a| !a.starts_with('-'));
+    positional.next() == Some("auth") && positional.next() == Some("token")
+}
+
 pub fn repos_match(left: &str, right: &str) -> bool {
     left.trim_end_matches(".git")
         .eq_ignore_ascii_case(right.trim_end_matches(".git"))

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -1310,6 +1310,11 @@ fn scope_label(scope: &[String]) -> String {
 
 /// Two `owner/name` spellings naming the same repository: GitHub is
 /// case-insensitive and an origin URL may carry a `.git` suffix.
+pub fn repos_match(left: &str, right: &str) -> bool {
+    left.trim_end_matches(".git")
+        .eq_ignore_ascii_case(right.trim_end_matches(".git"))
+}
+
 /// Whether this argv is `gh auth token`.
 ///
 /// One rule, two readers: the gate serves the cached token for it instead of
@@ -1321,11 +1326,6 @@ fn scope_label(scope: &[String]) -> String {
 pub fn is_auth_token_request(args: &[&str]) -> bool {
     let mut positional = args.iter().copied().filter(|a| !a.starts_with('-'));
     positional.next() == Some("auth") && positional.next() == Some("token")
-}
-
-pub fn repos_match(left: &str, right: &str) -> bool {
-    left.trim_end_matches(".git")
-        .eq_ignore_ascii_case(right.trim_end_matches(".git"))
 }
 
 fn requires_invocation_repo_check(cmd: &ParsedCommand) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3513,13 +3513,12 @@ fn exec_real(
 }
 
 /// Check if args represent a `gh auth token` invocation.
+///
+/// Delegates so the gate and `cplt check exec` cannot disagree about what
+/// counts (#440).
 fn is_gh_auth_token_request(args: &[String]) -> bool {
-    // args are the arguments after `--` in `cplt gh-gate ... -- auth token`
-    let mut iter = args
-        .iter()
-        .map(String::as_str)
-        .filter(|a| !a.starts_with('-'));
-    iter.next() == Some("auth") && iter.next() == Some("token")
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    gh_proxy::is_auth_token_request(&refs)
 }
 
 /// Serve the cached GitHub token from the scratch dir's `.gh-token` file.


### PR DESCRIPTION
Two more cases of `check exec` telling the reader less than the launch does. Both surfaced while debugging a real multi-repo session, not from reading code.

## The guidance was being thrown away

The guards write remedies specific to the command refused — which repository to name, which spelling is allowed instead. `refusal_decision` kept `first_line(msg)` and dropped the rest, substituting a generic fix. So the `sandbox.repo_dirs` guidance added in #450 was invisible in `check exec`.

Before, in a repository with two named sibling checkouts in scope:

```
Fix: use a read-only / in-scope gh command, run it from the startup
     repository's checkout, or relax the gh guard (e.g. [sandbox] gh_proxy settings)
```

After — the same text the launch prints:

```
Fix: Ways forward: read-only commands take an explicit repository — `gh pr view -R
     <owner>/<repo> <number>` … If the agent works in that repository too and it is
     checked out inside this one, name it with `cplt config set --local
     sandbox.repo_dirs <DIR>` and it joins the scope set.
```

The lines addressed to the agent ("make a note of this for the human operator") and the escape hatch are dropped, since neither belongs in a `Fix:` an operator reads.

That this was the *worse* surface is the point: `check exec` is what someone runs deliberately to ask "what happens and what do I do", while the launch message interrupts an agent mid-task.

## #440: the cached token

`gh auth token` was reported blocked while the launch serves it from the token file written at startup — the mechanism that lets an agent authenticate without the token being an environment variable every child process can read.

```
gh auth token: ALLOWED
  Reason: gh auth token is served from the token file cplt wrote at startup, not by
  running gh — so the agent can authenticate without the token being an environment
  variable every child process can read.
```

The predicate lived in `main.rs`, where the library could not see it. It moves to `gh_proxy` and both callers share it, so the gate and the explanation cannot disagree about what counts as `gh auth token`.

## The pattern, again

Fifth and sixth instances. #453 closed the structural cause for **inputs** — `ExecContext` is derived from the launch's own resolution, so a new input reaches both surfaces or neither. It did not close it for **outputs**: a guard can still add a remedy the explanation does not repeat, which is exactly what happened here. Whether that needs the same treatment is worth deciding rather than discovering a seventh time.

Closes #440.