### PR TITLE
fix(sandbox): the .env deny covered package fixtures and broke go mod verify

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -6,7 +6,7 @@ The sandbox is kernel-enforced, so **all restrictions apply to every process spa
 
 `.env*`, `.pem`, `.key`, `.p12`, `.pfx`, `.jks` files are **blocked from reading** by default. This stops a rogue agent exfiltrating secrets, but it has side effects.
 
-**The rule is not limited to the project directory.** It is a pattern on the file name, applied everywhere the sandbox can reach, so it also covers files with those names inside dependency caches — where they are usually package content rather than anyone's secret:
+**The rule is a pattern on the file name, not a location**, so it applies everywhere the sandbox can reach. The two extracted dependency stores are carved back out for *reading* (#477), because a `.env` there is package content; everywhere else the name is enough to deny it:
 
 | Operation                      | Impact     | Why                                                                   |
 | ------------------------------ | ---------- | --------------------------------------------------------------------- |
@@ -18,8 +18,8 @@ The sandbox is kernel-enforced, so **all restrictions apply to every process spa
 | TLS dev servers (`.pem` certs) | ⚠️ Blocked  | Local HTTPS certs in `.pem`/`.key` files can't be read                |
 | `.env.example`                 | ⚠️ Blocked  | Matches the `.env.*` pattern; use `--allow-env-files` if needed       |
 | Writing `.env` files           | ✅ Works    | Only read is denied; Copilot can create `.env` from templates         |
-| `go mod verify`, `mise run` over it | ⚠️ Fails | Hashes every file in `~/go/pkg/mod`, and modules ship fixtures with these names (`gotenv` has a `.env`, `unleasherator` a `.env.local`). One denied read aborts the whole command |
-| Reading a `.pem` test fixture in any dependency | ⚠️ Blocked | Same reason: the pattern matches the name, not the location |
+| `go mod verify`, `cargo` over an extracted crate | ✅ Works | Read is re-allowed under `~/go/pkg/mod` and `~/.cargo/registry`: a `.env` there is a library's test fixture (`gotenv` ships one), not your secret, and the content is checksum-verified and came from a registry. Write stays denied |
+| A `.env` in another dependency store | ⚠️ Blocked | The carve-out is a short explicit list, not a heuristic — only trees that are content-addressed, verified and registry-sourced |
 
 **Fix:**
 

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -338,10 +338,10 @@ pub fn linux_docker_socket_paths(
 /// content is public, content-addressed and came from a registry rather than
 /// from the user.
 ///
-/// Narrowing it is a security decision rather than a cleanup, so it is tracked
-/// rather than done here: scoping to writable roots would let a broad
-/// `allow.read` expose real `.env` files, and carving out caches means naming
-/// every dependency store. Documented in `docs/known-impacts.md`.
+/// [`DEPENDENCY_SOURCE_TREES`] carves the read side back out for the two
+/// extracted stores, which is as far as this is narrowed: scoping the whole
+/// rule to writable roots would let a broad `allow.read` expose real `.env`
+/// files. Documented in `docs/known-impacts.md`.
 pub const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
     // .env files — the #1 source of leaked secrets in project dirs
     r"\.env$",
@@ -353,6 +353,25 @@ pub const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
     r"\.pfx$",
     r"\.jks$",
 ];
+
+/// Dependency trees where [`SENSITIVE_PROJECT_PATTERNS`] is collateral rather
+/// than protection, given as [`HOME_TOOL_DIRS`] paths so a relocated
+/// `CARGO_HOME` / `GOPATH` resolves with the rest.
+///
+/// These are the stores that hold **extracted** package sources: a `.env` under
+/// one of them is a file some library shipped, not a secret of the user's.
+/// `gotenv` ships one as a test fixture, and `go mod verify` hashes every file
+/// in the module cache, so a read it cannot make aborts the whole command
+/// (#477). The same is true of a `.pem` test fixture in any dependency.
+///
+/// Read is re-allowed here, never write. The properties that make this safe are
+/// the ones these trees have and a user directory does not: the content is
+/// content-addressed, verified against a checksum, and came from a registry
+/// rather than from the person running cplt. Anything without all three stays
+/// denied — which is why this is a short explicit list and not a heuristic.
+///
+/// macOS only, like the denies themselves: Landlock cannot express either side.
+pub const DEPENDENCY_SOURCE_TREES: &[&str] = &[".cargo/registry", "go/pkg/mod"];
 
 /// Prefixes of ~/Library/Caches/ subdirectories to deny (non-dev caches).
 /// Uses reverse-domain bundle IDs which are stable across app versions.

--- a/src/sandbox_policy.rs
+++ b/src/sandbox_policy.rs
@@ -355,8 +355,14 @@ pub const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
 ];
 
 /// Dependency trees where [`SENSITIVE_PROJECT_PATTERNS`] is collateral rather
-/// than protection, given as [`HOME_TOOL_DIRS`] paths so a relocated
-/// `CARGO_HOME` / `GOPATH` resolves with the rest.
+/// than protection.
+///
+/// Each entry is a [`HOME_TOOL_DIRS`] path plus the subpath under it that holds
+/// **extracted** sources, because the two do not coincide: `go/pkg` is the tool
+/// dir and the module cache is `go/pkg/mod` beneath it. Naming the tool dir is
+/// what makes a relocated `CARGO_HOME` / `GOPATH` / `GOMODCACHE` resolve with
+/// the rest of the policy — matching on `go/pkg/mod` directly finds no entry
+/// and silently falls back to the default location.
 ///
 /// These are the stores that hold **extracted** package sources: a `.env` under
 /// one of them is a file some library shipped, not a secret of the user's.
@@ -371,7 +377,7 @@ pub const SENSITIVE_PROJECT_PATTERNS: &[&str] = &[
 /// denied — which is why this is a short explicit list and not a heuristic.
 ///
 /// macOS only, like the denies themselves: Landlock cannot express either side.
-pub const DEPENDENCY_SOURCE_TREES: &[&str] = &[".cargo/registry", "go/pkg/mod"];
+pub const DEPENDENCY_SOURCE_TREES: &[(&str, &str)] = &[(".cargo/registry", ""), ("go/pkg", "mod")];
 
 /// Prefixes of ~/Library/Caches/ subdirectories to deny (non-dev caches).
 /// Uses reverse-domain bundle IDs which are stable across app versions.

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -502,14 +502,19 @@ fn emit_sensitive_project_denies(
 fn dependency_source_trees(home: &str, tool_dirs: Option<&[ResolvedToolDir]>) -> Vec<String> {
     DEPENDENCY_SOURCE_TREES
         .iter()
-        .map(|rel| {
-            tool_dirs
+        .map(|(tool_dir, sub)| {
+            let base = tool_dirs
                 .and_then(|dirs| {
                     dirs.iter()
-                        .find(|d| d.dir.path == *rel)
+                        .find(|d| d.dir.path == *tool_dir)
                         .map(|d| d.path.to_string_lossy().into_owned())
                 })
-                .unwrap_or_else(|| format!("{home}/{rel}"))
+                .unwrap_or_else(|| format!("{home}/{tool_dir}"));
+            if sub.is_empty() {
+                base
+            } else {
+                format!("{base}/{sub}")
+            }
         })
         .collect()
 }

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -21,12 +21,12 @@ macro_rules! sbpl {
 
 use super::SandboxConfig;
 use super::policy::{
-    DENIED_CACHE_PREFIXES, DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS, EXEC_IN_WRITABLE,
-    GPG_SIGNING_ALLOW_FILES, PROTECTED_IN_GITDIR, PROTECTED_IN_ROOT, PathBinDir, Protected,
-    ResolvedToolDir, SENSITIVE_PROJECT_PATTERNS, SYSTEM_READ_FILES, TOOL_READ_DIRS,
-    XCODE_SELECT_LINK, active_tool_dirs, ancestor_alternation, app_dirs, escape_regex,
-    nested_alternation, path_bin_dirs, playwright_runtime_intent, rel_is_glob, rel_regex,
-    validate_playwright_socket_dir, validate_sbpl_path,
+    DENIED_CACHE_PREFIXES, DENIED_DOTFILES, DENIED_FILES, DENIED_HOME_SUBPATHS,
+    DEPENDENCY_SOURCE_TREES, EXEC_IN_WRITABLE, GPG_SIGNING_ALLOW_FILES, PROTECTED_IN_GITDIR,
+    PROTECTED_IN_ROOT, PathBinDir, Protected, ResolvedToolDir, SENSITIVE_PROJECT_PATTERNS,
+    SYSTEM_READ_FILES, TOOL_READ_DIRS, XCODE_SELECT_LINK, active_tool_dirs, ancestor_alternation,
+    app_dirs, escape_regex, nested_alternation, path_bin_dirs, playwright_runtime_intent,
+    rel_is_glob, rel_regex, validate_playwright_socket_dir, validate_sbpl_path,
 };
 
 /// Device nodes a sandboxed process may open for writing, by exact path.
@@ -200,6 +200,8 @@ pub fn generate_profile_with_playwright_socket_dir(
         &project_roots,
         config.extra_write,
         config.allow_env_files,
+        &home,
+        config.existing_home_tool_dirs,
     );
     // Same reason, and one more: the worktree common-dir allow is emitted early
     // (so DENIED_DOTFILES still wins over it), which would leave its denies
@@ -392,6 +394,8 @@ fn emit_sensitive_project_denies(
     project_roots: &[String],
     extra_write: &[PathBuf],
     allow_env_files: bool,
+    home: &str,
+    tool_dirs: Option<&[ResolvedToolDir]>,
 ) {
     // All security-critical project denies are emitted LAST in the profile.
     // SBPL uses last-match-wins, so these must come after all user-configured
@@ -470,8 +474,44 @@ fn emit_sensitive_project_denies(
             sbpl!(sb, "(deny file-read* (regex #\"/{pattern}\"))");
             sbpl!(sb, "(deny file-write* (regex #\"/{pattern}\"))");
         }
+        // Re-allow READ inside the extracted dependency stores, after the deny,
+        // because SBPL is last-match-wins. Write stays denied: nothing should be
+        // writing a `.env` into a module cache.
+        //
+        // These files are package content, not the user's secrets — `gotenv`
+        // ships a `.env` as a test fixture — and `go mod verify` hashes every
+        // file in the cache, so one unreadable fixture aborts the command
+        // (#477). Scoped to a short explicit list rather than a heuristic: the
+        // properties that make it safe (content-addressed, checksum-verified,
+        // from a registry) are ones only these trees have.
+        for tree in dependency_source_trees(home, tool_dirs) {
+            if validate_sbpl_path(Path::new(&tree)).is_err() {
+                continue;
+            }
+            let t = escape_regex(&tree);
+            for pattern in SENSITIVE_PROJECT_PATTERNS {
+                sbpl!(sb, "(allow file-read* (regex #\"^{t}/.*/{pattern}\"))");
+            }
+        }
         sbpl!(sb);
     }
+}
+
+/// Absolute paths of [`DEPENDENCY_SOURCE_TREES`], honouring a relocated
+/// `CARGO_HOME` / `GOPATH` when the host probe resolved one.
+fn dependency_source_trees(home: &str, tool_dirs: Option<&[ResolvedToolDir]>) -> Vec<String> {
+    DEPENDENCY_SOURCE_TREES
+        .iter()
+        .map(|rel| {
+            tool_dirs
+                .and_then(|dirs| {
+                    dirs.iter()
+                        .find(|d| d.dir.path == *rel)
+                        .map(|d| d.path.to_string_lossy().into_owned())
+                })
+                .unwrap_or_else(|| format!("{home}/{rel}"))
+        })
+        .collect()
 }
 
 fn emit_home_access(

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1398,6 +1398,64 @@ fn fish_startup_files_are_write_denied_in_both_granted_dirs() {
     );
 }
 
+/// #477: the `.env` / `.pem` deny is a name pattern applied everywhere, so it
+/// also covers package content in the extracted dependency stores — where the
+/// file is a library's test fixture, not the user's secret. `go mod verify`
+/// hashes every file in the module cache, so one unreadable fixture aborts it.
+///
+/// Read is re-allowed there and nowhere else; write stays denied on both sides.
+#[test]
+fn the_env_deny_is_lifted_for_read_inside_dependency_stores_only() {
+    let profile = generate_profile(&base_profile_options(), &[]);
+    let home = "/Users/test";
+    // Escaped as the emitter escapes it: the leading dot of `.cargo` is a regex
+    // metacharacter, and a test that expected the raw path would fail on the
+    // one tree whose name has one.
+    for tree in ["go/pkg/mod", "\\.cargo/registry"] {
+        assert!(
+            profile.contains(&format!(
+                "(allow file-read* (regex #\"^{home}/{tree}/.*/\\.env$\"))"
+            )),
+            "read must be re-allowed under {tree}\n{profile}"
+        );
+        assert!(
+            !profile.contains(&format!(
+                "(allow file-write* (regex #\"^{home}/{tree}/.*/\\.env$\"))"
+            )),
+            "write must stay denied under {tree}\n{profile}"
+        );
+    }
+    // The deny itself is still there, and the carve-out comes after it —
+    // SBPL is last-match-wins, so the order is the whole mechanism.
+    let deny = profile
+        .find("(deny file-read* (regex #\"/\\.env$\"))")
+        .expect("the deny stands");
+    let allow = profile
+        .find("(allow file-read* (regex #\"^/Users/test/go/pkg/mod/")
+        .expect("the carve-out is emitted");
+    assert!(
+        allow > deny,
+        "last match wins, so the carve-out must be later"
+    );
+}
+
+/// With the deny lifted entirely there is nothing to carve out of, and
+/// emitting allows for a rule that is not there would be noise.
+#[test]
+fn the_dependency_store_carve_out_is_absent_when_env_files_are_allowed() {
+    let profile = generate_profile(
+        &SandboxConfig {
+            allow_env_files: true,
+            ..base_profile_options()
+        },
+        &[],
+    );
+    assert!(
+        !profile.contains("go/pkg/mod/.*/\\.env$"),
+        "nothing to re-allow when nothing is denied\n{profile}"
+    );
+}
+
 // ============================================================
 // Named repositories (--repo-dir): project-grade roots (#344)
 // ============================================================

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1439,6 +1439,47 @@ fn the_env_deny_is_lifted_for_read_inside_dependency_stores_only() {
     );
 }
 
+/// A relocated `GOPATH` / `CARGO_HOME` must move the carve-out with it.
+///
+/// The trees are named by their `HOME_TOOL_DIRS` entry plus a subpath, because
+/// the two differ for Go: the tool dir is `go/pkg` and the module cache is
+/// `go/pkg/mod` under it. Matching `go/pkg/mod` directly finds no entry and
+/// falls back to the default location, which is the bug this pins — it would
+/// leave a user with a relocated `GOMODCACHE` still unable to run
+/// `go mod verify`, while the tests passed on a default machine.
+#[test]
+fn the_carve_out_follows_a_relocated_tool_root() {
+    use cplt::sandbox::{HOME_TOOL_DIRS, ResolvedToolDir};
+    let relocated: Vec<ResolvedToolDir> = HOME_TOOL_DIRS
+        .iter()
+        .filter(|d| d.path == "go/pkg" || d.path == ".cargo/registry")
+        .map(|d| ResolvedToolDir {
+            path: PathBuf::from(format!("/elsewhere/{}", d.path)),
+            dir: d,
+        })
+        .collect();
+    assert_eq!(relocated.len(), 2, "both tool dirs must exist to relocate");
+    let profile = generate_profile(
+        &SandboxConfig {
+            existing_home_tool_dirs: Some(&relocated),
+            ..base_profile_options()
+        },
+        &[],
+    );
+    for tree in ["/elsewhere/go/pkg/mod", "/elsewhere/\\.cargo/registry"] {
+        assert!(
+            profile.contains(&format!(
+                "(allow file-read* (regex #\"^{tree}/.*/\\.env$\"))"
+            )),
+            "the carve-out must follow the relocated root to {tree}\n{profile}"
+        );
+    }
+    assert!(
+        !profile.contains("(allow file-read* (regex #\"^/Users/test/go/pkg/mod/"),
+        "and must not also emit the default location\n{profile}"
+    );
+}
+
 /// With the deny lifted entirely there is nothing to carve out of, and
 /// emitting allows for a rule that is not there would be noise.
 #[test]


### PR DESCRIPTION
Closes #477, taking the middle option from that issue.

## The break

A user's `mise run all` failed during `go mod verify`:

```
github.com/subosito/gotenv.../.env
github.com/nais/unleasherator.../.env.local
```

`go mod verify` hashes every file in the module cache, so one unreadable file aborts the whole command. Those files are library test fixtures — `gotenv` ships a `.env` on purpose — not anyone's secret.

`SENSITIVE_PROJECT_PATTERNS` is a pattern on the file **name**, emitted as an unanchored regex. It reaches `~/go/pkg/mod/.../gotenv@v1.6.0/.env` exactly as readily as `<project>/.env`. The constant's own doc said "in the project directory"; that was corrected in #476, and this fixes the behaviour.

## The change

Read is re-allowed under `~/.cargo/registry` and `~/go/pkg/mod`, honouring a relocated `CARGO_HOME` / `GOPATH` through the same tool-dir resolution as the rest of the policy. Emitted **after** the deny, because SBPL is last-match-wins — the ordering is the mechanism, and there is a test asserting the carve-out comes later.

**Write stays denied on both sides.** Nothing should write a `.env` into a module cache.

## Why these two and not a rule

The list is explicit and short on purpose. What makes these trees safe to read is that their content is content-addressed, verified against a checksum, and came from a registry rather than from the person running cplt. A tree missing any of the three stays denied.

That is also why the other option on #477 was rejected: scoping the whole rule to writable roots would match the constant's name, and would let a broad `allow.read` over a directory of checkouts expose their real `.env` files. This narrows only where the protection was never doing anything.

macOS only, like the deny itself — Landlock can express neither side.

## Verification

End to end with a planted fixture:

```
modcache-env  READ_OK        (intended)
project-env   BLOCKED        (correct)
modcache-env  WRITE_BLOCKED  (correct)
```

Two unit tests: the carve-out is emitted for both trees, read only, after the deny; and it is absent entirely under `--allow-env-files`, where there is no deny to carve out of. Falsified by emptying the tree list — the first fails.

One note: my first version of the test expected the raw path and failed on `.cargo/registry`, whose leading dot the emitter escapes as a regex metacharacter. Test bug, not code, and worth the comment it now carries.