### PR TITLE
fix(audit): a named repository was reported clean without being looked at

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -660,24 +660,42 @@ fn git_output(project_dir: &Path, args: &[&str]) -> Option<String> {
     Some(String::from_utf8_lossy(&buf).into_owned())
 }
 
-/// Writable roots the audit does NOT measure: every `allow.write` grant that
-/// falls outside `project_dir`.
+/// Writable roots the audit does NOT measure: every `--repo-dir` root, plus
+/// every `allow.write` grant that falls outside `project_dir`.
 ///
 /// The audit runs git in `project_dir` alone, so a session that only touched a
 /// granted repository is reported as "no project file changes" — an absence of
 /// information rendered as a clean bill of health (#214). Naming the roots
 /// removes the false assurance; auditing them properly needs a per-root report
-/// format and belongs with the multi-repo work in #165.
+/// format and belongs with the multi-repo work in #344.
 ///
-/// Paths *inside* `project_dir` are omitted: the project's own `git status`
+/// A named root is listed even though it sits *inside* `project_dir`: it keeps
+/// its own git history, so the project's `git status` renders it as a single
+/// `?? <dir>/` line, or as nothing at all when it is gitignored. That is the
+/// same absence of information one level down, and it is the case `--repo-dir`
+/// exists to create.
+///
+/// Other paths inside `project_dir` are omitted: the project's own `git status`
 /// already covers them. (A grant pointing at a git-ignored subdirectory is a
 /// residual — git does not report those either, and this function cannot tell.)
-fn unaudited_roots<'a>(project_dir: &Path, allow_write: &'a [PathBuf]) -> Vec<&'a Path> {
-    allow_write
+fn unaudited_roots<'a>(
+    project_dir: &Path,
+    allow_write: &'a [PathBuf],
+    named_roots: &'a [PathBuf],
+) -> Vec<&'a Path> {
+    let mut roots: Vec<&Path> = named_roots.iter().map(PathBuf::as_path).collect();
+    for grant in allow_write
         .iter()
         .map(PathBuf::as_path)
         .filter(|p| !p.starts_with(project_dir))
-        .collect()
+    {
+        // A grant may name a root that `--repo-dir` already named; one line per
+        // path, or the count contradicts the list.
+        if !roots.contains(&grant) {
+            roots.push(grant);
+        }
+    }
+    roots
 }
 
 /// The warning line naming the writable roots the audit did not measure, or
@@ -698,8 +716,17 @@ fn unaudited_warning(project_dir: &Path, unaudited: &[&Path]) -> Option<String> 
         .map(|p| escape_path(&p.display().to_string()))
         .collect::<Vec<_>>()
         .join(", ");
+    // Said only when a listed root is nested, because that is the line that
+    // otherwise reads as a contradiction: "audit covers /w/app only" followed
+    // by "/w/app/lib was NOT audited".
+    let nested = if unaudited.iter().any(|p| p.starts_with(project_dir)) {
+        " A repository checked out inside the project keeps its own git history, so its \
+         changes never appear in the project's git status."
+    } else {
+        ""
+    };
     Some(format!(
-        "audit covers {} only — {} writable path{} outside it {} NOT audited: {list}",
+        "audit covers {} only — {} writable path{} {} NOT audited: {list}.{nested}",
         escape_path(&project_dir.display().to_string()),
         unaudited.len(),
         if unaudited.len() == 1 { "" } else { "s" },
@@ -885,6 +912,7 @@ impl SettleProbe {
 pub fn run<F: FnOnce() -> u8>(
     project_dir: &Path,
     allow_write: &[PathBuf],
+    named_roots: &[PathBuf],
     enabled: bool,
     exec: F,
 ) -> u8 {
@@ -907,7 +935,10 @@ pub fn run<F: FnOnce() -> u8>(
             "the session left processes running — anything they change from here on is NOT audited",
         );
     }
-    if let Some(line) = unaudited_warning(project_dir, &unaudited_roots(project_dir, allow_write)) {
+    if let Some(line) = unaudited_warning(
+        project_dir,
+        &unaudited_roots(project_dir, allow_write, named_roots),
+    ) {
         ui::warn(&line);
     }
     exit_code
@@ -1401,7 +1432,8 @@ mod tests {
         assert!(
             unaudited_roots(
                 &project,
-                &[PathBuf::from("/w/app/vendor"), PathBuf::from("/w/app")]
+                &[PathBuf::from("/w/app/vendor"), PathBuf::from("/w/app")],
+                &[]
             )
             .is_empty()
         );
@@ -1413,11 +1445,54 @@ mod tests {
                     PathBuf::from("/w/app/vendor"),
                     PathBuf::from("/w/lib"),
                     PathBuf::from("/w/app-tools"),
-                ]
+                ],
+                &[]
             ),
             vec![Path::new("/w/lib"), Path::new("/w/app-tools")]
         );
-        assert!(unaudited_roots(&project, &[]).is_empty());
+        assert!(unaudited_roots(&project, &[], &[]).is_empty());
+    }
+
+    /// A `--repo-dir` root is nested inside the project by construction today,
+    /// so the "inside the project is already covered" rule would drop exactly
+    /// the roots this exists to name.
+    #[test]
+    fn unaudited_roots_names_a_nested_named_repository() {
+        let project = PathBuf::from("/w/app");
+        assert_eq!(
+            unaudited_roots(&project, &[], &[PathBuf::from("/w/app/lib")]),
+            vec![Path::new("/w/app/lib")],
+        );
+        // A grant that names a root `--repo-dir` already named is one path, not
+        // two: the count in the warning has to match the list.
+        assert_eq!(
+            unaudited_roots(
+                &project,
+                &[PathBuf::from("/w/lib")],
+                &[PathBuf::from("/w/lib")]
+            ),
+            vec![Path::new("/w/lib")],
+        );
+    }
+
+    /// "audit covers /w/app only" next to "/w/app/lib was NOT audited" reads as
+    /// a contradiction unless the reason is stated, and the reason is the whole
+    /// point: a nested checkout has its own history.
+    #[test]
+    fn unaudited_warning_explains_a_nested_root_and_not_an_outside_one() {
+        let project = PathBuf::from("/w/app");
+        let nested = unaudited_warning(&project, &[Path::new("/w/app/lib")])
+            .expect("a named root is never covered");
+        assert!(
+            nested.contains("its own git history"),
+            "a nested root needs its reason: {nested:?}"
+        );
+        let outside =
+            unaudited_warning(&project, &[Path::new("/w/lib")]).expect("a grant outside it");
+        assert!(
+            !outside.contains("its own git history"),
+            "nothing is nested here, so the clause is noise: {outside:?}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1592,9 +1592,9 @@ fn merge_tool_path_env_overrides(resolved: &mut config::Resolved, home: &Path) -
 ///
 /// `owner/name` comes from the trusted git in the unsandboxed parent, the same
 /// source and the same moment the gh scope set is captured from. A root whose
-/// origin is not a GitHub URL has no `owner/name`; it is still in the set for
-/// files, `[deny]` and the audit, so it is shown by its directory name with the
-/// gh consequence spelled out rather than dropped from the block.
+/// origin is not a GitHub URL has no `owner/name`; it is still a named root for
+/// every other purpose, so it is shown by its directory name with the gh
+/// consequence spelled out rather than dropped from the block.
 fn repo_summary_rows(project_dir: &Path, roots: &[RepoRoot]) -> Vec<config::RepoSummaryRow> {
     if roots.is_empty() {
         return Vec::new();
@@ -3248,21 +3248,27 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     // baseline is captured just before exec and the report printed just after,
     // both in the parent (outside the sandbox) — see audit::run.
     let audit_enabled = resolved.audit && !resolved.quiet;
-    let exit_code = audit::run(&project_dir, &resolved.allow_write, audit_enabled, || {
-        sandbox::exec_sandboxed(
-            &prepared,
-            &agent_bin,
-            &copilot_args,
-            &repo_paths,
-            &resolved.pass_env,
-            resolved.inherit_env,
-            &disabled_categories,
-            &resolved.deny_env,
-            &resolved.gh_guard,
-            &resolved.git_guard,
-            resolved.quiet,
-        )
-    });
+    let exit_code = audit::run(
+        &project_dir,
+        &resolved.allow_write,
+        &repo_paths,
+        audit_enabled,
+        || {
+            sandbox::exec_sandboxed(
+                &prepared,
+                &agent_bin,
+                &copilot_args,
+                &repo_paths,
+                &resolved.pass_env,
+                resolved.inherit_env,
+                &disabled_categories,
+                &resolved.deny_env,
+                &resolved.gh_guard,
+                &resolved.git_guard,
+                resolved.quiet,
+            )
+        },
+    );
 
     // Cleanup
     if let Some(handle) = proxy_handle {
@@ -4290,21 +4296,27 @@ fn run_exec_command(
     // In exec mode quiet defaults on (scripting UX), so the audit is off unless
     // the user passes --no-quiet.
     let audit_enabled = resolved.audit && !resolved.quiet;
-    let exit_code = audit::run(&project_dir, &resolved.allow_write, audit_enabled, || {
-        sandbox::exec_sandboxed(
-            &prepared,
-            &exec_bin,
-            &exec_args,
-            &repo_paths,
-            &resolved.pass_env,
-            resolved.inherit_env,
-            &disabled_categories,
-            &resolved.deny_env,
-            &resolved.gh_guard,
-            &resolved.git_guard,
-            resolved.quiet,
-        )
-    });
+    let exit_code = audit::run(
+        &project_dir,
+        &resolved.allow_write,
+        &repo_paths,
+        audit_enabled,
+        || {
+            sandbox::exec_sandboxed(
+                &prepared,
+                &exec_bin,
+                &exec_args,
+                &repo_paths,
+                &resolved.pass_env,
+                resolved.inherit_env,
+                &disabled_categories,
+                &resolved.deny_env,
+                &resolved.gh_guard,
+                &resolved.git_guard,
+                resolved.quiet,
+            )
+        },
+    );
 
     if let Some(handle) = proxy_handle {
         // --observe-domains also works for `cplt exec -- <cmd>`: emit the

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -1505,6 +1505,67 @@ fi
         );
     }
 
+    /// The same #214 shape one level down, and the one `--repo-dir` creates:
+    /// a named repository is nested inside the project, so the project's own
+    /// `git status` reports it as one untracked entry or — gitignored, as here
+    /// — as nothing at all. Every edit inside it was invisible, and the session
+    /// still printed "no project file changes".
+    #[test]
+    fn audit_names_a_nested_named_repository_it_did_not_audit() {
+        require_sandbox!();
+        let project = TempProject::scaffold_node();
+        // Gitignored BEFORE the outer commit, so the outer status is genuinely
+        // clean and the report cannot be clean for any other reason.
+        project.write_file(".gitignore", "lib/\n");
+        project.write_file("lib/README.md", "# lib\n");
+        project.git_init();
+        let lib = project.canonical_path().join("lib");
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["add", "."],
+            vec!["commit", "-m", "lib", "--allow-empty"],
+        ] {
+            git_cmd(&lib)
+                .args(&args)
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .output()
+                .expect("git command");
+        }
+        let lib_path = lib.to_string_lossy().to_string();
+
+        // The agent touches ONLY the named repository.
+        let script = r#"
+if echo tampered > lib/README.md 2>/dev/null; then
+    echo "RESULT:named_write:OK"
+else
+    echo "RESULT:named_write:FAIL"
+fi
+"#;
+        let fake_dir = create_fake_copilot(&project, script);
+        let (stdout, stderr, success) = run_cplt(&project, &fake_dir, &["--repo-dir", &lib_path]);
+
+        assert!(
+            success,
+            "cplt should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_result_ok(&stdout, &stderr, "named_write");
+        assert!(
+            stderr.contains("no project file changes"),
+            "test premise: the project must be reported clean.\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("NOT audited") && stderr.contains(&lib_path),
+            "the named repository must be named as unaudited.\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("its own git history"),
+            "a nested root reads as a contradiction without its reason.\nstderr: {stderr}"
+        );
+    }
+
     // ============================================================
     // Mode combination tests
     // ============================================================


### PR DESCRIPTION
First of the multi-repo follow-ups from #344, in the order agreed there: make what a `--repo-dir` root actually gets honest before widening the grant to siblings.

## The defect

`audit::run` takes `project_dir` and the `allow.write` grants. It has never been passed the named roots. A repository named with `--repo-dir` is nested inside the project by construction today, so it inherits the project's file grant — but it keeps its own git history, and the launch repository's `git status` therefore reports it as one `?? <dir>/` line, or as nothing at all when it is gitignored.

`unaudited_roots` did not cover the gap either: it deliberately drops paths inside the project, on the grounds that the project's own status already covers them. That reasoning is correct for a plain directory and wrong for a checkout.

The result is #214's shape one level down — a session that edited only the named repository printed `no project file changes` and nothing else. An absence of information rendered as a clean bill of health.

## The change

- `unaudited_roots` takes the named roots and lists them unconditionally, deduping against an `allow.write` grant that names the same path so the count matches the list.
- `unaudited_warning` drops the `outside it` claim, which is false for a nested root, and adds the reason when a listed root is nested: `A repository checked out inside the project keeps its own git history, so its changes never appear in the project's git status.` Without it, `audit covers /w/app only` next to `/w/app/lib was NOT audited` reads as a contradiction.
- Both `audit::run` call sites pass `repo_paths`, which is already in scope at each.

Auditing a named root properly — one pass per root, per-root header, `Incomplete` rather than clean for a root that cannot be read — needs a report format change and stays with #344.

## Also: a doc comment that said the opposite

`repo_summary_rows` claimed a named root without a GitHub origin "is still in the set for files, `[deny]` and the audit". Files, yes, by inheritance from the project grant. `[deny]` and the audit, no: `load_repo_config` is called with `project_dir` alone, and so was `audit::run`. Corrected rather than left to be read as a promise.

## Verification

New e2e test `audit_names_a_nested_named_repository_it_did_not_audit`: the named repository is gitignored before the outer commit, so the project really is clean and the report cannot be clean for any other reason; the agent writes only inside the named repository. Falsified by passing `&[]` in place of `repo_paths` at the launch call site — the test then fails on a report that reads `no project file changes` and stops there.

Two unit tests cover the two rules that are easy to get wrong: a nested named root is listed (the "inside the project is covered" filter would otherwise drop exactly the roots this exists to name), and the nested clause appears only when something nested is listed.

Refs #344.