### PR TITLE
feat(git-guard): say when branch tracking is about to be silently dropped

### DIFF
--- a/docs/known-impacts.md
+++ b/docs/known-impacts.md
@@ -29,6 +29,14 @@ tracking was recorded. It was not.
 | `git config user.name <x>` | Fails loudly, exit 4 |
 | `git switch -c <branch>` (no tracking) | Clean, nothing to record |
 
+cplt says so when it can see the request coming: a `push`, `branch`, `checkout`
+or `switch` carrying `-u`, `--set-upstream`, `--set-upstream-to` or `--track`
+gets a note before the command runs, saying the success line will be false. That
+needs the git guard on, since the wrapper it prints from is the guard's. The
+implicit form, `git checkout -b <name> <remote>/<base>`, is named in the note
+rather than detected: it sets tracking from a positional that only git can tell
+from a pathspec.
+
 **The shape that works**, and what to tell an agent to do: push with an explicit
 refspec and open the PR with an explicit head, so nothing needs local config.
 

--- a/src/gh_proxy.rs
+++ b/src/gh_proxy.rs
@@ -2709,21 +2709,8 @@ pub fn gate_git(
     }
 
     // Find the subcommand by skipping global flags.
-    let mut i = 0;
-    let mut subcommand = None;
-    while i < args.len() {
-        let arg = args[i];
-        if GIT_GLOBAL_FLAGS_WITH_VALUE.contains(&arg) {
-            i += 2; // skip flag and its value
-            continue;
-        }
-        if arg.starts_with('-') {
-            i += 1;
-            continue;
-        }
-        subcommand = Some(arg);
-        break;
-    }
+    let i = git_subcommand_index(args).unwrap_or(args.len());
+    let subcommand = args.get(i).copied();
 
     // Defense in depth: block command-line config (`-c` / `--config-env`) that
     // could redirect where a push lands or redefine what a subcommand does.
@@ -3393,6 +3380,26 @@ const GIT_GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
     "--super-prefix",
     "--config-env",
 ];
+
+/// Index of the git subcommand in `args`, skipping the global flags that
+/// precede it — including those that consume a following space-separated value,
+/// so `git -C /elsewhere push` finds `push` and not `/elsewhere`.
+pub fn git_subcommand_index<S: AsRef<str>>(args: &[S]) -> Option<usize> {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_ref();
+        if GIT_GLOBAL_FLAGS_WITH_VALUE.contains(&arg) {
+            i += 2; // skip flag and its value
+            continue;
+        }
+        if arg.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        return Some(i);
+    }
+    None
+}
 
 /// The `-C` / `--git-dir` / `--work-tree` arguments of a git invocation, in
 /// order, so the guard's own git calls resolve against the repository the

--- a/src/main.rs
+++ b/src/main.rs
@@ -3870,15 +3870,16 @@ fn tracking_flag(args: &[String]) -> bool {
     if !cfg!(target_os = "macos") {
         return false;
     }
-    let sub = args
-        .iter()
-        .find(|a| !a.starts_with('-'))
-        .map(String::as_str)
-        .unwrap_or_default();
-    if !matches!(sub, "push" | "branch" | "checkout" | "switch") {
+    // Skip the global flags, and the values they take: `git -C /elsewhere push`
+    // must find `push`, not the path (#487 review).
+    let Some(i) = cplt::gh_proxy::git_subcommand_index(args) else {
+        return false;
+    };
+    if !matches!(args[i].as_str(), "push" | "branch" | "checkout" | "switch") {
         return false;
     }
-    args.iter().any(|a| {
+    // Only the subcommand's own arguments: a global flag's value is not a flag.
+    args[i + 1..].iter().any(|a| {
         a == "-u"
             || a == "--set-upstream"
             || a == "-t"
@@ -8866,6 +8867,16 @@ mod tests {
             vec!["branch", "--set-upstream-to=origin/main", "feat"],
             vec!["checkout", "-t", "origin/feat"],
             vec!["switch", "--track", "origin/feat"],
+            // Global flags, and the values they take, precede the subcommand.
+            vec!["-C", "/elsewhere", "push", "-u", "origin", "feat"],
+            vec![
+                "-c",
+                "core.pager=cat",
+                "push",
+                "--set-upstream",
+                "origin",
+                "feat",
+            ],
         ] {
             assert_eq!(
                 tracking_flag(&a(&args)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3850,6 +3850,55 @@ fn parse_allow_push_rules(json: &str) -> Vec<config::ResolvedPushRule> {
     serde_json::from_str(json).unwrap_or_default()
 }
 
+/// Whether this command asks git to record branch tracking, which the
+/// `.git/config` write deny will silently drop.
+///
+/// git treats the failed config write as non-fatal: it prints the error, prints
+/// `branch 'x' set up to track 'origin/y'.` — which is false — and exits 0. An
+/// agent reading the summary line or the exit code is told it worked (#402).
+/// A field agent read stderr and caught it; the next one may not.
+///
+/// macOS only, because that is where the deny is. Landlock cannot deny a file
+/// inside a writable directory, so on Linux `.git/config` stays writable and
+/// tracking is recorded normally — warning there would be the false statement.
+///
+/// Explicit tracking flags only. `git checkout -b feat origin/main` also sets
+/// tracking, from a positional that is only distinguishable from a pathspec by
+/// asking git, so the message names that form rather than this function
+/// guessing at it.
+fn tracking_flag(args: &[String]) -> bool {
+    if !cfg!(target_os = "macos") {
+        return false;
+    }
+    let sub = args
+        .iter()
+        .find(|a| !a.starts_with('-'))
+        .map(String::as_str)
+        .unwrap_or_default();
+    if !matches!(sub, "push" | "branch" | "checkout" | "switch") {
+        return false;
+    }
+    args.iter().any(|a| {
+        a == "-u"
+            || a == "--set-upstream"
+            || a == "-t"
+            || a == "--track"
+            || a == "--set-upstream-to"
+            || a.starts_with("--set-upstream-to=")
+            || a.starts_with("--track=")
+    })
+}
+
+/// The note printed for such a command.
+const TRACKING_DROPPED_NOTICE: &str = concat!(
+    "cplt: this records branch tracking in .git/config, which the sandbox denies. ",
+    "git will print `set up to track` and exit 0 anyway \u{2014} that line is false ",
+    "and the upstream is NOT recorded. Push with an explicit refspec and name the ",
+    "branch when you need it: `git push origin HEAD:my-branch`, then ",
+    "`gh pr create -R <owner>/<repo> --head my-branch`. The same applies to ",
+    "`git checkout -b <name> <remote>/<base>`."
+);
+
 /// Decide what `cplt git-gate` should do. Pure: no process is spawned here.
 ///
 /// The git guard has no repository pin to apply, so an allowed command and a
@@ -3877,7 +3926,12 @@ fn decide_git_gate(
         Some(real_git),
         repo_facts,
     ) {
-        Ok(()) => GateEffect::ExecPlain { notice: None },
+        Ok(()) => GateEffect::ExecPlain {
+            // Only where nothing else is being said: a refusal or a warn-mode
+            // notice is the more urgent message, and two notices on one command
+            // is how both get skimmed.
+            notice: tracking_flag(args).then(|| TRACKING_DROPPED_NOTICE.to_string()),
+        },
         Err(refusal) => match mode {
             config::EnforcementMode::Block => GateEffect::Refuse(refusal),
             config::EnforcementMode::Warn => GateEffect::ExecPlain {
@@ -8793,6 +8847,46 @@ mod tests {
         }
         let err = validate_flags(&[sub], &project).unwrap_err().to_string();
         assert!(err.contains(&inner.display().to_string()), "{err}");
+    }
+
+    /// #402: git records branch tracking in `.git/config`, which the sandbox
+    /// denies on macOS. git prints the error, prints `set up to track` anyway,
+    /// and exits 0 — so an agent reading the summary line or the exit code is
+    /// told the tracking was saved. It was not.
+    #[test]
+    fn tracking_flags_are_noticed_and_ordinary_commands_are_not() {
+        let a = |v: &[&str]| v.iter().map(|s| (*s).to_string()).collect::<Vec<_>>();
+        // Only meaningful where the deny is. On Linux `.git/config` stays
+        // writable, so warning would itself be the false statement.
+        let expected = cfg!(target_os = "macos");
+
+        for args in [
+            vec!["push", "-u", "origin", "feat"],
+            vec!["push", "--set-upstream", "origin", "feat"],
+            vec!["branch", "--set-upstream-to=origin/main", "feat"],
+            vec!["checkout", "-t", "origin/feat"],
+            vec!["switch", "--track", "origin/feat"],
+        ] {
+            assert_eq!(
+                tracking_flag(&a(&args)),
+                expected,
+                "should be noticed: {args:?}"
+            );
+        }
+
+        for args in [
+            vec!["push", "origin", "feat"],
+            vec!["push", "origin", "HEAD:feat"],
+            vec!["switch", "-c", "feat"],
+            vec!["status"],
+            // `-u` outside a tracking subcommand is a different flag entirely.
+            vec!["clean", "-u"],
+        ] {
+            assert!(
+                !tracking_flag(&a(&args)),
+                "must stay quiet, or the notice becomes noise: {args:?}"
+            );
+        }
     }
 
     /// A key that reads as true and does nothing is worse than one that is off:


### PR DESCRIPTION
The behaviour half of #402, per the decision to warn from the wrapper rather than intercept. The documentation half landed in #480.

## The problem

`.git/config` is write-denied on macOS. git treats the failed write as non-fatal:

```
error: could not write config file .git/config: Operation not permitted
branch 'feat' set up to track 'origin/main'.
```

The second line is false and the exit code is 0. An agent reading the summary line, or checking the exit status, is told the tracking was recorded. A field agent today read stderr and caught it — correctly, and said so. The next one may not.

## The change

A `push`, `branch`, `checkout` or `switch` carrying `-u`, `--set-upstream`, `--set-upstream-to` or `--track` gets a note before it runs:

```
cplt: this records branch tracking in .git/config, which the sandbox denies. git will print
`set up to track` and exit 0 anyway — that line is false and the upstream is NOT recorded.
Push with an explicit refspec and name the branch when you need it:
`git push origin HEAD:my-branch`, then `gh pr create -R <owner>/<repo> --head my-branch`.
The same applies to `git checkout -b <name> <remote>/<base>`.
```

Not intercepting, per the decision: the push itself succeeds and refusing it would break something that works.

## Three deliberate limits

- **macOS only.** Landlock cannot deny a file inside a writable directory, so on Linux `.git/config` stays writable and tracking is recorded normally. Warning there would be the false statement.
- **Explicit flags only.** `git checkout -b <name> <remote>/<base>` also sets tracking, from a positional only git can distinguish from a pathspec. The note names that form rather than this guessing at it.
- **Only where nothing else is being said.** A refusal, or a warn-mode notice, is the more urgent message; two notices on one command is how both get skimmed.

It also needs the git guard on, since the wrapper it prints from is the guard's. Stated in `known-impacts.md` rather than left to be discovered — that is the same gap #478 fixed for `inject_token`, and it is worth naming before someone hits it.

## Verification

`tracking_flags_are_noticed_and_ordinary_commands_are_not` covers five tracking forms and five that must stay quiet, including `git clean -u`, where `-u` is a different flag entirely. Falsified by removing the subcommand scope — it fails.

Verified in a real session: `git push -u origin feat` prints the note and the push proceeds.

One note on getting there: my first attempt printed nothing, and I nearly reported it as broken. The push was being refused because the fixture had no recorded `refs/remotes/origin/HEAD`, so the guard failed closed before reaching the notice — working as designed, bad fixture.

Closes #402's behaviour half.