### PR TITLE
fix(brief): stop telling the agent a non-GitHub root is in the gh scope

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -63,20 +63,27 @@ pub fn generate_session_brief(
     if !repos.is_empty() {
         out.push_str("## Repositories\n\n");
         for row in repos {
+            // `row.source` rather than a hard-coded `--repo-dir`: a root can
+            // equally come from `sandbox.repo_dirs` in the per-checkout local
+            // config, and naming a flag nobody passed is the same lie the
+            // launch warnings already avoid.
             let what = match row.grant {
                 crate::config::RepoGrant::Launch => {
                     "the launch repository: read, write, execute, and the repository `git push` \
                      targets by default"
+                        .to_string()
                 }
-                crate::config::RepoGrant::Inherited => {
-                    "named with --repo-dir, inside the launch repository: you already had these \
-                     files; naming it gives it its own audit and lets `git push` be judged by \
-                     its own default branch"
-                }
-                crate::config::RepoGrant::NewTree => {
-                    "named with --repo-dir: read, write and execute on a tree outside the launch \
-                     repository, audited, and `git push` judged by its own default branch"
-                }
+                crate::config::RepoGrant::Inherited => format!(
+                    "named for this session ({}), inside the launch repository: you already had \
+                     these files; naming it gives it its own audit and lets `git push` be judged \
+                     by its own default branch",
+                    row.source
+                ),
+                crate::config::RepoGrant::NewTree => format!(
+                    "named for this session ({}): read, write and execute on a tree outside the \
+                     launch repository, audited, and `git push` judged by its own default branch",
+                    row.source
+                ),
             };
             // Said per row rather than folded into the sentences above: a root
             // whose origin is not a GitHub URL is a named root for files,
@@ -720,6 +727,14 @@ mod tests {
                 source: "--repo-dir",
                 grant: RepoGrant::NewTree,
             },
+            // Persisted, not passed on this command line.
+            RepoSummaryRow {
+                name: "navikt/persisted".to_string(),
+                github: true,
+                path: std::path::PathBuf::from("/w/spleis/persisted"),
+                source: "local config",
+                grant: RepoGrant::Inherited,
+            },
         ];
         let brief = generate_session_brief(
             &base_resolved(),
@@ -752,6 +767,18 @@ mod tests {
                 "a GitHub origin is in scope: {line}"
             );
         }
+        // A root from `sandbox.repo_dirs` was named in the per-checkout local
+        // config, not by a flag. Naming a flag nobody passed sends the reader
+        // looking for something that is not there — the same reason the launch
+        // warnings say "named repository <path>" instead.
+        let persisted = brief
+            .lines()
+            .find(|l| l.contains("navikt/persisted"))
+            .expect("the row is listed");
+        assert!(
+            persisted.contains("local config") && !persisted.contains("--repo-dir"),
+            "a persisted root must not be attributed to a flag: {persisted}"
+        );
         // A single-repository session says nothing: the block would restate the
         // one thing the rest of the brief already assumes.
         let plain = generate_session_brief(

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -65,21 +65,37 @@ pub fn generate_session_brief(
         for row in repos {
             let what = match row.grant {
                 crate::config::RepoGrant::Launch => {
-                    "the launch repository: read, write, execute, and the repository `gh` and \
-                     `git push` target by default"
+                    "the launch repository: read, write, execute, and the repository `git push` \
+                     targets by default"
                 }
                 crate::config::RepoGrant::Inherited => {
                     "named with --repo-dir, inside the launch repository: you already had these \
-                     files; naming it puts it in the `gh` scope, gives it its own audit, and \
-                     lets `git push` be judged by its own default branch"
+                     files; naming it gives it its own audit and lets `git push` be judged by \
+                     its own default branch"
                 }
                 crate::config::RepoGrant::NewTree => {
                     "named with --repo-dir: read, write and execute on a tree outside the launch \
-                     repository, in the `gh` scope, audited, and `git push` judged by its own \
-                     default branch"
+                     repository, audited, and `git push` judged by its own default branch"
                 }
             };
-            let _ = writeln!(out, "- `{}` — {} ({what})", row.name, row.path.display());
+            // Said per row rather than folded into the sentences above: a root
+            // whose origin is not a GitHub URL is a named root for files,
+            // `[deny]`, the audit and the git guard, and is NOT in the gh
+            // scope. Claiming otherwise would tell the agent it can target a
+            // repository `gh` refuses — and would contradict the launch, which
+            // warns about exactly this root.
+            let gh = if row.github {
+                "; `gh` may target it"
+            } else {
+                "; NOT in the `gh` scope, because its origin is not a GitHub URL — `gh` \
+                 commands naming it are refused"
+            };
+            let _ = writeln!(
+                out,
+                "- `{}` — {} ({what}{gh})",
+                row.name,
+                row.path.display()
+            );
         }
         out.push_str(
             "\nThat list is the whole scope. A repository not on it is refused on purpose — \
@@ -685,13 +701,22 @@ mod tests {
         let rows = vec![
             RepoSummaryRow {
                 name: "navikt/spleis".to_string(),
+                github: true,
                 path: std::path::PathBuf::from("/w/spleis"),
                 source: "launch repository",
                 grant: RepoGrant::Launch,
             },
             RepoSummaryRow {
                 name: "navikt/model".to_string(),
+                github: true,
                 path: std::path::PathBuf::from("/w/model"),
+                source: "--repo-dir",
+                grant: RepoGrant::NewTree,
+            },
+            RepoSummaryRow {
+                name: "vendored (no GitHub origin)".to_string(),
+                github: false,
+                path: std::path::PathBuf::from("/w/vendored"),
                 source: "--repo-dir",
                 grant: RepoGrant::NewTree,
             },
@@ -710,6 +735,23 @@ mod tests {
             brief.contains("a refusal there is an answer, not an"),
             "the agent must be told not to route around the scope:\n{brief}"
         );
+        // A root with no GitHub origin is a named root for files, `[deny]`, the
+        // audit and the git guard, and is NOT in the gh scope — the launch
+        // warns about exactly this root, and the brief must not contradict it.
+        let vendored = brief
+            .lines()
+            .find(|l| l.contains("vendored"))
+            .expect("the row is listed");
+        assert!(
+            vendored.contains("NOT in the `gh` scope"),
+            "a non-GitHub origin must not be described as targetable: {vendored}"
+        );
+        for line in brief.lines().filter(|l| l.contains("navikt/")) {
+            assert!(
+                line.contains("`gh` may target it"),
+                "a GitHub origin is in scope: {line}"
+            );
+        }
         // A single-repository session says nothing: the block would restate the
         // one thing the rest of the brief already assumes.
         let plain = generate_session_brief(

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -797,6 +797,13 @@ pub struct RepoSummaryRow {
     /// Where the root was named: `launch repository`, `--repo-dir`, or
     /// `local config`.
     pub source: &'static str,
+    /// Whether `name` is a real `owner/name` from a GitHub origin.
+    ///
+    /// A root whose origin is not a GitHub URL is a named root for files,
+    /// `[deny]`, the audit and the git guard, and is **not** in the gh scope —
+    /// the launch says so, and anything else describing the root has to agree
+    /// or the agent is told it can target a repository `gh` will refuse.
+    pub github: bool,
     /// What naming the root changed about file access.
     ///
     /// A root nested inside the project directory already inherited the

--- a/src/main.rs
+++ b/src/main.rs
@@ -1591,34 +1591,45 @@ fn repo_summary_rows(project_dir: &Path, roots: &[RepoRoot]) -> Vec<config::Repo
         return Vec::new();
     }
     let real_git = cplt::git::trusted_git();
-    let name_of = |dir: &Path| {
-        real_git
-            .and_then(|git| gh_proxy::detect_current_repo(git, dir).ok())
-            .unwrap_or_else(|| {
+    // Returns the name AND whether it is a real `owner/name`: everything that
+    // describes a root downstream has to agree with the launch about whether
+    // `gh` can target it, and the fallback string is not a fact to re-derive by
+    // looking for a parenthesis.
+    let name_of =
+        |dir: &Path| match real_git.and_then(|git| gh_proxy::detect_current_repo(git, dir).ok()) {
+            Some(repo) => (repo, true),
+            None => (
                 format!(
                     "{} (no GitHub origin)",
                     dir.file_name().unwrap_or_default().to_string_lossy()
-                )
-            })
-    };
+                ),
+                false,
+            ),
+        };
+    let (launch_name, launch_github) = name_of(project_dir);
     let mut rows = vec![config::RepoSummaryRow {
-        name: name_of(project_dir),
+        name: launch_name,
+        github: launch_github,
         path: project_dir.to_path_buf(),
         source: "launch repository",
         grant: config::RepoGrant::Launch,
     }];
-    rows.extend(roots.iter().map(|root| config::RepoSummaryRow {
-        name: name_of(&root.dir),
-        path: root.dir.clone(),
-        source: root.source.label(),
-        // A nested root inherits the project grant; a sibling is a tree the
-        // session could not otherwise reach at all. Same row, very different
-        // thing to have agreed to.
-        grant: if root.dir.starts_with(project_dir) {
-            config::RepoGrant::Inherited
-        } else {
-            config::RepoGrant::NewTree
-        },
+    rows.extend(roots.iter().map(|root| {
+        let (name, github) = name_of(&root.dir);
+        config::RepoSummaryRow {
+            name,
+            github,
+            path: root.dir.clone(),
+            source: root.source.label(),
+            // A nested root inherits the project grant; a sibling is a tree the
+            // session could not otherwise reach at all. Same row, very different
+            // thing to have agreed to.
+            grant: if root.dir.starts_with(project_dir) {
+                config::RepoGrant::Inherited
+            } else {
+                config::RepoGrant::NewTree
+            },
+        }
     }));
     rows
 }


### PR DESCRIPTION
A defect in #470, found by running the finished feature against a fixture whose remotes are file URLs — the shape that makes the `(no GitHub origin)` fallback fire.

## The contradiction

The `## Repositories` section said every named root was "in the `gh` scope". For a root whose origin is not a GitHub URL that is false, and the launch had already said so one screen earlier:

```
[cplt] named repository /w/lib is not in the gh scope: local origin is not a
       supported GitHub repository URL. gh commands targeting it are refused.
```

So the brief contradicted the warning the operator had just read, and told the agent it could target a repository `gh` will refuse — which is the one thing that section exists to stop it working out from refusals.

## The fix

`RepoSummaryRow` carries `github: bool` — whether `name` is a real `owner/name` or the `(no GitHub origin)` fallback. Nothing downstream re-derives that by looking for a parenthesis in a display string, which is the other way this could have been written and the way it would drift.

The gh clause is then stated per row, either way round:

```
- `navikt/model` — /w/model (named with --repo-dir: read, write and execute on a tree outside
  the launch repository, audited, and `git push` judged by its own default branch; `gh` may target it)
- `vendored (no GitHub origin)` — /w/vendored (…; NOT in the `gh` scope, because its origin is not
  a GitHub URL — `gh` commands naming it are refused)
```

The other three capabilities are unaffected: a root with no GitHub origin is still a named root for files, `[deny]`, the audit and the git guard. Only the gh half was ever conditional, and only the brief claimed otherwise.

## Verification

`the_brief_lists_the_repositories_and_says_a_refusal_outside_them_is_the_answer` gains a third row with `github: false` and asserts both directions — that row says NOT in scope, and every GitHub-origin row says `gh` may target it. Falsified by forcing the flag true: the test fails.

Confirmed live against the file-URL fixture that surfaced it.

Refs #344.