### PR TITLE
feat(proxy): warn about wildcard domain entries, which match nothing

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -110,8 +110,10 @@ itself and every subdomain under it, at any depth:
 So write `cloud.nais.io`, not `*.cloud.nais.io`. A `*` is compared literally and
 matches nothing — and in an allowlist, where the file is the whole policy, that
 does not merely fail to help: it leaves the hosts you meant to permit blocked,
-with an entry on screen that looks right. cplt warns at startup about any entry
-containing a `*` rather than letting the session fail closed silently.
+with an entry on screen that looks right. cplt warns at startup about a `*` in a domain **file**
+(`--allowed-domains`, `--blocked-domains`, a subscription cache) rather than
+letting the session fail closed silently. Lists set as config arrays, such as
+`proxy.allow_private_domains`, are not checked yet.
 
 The same matching applies to the blocklist, `proxy.allow_private_domains` and
 `proxy.upstream_no_proxy`.

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -98,6 +98,24 @@ forced = true
 
 The proxy supports both blocking (deny known-bad domains) and allowlisting (permit only known-good domains). You can use both lists together; the allowlist is checked first, then the blocklist.
 
+### How a domain entry matches
+
+**There is no wildcard syntax, and none is needed.** An entry matches the host
+itself and every subdomain under it, at any depth:
+
+| Entry | Matches | Does not match |
+| --- | --- | --- |
+| `cloud.nais.io` | `cloud.nais.io`, `foo.cloud.nais.io`, `a.b.cloud.nais.io` | `evilcloud.nais.io` |
+
+So write `cloud.nais.io`, not `*.cloud.nais.io`. A `*` is compared literally and
+matches nothing — and in an allowlist, where the file is the whole policy, that
+does not merely fail to help: it leaves the hosts you meant to permit blocked,
+with an entry on screen that looks right. cplt warns at startup about any entry
+containing a `*` rather than letting the session fail closed silently.
+
+The same matching applies to the blocklist, `proxy.allow_private_domains` and
+`proxy.upstream_no_proxy`.
+
 ### Blocklist
 
 Block domains commonly used for data exfiltration. A default blocklist ships with cplt, built from real attack infrastructure observed in 2025 and 2026 supply chain incidents. It covers webhook capture services, paste sites, file sharing, tunneling services, and IP recon endpoints. See [`blocked-domains.txt`](../blocked-domains.txt) for the full list with sources.

--- a/src/proxy_domains.rs
+++ b/src/proxy_domains.rs
@@ -394,26 +394,50 @@ pub fn parse_lines_file(path: &Path) -> Option<Vec<String>> {
 /// The user writes the glob they would write in any other tool and gets a
 /// fail-closed session with no explanation.
 fn warn_wildcard_entries(path: &Path, entries: &[String]) {
-    let bad: Vec<&str> = entries
+    if let Some(line) = wildcard_warning_line(path, entries) {
+        eprintln!(
+            "{}[proxy]{} {line}",
+            crate::ui::color(crate::ui::YELLOW),
+            crate::ui::color(crate::ui::RESET),
+        );
+    }
+}
+
+/// The warning text, or `None` when there is nothing to warn about.
+///
+/// Split from the printing so the escaping can be asserted on the bytes that
+/// would reach the terminal.
+///
+/// SECURITY: the file's contents are echoed, and nothing validates a line. A
+/// domain list can be a subscription, a shared team file, or something a
+/// repository asked the user to add, so a line carrying C1 or CSI bytes could
+/// rewrite what the rest of this warning says. Same reasoning and the same
+/// primitive as the audit report's paths (GHSA-c47q-c3c8-7wrf):
+/// `escape_debug` covers C0, C1, DEL, bidi overrides and zero-width
+/// formatters while leaving a legitimate internationalized domain readable.
+fn wildcard_warning_line(path: &Path, entries: &[String]) -> Option<String> {
+    let esc = |s: &str| s.escape_debug().to_string();
+    let bad: Vec<String> = entries
         .iter()
         .filter(|e| e.contains('*'))
-        .map(String::as_str)
+        .map(|e| esc(e))
         .collect();
     if bad.is_empty() {
-        return;
+        return None;
     }
-    let suggestion = bad
-        .first()
-        .map(|e| e.trim_start_matches('*').trim_start_matches('.'))
+    let suggestion = entries
+        .iter()
+        .find(|e| e.contains('*'))
+        .map(|e| esc(e.trim_start_matches('*').trim_start_matches('.')))
         .filter(|s| !s.is_empty())
-        .unwrap_or("example.com");
-    eprintln!(
-        "{}[proxy]{} Warning: {} contains wildcard entries ({}) which match no host. Matching is exact host plus subdomains, so write `{suggestion}` to cover `{suggestion}` and everything under it.",
-        crate::ui::color(crate::ui::YELLOW),
-        crate::ui::color(crate::ui::RESET),
-        path.display(),
+        .unwrap_or_else(|| "example.com".to_string());
+    Some(format!(
+        "Warning: {} contains wildcard entries ({}) which match no host. \
+Matching is exact host plus subdomains, so write `{suggestion}` to cover \
+`{suggestion}` and everything under it.",
+        esc(&path.display().to_string()),
         bad.join(", "),
-    );
+    ))
 }
 
 #[cfg(test)]
@@ -447,6 +471,9 @@ mod wildcard_tests {
     #[test]
     fn parsing_a_file_with_a_wildcard_still_returns_the_entries() {
         let dir = std::env::temp_dir().join(format!("cplt-wild-{}", std::process::id()));
+        // Removed first: a panic before the cleanup below would otherwise leave
+        // this directory behind and the next run would read stale state.
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let f = dir.join("domains.txt");
         std::fs::write(
@@ -466,6 +493,44 @@ github.com
             ])
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// SECURITY (same class as GHSA-c47q-c3c8-7wrf): the warning echoes lines
+    /// from a file cplt did not write. A domain list can be a subscription, a
+    /// shared team file, or one a repository asked the user to add, so a line
+    /// carrying terminal control bytes must not be able to rewrite the warning
+    /// around it.
+    ///
+    /// Asserted on BYTES: a `contains("\\u{1b}")` check alone passes just as
+    /// happily on a line that ALSO still carries the raw ESC.
+    #[test]
+    fn the_wildcard_warning_escapes_terminal_control_bytes() {
+        let entries = vec![
+            "*.evil\u{1b}]0;pwned\u{7}.com".to_string(),
+            "*.høyre-æøå.no".to_string(),
+        ];
+        let rendered = wildcard_warning_line(std::path::Path::new("/w/list.txt"), &entries)
+            .expect("wildcards are present");
+        let raw: Vec<u8> = rendered
+            .bytes()
+            .filter(|b| *b < 0x20 || *b == 0x7f)
+            .collect();
+        assert!(
+            raw.is_empty(),
+            "control bytes {raw:?} reached: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("\\u{1b}") && rendered.contains("\\u{7}"),
+            "the attempt must survive as evidence: {rendered:?}"
+        );
+        // Lossless for a legitimate internationalized domain.
+        assert!(
+            rendered.contains("høyre-æøå.no"),
+            "a real IDN was mangled: {rendered:?}"
+        );
+        assert!(
+            wildcard_warning_line(std::path::Path::new("/w/x"), &["a.com".to_string()]).is_none()
+        );
     }
 }
 

--- a/src/proxy_domains.rs
+++ b/src/proxy_domains.rs
@@ -371,13 +371,102 @@ pub fn parse_lines_file(path: &Path) -> Option<Vec<String>> {
             return None;
         }
     };
-    Some(
-        contents
-            .lines()
-            .map(|l| l.trim().to_lowercase().trim_end_matches('.').to_string())
-            .filter(|l| !l.is_empty() && !l.starts_with('#'))
-            .collect(),
-    )
+    let entries: Vec<String> = contents
+        .lines()
+        .map(|l| l.trim().to_lowercase().trim_end_matches('.').to_string())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect();
+    warn_wildcard_entries(path, &entries);
+    Some(entries)
+}
+
+/// Warn about `*` in a domain list, which matches nothing.
+///
+/// Domain matching is exact-host-or-subdomain-suffix ([`is_domain_match`]):
+/// `cloud.nais.io` already covers `foo.cloud.nais.io` at any depth. There is no
+/// glob syntax, so `*.cloud.nais.io` is compared literally and matches no host
+/// at all.
+///
+/// That is worth a warning rather than silence because of which direction it
+/// fails in. In an allowlist the file is the whole policy, so an entry that
+/// matches nothing does not merely fail to help — it leaves the hosts the user
+/// meant to permit blocked, with an entry on screen that looks exactly right.
+/// The user writes the glob they would write in any other tool and gets a
+/// fail-closed session with no explanation.
+fn warn_wildcard_entries(path: &Path, entries: &[String]) {
+    let bad: Vec<&str> = entries
+        .iter()
+        .filter(|e| e.contains('*'))
+        .map(String::as_str)
+        .collect();
+    if bad.is_empty() {
+        return;
+    }
+    let suggestion = bad
+        .first()
+        .map(|e| e.trim_start_matches('*').trim_start_matches('.'))
+        .filter(|s| !s.is_empty())
+        .unwrap_or("example.com");
+    eprintln!(
+        "{}[proxy]{} Warning: {} contains wildcard entries ({}) which match no host. Matching is exact host plus subdomains, so write `{suggestion}` to cover `{suggestion}` and everything under it.",
+        crate::ui::color(crate::ui::YELLOW),
+        crate::ui::color(crate::ui::RESET),
+        path.display(),
+        bad.join(", "),
+    );
+}
+
+#[cfg(test)]
+mod wildcard_tests {
+    use super::*;
+
+    /// `*.example.com` matches nothing: matching is exact host or subdomain
+    /// suffix, with no glob syntax. In an allowlist the file IS the policy, so
+    /// the entry does not merely fail to help — it leaves the hosts the user
+    /// meant to permit blocked, looking correct on screen.
+    #[test]
+    fn a_wildcard_entry_matches_nothing_and_the_bare_domain_matches_everything() {
+        let glob = vec!["*.cloud.nais.io".to_string()];
+        for host in ["cloud.nais.io", "foo.cloud.nais.io", "a.b.cloud.nais.io"] {
+            assert!(
+                !crate::proxy::is_domain_match(host, &glob),
+                "the glob must not match {host} — this is what makes it a trap"
+            );
+        }
+        let plain = vec!["cloud.nais.io".to_string()];
+        for host in ["cloud.nais.io", "foo.cloud.nais.io", "a.b.cloud.nais.io"] {
+            assert!(
+                crate::proxy::is_domain_match(host, &plain),
+                "the bare domain must cover {host} at any depth"
+            );
+        }
+        // And it must not over-reach onto a different registrable domain.
+        assert!(!crate::proxy::is_domain_match("evilcloud.nais.io", &plain));
+    }
+
+    #[test]
+    fn parsing_a_file_with_a_wildcard_still_returns_the_entries() {
+        let dir = std::env::temp_dir().join(format!("cplt-wild-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("domains.txt");
+        std::fs::write(
+            &f,
+            "*.cloud.nais.io
+github.com
+",
+        )
+        .unwrap();
+        // Warned about, not dropped: silently discarding a line the user wrote
+        // would be a second surprise on top of the first.
+        assert_eq!(
+            parse_lines_file(&f),
+            Some(vec![
+                "*.cloud.nais.io".to_string(),
+                "github.com".to_string()
+            ])
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }
 
 /// Parse `proxy.allow_private_domains` from a TOML config file.


### PR DESCRIPTION
From a support question: *does it support wildcards, and what is the best way to allow `*.cloud.nais.io`?*

## The answer, and the trap

`is_domain_match` is exact host **or** subdomain suffix:

```rust
host == *pattern || host.ends_with(&format!(".{pattern}"))
```

So `cloud.nais.io` already covers `cloud.nais.io`, `foo.cloud.nais.io` and `a.b.cloud.nais.io`. There is no glob syntax, and `*.cloud.nais.io` is compared literally and matches **no host at all**.

Nothing said so. The entry parses, sits in the list looking correct, and matches nothing.

That direction is what makes it worth a warning rather than a doc line. In an allowlist the file *is* the policy: a wildcard entry does not merely fail to help, it leaves precisely the hosts the user meant to permit blocked, in a session that fails closed with no explanation. Anyone who writes the glob they would write in any other tool lands there.

## The change

```
[proxy] Warning: /path/domains.txt contains wildcard entries (*.cloud.nais.io) which match
no host. Matching is exact host plus subdomains, so write `cloud.nais.io` to cover
`cloud.nais.io` and everything under it.
```

The suggestion is derived from what they wrote, so it is the line they can paste. Entries are **kept, not dropped** — silently discarding a line the user wrote would be a second surprise on top of the first, and the warning is the point.

## Verification

- `a_wildcard_entry_matches_nothing_and_the_bare_domain_matches_everything` asserts both halves: the glob matches none of the three depths, the bare domain matches all three, and neither matches `evilcloud.nais.io` — the case the suffix rule deliberately excludes and the reason it is `.{pattern}` rather than a substring.
- `parsing_a_file_with_a_wildcard_still_returns_the_entries` pins the keep-not-drop decision.
- Verified in a real session with `--allowed-domains`.

`docs/proxy.md` gains a matching table under Domain filtering, and notes that the same rule applies to the blocklist, `proxy.allow_private_domains` and `proxy.upstream_no_proxy`.