### PR TITLE
docs(proxy): the three domain lists answer three different questions

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -96,7 +96,29 @@ forced = true
 
 ## Domain filtering
 
-The proxy supports both blocking (deny known-bad domains) and allowlisting (permit only known-good domains). You can use both lists together; the allowlist is checked first, then the blocklist.
+There are **three** domain lists, and they answer different questions. Reading
+them as three flavours of the same thing is the usual source of confusion,
+because only two of them are about permission at all.
+
+| List | The question it answers | Default | Reload |
+| --- | --- | --- | --- |
+| **Blocklist** (`--blocked-domains`) | "Never connect here." Exfiltration sinks: paste sites, webhook capture, tunnels. | A curated list ships with cplt | Live, re-read per request |
+| **Allowlist** (`--allowed-domains`, `--default-allowlist`) | "Connect *only* here." Everything not listed is refused. | Off | At startup only — a new host needs a relaunch |
+| **Private-domain waiver** (`proxy.allow_private_domains`) | "This name is a trusted internal service." Not about permission: it is the DNS-rebinding guard. | Empty | Live, ~5s |
+
+The third is the one people do not expect. cplt refuses any host that resolves
+to a **private IP**, whatever the lists say, because a public name pointing at
+`10.x` is how an agent reaches your internal network. An intranet service is
+therefore blocked with `403 ... Private target blocked by cplt` even with no
+allowlist in force and nothing on the blocklist — the fix is to name it here,
+not to touch the other two:
+
+```bash
+cplt config set proxy.allow_private_domains dev-nais.cloud.nais.io
+```
+
+The blocklist and the allowlist can be used together; the allowlist is checked
+first, then the blocklist.
 
 ### How a domain entry matches
 
@@ -154,6 +176,30 @@ cplt update-lists
 **Tighten-only, fail-open semantics.** Blocklists can only add blocks, so the worst case of a bad, stale, or unreachable list is that a domain simply is not blocked, which is no worse than today. On a fetch failure cplt keeps and uses the last-good cache, or treats the list as empty if there is none, and never blocks the run on the network. When a subscription pins a `sha256`, a hash mismatch rejects the downloaded copy, keeps the last-good cache, and warns loudly about possible tampering. Pinning is encouraged rather than required, because an unverified blocklist cannot open an exfiltration channel.
 
 > **Allowlist subscriptions are a separate future feature.** An allowlist subscription would define what is permitted and is therefore cplt's security boundary. A tampered or MITM'd allowlist opens an exfiltration channel for every subscriber. That tier must be fail-closed and verification-required, and is deliberately not part of Phase 1. Only blocklist subscriptions exist today.
+
+### Private-domain waiver
+
+Separate from both lists above, and the one most likely to be the cause when an
+internal service is refused. cplt blocks any hostname that resolves to a private
+or otherwise reserved address, because a public DNS name that resolves inward is
+the standard DNS-rebinding path into a corporate network. The set is wider than
+RFC 1918: loopback, `10/8`, `172.16/12`, `192.168/16`, link-local
+(`169.254.0.0/16`, which covers the cloud metadata endpoint), CGNAT
+(`100.64.0.0/10`, so Tailscale and VPN ranges), benchmarking, reserved, and the
+IPv6 equivalents including v4-mapped forms.
+
+`proxy.allow_private_domains` waives that check for names you trust. Suffix
+matching, like every other list: `nav.cloud.nais.io` covers every subdomain, but
+does **not** cover `dev-nais.cloud.nais.io`, which is a different domain.
+
+```bash
+cplt config set proxy.allow_private_domains intern.nav.no
+cplt --allow-private-domain intern.nav.no          # this run only
+```
+
+An IP literal cannot be waived — give the host a name. A repository may propose
+entries in `[propose.proxy]`, which is the only proxy key `.cplt.toml` can
+propose, and they apply only after `cplt trust accept`.
 
 ### Allowlist
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -102,9 +102,16 @@ because only two of them are about permission at all.
 
 | List | The question it answers | Default | Reload |
 | --- | --- | --- | --- |
-| **Blocklist** (`--blocked-domains`) | "Never connect here." Exfiltration sinks: paste sites, webhook capture, tunnels. | A curated list ships with cplt | Live, re-read per request |
-| **Allowlist** (`--allowed-domains`, `--default-allowlist`) | "Connect *only* here." Everything not listed is refused. | Off | At startup only — a new host needs a relaunch |
+| **Blocklist** (`--blocked-domains`) | "Never connect here." Exfiltration sinks: paste sites, webhook capture, tunnels. | A curated list ships with cplt | Live, ~5s |
+| **Allowlist** (`--allowed-domains`, `--default-allowlist`) | "Connect *only* here." Everything not listed is refused. | Off | Live, ~5s |
 | **Private-domain waiver** (`proxy.allow_private_domains`) | "This name is a trusted internal service." Not about permission: it is the DNS-rebinding guard. | Empty | Live, ~5s |
+
+All three re-read their backing file on the same ~5 second TTL, so editing a
+list adds **and revokes** entries in a running session. One thing does not
+reload: whether the allowlist is *enforced at all* is decided at startup, so
+switching allowlisting on or off needs a new session even though its contents do
+not. Entries that came from the command line, or from a trust-approved
+`[propose.proxy]` block, are read once and survive every refresh.
 
 The third is the one people do not expect. cplt refuses any host that resolves
 to a **private IP**, whatever the lists say, because a public name pointing at
@@ -183,10 +190,14 @@ Separate from both lists above, and the one most likely to be the cause when an
 internal service is refused. cplt blocks any hostname that resolves to a private
 or otherwise reserved address, because a public DNS name that resolves inward is
 the standard DNS-rebinding path into a corporate network. The set is wider than
-RFC 1918: loopback, `10/8`, `172.16/12`, `192.168/16`, link-local
-(`169.254.0.0/16`, which covers the cloud metadata endpoint), CGNAT
-(`100.64.0.0/10`, so Tailscale and VPN ranges), benchmarking, reserved, and the
-IPv6 equivalents including v4-mapped forms.
+RFC 1918 — see `is_private_ip` for the authority:
+
+- IPv4: loopback `127/8`, private `10/8` `172.16/12` `192.168/16`, link-local
+  `169.254/16` (which covers the cloud metadata endpoint), CGNAT `100.64/10`
+  (Tailscale, VPN), benchmarking `198.18/15`, reserved `240/4`, protocol
+  assignment `192.0.0/24`, unspecified `0.0.0.0`, broadcast `255.255.255.255`
+- IPv6: loopback `::1`, unspecified `::`, ULA `fc00::/7`, link-local `fe80::/10`,
+  and v4-mapped forms of the above
 
 `proxy.allow_private_domains` waives that check for names you trust. Suffix
 matching, like every other list: `nav.cloud.nais.io` covers every subdomain, but

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,13 +168,15 @@ struct Cli {
     /// File with domains to block (one per line, e.g. pastebin.com).
     /// Only relevant when --with-proxy is enabled.
     /// The proxy refuses CONNECT requests to these domains.
-    /// The file is re-read on every request, so you can edit it live.
+    /// The file is re-read every ~5 seconds, so you can edit it live.
     #[arg(long, value_name = "FILE")]
     blocked_domains: Option<PathBuf>,
 
     /// File with domains to allow (one per line). When set, the proxy permits
     /// connections to the listed domains and blocks everything else. The
-    /// blocklist still applies on top. Parsed at startup.
+    /// blocklist still applies on top. The file is re-read every ~5 seconds, so
+    /// you can add hosts live; whether the allowlist is enforced at all is
+    /// decided at startup.
     #[arg(long, value_name = "FILE")]
     allowed_domains: Option<PathBuf>,
 


### PR DESCRIPTION
Prompted by cplt's own maintainer reading a `403 Private target blocked by cplt` as a blocklist or allowlist problem. That is a fair reading of the documentation.

## The gap

`## Domain filtering` has `### Blocklist` and `### Allowlist`. `proxy.allow_private_domains` has no heading anywhere — it appears in a reload note under Allowlist and in one troubleshooting line. So a reader scanning the section learns there are two lists, and never learns that the third exists or that it is not about permission at all.

The concrete failure: an internal service is refused with **no allowlist in force and nothing on the blocklist**, and the two documented lists have nothing to say about it. The user then goes looking in the wrong two places.

## The change

The section opens with all three side by side — the question each answers, its default, and whether it reloads live:

| List | The question it answers | Default | Reload |
| --- | --- | --- | --- |
| Blocklist | "Never connect here." | Curated list ships | Live, per request |
| Allowlist | "Connect *only* here." | Off | Startup only |
| Private-domain waiver | "This name is a trusted internal service." | Empty | Live, ~5s |

and `### Private-domain waiver` gets a heading beside the other two, stating that the refusal happens whatever the lists say, and that suffix matching means `nav.cloud.nais.io` does **not** cover `dev-nais.cloud.nais.io` — which is exactly the case that produced the report.

The reload column matters on its own: two of the three take effect live and one needs a relaunch, and nothing said so in one place.

## Accuracy

The private range is described as `is_private_ip` actually defines it, not as "RFC 1918": loopback, `10/8`, `172.16/12`, `192.168/16`, link-local (which is what covers the cloud metadata endpoint), CGNAT `100.64.0.0/10` (Tailscale, VPN), benchmarking, reserved, and the IPv6 equivalents including v4-mapped. My first draft said RFC 1918 plus loopback and link-local, which understates it.