### PR TITLE
fix(settings): Enter flips a boolean instead of asking you to type one

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -24,9 +24,9 @@ use ratatui::{
 
 use crate::config::{
     self, ConfigKeyInfo, ConfigLayer, ConfigValueType, RepoKeyTarget, Resolved, all_config_keys,
-    append_value_in_doc, get_value_from_doc, repo_key_target, security_confirmation,
-    set_repo_value_in_doc, set_value_in_doc, unset_value_in_doc, validate_global_document,
-    write_document_atomically, write_repo_document_atomically,
+    append_value_in_doc, get_value_from_doc, repo_key_rejection_reason, repo_key_target,
+    security_confirmation, set_repo_value_in_doc, set_value_in_doc, unset_value_in_doc,
+    validate_global_document, write_document_atomically, write_repo_document_atomically,
 };
 use crate::{repo_config, trust};
 
@@ -116,8 +116,9 @@ impl SettingsApp {
             editing_filter: false,
             editing_value: false,
             value_input: String::new(),
-            status: "Use / to search, Tab to change scope, Enter to edit, Ctrl+S to save."
-                .to_string(),
+            status:
+                "Use / to search, Tab to change scope, Enter to toggle or edit, Ctrl+S to save."
+                    .to_string(),
             pending: Vec::new(),
             global_doc,
             global_path,
@@ -246,7 +247,20 @@ impl SettingsApp {
         }
         if self.scope == Scope::Repository {
             let Some(RepoKeyTarget::ProposeBool) = repo_key_target(key) else {
-                self.status = "Repository deny and list values are edited with Enter.".to_string();
+                // "edited with Enter" was circular once Enter started routing
+                // booleans here. Say what is actually true of this key: either
+                // repo config will not take it at all, or it is not a boolean
+                // proposal and needs the value editor.
+                self.status = if repo_key_target(key).is_none() {
+                    format!(
+                        "{}.{} is not valid in repo config: {}",
+                        key.section,
+                        key.key,
+                        repo_key_rejection_reason(key)
+                    )
+                } else {
+                    "Repository deny and list values are edited in the value field.".to_string()
+                };
                 return;
             };
             let preview = self.preview_repo_doc();
@@ -914,7 +928,20 @@ fn run_loop(
                 app.selected = (app.selected + 1).min(app.visible_keys().len().saturating_sub(1));
             }
             KeyCode::Char(' ') => app.toggle_selected(),
-            KeyCode::Enter => app.begin_value_edit(),
+            // Enter on a boolean flips it rather than opening a text field to
+            // type `true` or `false` into. There are two values and the editor
+            // asks the reader to spell one — Space already did the right thing,
+            // and Enter is the key someone presses first.
+            KeyCode::Enter => {
+                if app
+                    .selected_key()
+                    .is_some_and(|key| key.value_type == ConfigValueType::Bool)
+                {
+                    app.toggle_selected();
+                } else {
+                    app.begin_value_edit();
+                }
+            }
             KeyCode::Char('r') => {
                 if let Some(key) = app.selected_key() {
                     if app.scope == Scope::Effective {
@@ -1057,7 +1084,7 @@ fn render(frame: &mut ratatui::Frame, app: &mut SettingsApp) {
         },
     );
     let footer = format!(
-        "{}\nFilter: {}{}  Pending: {}  [/] search [Tab] scope [Space] toggle [Enter] edit [R] reset [Ctrl+S] save [Q] quit",
+        "{}\nFilter: {}{}  Pending: {}  [/] search [Tab] scope [Enter] toggle/edit [R] reset [Ctrl+S] save [Q] quit",
         app.status,
         app.filter,
         if app.editing_filter { "▌" } else { "" },


### PR DESCRIPTION
A boolean has two values, and Enter opened a text field to spell one of them into. Space already toggled — but Enter is the key someone presses first, and it led to the worse path.

Enter now toggles for boolean keys and opens the value editor for everything else.

## One knock-on, fixed

A boolean in Repository scope that is not a `[propose]` boolean used to fall into:

> Repository deny and list values are edited with Enter.

Which is what the reader had just pressed. It now says whichever of the two things is actually true: that repo config will not take the key at all — naming the reason it gives — or that it needs the value field.

Footer and opening hint updated to match. A keymap that describes a key as doing something it no longer does is how people stop reading the footer.