### PR TITLE
feat: say which repositories the session covers, to the agent and to check

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -38,7 +38,12 @@ pub const BLOCK_END: &str = "<!-- cplt:sandbox end -->";
 /// Rendered from the live resolved config: if the user allowed `~/.aws`,
 /// this must not claim AWS is blocked. Kept short — a few lines, not a
 /// policy dump (`--verbose` / `cplt config show` cover that).
-pub fn generate_session_brief(resolved: &Resolved, agent: Agent, home: &Path) -> String {
+pub fn generate_session_brief(
+    resolved: &Resolved,
+    agent: Agent,
+    home: &Path,
+    repos: &[crate::config::RepoSummaryRow],
+) -> String {
     use std::fmt::Write as _;
 
     let mut out = String::new();
@@ -49,6 +54,41 @@ pub fn generate_session_brief(resolved: &Resolved, agent: Agent, home: &Path) ->
          fresh every launch from the resolved policy — trust it over guesses.\n\n",
         agent.display_name()
     );
+
+    // Which repositories this session covers, and what each one grants. Without
+    // it the agent has to infer the scope from refusals, and a session that did
+    // exactly that produced two recommendations to turn the gh guard off — the
+    // refusal named an escape hatch and nothing narrower, so the model relayed
+    // the only fix it was shown.
+    if !repos.is_empty() {
+        out.push_str("## Repositories\n\n");
+        for row in repos {
+            let what = match row.grant {
+                crate::config::RepoGrant::Launch => {
+                    "the launch repository: read, write, execute, and the repository `gh` and \
+                     `git push` target by default"
+                }
+                crate::config::RepoGrant::Inherited => {
+                    "named with --repo-dir, inside the launch repository: you already had these \
+                     files; naming it puts it in the `gh` scope, gives it its own audit, and \
+                     lets `git push` be judged by its own default branch"
+                }
+                crate::config::RepoGrant::NewTree => {
+                    "named with --repo-dir: read, write and execute on a tree outside the launch \
+                     repository, in the `gh` scope, audited, and `git push` judged by its own \
+                     default branch"
+                }
+            };
+            let _ = writeln!(out, "- `{}` — {} ({what})", row.name, row.path.display());
+        }
+        out.push_str(
+            "\nThat list is the whole scope. A repository not on it is refused on purpose — \
+             the user chose what this session spans, so a refusal there is an answer, not an \
+             obstacle to route around. Report it and carry on; only the user can add one, \
+             with `--repo-dir` or `cplt config set --local sandbox.repo_dirs <DIR>`, and it \
+             takes a new session.\n\n",
+        );
+    }
 
     out.push_str("## Rules\n\n");
     out.push_str(
@@ -373,6 +413,7 @@ mod md_probe {
     ///
     /// Lines inside the leading HTML comment are exempt: Markdown does not
     /// render comment content, and one line there is deliberately indented.
+
     #[test]
     fn managed_block_has_no_markdown_indentation() {
         let b = super::managed_block();
@@ -634,15 +675,61 @@ mod tests {
         Path::new("/home/tester")
     }
 
+    /// The scope has to be in the brief, or the agent infers it from refusals.
+    /// A session that did exactly that produced two recommendations to turn the
+    /// gh guard off: the refusal named an escape hatch and nothing narrower, so
+    /// the model relayed the only fix it was shown.
+    #[test]
+    fn the_brief_lists_the_repositories_and_says_a_refusal_outside_them_is_the_answer() {
+        use crate::config::{RepoGrant, RepoSummaryRow};
+        let rows = vec![
+            RepoSummaryRow {
+                name: "navikt/spleis".to_string(),
+                path: std::path::PathBuf::from("/w/spleis"),
+                source: "launch repository",
+                grant: RepoGrant::Launch,
+            },
+            RepoSummaryRow {
+                name: "navikt/model".to_string(),
+                path: std::path::PathBuf::from("/w/model"),
+                source: "--repo-dir",
+                grant: RepoGrant::NewTree,
+            },
+        ];
+        let brief = generate_session_brief(
+            &base_resolved(),
+            crate::agent::Agent::Copilot,
+            std::path::Path::new("/projects/app"),
+            &rows,
+        );
+        assert!(brief.contains("## Repositories"), "{brief}");
+        for expected in ["navikt/spleis", "navikt/model", "/w/model"] {
+            assert!(brief.contains(expected), "missing {expected}:\n{brief}");
+        }
+        assert!(
+            brief.contains("a refusal there is an answer, not an"),
+            "the agent must be told not to route around the scope:\n{brief}"
+        );
+        // A single-repository session says nothing: the block would restate the
+        // one thing the rest of the brief already assumes.
+        let plain = generate_session_brief(
+            &base_resolved(),
+            crate::agent::Agent::Copilot,
+            std::path::Path::new("/projects/app"),
+            &[],
+        );
+        assert!(!plain.contains("## Repositories"), "{plain}");
+    }
+
     #[test]
     fn brief_flips_env_files_warning_with_config() {
         let mut resolved = base_resolved();
         resolved.allow_env_files = false;
-        let brief = generate_session_brief(&resolved, Agent::Copilot, home());
+        let brief = generate_session_brief(&resolved, Agent::Copilot, home(), &[]);
         assert!(brief.contains("also denied by default"));
 
         resolved.allow_env_files = true;
-        let brief = generate_session_brief(&resolved, Agent::Copilot, home());
+        let brief = generate_session_brief(&resolved, Agent::Copilot, home(), &[]);
         assert!(!brief.contains("also denied"));
         assert!(brief.contains("readable this session"));
     }
@@ -651,11 +738,11 @@ mod tests {
     fn brief_flips_network_line_with_default_allowlist() {
         let mut resolved = base_resolved();
         resolved.default_allowlist = false;
-        let brief = generate_session_brief(&resolved, Agent::OpenCode, home());
+        let brief = generate_session_brief(&resolved, Agent::OpenCode, home(), &[]);
         assert!(!brief.contains("built-in allowlist"));
 
         resolved.default_allowlist = true;
-        let brief = generate_session_brief(&resolved, Agent::OpenCode, home());
+        let brief = generate_session_brief(&resolved, Agent::OpenCode, home(), &[]);
         assert!(brief.contains("built-in allowlist"));
     }
 
@@ -667,7 +754,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.default_allowlist = true;
         resolved.proxy_forced = false;
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             !brief.contains("fails closed"),
             "plain proxy mode must not claim fail-closed:\n{brief}"
@@ -675,14 +762,14 @@ mod tests {
         assert!(brief.contains("direct `*:443` connections are still permitted"));
 
         resolved.proxy_forced = true;
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(brief.contains("fails closed"));
     }
 
     #[test]
     fn brief_says_ssh_blocked_but_not_https_git() {
         let resolved = base_resolved();
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(brief.contains("SSH is blocked"));
         // git_guard gates HTTPS push; the sandbox itself does not block
         // HTTPS remotes, and the brief must not claim otherwise.
@@ -698,7 +785,7 @@ mod tests {
         resolved.allow_read = vec![home().join(".ssh/id_ed25519")];
         resolved.pass_env = vec!["SSH_AUTH_SOCK".to_string()];
         resolved.allow_socket = vec![PathBuf::from("/private/tmp/x/Listeners")];
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(brief.contains("SSH is blocked"), "{brief}");
         assert!(brief.contains("outbound TCP is limited to 443"), "{brief}");
     }
@@ -710,7 +797,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
         resolved.allow_read = vec![home().join(".ssh/id_ed25519")];
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(!brief.contains("SSH is blocked"), "{brief}");
         assert!(brief.contains("SSH may work this session"));
         // The blanket credentials claim needs the same treatment.
@@ -728,14 +815,14 @@ mod tests {
         resolved.allow_ports = vec![22];
         resolved.allow_read = vec![home().join(".ssh/id_ed25519")];
 
-        let default_mode = generate_session_brief(&resolved, Agent::Claude, home());
+        let default_mode = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             default_mode.contains("SSH may work this session"),
             "default mode still opens port 22:\n{default_mode}"
         );
 
         resolved.proxy_forced = true;
-        let forced = generate_session_brief(&resolved, Agent::Claude, home());
+        let forced = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             forced.contains("SSH is blocked"),
             "proxy.forced closes the direct path port 22 needs:\n{forced}"
@@ -748,7 +835,7 @@ mod tests {
     fn brief_blames_the_keys_when_the_port_is_open_but_nothing_authenticates() {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             brief.contains("the blocker is the keys, not the port"),
             "{brief}"
@@ -771,7 +858,7 @@ mod tests {
         resolved.pass_env = vec!["SSH_AUTH_SOCK".to_string()];
         resolved.allow_socket = vec![PathBuf::from("/private/tmp/x/Listeners")];
         resolved.inherit_env = true;
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             brief.contains("the blocker is the keys, not the port"),
             "--inherit-env strips SSH_AUTH_SOCK even with --pass-env:\n{brief}"
@@ -779,7 +866,7 @@ mod tests {
 
         // Same config without inherit_env: the socket does arrive.
         resolved.inherit_env = false;
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(brief.contains("SSH may work this session"), "{brief}");
     }
 
@@ -792,7 +879,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
         resolved.allow_read = vec![home().join(".ssh")];
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             brief.contains("the blocker is the keys, not the port"),
             "{brief}"
@@ -813,7 +900,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
         resolved.allow_write = vec![home().join(".ssh/known_hosts")];
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             brief.contains("Also writable this session"),
             "the credentials claim must name the write exception:\n{brief}"
@@ -831,7 +918,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
         resolved.allow_read = vec![home().to_path_buf()];
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             brief.contains("SSH may work this session"),
             "Landlock grants $HOME outright:\n{brief}"
@@ -852,7 +939,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.allow_localhost_any = true;
         assert!(!resolved.allow_ports.contains(&22), "port 22 not listed");
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             !brief.contains("outbound TCP is limited to 443"),
             "no connect restriction is in the ruleset at all:\n{brief}"
@@ -867,7 +954,7 @@ mod tests {
     /// the sandbox — not "read-only".
     #[test]
     fn brief_does_not_call_the_config_readable() {
-        let brief = generate_session_brief(&base_resolved(), Agent::Claude, home());
+        let brief = generate_session_brief(&base_resolved(), Agent::Claude, home(), &[]);
         assert!(brief.contains("not readable from in here"), "{brief}");
         assert!(!brief.contains("read-only from in here"));
     }
@@ -877,7 +964,7 @@ mod tests {
         let mut resolved = base_resolved();
         resolved.default_allowlist = true;
         resolved.allow_all_domains = true;
-        let brief = generate_session_brief(&resolved, Agent::Claude, home());
+        let brief = generate_session_brief(&resolved, Agent::Claude, home(), &[]);
         assert!(
             !brief.contains("built-in allowlist"),
             "must not claim an allowlist applies under --allow-all-domains"
@@ -1069,6 +1156,7 @@ mod tests {
             &resolved,
             crate::agent::Agent::Copilot,
             std::path::Path::new("/projects/app"),
+            &[],
         );
         assert!(
             !brief.contains("The proxy refuses everything"),
@@ -1085,6 +1173,7 @@ mod tests {
             &resolved,
             crate::agent::Agent::Copilot,
             std::path::Path::new("/projects/app"),
+            &[],
         );
         assert!(brief.contains("The proxy refuses everything"));
     }

--- a/src/check.rs
+++ b/src/check.rs
@@ -216,9 +216,17 @@ pub fn explain_path(
     } else {
         (
             "not covered by any allow rule, so it is denied by default.".to_string(),
+            // `--repo-dir` is named because the other two do not cover the
+            // case they look like they cover: a write grant is deliberately
+            // non-executable, so following this advice for another repository
+            // makes its files editable and its build still fail. Named without
+            // probing the path — `explain_path` stays pure, and the sentence is
+            // true whether or not this particular path is a repository.
             Some(
                 "grant access with --allow-read <PATH> (read) or --allow-write <PATH> (read+write), \
-                 or add it under [allow] read/write in config."
+                 or add it under [allow] read/write in config. If it is another git repository \
+                 you also need to build, test or push in, name it with --repo-dir <DIR> instead: \
+                 a write grant is not executable, so its build will not run under --allow-write."
                     .to_string(),
             ),
         )
@@ -1167,7 +1175,16 @@ mod tests {
         let e = explain_path(&p, home, proj, Path::new("/opt/other"));
         assert_eq!(e.read_decision(), Decision::Blocked);
         assert!(!e.credential);
-        assert!(e.fix.as_deref().unwrap().contains("--allow-read"));
+        let fix = e.fix.as_deref().unwrap();
+        assert!(fix.contains("--allow-read"));
+        // The two grants named first do not cover the case they look like they
+        // cover: `--allow-write` is deliberately non-executable, so a reader who
+        // follows it for another repository gets editable files and a build that
+        // still will not run. The narrow remedy has to be in the same sentence.
+        assert!(
+            fix.contains("--repo-dir") && fix.contains("not executable"),
+            "the fix must name the remedy that actually works for a repository: {fix}"
+        );
     }
 
     // ── explain_domain ──

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2022,7 +2022,7 @@ fn gate_with_scope_resolver(
                 // session that hit this concluded it was blocked when a
                 // supported command would have worked (#403). The higher-level
                 // read commands really are allowed cross-repo with an explicit
-                // `-R`, and a repository checked out inside the project can be
+                // `-R`, and another repository the user works in can be
                 // named into the scope set.
                 Err(Refusal {
                     headline: format!(
@@ -2044,9 +2044,10 @@ fn gate_with_scope_resolver(
                          `gh pr view -R <owner>/<repo> <number>`, `gh pr diff -R <owner>/<repo> \
                          <number>`, `gh issue view -R <owner>/<repo> <number>` — and are allowed \
                          against any repository. Raw `gh api` is not. If the agent \
-                         works in that repository too and it is checked out inside this one, name it \
-                         with `cplt config set --local sandbox.repo_dirs <DIR>` and it joins the \
-                         scope set. Otherwise relaunch cplt against that repository.",
+                         works in that repository too and it is checked out on this machine, \
+                         name it with `cplt config set --local sandbox.repo_dirs <DIR>` and it \
+                         joins the scope set — beside this repository or inside it, either \
+                         works. Otherwise relaunch cplt against that repository.",
                         result.reason,
                     ),
                     agent_note: &[RESTRICTED, NOTE],

--- a/src/main.rs
+++ b/src/main.rs
@@ -2465,6 +2465,7 @@ fn write_session_sandbox_brief(
     active_agent: agent::Agent,
     scratch_path: Option<&Path>,
     home_dir: &Path,
+    repos: &[config::RepoSummaryRow],
 ) {
     if !resolved.brief {
         return;
@@ -2482,7 +2483,7 @@ fn write_session_sandbox_brief(
         );
         return;
     };
-    let content = brief::generate_session_brief(resolved, active_agent, home_dir);
+    let content = brief::generate_session_brief(resolved, active_agent, home_dir, repos);
     if let Err(e) = brief::write_session_brief(scratch, &content) {
         ui::warn(&format!("Could not write sandbox brief: {e}"));
     }
@@ -3129,6 +3130,9 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
 
     let repo_paths: Vec<PathBuf> = repo_roots.iter().map(|r| r.dir.clone()).collect();
     let repo_git_dirs = sandbox::named_root_git_dirs(&repo_paths);
+    // Built once: the brief, the startup summary and `doctor` must not each
+    // resolve the identities separately and risk disagreeing.
+    let repo_rows = repo_summary_rows(&project_dir, &repo_roots);
 
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
 
@@ -3181,7 +3185,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
         &probe,
         AssemblyOptions {
             agent: active_agent,
-            repos: NamedRepos::new(&repo_paths, &repo_git_dirs),
+            repos: NamedRepos::new(&repo_paths, &repo_git_dirs, &repo_rows),
             copilot_install_dir: copilot_install_dir.as_deref(),
             electron_app_dir: electron_app_dir.as_deref(),
             announce_scratch: true,
@@ -3269,12 +3273,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
 
     // Print comprehensive summary and confirm before launching Copilot
     if !resolved.quiet {
-        resolved.print_summary(
-            &project_dir,
-            &home_dir,
-            active_agent,
-            &repo_summary_rows(&project_dir, &repo_roots),
-        );
+        resolved.print_summary(&project_dir, &home_dir, active_agent, &repo_rows);
     }
     if let Err(e) = prompt_confirm(resolved.yes, resolved.quiet) {
         bail!("{e}");
@@ -4059,7 +4058,13 @@ fn assemble_sandbox(
     // AGENTS.md layer writes into the user's repo and must not run until the
     // launch is confirmed — see `apply_persistent_sandbox_brief`, which the
     // `exec` and `check` paths deliberately never call.
-    write_session_sandbox_brief(resolved, active_agent, scratch_path, home_dir);
+    write_session_sandbox_brief(
+        resolved,
+        active_agent,
+        scratch_path,
+        home_dir,
+        opts.repos.rows,
+    );
 
     // macOS-only, opt-in (sandbox.gradle_init): install the guarded Gradle
     // init script so sandboxed builds keep the preferIPv4Stack workaround for
@@ -4151,12 +4156,23 @@ struct SessionPaths<'a> {
 struct NamedRepos<'a> {
     dirs: &'a [PathBuf],
     git_dirs: &'a [PathBuf],
+    /// The same set as the startup summary renders it, with each repository's
+    /// `owner/name` and what its grant is. Carried here so the agent-facing
+    /// brief and the operator-facing summary cannot describe different scopes.
+    rows: &'a [config::RepoSummaryRow],
 }
 
 impl<'a> NamedRepos<'a> {
-    /// Resolve the gitdirs for an already-validated set of roots.
-    fn new(dirs: &'a [PathBuf], git_dirs: &'a [PathBuf]) -> Self {
-        Self { dirs, git_dirs }
+    fn new(
+        dirs: &'a [PathBuf],
+        git_dirs: &'a [PathBuf],
+        rows: &'a [config::RepoSummaryRow],
+    ) -> Self {
+        Self {
+            dirs,
+            git_dirs,
+            rows,
+        }
     }
 }
 
@@ -4283,6 +4299,9 @@ fn run_exec_command(
 
     let repo_paths: Vec<PathBuf> = repo_roots.iter().map(|r| r.dir.clone()).collect();
     let repo_git_dirs = sandbox::named_root_git_dirs(&repo_paths);
+    // Built once: the brief, the startup summary and `doctor` must not each
+    // resolve the identities separately and risk disagreeing.
+    let repo_rows = repo_summary_rows(&project_dir, &repo_roots);
 
     // exec defaults to quiet+yes (scripting UX). User can override with --no-quiet / --no-yes.
     if !cli.no_quiet {
@@ -4350,7 +4369,7 @@ fn run_exec_command(
         config_path.as_ref(),
         &home_dir,
         &project_dir,
-        NamedRepos::new(&repo_paths, &repo_git_dirs),
+        NamedRepos::new(&repo_paths, &repo_git_dirs, &repo_rows),
     )?;
 
     // Resolve the binary and args to pass to the sandbox.
@@ -4396,12 +4415,7 @@ fn run_exec_command(
 
     // Summary (only shown with --no-quiet)
     if !resolved.quiet {
-        resolved.print_summary(
-            &project_dir,
-            &home_dir,
-            active_agent,
-            &repo_summary_rows(&project_dir, &repo_roots),
-        );
+        resolved.print_summary(&project_dir, &home_dir, active_agent, &repo_rows);
     }
     if let Err(e) = prompt_confirm(resolved.yes, resolved.quiet) {
         bail!("{e}");
@@ -4779,6 +4793,9 @@ fn run_check_command(
     // against: `check` must build the policy the launch would build.
     let repo_paths: Vec<PathBuf> = repo_roots.iter().map(|r| r.dir.clone()).collect();
     let repo_git_dirs = sandbox::named_root_git_dirs(&repo_paths);
+    // Built once: the brief, the startup summary and `doctor` must not each
+    // resolve the identities separately and risk disagreeing.
+    let repo_rows = repo_summary_rows(&project_dir, &repo_roots);
 
     // Shell, not `active_agent`: `check` probes under the Shell profile.
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, agent::Agent::Shell);
@@ -4819,7 +4836,7 @@ fn run_check_command(
         config_path.as_ref(),
         &home_dir,
         &project_dir,
-        NamedRepos::new(&repo_paths, &repo_git_dirs),
+        NamedRepos::new(&repo_paths, &repo_git_dirs, &repo_rows),
     )?;
 
     let proxy_enabled = proxy_handle.is_some();
@@ -5445,6 +5462,9 @@ fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
     // same named roots the launch would (#447).
     let repo_paths: Vec<PathBuf> = repo_roots.iter().map(|r| r.dir.clone()).collect();
     let repo_git_dirs = sandbox::named_root_git_dirs(&repo_paths);
+    // Built once: the brief, the startup summary and `doctor` must not each
+    // resolve the identities separately and risk disagreeing.
+    let repo_rows = repo_summary_rows(&project_dir, &repo_roots);
     let tilde = |p: &Path| doctor::tilde(p, &home_dir);
     let mut findings: Vec<Finding> = Vec::new();
     let mut ok: Vec<String> = Vec::new();
@@ -5620,7 +5640,7 @@ fn run_doctor(cli: &Cli, verbose: bool) -> ExitCode {
         &probe,
         active_agent,
         &agent_dirs,
-        NamedRepos::new(&repo_paths, &repo_git_dirs),
+        NamedRepos::new(&repo_paths, &repo_git_dirs, &repo_rows),
         SessionPaths::default(),
         keychain_substitute,
     );

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -1643,10 +1643,13 @@ if echo h > "{sibling_path}/.git/hooks/pre-commit" 2>/dev/null; then echo "RESUL
         main.write_file("f.txt", "content\n");
         main.git_init();
         let main_path = main.canonical_path();
-        let worktree = main_path.parent().expect("a parent").join(format!(
-            "{}-wt",
-            main_path.file_name().expect("a name").to_string_lossy()
-        ));
+        // Inside a second TempProject rather than beside the first: a linked
+        // worktree is a real directory `git worktree remove` may fail to clean
+        // (an early return, a git that refuses), and a test must not leave one
+        // behind in the developer's checkout. The guard removes this one either
+        // way.
+        let holder = TempProject::new("repo-dir-worktree-holder");
+        let worktree = holder.canonical_path().join("wt");
         let added = git_cmd(&main_path)
             .args(["worktree", "add", "-b", "wt"])
             .arg(&worktree)


### PR DESCRIPTION
Stacked on #469. The last item from #344 that is agent-facing rather than kernel-facing, and the one its §8 argued for from evidence.

## Why

The brief has four sections and never named the project directory, let alone the repositories in scope. An agent had to infer the scope from refusals — and a session that did exactly that produced two recommendations to turn the gh guard off. The cause is direct: `escape_hatch()` appends `--no-gh-guard` and `gh_guard.mode = "warn"` to every refusal, and the scope refusal named nothing narrower. The model relayed the only fix it was shown.

## What it adds

```
## Repositories

- `navikt/app` — /w/app (the launch repository: read, write, execute, and the repository `gh` and `git push` target by default)
- `navikt/lib` — /w/lib (named with --repo-dir: read, write and execute on a tree outside the launch repository, in the `gh` scope, audited, and `git push` judged by its own default branch)

That list is the whole scope. A repository not on it is refused on purpose — the user chose what this session spans, so a refusal there is an answer, not an obstacle to route around. Report it and carry on; only the user can add one, with `--repo-dir` or `cplt config set --local sandbox.repo_dirs <DIR>`, and it takes a new session.
```

A nested root and a sibling get different lines: one already had those files, the other is a tree the session could not otherwise reach.

The rows come from the same `repo_summary_rows` the startup summary renders, computed once and passed to both. The agent-facing brief and the operator-facing summary describe the same scope by construction rather than by two functions agreeing.

Nothing is printed for a single-repository session — the block would restate what the rest of the brief already assumes.

## Also

`gh` scope refusals said a repository could be named "if it is checked out inside this one". That stopped being true in #467. Now: "checked out on this machine — beside this repository or inside it, either works."

## Verification

- `the_brief_lists_the_repositories_and_says_a_refusal_outside_them_is_the_answer` — asserts the section, both rows, and the do-not-route-around line, plus the negative: a single-repository session emits no block. Falsified by disabling the section; it fails.
- Verified in a real session: `cplt --brief --repo-dir ../lib` writes exactly the block above to `CPLT_BRIEF.md`.

Refs #344.

---

## Also: `cplt check path` names the remedy that works

`cplt check path` on a blocked path offered `--allow-read` and `--allow-write` and nothing else. For a path in another git repository — the case that now has a real answer — following that advice makes the files editable and leaves the build failing, because a write grant is deliberately non-executable.

The fix line names `--repo-dir` alongside them and says why, so the reader can tell which of the three covers what they are trying to do. Named without probing the path, so `explain_path` stays pure; the sentence is true whether or not this particular path is a repository. `unlisted_path_is_blocked_with_fix` asserts both the remedy and the reason.

Same defect as the brief section, one surface over: the only remedy on offer was the one that does not do what the reader needs.