### PR TITLE
feat(repo-config): let a project propose the environment variables it needs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,7 +283,6 @@ The settings below are machine-specific or local CLI preferences, so `.cplt.toml
 | `sandbox.brief` | local agent-context preference |
 | `sandbox.agents_md` | a repo must not be able to make cplt write into its own `AGENTS.md` |
 | `sandbox.use_bubblewrap` | depends on bwrap being installed on the machine |
-| `sandbox.pass_env` | machine-specific env passthrough |
 | `sandbox.audit` | local output preference, not project sandbox policy |
 | `sandbox.gradle_init` | writes to the machine's Gradle user home, not project policy |
 | `sandbox.inherit_env` | too dangerous for repo config, it would affect every team member |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,6 +268,8 @@ Each toggle resolves in this order: explicit CLI flag, then explicit config valu
 
 Project-specific sandbox permissions belong in `.cplt.toml`, approved with `cplt trust`. That covers `sandbox.allow_jvm_attach`, `sandbox.allow_msbuild`, `sandbox.allow_docker`, `sandbox.allow_localhost_any`, and `allow.ports`. Machine-specific paths such as `allow.read ~/.gitconfig` go in `~/.config/cplt/config.toml`.
 
+`sandbox.pass_env` is the exception among the environment settings: a project can propose the variables its build needs (`NODE_ENV`, `TZ`, `SPRING_PROFILES_ACTIVE`), because it names them one at a time and a reviewer sees the list in the diff. The value still comes from whoever launches the agent, never from the file, and each developer approves once with `cplt trust`. `sandbox.inherit_env` stays refused — it passes the whole environment, so there is nothing for a reviewer to review.
+
 The settings below are machine-specific or local CLI preferences, so `.cplt.toml` does not support them at all. `cplt config set --repo <key>` rejects each one with an explanation. Set them globally instead.
 
 | Key | Why |

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1550,6 +1550,18 @@ impl Resolved {
             }
         }
 
+        // `pass_env` proposals (#443). The variable is read from the parent's
+        // environment at launch, so what a repo can express here is a *name*,
+        // never a value — and it does nothing until this machine's human has
+        // accepted it.
+        if is_approved("sandbox.pass_env") {
+            for name in &repo_config.propose.pass_env {
+                if !self.pass_env.contains(name) {
+                    self.pass_env.push(name.clone());
+                }
+            }
+        }
+
         // Port proposals
         if is_approved("allow.ports") {
             for &port in &repo_config.propose.allow.ports {

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -1560,6 +1560,11 @@ impl Resolved {
                     self.pass_env.push(name.clone());
                 }
             }
+            // The list is sorted and deduped when config and CLI are merged;
+            // appending here would leave it neither, and every other proposal
+            // that extends a list restores the invariant.
+            self.pass_env.sort();
+            self.pass_env.dedup();
         }
 
         // Port proposals

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -16,6 +16,8 @@ pub enum RepoKeyTarget {
     ProposeAllow(&'static str),
     /// Goes under [propose.proxy] as an array.
     ProposeProxy(&'static str),
+    /// Goes under [propose] as a top-level string array.
+    ProposeStrArray(&'static str),
     /// Goes under [deny] directly.
     Deny(&'static str),
 }
@@ -169,6 +171,7 @@ pub fn repo_key_target(key_info: &ConfigKeyInfo) -> Option<RepoKeyTarget> {
     }
     match (key_info.section, key_info.key) {
         // Propose arrays
+        ("sandbox", "pass_env") => Some(RepoKeyTarget::ProposeStrArray("pass_env")),
         ("allow", "read") => Some(RepoKeyTarget::ProposeAllow("read")),
         ("allow", "write") => Some(RepoKeyTarget::ProposeAllow("write")),
         ("allow", "ports") => Some(RepoKeyTarget::ProposeAllow("ports")),
@@ -212,11 +215,6 @@ pub fn repo_key_rejection_reason(key_info: &ConfigKeyInfo) -> &'static str {
         // (#443). The hazard is the direction of the read: `pass_env` names a
         // variable in the *parent's* environment, so a committed entry pulls
         // whatever this machine happens to have under that name.
-        ("sandbox", "pass_env") => {
-            "names a variable to copy from whoever launched the agent, so a committed entry \
-             would pull whatever each machine happens to have under that name — including a \
-             credential a repo must not be able to ask for by spelling"
-        }
         ("sandbox", "repo_dirs") => {
             "naming other trees as project-grade roots is a path grant, and repo config \
              cannot grant paths. It is a per-checkout user setting: \
@@ -296,6 +294,38 @@ pub fn set_repo_value_in_doc(
                     )));
                 }
                 section[key_info.key] = toml_edit::value(b);
+            }
+        }
+        // A top-level `[propose]` array — the same shape as `ProposeAllow`
+        // without the nested table, since `pass_env` is a sandbox key rather
+        // than a path or port grant.
+        RepoKeyTarget::ProposeStrArray(array_key) => {
+            let propose = doc
+                .entry("propose")
+                .or_insert(Item::Table(Table::new()))
+                .as_table_mut()
+                .ok_or_else(|| ConfigError::Validation("invalid [propose] section".to_string()))?;
+            if unset {
+                if value.is_empty() {
+                    propose.remove(array_key);
+                } else if let Some(arr) = propose.get_mut(array_key).and_then(|v| v.as_array_mut())
+                {
+                    arr.retain(|v| v.as_str().unwrap_or_default() != value);
+                    if arr.is_empty() {
+                        propose.remove(array_key);
+                    }
+                } else {
+                    propose.remove(array_key);
+                }
+            } else {
+                let arr = propose
+                    .entry(array_key)
+                    .or_insert(Item::Value(Value::Array(Array::new())))
+                    .as_array_mut()
+                    .ok_or_else(|| ConfigError::Validation("expected array".to_string()))?;
+                if !arr.iter().any(|v| v.as_str() == Some(value)) {
+                    arr.push(value);
+                }
             }
         }
         RepoKeyTarget::ProposeAllow(array_key) => {

--- a/src/config/repo.rs
+++ b/src/config/repo.rs
@@ -206,15 +206,15 @@ pub fn repo_key_rejection_reason(key_info: &ConfigKeyInfo) -> &'static str {
         ("sandbox", "use_bubblewrap") => {
             "depends on bwrap being installed locally, not project policy"
         }
+        // The contrast with `pass_env`, which IS proposable (#443), is
+        // reviewability rather than anything about environment variables:
+        // `pass_env` names them one at a time so a reviewer can read the list,
+        // this passes everything so there is nothing to review.
         ("sandbox", "inherit_env") => {
-            "too dangerous for repo config, it would affect all team members"
+            "passes the whole environment, so a repo cannot enumerate what it is asking for \
+             and a reviewer cannot see it. `sandbox.pass_env` names variables one at a time \
+             and can be proposed"
         }
-        // Not "environment variables are machine-specific" — plenty are the
-        // application's (NODE_ENV, TZ, SPRING_PROFILES_ACTIVE) and are not
-        // sensitive at all, so that premise loses an argument it should win
-        // (#443). The hazard is the direction of the read: `pass_env` names a
-        // variable in the *parent's* environment, so a committed entry pulls
-        // whatever this machine happens to have under that name.
         ("sandbox", "repo_dirs") => {
             "naming other trees as project-grade roots is a path grant, and repo config \
              cannot grant paths. It is a per-checkout user setting: \

--- a/src/main.rs
+++ b/src/main.rs
@@ -6369,11 +6369,14 @@ fn run_config_set_repo(
     );
 
     // Remind about trust approval for propose keys
+    // Every `[propose]` shape, including the top-level arrays: a proposal the
+    // author is not told to approve is one that silently does nothing.
     if matches!(
         target,
         config::RepoKeyTarget::ProposeBool
             | config::RepoKeyTarget::ProposeAllow(_)
             | config::RepoKeyTarget::ProposeProxy(_)
+            | config::RepoKeyTarget::ProposeStrArray(_)
     ) && !unset
     {
         eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6354,7 +6354,8 @@ fn run_config_set_repo(
         let section_name = match target {
             config::RepoKeyTarget::ProposeBool
             | config::RepoKeyTarget::ProposeAllow(_)
-            | config::RepoKeyTarget::ProposeProxy(_) => "propose",
+            | config::RepoKeyTarget::ProposeProxy(_)
+            | config::RepoKeyTarget::ProposeStrArray(_) => "propose",
             config::RepoKeyTarget::Deny(_) => "deny",
             _ => "unknown",
         };

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -64,6 +64,21 @@ pub struct ProposeSection {
     pub gh_guard: Option<bool>,
     pub git_push_prevention: Option<bool>,
 
+    /// Environment variables the project needs passed through.
+    ///
+    /// `pass_env` names a variable in the *parent's* environment, so a
+    /// committed entry pulls whatever the machine running the agent happens to
+    /// have under that name. That is why it is a proposal rather than a `deny`:
+    /// the repository states what the build needs, a reviewer sees the list in
+    /// the diff, and each developer accepts it on their own machine — where an
+    /// edit changes the file's hash and de-activates the approval (#443).
+    ///
+    /// Plenty of these are the application's rather than the machine's —
+    /// `NODE_ENV`, `TZ`, `SPRING_PROFILES_ACTIVE` — and none of those is
+    /// sensitive. The refusal used to claim otherwise.
+    #[serde(default)]
+    pub pass_env: Vec<String>,
+
     /// Proposed path/port expansions.
     #[serde(default)]
     pub allow: ProposeAllowSection,
@@ -465,6 +480,9 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     }
     if !propose.allow.socket.is_empty() {
         keys.push("allow.socket");
+    }
+    if !propose.pass_env.is_empty() {
+        keys.push("sandbox.pass_env");
     }
     if !propose.allow.ports.is_empty() {
         keys.push("allow.ports");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -737,6 +737,7 @@ fn repo_value_is_unset(doc: &toml_edit::DocumentMut, key: &ConfigKeyInfo) -> boo
         Some(RepoKeyTarget::ProposeBool) => !repo_proposal_enabled(doc, key),
         Some(RepoKeyTarget::ProposeAllow(name)) => nested_repo_value(doc, "propose", "allow", name),
         Some(RepoKeyTarget::ProposeProxy(name)) => nested_repo_value(doc, "propose", "proxy", name),
+        Some(RepoKeyTarget::ProposeStrArray(name)) => direct_repo_value(doc, "propose", name),
         Some(RepoKeyTarget::Deny(name)) => direct_repo_value(doc, "deny", name),
         None => true,
     }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -6448,8 +6448,11 @@ fn repo_key_target_rejects_machine_specific_keys() {
         "sandbox.quiet",
         "sandbox.validate",
         "sandbox.scratch_dir",
+        // `inherit_env` stays rejected: it passes the whole environment, so a
+        // repo could not enumerate what it is asking for and a reviewer could
+        // not see it. `pass_env` names variables one at a time, which is why it
+        // moved to `[propose]` (#443) and is asserted below instead.
         "sandbox.inherit_env",
-        "sandbox.pass_env",
         "proxy.enabled",
         "proxy.port",
         "proxy.log_file",
@@ -6466,6 +6469,21 @@ fn repo_key_target_rejects_machine_specific_keys() {
             "{key_str} should be rejected in repo config"
         );
     }
+
+    // The deliberate exception (#443). The old refusal said environment
+    // variables are machine-specific and not project policy; plenty are the
+    // application's — NODE_ENV, TZ, SPRING_PROFILES_ACTIVE — and none of those
+    // is sensitive. The real hazard is that the name is resolved against the
+    // *parent's* environment, which is what `[propose]` plus a per-machine
+    // acceptance is for.
+    let pass_env = lookup_key("sandbox.pass_env").unwrap();
+    assert!(
+        matches!(
+            repo_key_target(pass_env),
+            Some(cplt::config::RepoKeyTarget::ProposeStrArray("pass_env"))
+        ),
+        "sandbox.pass_env is proposable, and nothing else changed about it"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`sandbox.pass_env` was refused in `.cplt.toml` because "environment variables are machine-specific, not project policy". That premise is wrong often enough to lose the argument: `NODE_ENV`, `TZ` and `SPRING_PROFILES_ACTIVE` are the application's, and none is sensitive. If a project's tests need `TZ=Europe/Oslo`, that is project policy in the same sense `allow.ports 5432` is — and every developer had to discover it separately.

#450 fixed the message to state the real hazard. This changes the behaviour to match it.

## The hazard is an argument for `[propose]`, not against it

`pass_env` names a variable in the **parent's** environment, so a committed entry pulls whatever each machine happens to have under that name. A committed `pass_env = ["GITHUB_TOKEN"]` reads as ordinary configuration in a diff.

That is an argument against applying it automatically. It is not an argument against *proposing* it — `[propose]` plus the hash-pinned trust store is precisely "the repo asks, a human accepts on this machine, and an edit de-activates the approval". A repo names variables one at a time, a reviewer sees the list in the diff, and each developer accepts once. The value never comes from the file.

## Verified end to end

```
$ cplt config set --repo sandbox.pass_env NODE_ENV
[cplt] sandbox.pass_env = NODE_ENV → .cplt.toml [propose]

$ cplt trust
  sandbox.pass_env    ○ pending

# unapproved: the launch applies nothing
# after `cplt trust accept --all`, with NODE_ENV=production in the parent:
$ cplt exec -- env | grep NODE_ENV
NODE_ENV=production
```

## `inherit_env` stays refused, for a reason now written down

The test used to list the two together. They are different: `inherit_env` passes the *whole* environment, so a repo cannot enumerate what it is asking for and a reviewer cannot see it. The line between them is reviewability, not "environment variables are machine-specific" — and the test says so now instead of grouping them.

Docs updated in both places, including a stale table row that still listed `pass_env` as unsupported three lines above the new paragraph explaining it.

Closes #443.