### PR TITLE
fix(gh-guard): inject_token did nothing with the guard off, and said nothing

### DIFF
--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -272,6 +272,20 @@ variable. `gh auth token` inside such a sandbox returns nothing and no
 
 It falls back gracefully if `gh` is not installed or not authenticated.
 
+**On Linux this is often the only way to stay signed in.** The Secret Service
+(gnome-keyring, kwallet, anything behind libsecret) is reached over D-Bus, and
+the sandbox masks the session bus socket and does not pass
+`DBUS_SESSION_BUS_ADDRESS`. An agent that stores its credential in the system
+vault therefore finds none — the Copilot CLI reports `System vault not
+available` and offers to write the token to its config file in plain text — and
+asks you to sign in again every session. Authenticate on the host, where the
+keyring works, and let cplt hand the token in.
+
+`inject_token` requires `gh_guard.enabled`: the injection is part of installing
+the gh wrapper, which the guard owns. With the guard off it does nothing, and
+cplt says so at launch rather than leaving a key that reads as true and has no
+effect.
+
 If you prefer the token in the environment instead, set `inject_token = true`.
 `cplt config set` refuses it without `--force`, and `cplt config show` marks it
 `⚠ DANGEROUS`, because the token is then inherited by every process in the

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -41,6 +41,43 @@ On macOS this applies to every writable root, the launch repository included,
 not only to repositories named with `--repo-dir`. Tracked in
 [#402](https://github.com/navikt/cplt/issues/402), which also covers whether
 the guard should intercept these forms and fail loudly instead.
+||||||| parent of fc464a5 (fix(gh-guard): inject_token did nothing with the guard off, and said nothing)
+
+## Linux: the system keyring is unreachable, so agents ask you to sign in again
+
+`gnome-keyring`, `kwallet` and anything else behind libsecret are reached over
+D-Bus. The sandbox masks the session bus socket (`$XDG_RUNTIME_DIR/bus`) and
+`/run/dbus/system_bus_socket`, and does not pass `DBUS_SESSION_BUS_ADDRESS`, so
+there is no Secret Service inside it. An agent that keeps its credential there
+finds no vault:
+
+```
+! System vault not available
+  The recommended secure storage (keychain, keyring, or credential manager)
+  could not be found or accessed.
+  Store token in plain text config file?
+```
+
+This is not a distribution problem, and it is not specific to Ubuntu. D-Bus is a
+broad IPC channel into the whole desktop session, which is why it is masked.
+
+**Fix:** authenticate on the host, where the keyring works, and let cplt pass
+the token in.
+
+```bash
+gh auth login                                   # outside cplt, once
+cplt config set gh_guard.inject_token true --force   # needs gh_guard.enabled
+```
+
+`--force` is required because putting the token in the environment is a real
+weakening: it is inherited by every process in the sandbox and readable from any
+of them, through `/proc/<pid>/environ` on Linux or `ps -E` on macOS. See
+[gh-guard.md](gh-guard.md). Answering "yes, store in plain text" also works and
+persists across sessions, at the cost of a token on disk in the agent's config
+directory.
+
+macOS is unaffected: the Keychain is granted (narrowed per agent by
+`keychain_substitute`).
 
 ## `.env` file blocking
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1711,9 +1711,11 @@ fn warn_inject_token_without_guard(resolved: &config::Resolved) {
         ui::warn(
             "gh_guard.inject_token is set but gh_guard.enabled is false, so no token is \
              injected: the injection runs as part of installing the gh wrapper, which the \
-             guard owns. Turn the guard on to use it (`cplt config set gh_guard.enabled \
-             true`), or drop inject_token so the config does not claim something that is \
-             not happening.",
+             guard owns. Either turn the guard on to use it, with `cplt config set \
+             gh_guard.enabled true`, or remove the key so the config stops claiming \
+             something that is not happening: `cplt config set gh_guard.inject_token \
+             false`, or `cplt config set gh_guard.inject_token --unset` to drop the line \
+             entirely.",
         );
     }
 }
@@ -8748,10 +8750,6 @@ mod tests {
         assert!(err.contains(&inner.display().to_string()), "{err}");
     }
 
-    /// A repository beside the launch repository is the shape most checkouts
-    /// have, and it is now accepted. Every other rule still applies to it —
-    /// git toplevel, no symlinked leaf, not an unsafe root — and those are
-    /// asserted by their own tests; this one is about the location alone.
     /// A key that reads as true and does nothing is worse than one that is off:
     /// `config show` says `inject_token = true`, no token reaches the agent,
     /// and nothing connects the two.
@@ -8831,6 +8829,10 @@ mod tests {
         );
     }
 
+    /// A repository beside the launch repository is the shape most checkouts
+    /// have, and it is now accepted. Every other rule still applies to it —
+    /// git toplevel, no symlinked leaf, not an unsafe root — and those are
+    /// asserted by their own tests; this one is about the location alone.
     #[test]
     fn repo_dir_accepts_a_sibling_repository() {
         let (_guard, root) = canonical_tempdir();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1688,6 +1688,36 @@ fn warn_exec_tool_dir_shadowing(
     }
 }
 
+/// `gh_guard.inject_token` does nothing while the guard is off.
+///
+/// The injection happens inside the `gh_guard.enabled` branch of the wrapper
+/// install, so turning the guard off turns it off too. That is defensible —
+/// the token is extracted for the wrapper's benefit — but it is invisible: the
+/// key reads as true in `cplt config show`, no token reaches the agent, and
+/// nothing connects the two.
+///
+/// It matters most on Linux, where it is the answer to a real problem. The
+/// Secret Service (gnome-keyring, kwallet) is reached over D-Bus, whose socket
+/// the sandbox masks, so an agent that stores its credential in the system
+/// vault cannot reach one and asks the user to log in again every session.
+/// Injecting a token extracted in the parent is the way out, and a user who
+/// sets it while the guard is off gets no token and no explanation.
+fn inject_token_is_inert(gh_guard: &config::GhGuardPolicy) -> bool {
+    gh_guard.inject_token && !gh_guard.enabled
+}
+
+fn warn_inject_token_without_guard(resolved: &config::Resolved) {
+    if inject_token_is_inert(&resolved.gh_guard) {
+        ui::warn(
+            "gh_guard.inject_token is set but gh_guard.enabled is false, so no token is \
+             injected: the injection runs as part of installing the gh wrapper, which the \
+             guard owns. Turn the guard on to use it (`cplt config set gh_guard.enabled \
+             true`), or drop inject_token so the config does not claim something that is \
+             not happening.",
+        );
+    }
+}
+
 /// Repositories reachable only through an `allow.write` grant, which is
 /// writable and deliberately **not** executable.
 ///
@@ -3268,6 +3298,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
 
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
     warn_write_granted_repos(&resolved, &project_dir, &repo_paths);
+    warn_inject_token_without_guard(&resolved);
 
     // Probe the host for everything the sandbox profile depends on.
     let probe = HostProbe::probe(&mut resolved, &home_dir, &project_dir);
@@ -4487,6 +4518,7 @@ fn run_exec_command(
     // effect this session cannot have (#343).
     warn_exec_tool_dir_shadowing(&resolved, &home_dir, active_agent);
     warn_write_granted_repos(&resolved, &project_dir, &repo_paths);
+    warn_inject_token_without_guard(&resolved);
 
     // Build the resolved Shell sandbox (discovery → proxy → prepare). Shared
     // with `cplt check`, which runs its probes under the identical policy.
@@ -8720,6 +8752,29 @@ mod tests {
     /// have, and it is now accepted. Every other rule still applies to it —
     /// git toplevel, no symlinked leaf, not an unsafe root — and those are
     /// asserted by their own tests; this one is about the location alone.
+    /// A key that reads as true and does nothing is worse than one that is off:
+    /// `config show` says `inject_token = true`, no token reaches the agent,
+    /// and nothing connects the two.
+    ///
+    /// This pins the predicate, not the printing: it fails if the condition
+    /// drifts, and it would NOT catch the warning ceasing to be called, or
+    /// `sandbox_exec` being changed so injection happens with the guard off —
+    /// at which point the warning becomes the false statement. Said plainly
+    /// because a two-line condition invites a test that restates it and proves
+    /// nothing.
+    #[test]
+    fn inject_token_is_inert_only_when_the_guard_is_off() {
+        let policy = |inject: bool, enabled: bool| config::GhGuardPolicy {
+            inject_token: inject,
+            enabled,
+            ..config::GhGuardPolicy::default()
+        };
+        assert!(inject_token_is_inert(&policy(true, false)), "set but inert");
+        assert!(!inject_token_is_inert(&policy(true, true)), "doing its job");
+        assert!(!inject_token_is_inert(&policy(false, false)));
+        assert!(!inject_token_is_inert(&policy(false, true)));
+    }
+
     /// The shape a user hit: two repositories side by side under one
     /// `allow.write`, and the agent `cd ..`s into the other one. The grant
     /// makes it writable and not executable, so `./gradlew` there fails with


### PR DESCRIPTION
From a Linux user who has to sign in to Copilot every session:

```
! System vault not available
  The recommended secure storage (keychain, keyring, or credential manager)
  could not be found or accessed.
  Store token in plain text config file?
```

Their guess was "maybe an Ubuntu thing, not cplt". It is cplt, and it is deliberate.

## The vault part is by design

The Secret Service — gnome-keyring, kwallet, anything behind libsecret — is reached over D-Bus. `socket_mask_paths` masks `$XDG_RUNTIME_DIR/bus` and `/run/dbus/system_bus_socket`, and `DBUS_SESSION_BUS_ADDRESS` is not in the environment allowlist. So there is no Secret Service inside the sandbox, on any distribution. D-Bus is a broad IPC channel into the whole desktop session; masking it is the right call.

macOS is unaffected — the Keychain is granted, narrowed per agent by `keychain_substitute`.

## The part that is a defect

The answer to this is `gh_guard.inject_token`: extract the token in the unsandboxed parent, where the keyring works, and pass it in as `GH_TOKEN`. A user who follows that advice with the guard turned off gets nothing.

```rust
if gh_guard.enabled {
    if gh_guard.inject_token {
        inject_gh_token_if_needed(cmd, agent, deny_env);
    }
```

The injection is part of installing the gh wrapper, which the guard owns. That nesting is defensible. What is not is that it is invisible: `cplt config show` reports `inject_token = true`, no token reaches the agent, and nothing connects the two. The user is left where they started, having changed a setting that looks right — and this population is exactly the one that turns the guard off, which is how the setting and its precondition end up contradicting each other.

The launch now says so. **Not a behaviour change**: moving the injection outside the guard would hand a token to sessions that asked for neither, which is the wrong direction.

## Documented where the person will look

They will not think to look under "gh guard", so `docs/known-impacts.md` gains a Linux keyring section with the exact prompt text, why it happens, and the fix. `docs/gh-guard.md` states the `gh_guard.enabled` dependency next to the `inject_token` example.

## Verification

`inject_token_is_inert_only_when_the_guard_is_off` pins the predicate over all four combinations. Its doc says what it does **not** prove — that the warning is still called, or that `sandbox_exec` has not been changed so injection happens with the guard off, at which point the warning becomes the false statement. Worth saying, because a two-line condition invites a test that restates it and proves nothing; the first version of this test did exactly that and was replaced.

Verified by hand: the warning fires with `inject_token = true, enabled = false`, and is silent with the guard on.