### PR TITLE
fix(release): only release from a push to this repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,9 +20,23 @@ env:
 jobs:
   version:
     name: Determine version
+    # `branches: [main]` on `workflow_run` filters the TRIGGERING run's head
+    # branch, not the base. CI runs on `pull_request`, so a fork PR opened from
+    # a branch named `main` produces a CI run this filter matches — and the jobs
+    # below check out `workflow_run.head_sha`, which is the fork's commit, then
+    # build it, attest it (`id-token: write`) and publish a release
+    # (`contents: write`) that the Homebrew tap serves to users.
+    #
+    # The only gate was `conclusion == 'success'`, and a fork PR's CI needs a
+    # maintainer to approve the run — a routine click while reviewing a
+    # contribution, not a security decision anyone would weigh. Require the
+    # triggering run to be a push to this repository instead: releases come
+    # from main, never from a pull request (#357).
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}


### PR DESCRIPTION
**A fork pull request could have caused cplt to build, attest and publish a release from the fork's commit.** Not exploited — see below — but reachable, and gated on a click a maintainer makes routinely.

## The chain

1. **CI runs on `pull_request`**, including from forks.
2. **`branches: [main]` on a `workflow_run` trigger filters the *triggering run's head branch*, not the base.** A fork PR opened from a branch named `main` — what many contributors push from — matches it.
3. The release jobs check out **`github.event.workflow_run.head_sha`**, which is the fork's commit.
4. They build it, attest it (`id-token: write`, `attestations: write`), and publish a GitHub release (`contents: write`).
5. **The Homebrew tap serves those releases to users.**

The only gate was `conclusion == 'success'`. A fork PR's CI does need a maintainer to approve the run — but that is a routine click while reviewing a contribution, not a decision anyone weighs as *"should this build and publish a signed release under our attestation identity"*. One approval on a PR from a fork whose branch happens to be named `main` was enough.

## The fix

The triggering run must now be a **push**, from **this repository**:

```yaml
github.event_name == 'workflow_dispatch' ||
(github.event.workflow_run.conclusion == 'success' &&
 github.event.workflow_run.event == 'push' &&
 github.event.workflow_run.head_repository.full_name == github.repository)
```

Releases come from main; a pull request cannot produce one, approved or not. `workflow_dispatch` is unchanged. The reasoning is in the workflow beside the condition, because the next person editing that trigger needs it more than a commit log does.

## Not exploited, verified

Every one of the **last 100 releases** was built from a commit that is an ancestor of `main` — checked with `git merge-base --is-ancestor`, not assumed. The only fork PR in the repository (#435) is from `feat/54-network-snapshot`, which the branch filter never matched.

`release.yaml` was the only workflow with this shape. CI's use of `github.event.pull_request.head.sha` is a version string in a fork-context build with no secrets, which is fine.

## No advisory

No shipped version was affected. The exposure was in the pipeline, and nothing was published from it — so there is nothing for a user to upgrade away from, and an advisory would ask people to act where there is no action.

Closes #357.