### PR TITLE
feat(proxy): allow.domains, so the allowlist is managed with cplt not an editor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ Per-repo config (`.cplt.toml`) sits outside that hierarchy, as a separate layer 
 
 Sessions that span several repositories are configured separately again — see [Working across several repositories](#working-across-several-repositories---repo-dir).
 
-List values merge instead of replacing, so repeated `cplt config set` commands accumulate for `allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, and `deny.paths`.
+List values merge instead of replacing, so repeated `cplt config set` commands accumulate for `allow.read`, `allow.write`, `allow.ports`, `allow.localhost`, `allow.domains`, and `deny.paths`.
 
 Point `CPLT_CONFIG` at another file to use it instead of the default location:
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -212,6 +212,32 @@ An IP literal cannot be waived — give the host a name. A repository may propos
 entries in `[propose.proxy]`, which is the only proxy key `.cplt.toml` can
 propose, and they apply only after `cplt trust accept`.
 
+### Adding hosts with `allow.domains`
+
+The allowlist file is the right shape for a long, shared or subscription-fed
+list. For the handful of hosts one person needs, `allow.domains` is a config
+list like every other:
+
+```bash
+cplt config set allow.domains cloud.nais.io
+cplt config set allow.domains cloud.nais.io --unset
+```
+
+**It widens an allowlist that is in force, and never turns one on.** Every other
+`allow.*` key adds a permission without taking one away — `allow.read` does not
+mean "only read this" — so this one does not get to be the exception that
+switches a session to fail-closed the first time you add a host. With no
+allowlist active the entries sit there doing nothing, and `cplt config show`
+says so rather than letting them look effective.
+
+A `*` is refused at the point of typing, with the working form given, because
+matching is exact host plus subdomains and a wildcard entry matches nothing.
+
+A repository may propose entries in `[propose.allow] domains`, inert until
+`cplt trust accept` on each machine. An approved entry can only let an already
+filtering session reach one more host; it cannot open a session that was not
+filtering.
+
 ### Allowlist
 
 Restrict connections to specific domains. When the allowlist is set, the proxy blocks everything not in it. An `allowed-domains.txt` for Copilot-only access looks like this:

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -230,8 +230,11 @@ switches a session to fail-closed the first time you add a host. With no
 allowlist active the entries sit there doing nothing, and `cplt config show`
 says so rather than letting them look effective.
 
-A `*` is refused at the point of typing, with the working form given, because
-matching is exact host plus subdomains and a wildcard entry matches nothing.
+A `*` matches no host, because matching is exact host plus subdomains. Where
+cplt can catch that for you it does: `cplt config set` refuses it with the
+working form, and a `.cplt.toml` proposing one fails validation. A wildcard in
+an allowlist **file** is only warned about at launch, since nothing sees it
+until the file is read.
 
 A repository may propose entries in `[propose.allow] domains`, inert until
 `cplt trust accept` on each machine. An approved entry can only let an already

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -857,6 +857,7 @@ mod tests {
             deny_paths: Vec::new(),
             allow_ports: Vec::new(),
             allow_localhost: Vec::new(),
+            allow_domains: Vec::new(),
             allow_localhost_any: false,
             allow_env_files: false,
             no_validate: false,

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -364,6 +364,24 @@ pub fn display_config(loaded: Option<&LoadedConfig>, local: Option<&LoadedConfig
             c.allow.localhost
         );
     }
+    if c.allow.domains.is_empty() {
+        println!("{blue}[cplt]{nc}    domains          = {dim}[]{nc}");
+    } else {
+        // Says when the key is inert. It widens an allowlist already in force
+        // and turns none on, so with no allowlist active these entries change
+        // nothing — and a list sitting there looking effective is exactly the
+        // kind of thing that sends someone debugging the wrong layer.
+        let inert =
+            if c.proxy.default_allowlist.unwrap_or(false) || c.proxy.allowed_domains.is_some() {
+                String::new()
+            } else {
+                format!(" {dim}(no allowlist in force, so these add nothing yet){nc}")
+            };
+        println!(
+            "{blue}[cplt]{nc}    domains          = {:?}{inert}",
+            c.allow.domains
+        );
+    }
     println!();
 
     // [deny]

--- a/src/config/editing.rs
+++ b/src/config/editing.rs
@@ -81,6 +81,15 @@ fn parse_value_for_key(
 }
 
 /// Parse a single element value for appending to an array.
+/// Keys whose elements are hostnames, where a `*` is a mistake rather than a
+/// path component.
+fn is_domain_key(key_info: &ConfigKeyInfo) -> bool {
+    matches!(
+        (key_info.section, key_info.key),
+        ("allow", "domains") | ("proxy", "allow_private_domains") | ("proxy", "upstream_no_proxy")
+    )
+}
+
 fn parse_element_for_key(
     key_info: &ConfigKeyInfo,
     value: &str,
@@ -101,6 +110,28 @@ fn parse_element_for_key(
                     "value contains a comma. Add one value at a time:\n  \
                      cplt config set {}.{} <VALUE>",
                     key_info.section, key_info.key
+                )));
+            }
+            // A `*` in a domain matches nothing: matching is exact host plus
+            // subdomains, with no glob syntax (#481). For a file, cplt warns
+            // at launch; for a config array it can be refused at the point of
+            // typing, which is better — the user is right there, and the
+            // correction is mechanical.
+            if is_domain_key(key_info)
+                && let Some(bare) = value.strip_prefix("*.")
+            {
+                return Err(ConfigError::Validation(format!(
+                    "{value} is not a pattern cplt understands. Matching is exact host \
+                     plus subdomains, so `{bare}` already covers `{bare}` and everything \
+                     under it:\n  cplt config set {}.{} {bare}",
+                    key_info.section, key_info.key
+                )));
+            }
+            if is_domain_key(key_info) && value.contains('*') {
+                return Err(ConfigError::Validation(format!(
+                    "{value} contains a wildcard, which matches no host. Matching is exact \
+                     host plus subdomains — name the domain itself and every subdomain is \
+                     covered."
                 )));
             }
             // Expand ~ so stored values are always absolute paths.

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -436,6 +436,20 @@ impl Config {
         allow_localhost.sort_unstable();
         allow_localhost.dedup();
 
+        // Allow-domains: config only, plus whatever the repo proposed and the
+        // user approved (added later, in `apply_repo_config`). Normalized the
+        // same way every other domain list is, so `Example.COM.` and
+        // `example.com` are one entry.
+        let mut allow_domains: Vec<String> = self
+            .allow
+            .domains
+            .iter()
+            .map(|d| crate::proxy::normalize_hostname(d))
+            .filter(|d| !d.is_empty())
+            .collect();
+        allow_domains.sort();
+        allow_domains.dedup();
+
         let allow_localhost_any = bools.allow_localhost_any;
 
         // Pass-env: merge config + CLI
@@ -610,6 +624,7 @@ impl Config {
             deny_paths,
             allow_ports,
             allow_localhost,
+            allow_domains,
             allow_localhost_any,
             allow_env_files,
             no_validate,
@@ -1617,6 +1632,20 @@ impl Resolved {
             }
             self.allow_ports.sort_unstable();
             self.allow_ports.dedup();
+        }
+        if is_approved("allow.domains") {
+            // Normalized and empty-filtered on the same rule as
+            // `proxy.allow_private_domains` below: `.cplt.toml` validation
+            // rejects "" but not "." or " ", which normalize to nothing.
+            for domain in &repo_config.propose.allow.domains {
+                let domain = crate::proxy::normalize_hostname(domain);
+                if domain.is_empty() || self.allow_domains.contains(&domain) {
+                    continue;
+                }
+                self.allow_domains.push(domain);
+            }
+            self.allow_domains.sort();
+            self.allow_domains.dedup();
         }
         if is_approved("allow.localhost") {
             for &port in &repo_config.propose.allow.localhost {

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -398,6 +398,7 @@ impl Config {
                     socket: _,
                     ports: _,
                     localhost: _,
+                    domains: _,
                 },
             deny: super::types::DenyConfig { paths: _ },
             sandbox:
@@ -485,7 +486,8 @@ impl Config {
             exec,
             socket,
             ports,
-            localhost
+            localhost,
+            domains
         );
         union_lists!(out.deny, local.deny, paths);
         take_set!(

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -173,6 +173,14 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
     },
     ConfigKeyInfo {
         section: "allow",
+        key: "domains",
+        value_type: ConfigValueType::StrArray,
+        dangerous: false,
+        default_display: "[]",
+        description: "Domains to add to the proxy allowlist. Adds to an allowlist already in force; does not turn one on.",
+    },
+    ConfigKeyInfo {
+        section: "allow",
         key: "ports",
         value_type: ConfigValueType::U16Array,
         dangerous: false,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -566,6 +566,13 @@ pub struct AllowConfig {
     pub ports: Vec<u16>,
     /// Localhost ports to allow (localhost is blocked by default).
     pub localhost: Vec<u16>,
+    /// Domains to add to the proxy allowlist (#482).
+    ///
+    /// Widens an allowlist that is already in force and does **not** turn one
+    /// on. Every other `allow.*` key adds a permission without removing one —
+    /// `allow.read` does not mean "only read this" — so this must not be the
+    /// key that silently switches a session to fail-closed.
+    pub domains: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -891,6 +898,10 @@ pub struct Resolved {
     pub deny_paths: Vec<PathBuf>,
     pub allow_ports: Vec<u16>,
     pub allow_localhost: Vec<u16>,
+    /// Domains added to the proxy allowlist by `allow.domains` and by any
+    /// trust-approved `[propose.allow] domains`. Widens an active allowlist;
+    /// never activates one.
+    pub allow_domains: Vec<String>,
     pub allow_localhost_any: bool,
     pub allow_env_files: bool,
     pub no_validate: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2903,6 +2903,7 @@ fn start_proxy_if_enabled(
         allow_localhost_any: resolved.allow_localhost_any,
         allowed_domains_file,
         allowed_domains_initial: Vec::new(),
+        extra_allowed_domains: resolved.allow_domains.clone(),
         default_allowlist,
         cli_private_domains: cli.allow_private_domains.clone(),
         // Reloadable portion: what the config file itself supplied. The two

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -525,6 +525,9 @@ pub struct ProxyOptions {
     /// Initial allowed domains from CLI/config (used for startup validation).
     /// After startup, the file is the source of truth for dynamic reload.
     pub allowed_domains_initial: Vec<String>,
+    /// `allow.domains` plus trust-approved `[propose.allow] domains` (#482).
+    /// Widens an allowlist already in force; never activates one.
+    pub extra_allowed_domains: Vec<String>,
     /// Agent built-in default allowlist (issue #52). Empty = feature off
     /// (unchanged allow-all). When set, it is merged with `allowed_domains_file`
     /// to form the effective, fail-closed allowlist. Frozen at startup.
@@ -575,6 +578,7 @@ pub fn start(opts: ProxyOptions) -> Result<ProxyHandle, String> {
             subscription_blocklist: opts.subscription_blocklist,
             allowed_domains_file: opts.allowed_domains_file,
             allowed_domains_initial: opts.allowed_domains_initial,
+            extra_allowed_domains: opts.extra_allowed_domains,
             default_allowlist: opts.default_allowlist,
             cli_private_domains: opts.cli_private_domains,
             config_private_domains: opts.config_private_domains,
@@ -2378,6 +2382,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist,
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -2654,6 +2659,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: copilot_defaults(),
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -2740,6 +2746,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -2868,6 +2875,7 @@ mod tests {
             allow_localhost_any,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -3093,6 +3101,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(), // NOT allow-listed
@@ -3154,6 +3163,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains: vec!["corp.internal".to_string()], // allow-listed
@@ -3606,6 +3616,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains: Vec::new(),
@@ -3817,6 +3828,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains,
@@ -4248,6 +4260,7 @@ mod tests {
             allow_localhost_any: false,
             allowed_domains_file: None,
             allowed_domains_initial: Vec::new(),
+            extra_allowed_domains: Vec::new(),
             default_allowlist: Vec::new(),
             subscription_blocklist: Vec::new(),
             cli_private_domains,

--- a/src/proxy_domains.rs
+++ b/src/proxy_domains.rs
@@ -145,6 +145,17 @@ pub struct PolicySpec {
     /// The agent's built-in fail-closed allowlist (#52), frozen at startup.
     /// Empty = feature off (unchanged allow-all).
     pub default_allowlist: Vec<String>,
+    /// `allow.domains` from config, plus any `[propose.allow] domains` the user
+    /// approved for this repository (#482).
+    ///
+    /// Merged into the allowlist's contents and deliberately NOT into
+    /// [`DomainPolicy::allowlist_active`]. Every other `allow.*` key adds a
+    /// permission without taking one away — `allow.read` does not mean "only
+    /// read this" — so `allow.domains` must not be the one that silently
+    /// switches a session to fail-closed the first time someone adds a host to
+    /// it. It widens an allowlist that is already in force, and does nothing
+    /// when none is.
+    pub extra_allowed_domains: Vec<String>,
     /// Private domains from `--allow-private-domain`. Read once from argv.
     pub cli_private_domains: Vec<String>,
     /// Private domains that came from `config_file`'s own
@@ -210,6 +221,7 @@ impl DomainPolicy {
         // The intent bit: did anything ask for a domain allowlist this run?
         // Captured from the *sources*, before any of them is read, so an
         // allowlist that parses to zero domains still counts as active.
+        // `extra_allowed_domains` is absent here on purpose: see its docs.
         let allowlist_active = !spec.default_allowlist.is_empty()
             || spec.allowed_domains_file.is_some()
             || !spec.allowed_domains_initial.is_empty();
@@ -255,7 +267,10 @@ impl DomainPolicy {
                 now,
             ),
             allowed: DomainList::new(
-                spec.default_allowlist,
+                spec.default_allowlist
+                    .into_iter()
+                    .chain(spec.extra_allowed_domains)
+                    .collect(),
                 spec.allowed_domains_file,
                 parse_lines_file,
                 allowlist_initial,

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -102,6 +102,15 @@ pub struct ProposeAllowSection {
     pub ports: Vec<u16>,
     #[serde(default)]
     pub localhost: Vec<u16>,
+    /// Domains the project asks to add to the proxy allowlist (#482).
+    ///
+    /// Proposable like the rest of `[propose.allow]`, and inert until
+    /// `cplt trust accept` on each machine. It widens an allowlist already in
+    /// force and cannot turn one on, so an approved entry can only let a
+    /// fail-closed session reach one more host — it can never open a session
+    /// that was not filtering to begin with.
+    #[serde(default)]
+    pub domains: Vec<String>,
 }
 
 /// Proposed proxy settings.
@@ -489,6 +498,9 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     }
     if !propose.allow.localhost.is_empty() {
         keys.push("allow.localhost");
+    }
+    if !propose.allow.domains.is_empty() {
+        keys.push("allow.domains");
     }
     if !propose.proxy.allow_private_domains.is_empty() {
         keys.push("proxy.allow_private_domains");

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -444,17 +444,38 @@ fn validate_repo_config(config: &RepoConfig) -> Result<(), String> {
         }
     }
 
-    // Validate private domains: must be non-empty, no whitespace
-    for domain in &config.propose.proxy.allow_private_domains {
-        if domain.is_empty() || domain.trim().is_empty() {
-            return Err(
-                "propose.proxy.allow_private_domains contains empty domain name".to_string(),
-            );
-        }
-        if domain.contains(char::is_whitespace) {
-            return Err(format!(
-                "propose.proxy.allow_private_domains entry {domain:?} contains whitespace"
-            ));
+    // Both domain lists get the same checks, and one they did not have before:
+    // a `*` matches no host, because matching is exact host plus subdomains.
+    // `cplt config set` refuses a wildcard while the user is still typing;
+    // a `.cplt.toml` is written in an editor, so the equivalent moment is here.
+    // Without it a repository proposes `*.example.com`, every developer
+    // approves it, and it reaches nothing on any of their machines.
+    for (label, domains) in [
+        (
+            "propose.proxy.allow_private_domains",
+            &config.propose.proxy.allow_private_domains,
+        ),
+        ("propose.allow.domains", &config.propose.allow.domains),
+    ] {
+        for domain in domains {
+            if domain.is_empty() || domain.trim().is_empty() {
+                return Err(format!("{label} contains empty domain name"));
+            }
+            if domain.contains(char::is_whitespace) {
+                return Err(format!("{label} entry {domain:?} contains whitespace"));
+            }
+            if let Some(bare) = domain.strip_prefix("*.") {
+                return Err(format!(
+                    "{label} entry {domain:?} matches no host. Matching is exact host plus \
+                     subdomains, so {bare:?} already covers it and everything under it"
+                ));
+            }
+            if domain.contains('*') {
+                return Err(format!(
+                    "{label} entry {domain:?} contains a wildcard, which matches no host. \
+                     Name the domain itself and every subdomain is covered"
+                ));
+            }
         }
     }
 
@@ -628,6 +649,26 @@ allow_network = true
 ";
         let err = parse_repo_config(toml).unwrap_err();
         assert!(err.contains("unknown field"), "got: {err}");
+    }
+
+    /// A repository proposing `*.example.com` would be approved by every
+    /// developer and reach nothing on any of their machines. `config set`
+    /// refuses a wildcard while the user is typing; a `.cplt.toml` is written
+    /// in an editor, so validation is the equivalent moment.
+    #[test]
+    fn validate_rejects_a_wildcard_in_either_domain_list() {
+        for toml in [
+            "[propose.allow]\ndomains = [\"*.example.com\"]\n",
+            "[propose.proxy]\nallow_private_domains = [\"*.intern.nav.no\"]\n",
+        ] {
+            let err = parse_and_validate(toml).unwrap_err();
+            assert!(
+                err.contains("matches no host"),
+                "must name the problem, got: {err}"
+            );
+        }
+        // The bare form is what works, and must still pass.
+        assert!(parse_and_validate("[propose.allow]\ndomains = [\"example.com\"]\n").is_ok());
     }
 
     #[test]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -361,6 +361,20 @@ pub fn proposal_content_hash(propose: &crate::repo_config::ProposeSection) -> St
         hasher.update(format!("allow.localhost={port}\n").as_bytes());
     }
 
+    // Hashed like every other proposed array: changing the requested domains
+    // must invalidate an approval, or a repository could add a host after the
+    // user reviewed the list.
+    let mut allow_domains: Vec<&str> = propose
+        .allow
+        .domains
+        .iter()
+        .map(std::string::String::as_str)
+        .collect();
+    allow_domains.sort_unstable();
+    for d in &allow_domains {
+        hasher.update(format!("allow.domains={d}\n").as_bytes());
+    }
+
     let mut domains: Vec<&str> = propose
         .proxy
         .allow_private_domains

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1497,6 +1497,56 @@ fn the_dependency_store_carve_out_is_absent_when_env_files_are_allowed() {
     );
 }
 
+/// #482: `allow.domains` widens an allowlist that is in force and must never
+/// turn one on. Every other `allow.*` key adds a permission without removing
+/// one — `allow.read` does not mean "only read this" — so this must not be the
+/// key that silently switches a session to fail-closed the first time someone
+/// adds a host.
+#[test]
+fn allow_domains_widens_an_active_allowlist_and_never_activates_one() {
+    use cplt::proxy::{DomainPolicy, PolicySpec};
+    use std::time::Instant;
+
+    let spec = |default_allowlist: Vec<String>, extra: Vec<String>| PolicySpec {
+        blocked_file: PathBuf::from("/nonexistent-blocklist"),
+        subscription_blocklist: Vec::new(),
+        allowed_domains_file: None,
+        allowed_domains_initial: Vec::new(),
+        default_allowlist,
+        extra_allowed_domains: extra,
+        cli_private_domains: Vec::new(),
+        config_private_domains: Vec::new(),
+        repo_private_domains: Vec::new(),
+        config_file: None,
+        allowed_ports: Vec::new(),
+        allow_localhost_ports: Vec::new(),
+        allow_localhost_any: false,
+    };
+    let now = Instant::now();
+
+    // Alone: contents carried, allowlist NOT switched on.
+    let policy = DomainPolicy::build(spec(Vec::new(), vec!["cloud.nais.io".into()]), now)
+        .expect("valid spec");
+    assert!(
+        !policy.allowlist_active,
+        "adding a domain must not put the session into fail-closed mode"
+    );
+
+    // With an allowlist in force: merged in alongside it.
+    let policy = DomainPolicy::build(
+        spec(vec!["github.com".into()], vec!["cloud.nais.io".into()]),
+        now,
+    )
+    .expect("valid spec");
+    assert!(policy.allowlist_active);
+    let allowed = policy.allowed_domains(now);
+    assert!(
+        allowed.contains(&"github.com".to_string())
+            && allowed.contains(&"cloud.nais.io".to_string()),
+        "both halves must be reachable: {allowed:?}"
+    );
+}
+
 // ============================================================
 // Named repositories (--repo-dir): project-grade roots (#344)
 // ============================================================
@@ -7667,6 +7717,7 @@ exec = []
 socket = []
 ports = []
 localhost = []
+domains = []
 
 [deny]
 paths = []


### PR DESCRIPTION
Closes #482.

Every list in cplt is a config array with append and removal through `cplt config set` — `allow.ports`, `allow.localhost`, `sandbox.repo_dirs`, `proxy.allow_private_domains`. The domain allowlist was the exception: a path to a file the user creates and edits by hand.

```bash
cplt config set allow.domains cloud.nais.io
cplt config set allow.domains cloud.nais.io --unset
```

## The design decision worth reviewing

**It widens an allowlist already in force and never turns one on.**

Feeding it into `allowlist_active` would have been consistent with `--allowed-domains`, which does activate. But it would make `allow.domains` the one `allow.*` key that *takes permissions away*: a single `config set` would switch the session to fail-closed and block every other host. `allow.read` does not mean "only read this", and this should not mean "only reach this".

The cost is that with no allowlist active the entries do nothing. `cplt config show` says so rather than letting them look effective:

```
domains          = ["cloud.nais.io"] (no allowlist in force, so these add nothing yet)
```

If you would rather it activate, that is a one-line change and this is the place to say so.

## Proposable, per the decision on #482

`[propose.allow] domains`, inert until `cplt trust accept` on each machine. You chose to allow this over my recommendation to start refused, and the non-activation property is what makes it comfortable: an approved entry can only let an **already filtering** session reach one more host — it cannot open a session that was not filtering. Entries are hashed into the approval like every other proposed array, so a repository cannot add a host after the user reviewed the list.

## Wildcards refused at the point of typing

```
$ cplt config set allow.domains '*.cloud.nais.io'
[cplt] *.cloud.nais.io is not a pattern cplt understands. Matching is exact host plus
subdomains, so `cloud.nais.io` already covers `cloud.nais.io` and everything under it:
  cplt config set allow.domains cloud.nais.io
```

#481 could only warn at launch for a file. A config array can be corrected while the user is still there. Covers `proxy.allow_private_domains` and `proxy.upstream_no_proxy` too.

## Verification

`allow_domains_widens_an_active_allowlist_and_never_activates_one` asserts both halves. Falsified twice: adding the field to `allowlist_active` fails it, and dropping the merge fails it.

**One correction to something I said earlier in the session.** I had reported repeated "intermittent" test failures. This time I captured the run to a log, and the failure was not intermittent at all: `registry_keys_match_validate_all_valid_keys_fixture` was correctly refusing `allow.domains` because I had not added it to the coverage fixture. That test is doing exactly what #126 asks for. I should not have called it a flake without capturing the name.