### PR TITLE
fix(repo-config): ignore and report unknown keys instead of failing the file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,6 +491,40 @@ Both are global-only keys — a repository cannot ask cplt to write into its own
 
 ## Per-repo configuration (`.cplt.toml`)
 
+### Keys this cplt does not know
+
+A `.cplt.toml` may use keys a newer cplt understands. They are **ignored and
+reported**, not treated as errors, so a repository can adopt a key before every
+developer has upgraded:
+
+```
+[cplt] .cplt.toml uses a key this version of cplt does not understand
+       (propose.allow_future_thing), and it is ignored. That is usually a newer
+       cplt writing the file than the one reading it: upgrade, or check the
+       spelling if you wrote them by hand.
+```
+
+The two sections fail in opposite directions, and the warning says which:
+
+- An unknown key under `[propose]` grants nothing, so ignoring it **fails
+  closed**. This is also why a repository cannot smuggle in a key like `preset`
+  that a future version might honour: an unknown key does nothing here.
+- An unknown key under `[deny]` is a restriction its author expected and this
+  version will not apply. The warning calls that out explicitly, because
+  nothing else in the session will mention it.
+
+Everything the version *does* understand still applies. Before this, one unknown
+key failed the whole parse — the launch repository lost its `[deny]` along with
+it, and a named repository stopped the launch.
+
+Malformed TOML is a different thing and still an error: it is not version skew,
+and there is nothing to salvage from it.
+
+An unknown key does not invalidate an existing trust approval, because it
+proposes nothing. When you upgrade and the key becomes real, it starts counting
+towards the approval hash and you are asked to review it — approval tracks what
+the file can actually do on your machine.
+
 Commit a `.cplt.toml` to your repository for project-specific sandbox settings, so every developer does not have to configure the same CLI flags or global config. Global config stays the default, so pass `--repo` explicitly for project settings:
 
 ```bash

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -2919,6 +2919,7 @@ validate = false
             deny: crate::repo_config::DenySection {
                 paths: vec!["secrets".to_string()],
                 env: vec![],
+                ..Default::default()
             },
             propose: crate::repo_config::ProposeSection {
                 allow: crate::repo_config::ProposeAllowSection {
@@ -2929,6 +2930,7 @@ validate = false
                 },
                 ..Default::default()
             },
+            ..Default::default()
         };
 
         resolved.apply_repo_config(
@@ -3053,6 +3055,7 @@ validate = false
             deny: crate::repo_config::DenySection {
                 paths: vec!["~/secrets".to_string()],
                 env: vec!["MY_SECRET".to_string(), "VAULT_TOKEN".to_string()],
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -3217,6 +3220,7 @@ validate = false
                         "mimir.nav.cloud.nais.io.".to_string(),
                         ".".to_string(),
                     ],
+                    ..Default::default()
                 },
                 ..Default::default()
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2251,7 +2251,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 }
                 warn_unknown_repo_config_keys(
                     &loaded.config,
-                    &format!("{}/.cplt.toml", root.dir.display()),
+                    &root.dir.join(".cplt.toml").display().to_string(),
                 );
                 resolved.apply_repo_deny(&loaded.config, &loaded.dir);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1690,6 +1690,43 @@ fn warn_exec_tool_dir_shadowing(
     }
 }
 
+/// Report `.cplt.toml` keys this cplt does not understand.
+///
+/// Not gated on `quiet`, and deliberately: the whole point of ignoring an
+/// unknown key rather than refusing the file (#484) is that a repository can
+/// adopt a key before every developer has upgraded. The cost of that is a
+/// window where a key the author wrote is not applied, and the only thing
+/// standing between that and a silent surprise is this line.
+///
+/// A `[deny]` key gets the stronger wording. An ignored `[propose]` key costs
+/// the repository a relaxation it asked for, which surfaces as a build that
+/// cannot do something; an ignored `[deny]` key costs a restriction its author
+/// believed was in force, and nothing else in the session will mention it.
+fn warn_unknown_repo_config_keys(config: &repo_config::RepoConfig, label: &str) {
+    let unknown = repo_config::unknown_keys(config);
+    if unknown.is_empty() {
+        return;
+    }
+    let keys = unknown.join(", ");
+    let tightening = if repo_config::has_unknown_tightening_keys(config) {
+        " At least one is under [deny], so a restriction this repository asks \
+         for is NOT being applied."
+    } else {
+        ""
+    };
+    let (subject, verb) = if unknown.len() == 1 {
+        ("a key", "it is")
+    } else {
+        ("keys", "they are")
+    };
+    ui::warn(&format!(
+        "{label} uses {subject} this version of cplt does not understand \
+         ({keys}), and {verb} ignored.{tightening} That is usually a newer cplt \
+         writing the file than the one reading it: upgrade, or check the \
+         spelling if you wrote them by hand."
+    ));
+}
+
 /// `gh_guard.inject_token` does nothing while the guard is off.
 ///
 /// The injection happens inside the `gh_guard.enabled` branch of the wrapper
@@ -2093,6 +2130,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 };
                 ui::info(&format!("Repo config: .cplt.toml{source_note}"));
             }
+            warn_unknown_repo_config_keys(&loaded.config, ".cplt.toml");
 
             // Determine approved keys
             let approved_keys: Vec<String> = if cli.accept_repo_config {
@@ -2211,6 +2249,10 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                         ));
                     }
                 }
+                warn_unknown_repo_config_keys(
+                    &loaded.config,
+                    &format!("{}/.cplt.toml", root.dir.display()),
+                );
                 resolved.apply_repo_deny(&loaded.config, &loaded.dir);
             }
             // No `.cplt.toml` is the ordinary case and says nothing.

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -16,18 +16,34 @@ pub const REPO_CONFIG_FILE: &str = ".cplt.toml";
 
 /// Per-repo configuration parsed from `.cplt.toml`.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct RepoConfig {
     /// Keys that tighten the sandbox — applied automatically without approval.
     pub deny: DenySection,
     /// Keys that relax the sandbox — require user approval.
     pub propose: ProposeSection,
+    /// Top-level keys this version does not know.
+    ///
+    /// Collected rather than refused so a `.cplt.toml` can adopt a key a newer
+    /// cplt understands without breaking every developer who has not upgraded
+    /// yet (#484). Before this, one unknown key failed the whole parse: the
+    /// launch repository lost its `[deny]` too, and a named repository stopped
+    /// the launch outright.
+    ///
+    /// Ignoring is safe in the direction that matters. A `[propose]` key this
+    /// version cannot see grants nothing, so it fails closed — which is also
+    /// what makes a smuggled `preset` a non-event, the case
+    /// `deny_unknown_fields` was there for. A `[deny]` key that is ignored is a
+    /// restriction the author expected and did not get, which is why every
+    /// unknown key is reported rather than dropped in silence.
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 /// Restrictive keys — can only tighten the sandbox.
 /// Applied unconditionally (the agent has no incentive to restrict itself).
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct DenySection {
     /// Additional paths to deny access to (beyond the default deny list).
     #[serde(default)]
@@ -35,6 +51,11 @@ pub struct DenySection {
     /// Environment variables to strip (beyond the default blocklist).
     #[serde(default)]
     pub env: Vec<String>,
+    /// See [`RepoConfig::unknown`]. An ignored deny is a restriction its author
+    /// expected, so this is the section whose unknown keys matter most to
+    /// report.
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 /// Expansive keys — relax the sandbox. Require user trust approval.
@@ -43,9 +64,11 @@ pub struct DenySection {
 /// here. A preset composes several dangerous permissions at once (docker, tmp
 /// exec, ...) into a single opaque baseline, which would defeat the per-key
 /// trust review. Repos must request individual keys so each is reviewed and
-/// trusted on its own. `deny_unknown_fields` rejects a stray `preset` key.
+/// trusted on its own. A stray `preset` key lands in [`Self::unknown`] and is
+/// ignored, which is the same outcome `deny_unknown_fields` used to produce by
+/// refusing the file — without taking the rest of the config down with it.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct ProposeSection {
     pub allow_localhost_any: Option<bool>,
     pub allow_jvm_attach: Option<bool>,
@@ -86,11 +109,15 @@ pub struct ProposeSection {
     /// Proposed proxy settings.
     #[serde(default)]
     pub proxy: ProposeProxySection,
+    /// See [`RepoConfig::unknown`]. A `[propose]` key this version cannot see
+    /// grants nothing, so ignoring it fails closed.
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 /// Proposed allow expansions (paths, ports).
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct ProposeAllowSection {
     #[serde(default)]
     pub read: Vec<String>,
@@ -111,14 +138,20 @@ pub struct ProposeAllowSection {
     /// that was not filtering to begin with.
     #[serde(default)]
     pub domains: Vec<String>,
+    /// See [`RepoConfig::unknown`].
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 /// Proposed proxy settings.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct ProposeProxySection {
     #[serde(default)]
     pub allow_private_domains: Vec<String>,
+    /// See [`RepoConfig::unknown`].
+    #[serde(flatten)]
+    pub unknown: std::collections::BTreeMap<String, toml::Value>,
 }
 
 /// How the repo config was loaded — used for user-facing messages.
@@ -493,6 +526,46 @@ fn validate_repo_config(config: &RepoConfig) -> Result<(), String> {
 /// tightening as a pending relaxation. Filtering here fixes all of them at
 /// once. A consumer that wants "every boolean this file sets", such as
 /// `cplt init --merge`, must walk `PROPOSE_BOOLS` itself.
+/// Keys in a `.cplt.toml` that this cplt does not understand, dotted and
+/// sorted.
+///
+/// Reported rather than refused (#484). The two sections fail in opposite
+/// directions and the message says so: an unknown `[propose]` key grants
+/// nothing, while an unknown `[deny]` key is a restriction the author wrote and
+/// this version will not apply.
+#[must_use]
+pub fn unknown_keys(config: &RepoConfig) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |prefix: &str, map: &std::collections::BTreeMap<String, toml::Value>| {
+        for k in map.keys() {
+            out.push(if prefix.is_empty() {
+                k.clone()
+            } else {
+                format!("{prefix}.{k}")
+            });
+        }
+    };
+    push("", &config.unknown);
+    push("deny", &config.deny.unknown);
+    push("propose", &config.propose.unknown);
+    push("propose.allow", &config.propose.allow.unknown);
+    push("propose.proxy", &config.propose.proxy.unknown);
+    out.sort();
+    out
+}
+
+/// Whether any unknown key sits in a section that TIGHTENS the sandbox.
+///
+/// Worth separating because the consequence differs. An ignored `[propose]`
+/// key costs the repository a relaxation it asked for, which is a failure the
+/// user will notice as "my build cannot do X". An ignored `[deny]` key costs a
+/// restriction its author believed was in force, and nothing else in the
+/// session will ever mention it.
+#[must_use]
+pub fn has_unknown_tightening_keys(config: &RepoConfig) -> bool {
+    !config.deny.unknown.is_empty()
+}
+
 pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     let mut keys = Vec::new();
 
@@ -532,6 +605,84 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
 
 #[cfg(test)]
 mod tests {
+
+    /// #484: a `.cplt.toml` must be able to use a key a newer cplt understands
+    /// without breaking every developer who has not upgraded. Before this, one
+    /// unknown key failed the whole parse — the launch repository lost its
+    /// `[deny]` too, and a named repository stopped the launch outright.
+    #[test]
+    fn an_unknown_key_is_collected_and_the_known_ones_still_parse() {
+        let cfg: RepoConfig = toml::from_str(
+            r#"
+future_top_level = 1
+
+[deny]
+paths = ["secrets"]
+future_deny = ["x"]
+
+[propose]
+allow_docker = true
+preset = "full-trust"
+
+[propose.allow]
+ports = [5432]
+future_allow = ["y"]
+
+[propose.proxy]
+allow_private_domains = ["intern.nav.no"]
+future_proxy = true
+"#,
+        )
+        .expect("unknown keys must not fail the parse");
+
+        // The known values are intact — this is what the old behaviour threw away.
+        assert_eq!(cfg.deny.paths, vec!["secrets".to_string()]);
+        assert_eq!(cfg.propose.allow_docker, Some(true));
+        assert_eq!(cfg.propose.allow.ports, vec![5432]);
+        assert_eq!(
+            cfg.propose.proxy.allow_private_domains,
+            vec!["intern.nav.no".to_string()]
+        );
+
+        // Every unknown is reported, dotted by section so the reader can find it.
+        assert_eq!(
+            unknown_keys(&cfg),
+            vec![
+                "deny.future_deny".to_string(),
+                "future_top_level".to_string(),
+                "propose.allow.future_allow".to_string(),
+                "propose.preset".to_string(),
+                "propose.proxy.future_proxy".to_string(),
+            ]
+        );
+        assert!(
+            has_unknown_tightening_keys(&cfg),
+            "a [deny] key that is ignored is the one worth saying loudly"
+        );
+    }
+
+    /// The security property `deny_unknown_fields` was there for: a repository
+    /// must not smuggle a `preset` past the per-key trust review. Ignoring it
+    /// achieves the same outcome as refusing the file, without taking the rest
+    /// of the config down with it.
+    #[test]
+    fn a_smuggled_preset_is_inert_rather_than_fatal() {
+        let cfg: RepoConfig = toml::from_str(
+            "[propose]
+preset = \"full-trust\"\n",
+        )
+        .expect("no longer fatal");
+        assert!(unknown_keys(&cfg).contains(&"propose.preset".to_string()));
+        // Nothing about a preset reached the proposal, so nothing can approve it.
+        assert!(proposed_keys(&cfg.propose).is_empty());
+        assert!(!has_unknown_tightening_keys(&cfg), "preset is not a deny");
+    }
+
+    /// Malformed TOML is not a version-skew problem and must stay an error.
+    #[test]
+    fn a_syntax_error_is_still_an_error() {
+        assert!(toml::from_str::<RepoConfig>("this is = = not toml [[[\n").is_err());
+    }
     use super::*;
 
     #[test]
@@ -633,22 +784,34 @@ allow_private_domains = ["intern.nav.no"]
     }
 
     #[test]
-    fn reject_unknown_top_level_key() {
+    /// Was `reject_unknown_top_level_key`. Unknown keys are collected and
+    /// reported rather than refused (#484), so a `.cplt.toml` can adopt a key a
+    /// newer cplt understands without breaking developers who have not
+    /// upgraded. The assertion moved from "this fails" to "this is visible".
+    fn collect_unknown_top_level_key() {
         let toml = r"
 unknown_key = true
 ";
-        let err = parse_repo_config(toml).unwrap_err();
-        assert!(err.contains("unknown field"), "got: {err}");
+        let config = parse_repo_config(toml).expect("no longer refused");
+        assert_eq!(unknown_keys(&config), vec!["unknown_key".to_string()]);
     }
 
     #[test]
-    fn reject_unknown_propose_key() {
+    /// Was `reject_unknown_propose_key`. An unknown `[propose]` key grants
+    /// nothing, so ignoring it fails closed — and `proposed_keys` must not
+    /// offer it for approval, or the trust prompt would list a permission cplt
+    /// cannot apply.
+    fn collect_unknown_propose_key() {
         let toml = r"
 [propose]
 allow_network = true
 ";
-        let err = parse_repo_config(toml).unwrap_err();
-        assert!(err.contains("unknown field"), "got: {err}");
+        let config = parse_repo_config(toml).expect("no longer refused");
+        assert_eq!(
+            unknown_keys(&config),
+            vec!["propose.allow_network".to_string()]
+        );
+        assert!(proposed_keys(&config.propose).is_empty());
     }
 
     /// A repository proposing `*.example.com` would be approved by every

--- a/src/sandbox_bubblewrap.rs
+++ b/src/sandbox_bubblewrap.rs
@@ -2175,6 +2175,7 @@ mod tests {
             deny: crate::repo_config::DenySection {
                 paths: vec!["secrets".to_string()],
                 env: vec![],
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/sandbox_profile.rs
+++ b/src/sandbox_profile.rs
@@ -2885,6 +2885,7 @@ mod tests {
             deny: crate::repo_config::DenySection {
                 paths: vec!["secrets".to_string()],
                 env: vec![],
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -278,7 +278,14 @@ pub fn now_iso8601() -> String {
 
     format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
 }
-
+/// Unknown keys (see [`crate::repo_config::RepoConfig::unknown`]) are NOT
+/// hashed, and that is the behaviour to want. A key this cplt cannot see grants
+/// nothing, so an approval should not be invalidated by its presence — the
+/// repository added something inert as far as this version is concerned. When
+/// the user upgrades and the key becomes known, it starts feeding this hash,
+/// the approval goes stale, and they are asked to review it. Approval tracks
+/// what the file can actually do here, which is the property that matters.
+///
 /// Compute a stable content hash of the proposal section.
 ///
 /// This hash captures the *values* of all proposals so that if the

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -471,18 +471,30 @@ fn subscriptions_absent_means_empty_no_regression() {
 }
 
 #[test]
-fn repo_config_rejects_proxy_subscriptions() {
-    // A malicious repo must not be able to add a subscription. The repo config
-    // schema has no [proxy] table, so `.cplt.toml` cannot express one at all.
+fn repo_config_cannot_add_a_proxy_subscription() {
+    // A malicious repo must not be able to add a subscription. This used to be
+    // asserted as a parse ERROR, because `deny_unknown_fields` refused the
+    // whole file. Since #484 unknown keys are collected and ignored, so the
+    // assertion moves from the mechanism to the property that actually
+    // matters: the repo cannot express a subscription cplt will honour.
+    //
+    // Ignoring is the same outcome as refusing, without taking the rest of the
+    // file down with it — and it is reported, so a repo that meant something by
+    // it does not do so silently.
     let cplt_toml = "\
 [proxy.subscriptions]
 blocklists = [\"https://attacker.example/evil.txt\"]
 ";
-    let result = cplt::repo_config::parse_and_validate(cplt_toml);
-    assert!(
-        result.is_err(),
-        "repo .cplt.toml must reject [proxy.subscriptions]"
+    let config = cplt::repo_config::parse_and_validate(cplt_toml)
+        .expect("unknown keys no longer fail the parse");
+    assert_eq!(
+        cplt::repo_config::unknown_keys(&config),
+        vec!["proxy".to_string()],
+        "the whole [proxy] table is unknown to the repo schema"
     );
+    // Nothing reached anything cplt applies: no proposal to approve, no deny.
+    assert!(cplt::repo_config::proposed_keys(&config.propose).is_empty());
+    assert!(config.deny.paths.is_empty() && config.deny.env.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Closes #484. Settles the open question in #472.

## The problem

Every `.cplt.toml` struct carried `deny_unknown_fields`, so a file using a key a newer cplt understands was a **parse error** on an older one. Measured with one unknown `[propose]` key alongside a valid `[deny] paths`:

- **Launch repository:** warning, and the whole file discarded — including the `[deny]` this version understands perfectly well.
- **Named repository:** launch stops. That was #468, shipped yesterday.

For an org distributing cplt through Homebrew: no repository can adopt a new key until every developer has upgraded, and the breakage lands on the developer who hasn't, in a repository they didn't change.

## The change

Unknown keys are collected per section and reported by dotted name:

```
[cplt] .cplt.toml uses keys this version of cplt does not understand
       (deny.future_deny_key, propose.allow_future_thing), and they are ignored.
       At least one is under [deny], so a restriction this repository asks for is
       NOT being applied. That is usually a newer cplt writing the file than the
       one reading it: upgrade, or check the spelling if you wrote them by hand.
```

Strictness bought one thing — a loud error on a typo — and cost forward compatibility entirely. A warning buys the same thing and keeps it.

**The two sections fail in opposite directions**, and the message distinguishes them. An unknown `[propose]` key grants nothing, so it fails closed. An unknown `[deny]` key is a restriction its author believed was in force, and nothing else in the session would mention it — that case gets its own sentence.

## The security properties are unchanged

`ProposeSection`'s doc said `deny_unknown_fields` "rejects a stray `preset` key". An ignored key grants nothing, so a smuggled `preset` is inert — the same outcome, without discarding the rest of the file. Verified.

Same for `[proxy.subscriptions]`, which a malicious repo must not be able to add. **That test needed rewriting, and it is better for it:** it asserted the *mechanism* (a parse error) rather than the *property*. It now asserts that the repo cannot express a subscription cplt will honour — parse succeeds, `proxy` is reported unknown, no proposal to approve, no deny applied.

## Trust approvals

Unknown keys are deliberately **not** hashed into the approval. A key this cplt cannot see proposes nothing, so its presence must not invalidate an approval. When the user upgrades and the key becomes real, it starts feeding the hash, the approval goes stale, and they are asked to review it. Approval tracks what the file can actually do on that machine.

## Malformed TOML stays an error

It is not version skew and nothing can be salvaged from it. **That settles #472**: once unknown keys stop being parse failures, "fatal in both the launch repository and a named root" is easy to defend, because what is left is a genuinely broken file rather than a version-skew artefact.

## Verification

End to end, all four paths: named root proceeds with its `[deny]` applied and both unknown keys named; launch repository the same; a smuggled `preset` reported and inert; malformed TOML still fatal for a named root.

Unit tests cover collection across all five sections with dotted names, the inert `preset`, and the syntax error. Falsified by removing the `[deny]` reporting and separately by stubbing the tightening flag — each fails.

Two existing tests asserted the old behaviour and were rewritten with the reason in their doc comments, rather than deleted.

One note: `cargo check --target x86_64-unknown-linux-gnu` caught a struct literal in a Linux-only test that the macOS build never compiles. Second time today that cross-check has earned its place.