### PR TITLE
fix(check): run the probes under /bin/sh, not the user's login shell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4768,6 +4768,12 @@ fn probe_shell(
     // is not an assignment there, so the write probe exits non-zero and check
     // reports the sandbox as not enforcing (#488).
     let shell = PathBuf::from("/bin/sh");
+    // A missing `/bin/sh` is a probe that could not run, not a denial. Without
+    // this the spawn failure decodes as BLOCKED and `check` reports the sandbox
+    // as not enforcing for a reason that has nothing to do with the sandbox.
+    if !shell.exists() {
+        return PROBE_SPAWN_FAILED;
+    }
     let args = vec!["-c".to_string(), script.to_string()];
     sandbox::exec_sandboxed(
         prepared,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4763,9 +4763,11 @@ fn probe_shell(
     disabled: &[sandbox::HardeningCategory],
     script: &str,
 ) -> u8 {
-    let Ok(shell) = agent::Agent::Shell.resolve_binary() else {
-        return PROBE_SPAWN_FAILED;
-    };
+    // `/bin/sh`, never `$SHELL`: the probes are POSIX shell, and a user whose
+    // login shell is fish gets a syntax error instead of a verdict — `f=...`
+    // is not an assignment there, so the write probe exits non-zero and check
+    // reports the sandbox as not enforcing (#488).
+    let shell = PathBuf::from("/bin/sh");
     let args = vec!["-c".to_string(), script.to_string()];
     sandbox::exec_sandboxed(
         prepared,

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5786,6 +5786,10 @@ paths = [
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
+            output.status.success(),
+            "an enforcing battery exits 0:\n{stdout}"
+        );
+        assert!(
             stdout.contains("ENFORCING") && !stdout.contains("NOT ENFORCING"),
             "a user's login shell must not decide the verdict:\n{stdout}"
         );

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5754,6 +5754,43 @@ paths = [
         );
     }
 
+    /// The probes are POSIX shell, so they must run under `/bin/sh` and never
+    /// under `$SHELL`. A fish user got `fish: Unsupported use of '='` for the
+    /// write probe, which exits non-zero, so `check` reported a healthy sandbox
+    /// as NOT ENFORCING (#488).
+    ///
+    /// `$SHELL` here is a stub that fails whatever it is handed — the same
+    /// shape as fish refusing a POSIX assignment, without needing fish
+    /// installed. Falsified by restoring `Agent::Shell.resolve_binary()`: the
+    /// verdict flips to NOT ENFORCING.
+    #[test]
+    fn e2e_check_probes_ignore_a_hostile_user_shell() {
+        require_sandbox!();
+        let proj = check_project();
+        let stub = proj.path().join("not-a-posix-shell");
+        std::fs::write(&stub, "#!/bin/sh\nexit 127\n").expect("write stub");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+
+        let output = cplt_cmd()
+            .args(["--agent", "shell"])
+            .env("SHELL", &stub)
+            .arg("--project-dir")
+            .arg(proj.path())
+            .arg("check")
+            .output()
+            .expect("cplt check should run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("ENFORCING") && !stdout.contains("NOT ENFORCING"),
+            "a user's login shell must not decide the verdict:\n{stdout}"
+        );
+    }
+
     #[test]
     fn e2e_check_battery_json_shape() {
         require_sandbox!();


### PR DESCRIPTION
Closes #488. Reported from a real session: `cplt check` in `nais/unleash` said

```
  ✗ write project dir          → BLOCKED  [expected ALLOWED]
→ Sandbox is NOT ENFORCING. 3 expected-allowed check(s) were blocked
```

on a sandbox that was enforcing perfectly.

## Cause

`probe_shell` resolved its interpreter with `Agent::Shell.resolve_binary()` — that is `$SHELL`. The probes are POSIX scripts cplt writes itself (`f=...`, `$$`, `exec >/dev/null 2>&1`), and fish rejects the assignment:

```
fish: Unsupported use of '='. In fish, please use 'set f ...'
```

Non-zero exit, and `decode_fs_probe` reads any non-zero as denied. The read probe passed because `: < path` happens to survive fish, so the output looked like a sandbox verdict rather than a parse failure.

## Fix

One line: `/bin/sh`. The `cplt -c` path keeps `$SHELL` — there the user did ask for their own shell, and the command is theirs, not ours.

## Why this one matters more than its size

`check` is the command we send people to when something looks wrong. Telling a fish user their sandbox is not enforcing, with no actionable cause, is the failure mode that makes someone turn cplt off. `nav-pilot doctor` repeats the verdict, so it was saying the same thing.

## Verification

Before and after on the reporting host, with `SHELL=/opt/homebrew/bin/fish`:

```
✗ write project dir → BLOCKED  ...  Sandbox is NOT ENFORCING
✓ write project dir → ALLOWED  ...  Sandbox is ENFORCING (6 protections verified)
```

`e2e_check_probes_ignore_a_hostile_user_shell` points `$SHELL` at a stub that fails whatever it is handed — same shape as fish refusing a POSIX assignment, no fish needed on the runner. Falsified by restoring the old resolution: it fails with NOT ENFORCING.