### PR TITLE
feat: warn about unreachable repos in a write grant, probe named roots, and name the pushed-to repository

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,7 +152,13 @@ cplt --allow-write ~/src/sykepenger-model exec -- $EDITOR
 ```
 
 Use `--allow-write` when the sibling only needs to be edited, and `--repo-dir`
-when its own build, tests or pull requests have to run. A named root is a
+when its own build, tests or pull requests have to run.
+
+If you have `allow.write` over a directory that holds checkouts, cplt says so at
+launch and names the repositories it found. That grant looks like "let the agent
+work in these" and is not: a script there fails with `bad interpreter: Operation
+not permitted`, which names neither cplt nor the grant, and reads like a problem
+with the project. Naming the repositories is the fix. A named root is a
 second writable-and-executable tree, with the same protected paths as the
 project: `.git/hooks`, `.git/config`, `.cplt.toml` and the rest stay unwritable
 in it, so a hook cannot be planted to run outside the sandbox later.

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -4,7 +4,9 @@ The sandbox is kernel-enforced, so **all restrictions apply to every process spa
 
 ## `.env` file blocking
 
-`.env*`, `.pem`, `.key`, `.p12`, `.pfx`, `.jks` files in the project directory are **blocked from reading** by default. This stops a rogue agent exfiltrating secrets, but it has side effects:
+`.env*`, `.pem`, `.key`, `.p12`, `.pfx`, `.jks` files are **blocked from reading** by default. This stops a rogue agent exfiltrating secrets, but it has side effects.
+
+**The rule is not limited to the project directory.** It is a pattern on the file name, applied everywhere the sandbox can reach, so it also covers files with those names inside dependency caches — where they are usually package content rather than anyone's secret:
 
 | Operation                      | Impact     | Why                                                                   |
 | ------------------------------ | ---------- | --------------------------------------------------------------------- |
@@ -16,6 +18,8 @@ The sandbox is kernel-enforced, so **all restrictions apply to every process spa
 | TLS dev servers (`.pem` certs) | ⚠️ Blocked  | Local HTTPS certs in `.pem`/`.key` files can't be read                |
 | `.env.example`                 | ⚠️ Blocked  | Matches the `.env.*` pattern; use `--allow-env-files` if needed       |
 | Writing `.env` files           | ✅ Works    | Only read is denied; Copilot can create `.env` from templates         |
+| `go mod verify`, `mise run` over it | ⚠️ Fails | Hashes every file in `~/go/pkg/mod`, and modules ship fixtures with these names (`gotenv` has a `.env`, `unleasherator` a `.env.local`). One denied read aborts the whole command |
+| Reading a `.pem` test fixture in any dependency | ⚠️ Blocked | Same reason: the pattern matches the name, not the location |
 
 **Fix:**
 

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -3116,8 +3116,22 @@ pub fn gate_git(
         } else {
             format!("\n{}", block_hints.join("\n"))
         };
+        // Name the repository the push targets, but only where "which
+        // repository?" is a live question: a session spanning several, or a
+        // push that landed outside all of them. In a one-repository session
+        // there is nothing to disambiguate and the path is noise in every
+        // refusal.
+        let target = match repo_facts.target(&repo_args, real_git) {
+            Some(member) if !repo_facts.named.is_empty() => {
+                format!(" in {}", member.project_dir)
+            }
+            None if !repo_facts.git_common_dir.is_empty() || !repo_facts.named.is_empty() => {
+                " in a repository this session does not have in scope".to_string()
+            }
+            _ => String::new(),
+        };
         return Err(Refusal {
-            headline: format!("'git {sub}' is not allowed in this environment."),
+            headline: format!("'git {sub}'{target} is not allowed in this environment."),
             guidance: format!("Push prevention is enabled — commit your changes locally.{hints}"),
             agent_note: &[
                 "This operation is restricted by the cplt sandbox to prevent unintended pushes.",
@@ -7940,6 +7954,84 @@ mod tests {
             &facts,
         )
         .expect("with nothing identified the rule falls back to URL identity, as the launch says");
+    }
+
+    /// With several repositories in scope, "not allowed" without a subject
+    /// leaves an agent unable to tell "wrong repository" from "no rule
+    /// matched". The gh side has named the target since #230; the push side
+    /// did not.
+    #[test]
+    fn a_push_refusal_names_the_repository_when_there_is_a_choice() {
+        let Some((_tmp, launch)) =
+            scratch_repo_with_default("main", "https://github.com/o/launch.git", "main")
+        else {
+            return; // no git available
+        };
+        let Some((_tmp2, named)) =
+            scratch_repo_with_default("main", "https://github.com/o/named.git", "main")
+        else {
+            return;
+        };
+        let git = which_git().unwrap();
+        let dir = named.to_string_lossy().into_owned();
+
+        // One repository in scope, pushing in it: nothing to disambiguate, so
+        // the headline stays the shared one rather than carrying a path into
+        // every refusal.
+        let alone = capture_repo_facts(&git, &launch);
+        let launch_dir = launch.to_string_lossy().into_owned();
+        let err = gate_git(
+            &["-C", launch_dir.as_str(), "push", "origin", "main"],
+            true,
+            true,
+            false,
+            &[],
+            Some(&git),
+            &alone,
+        )
+        .expect_err("push prevention refuses")
+        .to_string();
+        assert!(
+            err.contains("'git push' is not allowed"),
+            "a single-repository session needs no subject: {err}"
+        );
+
+        // Pushing somewhere the session was never given, with one repository in
+        // scope: the subject is what makes that legible at all.
+        let err = gate_git(
+            &["-C", dir.as_str(), "push", "origin", "main"],
+            true,
+            true,
+            false,
+            &[],
+            Some(&git),
+            &alone,
+        )
+        .expect_err("push prevention refuses")
+        .to_string();
+        assert!(
+            err.contains("does not have in scope"),
+            "an out-of-scope push must say so: {err}"
+        );
+
+        // Two in scope, pushing in the named one: say which.
+        let mut facts = alone.clone();
+        facts.named = vec![capture_repo_facts(&git, &named)];
+        let err = gate_git(
+            &["-C", dir.as_str(), "push", "origin", "main"],
+            true,
+            true,
+            false,
+            &[],
+            Some(&git),
+            &facts,
+        )
+        .expect_err("push prevention refuses")
+        .to_string();
+        assert!(
+            err.contains(&facts.named[0].project_dir),
+            "the refusal must name the targeted repository: {err}"
+        );
     }
 
     /// #424: an allow_push rule carries launch/named-root identity. The

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2064,7 +2064,25 @@ fn gate_with_scope_resolver(
                     .map(|s| format!(" {s}"))
                     .unwrap_or_default(),
             ),
-            guidance: format!("Reason: {}", result.reason),
+            // A raw API write has a narrow key of its own, and a refusal that
+            // names only the blanket escape hatch is how a session ends up with
+            // the whole guard off: one reached for `gh_guard.mode = "warn"` for
+            // exactly this, which also drops the repository scope check. Say
+            // the small thing that opens this one command.
+            guidance: if result.reason.starts_with("gh api with") {
+                format!(
+                    "Reason: {}. Raw API writes are off by default because they bypass the \
+                     per-command policy the guard rests on; the higher-level commands \
+                     (`gh pr comment`, `gh issue comment`, `gh pr review`) are allowed and \
+                     scope-checked. If the raw call is genuinely needed, \
+                     `cplt config set gh_guard.allow_api_write true` opens writes to \
+                     repositories in scope and nothing else — it is far narrower than \
+                     turning the guard off. `gh api DELETE` stays refused either way.",
+                    result.reason
+                )
+            } else {
+                format!("Reason: {}", result.reason)
+            },
             agent_note: &[
                 "This operation is restricted by the cplt sandbox to prevent unintended changes.",
                 NOTE,
@@ -7954,6 +7972,60 @@ mod tests {
             &facts,
         )
         .expect("with nothing identified the rule falls back to URL identity, as the launch says");
+    }
+
+    /// A raw API write must be told about its own key, not just the blanket
+    /// escape hatch.
+    ///
+    /// A field session hit this and worked around it with
+    /// `gh_guard.mode = "warn"`, which also drops the repository scope check.
+    /// The refusal named only the escape hatch, so that is what the agent
+    /// relayed. `allow_api_write` opens writes to repositories in scope and
+    /// nothing else.
+    #[test]
+    fn a_raw_api_write_refusal_names_allow_api_write() {
+        let policy = GatePolicy {
+            mode: crate::config::EnforcementMode::Block,
+            scope_check: true,
+            block_auth_token: true,
+            unknown_command: UnknownCommandDecision::Block,
+            allow_api_write: false,
+        };
+        let scope = || Ok(vec!["o/r".to_string()]);
+        let err = gate_with_scope_resolver(
+            &[
+                "api",
+                "-X",
+                "POST",
+                "repos/o/r/pulls/1/comments",
+                "-f",
+                "body=x",
+            ],
+            &policy,
+            scope,
+            None,
+        )
+        .expect_err("raw API writes are off by default")
+        .to_string();
+        assert!(
+            err.contains("gh_guard.allow_api_write"),
+            "the narrow key must be named: {err}"
+        );
+        assert!(
+            err.contains("gh pr comment"),
+            "the supported route must be named too: {err}"
+        );
+        // A read must not carry the write advice.
+        assert!(
+            gate_with_scope_resolver(
+                &["api", "repos/o/r/pulls/1"],
+                &policy,
+                || Ok(vec!["o/r".to_string()]),
+                None,
+            )
+            .is_ok(),
+            "a GET is scope-checked, not refused"
+        );
     }
 
     /// With several repositories in scope, "not allowed" without a subject

--- a/src/main.rs
+++ b/src/main.rs
@@ -1688,6 +1688,107 @@ fn warn_exec_tool_dir_shadowing(
     }
 }
 
+/// Repositories reachable only through an `allow.write` grant, which is
+/// writable and deliberately **not** executable.
+///
+/// A grant like `allow.write = ["~/src"]` over a directory of checkouts reads
+/// as "let the agent work in these", and it is not: since #319 a write grant
+/// carries no execute, because a tree that is both is where an agent drops a
+/// binary and runs it. The launch project directory is carved back out of that
+/// deny; a repository beside it under the same grant is not. So `./gradlew` in
+/// the project works and `cd ../other && ./gradlew` fails with
+/// `bad interpreter: Operation not permitted` — a message that names neither
+/// cplt nor the grant, and that a reader reasonably attributes to native
+/// binaries or to their own project.
+///
+/// Reported by a user whose two repositories sat side by side under one grant.
+/// Nothing at launch said so, and the answer (`sandbox.repo_dirs`) is one
+/// config line.
+///
+/// Repositories inside the project directory are excluded: the project's own
+/// `process-exec` allow is emitted after the deny and covers its whole subtree,
+/// so those trees really are executable. So are repositories already named,
+/// which is the remedy this points at.
+fn write_granted_repos_without_exec(
+    allow_write: &[PathBuf],
+    project_dir: &Path,
+    named_roots: &[PathBuf],
+) -> Vec<(PathBuf, Vec<PathBuf>)> {
+    let is_repo = |d: &Path| d.join(".git").exists();
+    let mut out = Vec::new();
+    for grant in allow_write {
+        let mut repos: Vec<PathBuf> = Vec::new();
+        if is_repo(grant) {
+            repos.push(grant.clone());
+        } else if let Ok(entries) = std::fs::read_dir(grant) {
+            // One level only. A grant over a directory of checkouts is the
+            // shape that bites; walking deeper would cost a launch-time scan of
+            // an arbitrary tree to find cases nobody has hit.
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() && is_repo(&path) {
+                    repos.push(path);
+                }
+            }
+        }
+        // The project directory and anything under it are covered by the
+        // project's own `process-exec` allow, which is emitted after the deny.
+        // Listing the launch repository as un-executable would be false, and
+        // false in the direction that makes the whole warning easy to dismiss.
+        repos.retain(|r| {
+            !r.starts_with(project_dir)
+                && !project_dir.starts_with(r)
+                && !named_roots.iter().any(|n| n == r)
+        });
+        if !repos.is_empty() {
+            repos.sort();
+            out.push((grant.clone(), repos));
+        }
+    }
+    out
+}
+
+/// Warn about them. Not gated on `quiet`: the failure it explains is a build
+/// that does not run, with an error naming neither cplt nor the grant, and the
+/// session that reported it had `quiet = true`. Same reasoning as the
+/// trusted-binary warning above.
+fn warn_write_granted_repos(
+    resolved: &config::Resolved,
+    project_dir: &Path,
+    named_roots: &[PathBuf],
+) {
+    for (grant, repos) in
+        write_granted_repos_without_exec(&resolved.allow_write, project_dir, named_roots)
+    {
+        let names = repos
+            .iter()
+            .map(|r| r.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let subject = if repos.len() == 1 && repos[0] == grant {
+            format!(
+                "allow.write grants {}, which is a git repository",
+                grant.display()
+            )
+        } else {
+            format!(
+                "allow.write grants {}, which contains the git repositor{} {names}",
+                grant.display(),
+                if repos.len() == 1 { "y" } else { "ies" }
+            )
+        };
+        ui::warn(&format!(
+            "{subject}. A write grant is deliberately not executable, so its build and \
+             tests will not run there: a script fails with `bad interpreter: Operation not \
+             permitted`, which names neither cplt nor this grant. To work in it, name it \
+             instead — `cplt config set --local sandbox.repo_dirs <DIR>`, or `--repo-dir \
+             <DIR>` for one run — which grants read, write and execute and puts it in the \
+             `gh` and push scope. That is a real widening: a named repository is another \
+             tree the agent can drop a binary into and run."
+        ));
+    }
+}
+
 /// Load config, merge CLI flags, resolve paths, detect agent, print info messages.
 fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContext> {
     // Canonicalize CLI paths for consistency with config path handling
@@ -3148,6 +3249,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
     let repo_rows = repo_summary_rows(&project_dir, &repo_roots);
 
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
+    warn_write_granted_repos(&resolved, &project_dir, &repo_paths);
 
     // Probe the host for everything the sandbox profile depends on.
     let probe = HostProbe::probe(&mut resolved, &home_dir, &project_dir);
@@ -4366,6 +4468,7 @@ fn run_exec_command(
     // profile, so a warning about another agent's directories would name an
     // effect this session cannot have (#343).
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
+    warn_write_granted_repos(&resolved, &project_dir, &repo_paths);
 
     // Build the resolved Shell sandbox (discovery → proxy → prepare). Shared
     // with `cplt check`, which runs its probes under the identical policy.
@@ -4813,6 +4916,7 @@ fn run_check_command(
 
     // Shell, not `active_agent`: `check` probes under the Shell profile.
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, agent::Agent::Shell);
+    warn_write_granted_repos(&resolved, &project_dir, &repo_paths);
 
     // check prints its own report; never prompt.
     resolved.yes = true;
@@ -8554,6 +8658,62 @@ mod tests {
     /// have, and it is now accepted. Every other rule still applies to it —
     /// git toplevel, no symlinked leaf, not an unsafe root — and those are
     /// asserted by their own tests; this one is about the location alone.
+    /// The shape a user hit: two repositories side by side under one
+    /// `allow.write`, and the agent `cd ..`s into the other one. The grant
+    /// makes it writable and not executable, so `./gradlew` there fails with
+    /// `bad interpreter: Operation not permitted` — an error naming neither
+    /// cplt nor the grant.
+    #[test]
+    fn a_write_grant_over_a_directory_of_checkouts_is_reported() {
+        let (_guard, root) = canonical_tempdir();
+        let parent = root.join("parent");
+        let project = parent.join("appA");
+        let sibling = parent.join("appB");
+        for d in [&project, &sibling] {
+            std::fs::create_dir_all(d.join(".git")).unwrap();
+        }
+        let found = write_granted_repos_without_exec(std::slice::from_ref(&parent), &project, &[]);
+        assert_eq!(found.len(), 1, "the grant is reported once: {found:?}");
+        // The launch repository is under the project's own exec allow, so
+        // listing it would be false — and false in the direction that makes the
+        // whole warning easy to dismiss.
+        assert_eq!(found[0].1, vec![sibling.clone()], "only the sibling");
+
+        // Naming it is the remedy, so it must silence the warning.
+        assert!(
+            write_granted_repos_without_exec(
+                std::slice::from_ref(&parent),
+                &project,
+                std::slice::from_ref(&sibling),
+            )
+            .is_empty()
+        );
+    }
+
+    /// The two shapes that must stay silent, or the warning becomes noise
+    /// nobody reads: an ordinary tool-cache grant, and a grant inside the
+    /// project directory (covered by the project's own exec allow).
+    #[test]
+    fn a_write_grant_with_no_unreachable_repository_is_silent() {
+        let (_guard, root) = canonical_tempdir();
+        let project = root.join("project");
+        std::fs::create_dir_all(project.join(".git")).unwrap();
+        let cache = root.join("cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        assert!(
+            write_granted_repos_without_exec(std::slice::from_ref(&cache), &project, &[])
+                .is_empty(),
+            "a grant with no repository in it says nothing"
+        );
+
+        let vendored = project.join("vendor/lib");
+        std::fs::create_dir_all(vendored.join(".git")).unwrap();
+        assert!(
+            write_granted_repos_without_exec(&[project.join("vendor")], &project, &[]).is_empty(),
+            "a grant inside the project is executable through the project's own allow"
+        );
+    }
+
     #[test]
     fn repo_dir_accepts_a_sibling_repository() {
         let (_guard, root) = canonical_tempdir();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1714,6 +1714,8 @@ fn write_granted_repos_without_exec(
     project_dir: &Path,
     named_roots: &[PathBuf],
 ) -> Vec<(PathBuf, Vec<PathBuf>)> {
+    /// Entries examined per grant.
+    const SCAN_LIMIT: usize = 256;
     let is_repo = |d: &Path| d.join(".git").exists();
     let mut out = Vec::new();
     for grant in allow_write {
@@ -1721,10 +1723,14 @@ fn write_granted_repos_without_exec(
         if is_repo(grant) {
             repos.push(grant.clone());
         } else if let Ok(entries) = std::fs::read_dir(grant) {
-            // One level only. A grant over a directory of checkouts is the
-            // shape that bites; walking deeper would cost a launch-time scan of
-            // an arbitrary tree to find cases nobody has hit.
-            for entry in entries.flatten() {
+            // One level only, and bounded. A grant over a directory of
+            // checkouts is the shape that bites; walking deeper would cost a
+            // launch-time scan of an arbitrary tree to find cases nobody has
+            // hit. The entry cap matters because the grant is arbitrary: it can
+            // name a home directory or a network mount, and a `.git` probe per
+            // entry is a stat per entry. Stopping early can only under-report,
+            // and this is advice, not enforcement.
+            for entry in entries.flatten().take(SCAN_LIMIT) {
                 let path = entry.path();
                 if path.is_dir() && is_repo(&path) {
                     repos.push(path);
@@ -1760,11 +1766,22 @@ fn warn_write_granted_repos(
     for (grant, repos) in
         write_granted_repos_without_exec(&resolved.allow_write, project_dir, named_roots)
     {
-        let names = repos
+        // Bounded: a grant over a directory of many checkouts would otherwise
+        // put every path into one warning line, which is the fastest way to
+        // make a warning unreadable and therefore unread.
+        /// Repositories named in one warning line.
+        const LIST_LIMIT: usize = 5;
+        let shown = repos.len().min(LIST_LIMIT);
+        let mut names = repos
             .iter()
+            .take(shown)
             .map(|r| r.display().to_string())
             .collect::<Vec<_>>()
             .join(", ");
+        if repos.len() > shown {
+            use std::fmt::Write as _;
+            let _ = write!(names, " and {} more", repos.len() - shown);
+        }
         let subject = if repos.len() == 1 && repos[0] == grant {
             format!(
                 "allow.write grants {}, which is a git repository",
@@ -1782,9 +1799,10 @@ fn warn_write_granted_repos(
              tests will not run there: a script fails with `bad interpreter: Operation not \
              permitted`, which names neither cplt nor this grant. To work in it, name it \
              instead — `cplt config set --local sandbox.repo_dirs <DIR>`, or `--repo-dir \
-             <DIR>` for one run — which grants read, write and execute and puts it in the \
-             `gh` and push scope. That is a real widening: a named repository is another \
-             tree the agent can drop a binary into and run."
+             <DIR>` for one run — which grants read, write and execute, and, when its \
+             origin is a GitHub URL, puts it in the `gh` and push scope. That is a real \
+             widening: a named repository is another tree the agent can drop a binary \
+             into and run."
         ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4970,6 +4970,7 @@ fn run_check_command(
             &disabled,
             &home_dir,
             &project_dir,
+            &repo_paths,
             active_agent,
             agent_name,
             preset_name,
@@ -5104,6 +5105,7 @@ fn build_battery(
     disabled: &[sandbox::HardeningCategory],
     home_dir: &Path,
     project_dir: &Path,
+    named_roots: &[PathBuf],
     agent: agent::Agent,
     agent_name: String,
     preset_name: Option<String>,
@@ -5178,6 +5180,48 @@ fn build_battery(
         fix: None,
         note: baseline_note(write_proj),
     });
+
+    // ── Named repositories ──
+    // A named root is a second read/write/EXECUTE tree, which is the whole
+    // point of naming it and also the cost. `check` reports what enforcement
+    // actually does, so it has to look there: probing only the project
+    // directory left the one command a user runs to confirm the sandbox silent
+    // about the grant they had just added.
+    for root in named_roots {
+        let label = root.file_name().map_or_else(
+            || root.display().to_string(),
+            |n| n.to_string_lossy().into_owned(),
+        );
+        let expl = check::explain_path(policy, home_dir, project_dir, root);
+        items.push(check::CheckItem {
+            name: format!("write named repo {label}"),
+            category: "filesystem".to_string(),
+            target: root.display().to_string(),
+            decision: probe_write(prepared, resolved, disabled, root),
+            expected: Some(check::Decision::Allowed),
+            reason: expl.reason.clone(),
+            fix: expl.fix.clone(),
+            note: None,
+        });
+        // The property that separates a named root from an ungoverned tree.
+        // Hooks run OUTSIDE the sandbox on the user's next git operation there,
+        // so this is the one that must stay blocked however wide the grant is.
+        let hooks = root.join(".git/hooks");
+        if hooks.is_dir() {
+            items.push(check::CheckItem {
+                name: format!("write {label}/.git/hooks"),
+                category: "filesystem".to_string(),
+                target: hooks.display().to_string(),
+                decision: probe_write(prepared, resolved, disabled, &hooks),
+                expected: Some(check::Decision::Blocked),
+                reason: "git hooks run outside the sandbox on the next git operation in \
+                         that repository, so they stay unwritable in every writable root."
+                    .to_string(),
+                fix: None,
+                note: None,
+            });
+        }
+    }
 
     // Protection: a credential path must be BLOCKED for read.
     let (prot_path, prot_label) = pick_protected_read(home_dir);

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -324,10 +324,24 @@ pub fn linux_docker_socket_paths(
     paths
 }
 
-/// Sensitive file patterns in the project directory that are denied by default.
-/// These often contain secrets (API keys, database passwords, private keys).
-/// A rogue agent could read and exfiltrate these via HTTPS.
-/// Override with `--allow-env-files` if Copilot genuinely needs them.
+/// Sensitive file patterns denied by default. These often contain secrets (API
+/// keys, database passwords, private keys), which a rogue agent could read and
+/// exfiltrate over HTTPS. Override with `--allow-env-files`.
+///
+/// **Emitted as unanchored regexes, so they apply EVERYWHERE the sandbox can
+/// reach, not only in the project directory** — see `emit_sensitive_project_denies`.
+/// The name says "project" because that is the threat these were written for;
+/// the rule is wider, and the difference is not academic. Dependency caches
+/// carry package content matching these patterns: `gotenv` ships a `.env`
+/// fixture, so `go mod verify` — which hashes every file in the module cache —
+/// aborts on a read it cannot make. That is collateral, not protection: the
+/// content is public, content-addressed and came from a registry rather than
+/// from the user.
+///
+/// Narrowing it is a security decision rather than a cleanup, so it is tracked
+/// rather than done here: scoping to writable roots would let a broad
+/// `allow.read` expose real `.env` files, and carving out caches means naming
+/// every dependency store. Documented in `docs/known-impacts.md`.
 pub const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
     // .env files — the #1 source of leaked secrets in project dirs
     r"\.env$",

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -461,6 +461,12 @@ fn emit_sensitive_project_denies(
         for pattern in SENSITIVE_PROJECT_PATTERNS {
             // SBPL regex matches against the full path, so we anchor to
             // any directory separator to avoid matching path components.
+            //
+            // Anchored to a separator and NOTHING ELSE: this is a global rule,
+            // not a project-scoped one, whatever the constant is called. It
+            // reaches `~/go/pkg/mod/.../gotenv@v1.6.0/.env` as readily as
+            // `<project>/.env`, which is why `go mod verify` fails in a session
+            // that never went near a secret. See the constant's docs.
             sbpl!(sb, "(deny file-read* (regex #\"/{pattern}\"))");
             sbpl!(sb, "(deny file-write* (regex #\"/{pattern}\"))");
         }


### PR DESCRIPTION
From a user report this morning, and it is #344's Stage 1 item 1 — "identify `allow.write` roots that are git repositories and state what the grant lacks" — which was never built.

## What happened

Two repositories side by side under one `allow.write` on their parent. The agent ran `cd ../watson-admin-api && ./gradlew build` and got:

```
/bin/sh: ./gradlew: /bin/sh: bad interpreter: Operation not permitted
```

Reproduced exactly. The agent's own explanation to the user was that these are "native binaries using the execve syscall, which the cplt sandbox refuses". That is wrong, and provably so: a pure-JS shim with `#!/usr/bin/env node` fails identically, and the **same file** run as `node ./node_modules/.bin/oxlint` succeeds.

```
DIRECT:   /usr/bin/env: bad interpreter: Operation not permitted
VIA_NODE: RAN_OXLINT
```

The real mechanism: since #319 an `allow.write` tree is writable and deliberately **not** executable, because a tree that is both is where an agent drops a binary and runs it. The launch project directory is carved back out of that deny; a repository beside it under the same grant is not. So `./gradlew` in the project works and `cd ../other && ./gradlew` does not.

## What this changes

Not the decision — that one stands. What was missing is that nothing said so. The error names neither cplt nor the grant, so it reads like a broken project, and the remedy is one config line the reporter had no way to discover.

```
[cplt] allow.write grants /w/parent, which contains the git repository /w/parent/appB.
       A write grant is deliberately not executable, so its build and tests will not
       run there: a script fails with `bad interpreter: Operation not permitted`, which
       names neither cplt nor this grant. To work in it, name it instead — `cplt config
       set --local sandbox.repo_dirs <DIR>`, or `--repo-dir <DIR>` for one run — which
       grants read, write and execute and puts it in the `gh` and push scope. That is a
       real widening: a named repository is another tree the agent can drop a binary
       into and run.
```

Not gated on `quiet`. The reporting session had `quiet = true`, and what this explains is a build that silently does not run. Same reasoning as the trusted-binary warning it sits beside.

## Where it stays quiet

Otherwise it is noise nobody reads:

- a grant with no repository in it (`~/.gradle`, a cache directory);
- a repository inside the project directory, which the project's own `process-exec` allow covers and which is therefore genuinely executable — listing it would be false in the direction that makes the whole warning easy to dismiss;
- a repository already named with `--repo-dir`, since that is the remedy.

Scanning is one level deep. A grant over a directory of checkouts is the shape that bites; walking deeper would cost a launch-time scan of an arbitrary tree to find cases nobody has hit.

## Verification

Two unit tests: the reported shape (only the sibling listed, not the launch repository, and naming it silences the warning), and the two shapes that must stay silent. Falsified by neutering the filter — **both** tests fail.

Worth noting: the first version had a second guard that skipped grants inside the project directory. It was redundant with the filter, and no test could tell the two apart, so it is gone rather than kept as something a reader has to reason about.

Verified end to end at the reporter's exact configuration, `quiet` included.

Refs #344, #319.

---

## Also, from the same review of #344's acceptance criteria

Two more criteria were unmet. Both are about a multi-repository session being visible where it matters.

### `cplt check` now probes the named roots

It probed the project directory only. A named root is a second read/write/**execute** tree, and the one command a user runs to confirm enforcement said nothing about it:

```
  ✓ write named repo lib   → ALLOWED
  ✓ write lib/.git/hooks   → BLOCKED
```

The second is the property that separates a governed root from an ungoverned tree: hooks run **outside** the sandbox on the next git operation in that repository, so they stay unwritable however wide the grant is.

`check path <dir>` already answered correctly (that is the explain layer, fixed in #448); the probe suite never visited.

### A blocked `git push` names the repository it targeted

It said only `'git push' is not allowed in this environment.`, with the reasons appended as hints. The gh side has named its target since #230. With several repositories in scope, an agent could not tell "wrong repository" from "no rule matched" without reading to the end of the message.

The subject appears only where the question is live: a session spanning several repositories, or a push that landed outside all of them. A one-repository session has nothing to disambiguate, and a path in every refusal is noise.

Worth recording: my first version of that test asserted a single-repository session produces no subject, and it failed — because the push in that test really was out of scope, so the subject correctly fired. The test premise was wrong, not the code. It now covers both: pushing inside the one repository in scope gets the bare headline, pushing outside it says so.

### The third criterion is not fixed here

Bubblewrap expands a named root's protected paths at depth 0 only, so a repository nested deeper inside a named root has an unprotected `.cplt.toml` on Linux. That is a platform limit (the macOS equivalent is a regex and covers any depth; Landlock without bwrap enforces none of the table). Recorded as a gap rather than papered over with a bounded walk that would read as coverage while not being it; the parity work belongs with #386.