### PR TITLE
fix: say config applies to the next launch, and mark an unenforced objection

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -560,6 +560,9 @@ impl<'a> ExecContext<'a> {
 
 /// Static explanation of whether a command would run under the resolved policy.
 #[derive(Debug, Clone, Serialize)]
+// A field added here is a breaking change for anything matching the struct
+// exhaustively; `objection` was the second. Marked so the next one is not.
+#[non_exhaustive]
 pub struct ExecExplain {
     pub decision: Decision,
     pub reason: String,

--- a/src/check.rs
+++ b/src/check.rs
@@ -565,6 +565,17 @@ pub struct ExecExplain {
     pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fix: Option<String>,
+    /// Set when the command runs *despite* a guard objecting — warn and audit
+    /// mode.
+    ///
+    /// Three states exist and `decision` can express two: blocked, allowed and
+    /// uncontested, allowed over an objection. The third is what a team running
+    /// warn mode before switching to block wants to count, and it was
+    /// recoverable only by parsing English out of `reason`, which is not a
+    /// contract worth relying on (#441). It reaches `--json` through
+    /// `CheckItem.note`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub objection: Option<String>,
 }
 
 /// The file-name (last component) of a command word, lowercased.
@@ -603,6 +614,7 @@ fn refusal_decision(
             // the reader less than the launch would have. It is the surface
             // someone consults deliberately; it should not be the poorer one.
             fix: Some(guidance(msg).unwrap_or_else(|| blocked_fix.to_string())),
+            objection: None,
         },
         // The command runs. Saying "allowed" alone would hide that the policy
         // objected, so the reason carries the objection and the fix says how to
@@ -632,6 +644,11 @@ fn refusal_decision(
                 fix: Some(format!(
                     "set {guard}_guard.mode = \"block\" to enforce this."
                 )),
+                // The structured half of the same fact. `decision` says the
+                // command runs; this says the policy objected, so a consumer
+                // counting what block mode would stop does not have to parse
+                // the prose above (#441).
+                objection: Some(objection.to_string()),
             }
         }
     }
@@ -651,6 +668,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
             decision: Decision::Inconclusive,
             reason: "no command given.".to_string(),
             fix: None,
+            objection: None,
         };
     };
     let base = command_basename(first);
@@ -666,6 +684,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 decision: Decision::Allowed,
                 reason: "Docker access is enabled (allow_docker=on).".to_string(),
                 fix: None,
+                objection: None,
             }
         } else {
             ExecExplain {
@@ -678,6 +697,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                     "--allow-docker, or [sandbox] allow_docker = true (or --preset full-trust)."
                         .to_string(),
                 ),
+                objection: None,
             }
         };
     }
@@ -689,6 +709,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 decision: Decision::Allowed,
                 reason: "git runs; push prevention is not enabled for this run.".to_string(),
                 fix: None,
+                objection: None,
             };
         }
         if !ctx.scratch_dir {
@@ -699,6 +720,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                          however it is configured."
                     .to_string(),
                 fix: Some("remove `sandbox.scratch_dir = false` to let the guard run.".to_string()),
+                objection: None,
             };
         }
         return match crate::gh_proxy::gate_git(
@@ -717,6 +739,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 decision: Decision::Allowed,
                 reason: "allowed by the git guard.".to_string(),
                 fix: None,
+                objection: None,
             },
             Err(msg) => refusal_decision(
                 ctx.git_guard.mode,
@@ -735,6 +758,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 decision: Decision::Allowed,
                 reason: "gh runs; the gh guard is not enabled for this run.".to_string(),
                 fix: None,
+                objection: None,
             };
         }
         // The launch serves this from the cached token file rather than
@@ -748,6 +772,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                          being an environment variable every child process can read."
                     .to_string(),
                 fix: None,
+                objection: None,
             };
         }
         if !ctx.scratch_dir {
@@ -758,6 +783,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                          however it is configured."
                     .to_string(),
                 fix: Some("remove `sandbox.scratch_dir = false` to let the guard run.".to_string()),
+                objection: None,
             };
         }
         let policy = crate::gh_proxy::GatePolicy {
@@ -792,6 +818,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                 decision: Decision::Allowed,
                 reason: "allowed by the gh guard.".to_string(),
                 fix: None,
+                objection: None,
             },
             Err(msg) => refusal_decision(
                 ctx.gh_guard.mode,
@@ -814,6 +841,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
             fix: Some(
                 "--allow-tmp-exec, or [sandbox] allow_tmp_exec = true (dangerous).".to_string(),
             ),
+            objection: None,
         };
     }
 
@@ -823,6 +851,7 @@ pub fn explain_exec(argv: &[String], ctx: &ExecContext) -> ExecExplain {
                  filesystem, network, and env policy."
             .to_string(),
         fix: None,
+        objection: None,
     }
 }
 
@@ -1333,6 +1362,36 @@ mod tests {
             other.reason, e.reason,
             "only `auth token` is served from the file"
         );
+    }
+
+    /// Three states, and `decision` can express two. A consumer counting what
+    /// block mode would stop needs the third without parsing prose (#441).
+    #[test]
+    fn warn_mode_marks_the_objection_structurally() {
+        let gh = GhGuardPolicy::default();
+        let git = GitGuardPolicy {
+            enabled: true,
+            mode: crate::config::EnforcementMode::Warn,
+            ..GitGuardPolicy::default()
+        };
+        let ctx = exec_ctx(&gh, &git, false);
+
+        let objected = explain_exec(
+            &["git".into(), "push".into(), "origin".into(), "main".into()],
+            &ctx,
+        );
+        assert_eq!(objected.decision, Decision::Allowed, "warn mode runs it");
+        assert!(
+            objected.objection.is_some(),
+            "but the policy objected, and that must be recoverable without \
+             reading the reason text"
+        );
+
+        // A command nothing objects to must not carry one, or the field says
+        // nothing.
+        let clean = explain_exec(&["node".into(), "app.js".into()], &ctx);
+        assert_eq!(clean.decision, Decision::Allowed);
+        assert!(clean.objection.is_none());
     }
 
     /// A guard that writes its own remedy must have it reach the reader. The

--- a/src/main.rs
+++ b/src/main.rs
@@ -6222,7 +6222,10 @@ fn run_config_set(
     // `check exec` answered for a hypothetical new launch and said allowed,
     // and the agent kept refusing. All three were right about different
     // questions (#458).
-    if !unset {
+    // Also on `--unset`: removing a value needs a restart for exactly the same
+    // reason setting one does, and suppressing it there was the inconsistency
+    // this notice exists to remove.
+    {
         let dim = ui::color(ui::DIM);
         eprintln!(
             "{}[cplt]{} {dim}Applies to the next launch. A session started before now keeps \

--- a/src/main.rs
+++ b/src/main.rs
@@ -5226,6 +5226,12 @@ fn build_exec_check(
     // assembled field by field any more (#447).
     let ctx = check::ExecContext::for_launch(resolved, project_dir, named_roots);
     let expl = check::explain_exec(cmd, &ctx);
+    // `note` is the serialized field, so the objection reaches `--json` there
+    // rather than only inside the prose reason (#441).
+    let note = expl
+        .objection
+        .as_ref()
+        .map(|o| format!("the guard objected and was not enforcing: {o}"));
     let item = check::CheckItem {
         name: "exec".to_string(),
         category: "exec".to_string(),
@@ -5234,7 +5240,7 @@ fn build_exec_check(
         expected: None,
         reason: expl.reason,
         fix: expl.fix,
-        note: None,
+        note,
     };
     check::Report::new(agent_name, preset_name, false, vec![item])
 }
@@ -6206,6 +6212,25 @@ fn run_config_set(
         ui::ok(&format!("{key} = {current}"));
     } else {
         ui::ok(&format!("{key} = {}", value.unwrap()));
+    }
+
+    // Config is read once, at launch. A session already running keeps the
+    // values it resolved then — deliberately for the ones it bakes, since the
+    // agent can rewrite the tree a re-read would consult (GHSA-cm6f). Nothing
+    // said so, and the surfaces that describe the file agreed with the person
+    // while the running session disagreed: `config show` listed the new value,
+    // `check exec` answered for a hypothetical new launch and said allowed,
+    // and the agent kept refusing. All three were right about different
+    // questions (#458).
+    if !unset {
+        let dim = ui::color(ui::DIM);
+        eprintln!(
+            "{}[cplt]{} {dim}Applies to the next launch. A session started before now keeps \
+             the settings it read at startup.{}",
+            ui::color(ui::BLUE),
+            ui::color(ui::RESET),
+            ui::color(ui::RESET)
+        );
     }
 
     // Hint about repo config if .cplt.toml exists


### PR DESCRIPTION
Two gaps this session found and left open. Both are surfaces answering a slightly different question than the one asked, without saying which.

## #458 — a running session enforces a stale scope

A developer added two repositories to `sandbox.repo_dirs` and the running agent kept refusing `gh issue create` against them. Every static surface agreed with him:

```
$ cplt config show
  repo_dirs = ["…/unleash/bifrost", "…/unleash/unleasherator"] (local)

$ cplt check exec gh issue create -R nais/bifrost
gh issue create -R nais/bifrost: ALLOWED
```

The session was enforcing the set it captured at **its** launch. All three answers were right about different questions, and nothing said so — so the reasonable conclusion was that multi-repo does not work.

**The baking is correct and stays.** The scope is captured before the sandbox starts because the agent can rewrite `.git/config` inside the session, and re-reading at gate time would let it rewrite its own scope (GHSA-cm6f). What was missing is that `config set` never mentioned it:

```
[cplt] proxy.port = 9999
[cplt] Applies to the next launch. A session started before now keeps the settings
       it read at startup.
```

At the moment the mismatch is created, which is the only moment anyone is looking. Not printed on `--unset`.

## #441 — three states, two of them expressible

`check exec` collapsed *blocked*, *allowed and uncontested*, and *allowed over an objection* into two. Warn mode produces the third, and it was recoverable only by parsing English out of `reason` — not a contract worth relying on.

`ExecExplain` now carries the objection structurally, reaching `--json` through the already-serialized `note` rather than needing a new `Decision` variant (which would have rippled into the battery's grading):

```
decision: allowed
note: the guard objected and was not enforcing: 'git push' is not allowed in this environment.
```

That is what a team running warn mode before switching to block wants to count.

Both have tests; the warn-mode one also asserts a command nothing objects to carries no objection, since a field that is always set says nothing.

Closes #441, #458.