### PR TITLE
fix(config): show the keys that were invisible, mark the ones set demands --force for

### DIFF
--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -274,8 +274,9 @@ It falls back gracefully if `gh` is not installed or not authenticated.
 
 If you prefer the token in the environment instead, set `inject_token = true`.
 `cplt config set` refuses it without `--force`, and `cplt config show` marks it
-`⚠ DANGEROUS`, because the token is then visible to every process in the
-sandbox through `/proc/*/environ`:
+`⚠ DANGEROUS`, because the token is then inherited by every process in the
+sandbox — and readable from any of them, through `/proc/<pid>/environ` on Linux
+or `ps -E` on macOS:
 ```toml
 [gh_guard]
 inject_token = true   # injects GH_TOKEN env var (visible to all subprocesses)

--- a/docs/gh-guard.md
+++ b/docs/gh-guard.md
@@ -272,7 +272,10 @@ variable. `gh auth token` inside such a sandbox returns nothing and no
 
 It falls back gracefully if `gh` is not installed or not authenticated.
 
-If you prefer the token in the environment instead, set `inject_token = true`:
+If you prefer the token in the environment instead, set `inject_token = true`.
+`cplt config set` refuses it without `--force`, and `cplt config show` marks it
+`⚠ DANGEROUS`, because the token is then visible to every process in the
+sandbox through `/proc/*/environ`:
 ```toml
 [gh_guard]
 inject_token = true   # injects GH_TOKEN env var (visible to all subprocesses)

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -2,6 +2,42 @@
 
 The sandbox is kernel-enforced, so **all restrictions apply to every process spawned inside it**: dev servers, test runners, build tools, package managers. That is deliberate, since a sandboxed agent could otherwise escape by spawning a child process. It does affect some workflows.
 
+## Branch tracking is silently dropped
+
+`.git/config` is write-denied (it is a `core.hooksPath` and `url.*.insteadOf`
+vector). The commands that record branch tracking write there, and git treats
+the failure as non-fatal: it prints the error, prints a success line that is
+**false**, and exits 0.
+
+```
+error: could not write config file .git/config: Operation not permitted
+branch 'feat' set up to track 'origin/main'.
+```
+
+An agent reading the summary line, or checking the exit code, is told the
+tracking was recorded. It was not.
+
+| Command | What happens |
+| --- | --- |
+| `git push -u origin <branch>` | Push succeeds, upstream **not** recorded, exit 0 |
+| `git checkout -b <branch> origin/<base>` | Branch created, tracking **not** recorded, exit 0 |
+| `git branch --set-upstream-to=origin/<base>` | Records nothing, exit 0 |
+| `git config user.name <x>` | Fails loudly, exit 4 |
+| `git switch -c <branch>` (no tracking) | Clean, nothing to record |
+
+**The shape that works**, and what to tell an agent to do: push with an explicit
+refspec and open the PR with an explicit head, so nothing needs local config.
+
+```bash
+git push origin HEAD:my-branch
+gh pr create -R <owner>/<repo> --head my-branch
+```
+
+This applies to every writable root, the launch repository included, not only
+to repositories named with `--repo-dir`. Tracked in
+[#402](https://github.com/navikt/cplt/issues/402), which also covers whether
+the guard should intercept these forms and fail loudly instead.
+
 ## `.env` file blocking
 
 `.env*`, `.pem`, `.key`, `.p12`, `.pfx`, `.jks` files are **blocked from reading** by default. This stops a rogue agent exfiltrating secrets, but it has side effects.

--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -4,9 +4,13 @@ The sandbox is kernel-enforced, so **all restrictions apply to every process spa
 
 ## Branch tracking is silently dropped
 
-`.git/config` is write-denied (it is a `core.hooksPath` and `url.*.insteadOf`
-vector). The commands that record branch tracking write there, and git treats
-the failure as non-fatal: it prints the error, prints a success line that is
+**macOS only.** `.git/config` is write-denied there (it is a `core.hooksPath`
+and `url.*.insteadOf` vector). Landlock cannot deny a file inside a writable
+directory, so on Linux the file stays writable and branch tracking is recorded
+normally — the whole of this section applies to macOS sessions.
+
+The commands that record branch tracking write to that file, and git treats the
+failure as non-fatal: it prints the error, prints a success line that is
 **false**, and exits 0.
 
 ```
@@ -33,8 +37,8 @@ git push origin HEAD:my-branch
 gh pr create -R <owner>/<repo> --head my-branch
 ```
 
-This applies to every writable root, the launch repository included, not only
-to repositories named with `--repo-dir`. Tracked in
+On macOS this applies to every writable root, the launch repository included,
+not only to repositories named with `--repo-dir`. Tracked in
 [#402](https://github.com/navikt/cplt/issues/402), which also covers whether
 the guard should intercept these forms and fail loudly instead.
 

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -527,6 +527,30 @@ pub fn display_config(loaded: Option<&LoadedConfig>, local: Option<&LoadedConfig
             c.sandbox.keychain_substitute.is_some()
         )
     );
+    // The brief and its AGENTS.md layer had no rows at all, so a user who set
+    // `sandbox.brief = true` saw nothing here and had to reach for
+    // `config get` to confirm it. A key that changes behaviour and is absent
+    // from the command whose job is to report effective configuration is the
+    // same defect as a key that reports the wrong value.
+    let brief = c.sandbox.brief.unwrap_or(false);
+    println!(
+        "{blue}[cplt]{nc}    brief                 = {}{} {dim}(experimental){nc}",
+        brief,
+        src("sandbox", "brief", c.sandbox.brief.is_some())
+    );
+    // Gated on the brief, so say when it is set and inert rather than printing
+    // a `true` the launch will not act on.
+    let agents_md = c.sandbox.agents_md.unwrap_or(false);
+    println!(
+        "{blue}[cplt]{nc}    agents_md             = {}{}{} {dim}(experimental){nc}",
+        agents_md,
+        if agents_md && !brief {
+            " (inert: needs brief)"
+        } else {
+            ""
+        },
+        src("sandbox", "agents_md", c.sandbox.agents_md.is_some())
+    );
     let scratch = c.sandbox.scratch_dir.unwrap_or(true);
     println!(
         "{blue}[cplt]{nc}    scratch_dir           = {}{}",
@@ -598,6 +622,14 @@ fn local_mode_is_set(local: &Config, section: &str, key: &str) -> bool {
 /// `false`. Reusing the table makes that class of bug unrepresentable, and
 /// picks up the deprecated `sandbox.gh_proxy` / `sandbox.git_push_prevention`
 /// spellings for free, since the registry folds them in at the config layer.
+/// The `⚠ DANGEROUS` suffix for a key that is on and that `config set` refuses
+/// without `--force`. Plain text, not coloured: these rows are built as strings
+/// and coloured by the caller, and a marker that only appears in a terminal is
+/// not one a user can paste into a support thread.
+fn danger_suffix(on: bool) -> &'static str {
+    if on { " ⚠ DANGEROUS" } else { "" }
+}
+
 fn guard_lines(global: &Config, local: Option<&Config>) -> Vec<String> {
     let c = match local {
         Some(l) => global.overlay(l),
@@ -658,9 +690,13 @@ fn guard_lines(global: &Config, local: Option<&Config>) -> Vec<String> {
                 c.gh_guard.block_auth_token.is_some()
             )
         ),
+        // Marked when on, because `config set` refuses both of these without
+        // `--force`. A tool that demands a force-confirm to enable something
+        // and then lists it as unremarkable is telling the reader two things.
         format!(
-            "    inject_token          = {}{}",
+            "    inject_token          = {}{}{}",
             b.gh_inject_token,
+            danger_suffix(b.gh_inject_token),
             src(
                 "gh_guard",
                 "inject_token",
@@ -679,8 +715,9 @@ fn guard_lines(global: &Config, local: Option<&Config>) -> Vec<String> {
             )
         ),
         format!(
-            "    allow_api_write       = {}{}",
+            "    allow_api_write       = {}{}{}",
             b.gh_allow_api_write,
+            danger_suffix(b.gh_allow_api_write),
             src(
                 "gh_guard",
                 "allow_api_write",

--- a/src/config/editing.rs
+++ b/src/config/editing.rs
@@ -291,7 +291,10 @@ pub fn security_confirmation(key_info: &ConfigKeyInfo, value: &str, unset: bool)
                 "enabled" | "prevent_push" | "prevent_force_push",
                 "false"
             )
-            | ("gh_guard", "inject_token" | "allow_api_write", "true")
+            // `inject_token` and `allow_api_write` are not listed here: they
+            // carry `dangerous: true` in the registry and are caught by the
+            // branch above. Listing them twice is how the two lists came to
+            // disagree about which keys are dangerous in the first place.
             | ("gh_guard", "unknown_command", "allow")
             | ("gh_guard" | "git_guard", "mode", "warn" | "audit")
     );

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -474,7 +474,11 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         section: "gh_guard",
         key: "inject_token",
         value_type: ConfigValueType::Bool,
-        dangerous: false,
+        // `config set` already refuses this without `--force` (see
+        // `security_confirmation`), so leaving it unmarked here meant the tool
+        // demanded a force-confirm to enable it and then displayed it as
+        // unremarkable. A user hit exactly that and asked why.
+        dangerous: true,
         default_display: "false",
         description: "Pre-extract GH_TOKEN before sandbox launch (only for Copilot agent).",
     },
@@ -490,7 +494,8 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         section: "gh_guard",
         key: "allow_api_write",
         value_type: ConfigValueType::Bool,
-        dangerous: false,
+        // Same disagreement, same fix.
+        dangerous: true,
         default_display: "false",
         description: "Allow 'gh api' write operations (POST/PATCH/PUT and input flags). Writes are scope-checked to the current repo. GraphQL is always blocked.",
     },


### PR DESCRIPTION
Three reporting defects, all surfaced by user reports today rather than by review.

## `config set` and `config show` disagreed about what is dangerous

A Linux user enabling `gh_guard.inject_token` had to pass `--force`, and asked why. Fair question: `config show` then listed it as unremarkable, with no marker and no colour.

`security_confirmation` treats `inject_token` and `allow_api_write` as weakening; the registry marked both `dangerous: false`. Same fact, two lists, drifted apart.

The registry is now right, the duplicate arm in the hand-written match is gone, and the display marks them when on:

```
inject_token          = true ⚠ DANGEROUS
allow_api_write       = true ⚠ DANGEROUS
```

The `--force` requirement is **unchanged** and correct — putting the token in the environment makes it visible to every process in the sandbox through `/proc/*/environ`. Verified `enabled_dangerous_names()` reads the five `PresetBaseline` fields and not the registry, so preset behaviour is untouched.

## `sandbox.brief` and `sandbox.agents_md` had no rows at all

Setting `brief = true` changed behaviour and left `config show` looking identical; the only way to confirm it was `config get`. A key that is absent from the command whose job is to report effective configuration is the same defect as one that reports the wrong value.

```
brief                 = true (experimental)
agents_md             = false (default) (experimental)
```

`agents_md` also says when it is set but inert, since it is gated on the brief — the same class of silent no-op as #478.

## Branch tracking silently dropped, documented (#402)

`git push -u`, `checkout -b origin/x` and `--set-upstream-to` write to the denied `.git/config`, record nothing, print `branch 'x' set up to track ...` and **exit 0**. An agent reading the summary line is told it worked.

`known-impacts.md` now lists which commands do this, states that the success line is false, and gives the shape that works:

```bash
git push origin HEAD:my-branch
gh pr create -R <owner>/<repo> --head my-branch
```

A field agent worked that out for itself today, correctly, and said so. The next one should not have to. Whether the guard should intercept these forms and fail loudly stays on #402.

Refs #402, #477.