### PR TITLE
feat(config): resolve relative paths when setting them, and add -g/-l/-r

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,34 @@ it.
 Each refusal names the layer that does work, so you do not have to remember the
 table.
 
+`config set` takes `-g`, `-l` and `-r` for `--global`, `--local` and `--repo`.
+The long forms are used throughout this document because they say which file is
+being written.
+
+### Relative paths are resolved when you set them
+
+`../sibling` is how people name the repository next door, so `config set` takes
+it and stores what it resolves to:
+
+```bash
+cd ~/src/spleis
+cplt config set --local sandbox.repo_dirs ../sykepenger-model
+# [cplt] sandbox.repo_dirs = [/Users/you/src/sykepenger-model]
+```
+
+The file holds absolute paths only. A relative entry *in* the file has no
+stable anchor — it would mean different directories depending on where cplt was
+started — so what gets written is the resolved path, not what you typed. A
+`~/` entry is stored as typed: it is already anchor-independent, and expanding
+it would bake in one machine's home directory.
+
+The path has to exist when you set it. A relative entry cplt cannot resolve now
+is one the next launch would refuse anyway, and the error at write time names
+the directory you were standing in.
+
+Removing works the same way, so you can `--unset ../sykepenger-model` without
+looking up how it was stored.
+
 ### Rules that apply on every launch, not only when written
 
 A persisted entry is re-validated at each launch, because the file may be weeks

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -212,6 +212,49 @@ pub(super) fn parse_local(
     Ok(Some(config))
 }
 
+/// Whether `key` (dotted, e.g. `sandbox.repo_dirs`) holds paths in the local
+/// layer, and so must be stored absolute.
+///
+/// Kept next to [`path_valued`], which decides the same thing from the parsed
+/// config, so a new path key cannot be added to one and forgotten in the other.
+#[must_use]
+pub fn is_local_path_key(dotted: &str) -> bool {
+    path_valued(&Config::default())
+        .iter()
+        .any(|(key, _)| *key == dotted)
+}
+
+/// Resolve a relative path entry against `cwd` so it can be stored absolute.
+///
+/// `config set --local sandbox.repo_dirs ../sibling` is the natural way to say
+/// it, and refusing it made the user do path arithmetic cplt can do (#490).
+/// Storing the result rather than the input keeps the file's meaning
+/// independent of where it is read from — the reason relative entries are
+/// refused at load in the first place.
+///
+/// Canonicalized, so the stored entry survives a later `cd` and names the
+/// directory the user actually pointed at. `~/` is left alone: it is already
+/// anchor-independent, and expanding it would bake in a `$HOME` that differs
+/// between a Mac and a devcontainer.
+///
+/// # Errors
+/// If the path does not exist. A relative entry cplt cannot resolve now is one
+/// the launch would refuse anyway, and saying so here beats writing a file that
+/// fails at the next launch.
+pub fn resolve_path_entry(value: &str, cwd: &Path) -> Result<String, ConfigError> {
+    if value.starts_with('/') || value.starts_with('~') {
+        return Ok(value.to_string());
+    }
+    std::fs::canonicalize(cwd.join(value))
+        .map(|p| p.to_string_lossy().into_owned())
+        .map_err(|e| {
+            ConfigError::Validation(format!(
+                "cannot resolve {value:?} from {}: {e}",
+                cwd.display()
+            ))
+        })
+}
+
 /// Refuse relative path entries, at `config set --local` and again at load.
 ///
 /// In `config.toml` a relative path anchors to `~/.config/cplt/`, which is
@@ -737,6 +780,63 @@ mod tests {
             .unwrap();
         let err = validate_local_document(&doc).unwrap_err();
         assert!(err.to_string().contains("relative"), "{err}");
+    }
+
+    /// `config set --local sandbox.repo_dirs ../sibling` stores the absolute
+    /// path, so the file keeps its meaning wherever it is later read from —
+    /// which is the whole reason relative entries are refused at load.
+    #[test]
+    fn a_relative_entry_is_resolved_before_it_is_stored() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sibling = dir.path().join("sibling");
+        let cwd = dir.path().join("launch");
+        std::fs::create_dir_all(&sibling).expect("sibling");
+        std::fs::create_dir_all(&cwd).expect("cwd");
+
+        let stored = resolve_path_entry("../sibling", &cwd).expect("resolves");
+        assert_eq!(
+            std::fs::canonicalize(&sibling)
+                .expect("canonical")
+                .to_string_lossy(),
+            stored
+        );
+        // And the result is one the load-time rule accepts.
+        let cfg = Config::parse(&format!("[sandbox]\nrepo_dirs = [{stored:?}]\n")).expect("parses");
+        reject_relative_paths(&cfg, "local config").expect("absolute now");
+    }
+
+    /// Anchor-independent already, and expanding it would bake in one machine's
+    /// `$HOME`.
+    #[test]
+    fn absolute_and_tilde_entries_are_stored_as_typed() {
+        let cwd = Path::new("/nowhere");
+        assert_eq!(resolve_path_entry("/opt/src", cwd).unwrap(), "/opt/src");
+        assert_eq!(resolve_path_entry("~/code/x", cwd).unwrap(), "~/code/x");
+    }
+
+    /// Saying so at write time beats writing a file the next launch refuses.
+    #[test]
+    fn a_relative_entry_that_names_nothing_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = resolve_path_entry("../not-there", dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("cannot resolve"),
+            "should name the failure: {err}"
+        );
+    }
+
+    /// The two lists that decide "this key holds paths" must agree, or a new
+    /// path key gets resolved but not validated, or the reverse.
+    #[test]
+    fn the_path_keys_are_the_ones_the_load_rule_checks() {
+        for (key, _) in path_valued(&Config::default()) {
+            assert!(is_local_path_key(key), "{key} checked but not resolved");
+        }
+        assert!(!is_local_path_key("proxy.upstream"), "a URL is not a path");
+        assert!(
+            !is_local_path_key("sandbox.allow_cache_exec"),
+            "cache-dir names are not paths"
+        );
     }
 
     /// `sandbox.repo_dirs` is a path list, so the local layer's absolute-or-`~`

--- a/src/config/local.rs
+++ b/src/config/local.rs
@@ -242,8 +242,17 @@ pub fn is_local_path_key(dotted: &str) -> bool {
 /// the launch would refuse anyway, and saying so here beats writing a file that
 /// fails at the next launch.
 pub fn resolve_path_entry(value: &str, cwd: &Path) -> Result<String, ConfigError> {
-    if value.starts_with('/') || value.starts_with('~') {
+    // `~` and `~/…` only, matching `expand_tilde`: `~someone/repo` is not
+    // expanded anywhere in cplt, so storing it would leave an entry that reads
+    // as anchor-independent and is then treated as relative to wherever cplt
+    // was started (#490 review).
+    if value.starts_with('/') || value == "~" || value.starts_with("~/") {
         return Ok(value.to_string());
+    }
+    if value.starts_with('~') {
+        return Err(ConfigError::Validation(format!(
+            "{value:?} is not a path cplt expands: only ~ and ~/… name your home              directory. Write the path out."
+        )));
     }
     std::fs::canonicalize(cwd.join(value))
         .map(|p| p.to_string_lossy().into_owned())
@@ -264,7 +273,11 @@ pub fn resolve_path_entry(value: &str, cwd: &Path) -> Result<String, ConfigError
 fn reject_relative_paths(config: &Config, display: &str) -> Result<(), ConfigError> {
     for (key, values) in path_valued(config) {
         for value in values {
-            if !(value.starts_with('/') || value.starts_with('~')) {
+            // `~someone/repo` is not expanded by `expand_tilde`, so it would
+            // reach the launch as a relative path anchored to the working
+            // directory — the exact thing this rule exists to prevent (#490
+            // review). It is refused here rather than silently treated as one.
+            if !(value.starts_with('/') || *value == "~" || value.starts_with("~/")) {
                 return Err(ConfigError::Validation(format!(
                     "{display}: {key} entry {value:?} is relative — \
                      local config accepts absolute and ~/ paths only"
@@ -812,6 +825,25 @@ mod tests {
         let cwd = Path::new("/nowhere");
         assert_eq!(resolve_path_entry("/opt/src", cwd).unwrap(), "/opt/src");
         assert_eq!(resolve_path_entry("~/code/x", cwd).unwrap(), "~/code/x");
+    }
+
+    /// `expand_tilde` only knows `~` and `~/…`. Accepting `~someone/repo` as a
+    /// tilde path would store an entry that reads as anchor-independent and is
+    /// then handled as relative to wherever cplt was started — the invariant
+    /// this layer exists to hold.
+    #[test]
+    fn a_tilde_cplt_does_not_expand_is_not_a_path() {
+        let cwd = Path::new("/nowhere");
+        assert_eq!(resolve_path_entry("~", cwd).unwrap(), "~");
+        assert_eq!(resolve_path_entry("~/x", cwd).unwrap(), "~/x");
+        for bad in ["~someone/repo", "~root"] {
+            assert!(resolve_path_entry(bad, cwd).is_err(), "{bad} must not pass");
+            let cfg = Config::parse(&format!("[sandbox]\nrepo_dirs = [{bad:?}]\n")).unwrap();
+            assert!(
+                reject_relative_paths(&cfg, "local config").is_err(),
+                "{bad} must not load either"
+            );
+        }
     }
 
     /// Saying so at write time beats writing a file the next launch refuses.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,8 @@ pub use editing::{
 pub use error::ConfigError;
 pub use loading::exec_tool_dir_warning;
 pub use local::{
-    list_local, load_local, local_dir, local_path, parse_local_doc, stamp_local_header,
-    validate_local_document,
+    is_local_path_key, list_local, load_local, local_dir, local_path, parse_local_doc,
+    resolve_path_entry, stamp_local_header, validate_local_document,
 };
 pub(crate) use path::canonicalize_deepest;
 pub(crate) use path::lexically_normalized;

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -283,7 +283,7 @@ pub(super) const CONFIG_KEYS: &[ConfigKeyInfo] = &[
         value_type: ConfigValueType::StrArray,
         dangerous: false,
         default_display: "[]",
-        description: "Additional repositories this project spans (local config only: cplt config set --local). Absolute or ~/ paths, re-validated on every launch.",
+        description: "Additional repositories this project spans (local config only: cplt config set --local). Relative paths are resolved when set; stored absolute and re-validated on every launch.",
     },
     ConfigKeyInfo {
         section: "sandbox",

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,7 +777,7 @@ QUICK START:
 
         /// Scan machine-level tools and generate personal config
         /// (~/.config/cplt/config.toml) instead of per-repo .cplt.toml.
-        #[arg(long)]
+        #[arg(long, short = 'g')]
         global: bool,
     },
 
@@ -1017,7 +1017,7 @@ enum ConfigAction {
     Path {
         /// Print the per-repo user config path for this project instead,
         /// whether or not the file exists.
-        #[arg(long)]
+        #[arg(long, short = 'l')]
         local: bool,
     },
 
@@ -1064,18 +1064,18 @@ enum ConfigAction {
 
         /// Write to the repo-local .cplt.toml (proposed/deny settings).
         /// Relaxations go under [propose], tightenings under [deny].
-        #[arg(long, conflicts_with = "global")]
+        #[arg(long, short = 'r', conflicts_with = "global")]
         repo: bool,
 
         /// Write to the global config (~/.config/cplt/config.toml).
         /// This is the default behavior.
-        #[arg(long, conflicts_with = "repo")]
+        #[arg(long, short = 'g', conflicts_with = "repo")]
         global: bool,
 
         /// Write to this project's per-repo user config, outside the
         /// repository, at ~/.config/cplt/local/<hash>.toml. Requires a git
         /// repository: the file is keyed on the checkout's canonical path.
-        #[arg(long, conflicts_with_all = ["repo", "global"])]
+        #[arg(long, short = 'l', conflicts_with_all = ["repo", "global"])]
         local: bool,
     },
 
@@ -6550,6 +6550,27 @@ fn run_config_set(
     } else {
         None
     };
+    // `../sibling` is how a person names the repository next door. The local
+    // layer stores absolute paths only — a relative entry there has no stable
+    // anchor — so resolve it here rather than making the user do it (#490).
+    let resolved_value;
+    let value = match (local_project.as_ref(), value) {
+        (Some(_), Some(v)) if config::is_local_path_key(key) => {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            match config::resolve_path_entry(v, &cwd) {
+                Ok(abs) => {
+                    resolved_value = abs;
+                    Some(resolved_value.as_str())
+                }
+                Err(e) => {
+                    ui::error(&e.to_string());
+                    return ExitCode::FAILURE;
+                }
+            }
+        }
+        _ => value,
+    };
+
     let op = match &local_project {
         Some(project_dir) => config::ConfigSetOp::new_local(key, project_dir),
         None => config::ConfigSetOp::new(key),


### PR DESCRIPTION
Two small things a maintainer hit while linking repositories by hand.

## `../sibling` now works

```
$ cplt config set --local sandbox.repo_dirs ../sykepenger-model
[cplt] sandbox.repo_dirs = [/Users/you/src/sykepenger-model]
```

Before, this was refused with "local config accepts absolute and ~/ paths only" and the user got to work out the absolute path themselves. cplt knows the working directory.

The rule the refusal was protecting is still intact, and is the reason the *resolved* path is what gets stored: a relative entry inside the file has no stable anchor, so it would name different directories depending on where cplt was started. What changes is where the resolution happens — at write time, once, instead of never.

Details worth stating:

- `~/` is stored as typed. It is already anchor-independent, and expanding it would bake one machine's `$HOME` into a file that may be read on another.
- The path must exist when set. A relative entry cplt cannot resolve now is one the next launch would refuse anyway; failing at write time names the directory you were standing in, which is the fact you need.
- `--unset` resolves the same way, so a root can be removed by the same name it was added under.
- Canonicalized, so the entry survives a later `cd` and names the tree the user actually pointed at.

`is_local_path_key` reads the same table as the load-time check, with a test asserting the two agree — otherwise a future path key gets resolved but not validated, or validated but not resolved.

## `-g` / `-l` / `-r`

Short forms for `--global`, `--local` and `--repo` on `config set`, `-l` on `config path`, `-g` on `init`. These are the flags typed most often. Docs keep the long forms, since they name the file being written.

## Verification

`cargo test` clean, clippy clean, `--target x86_64-unknown-linux-gnu --all-targets` clean. Four new unit tests: resolution, `~/` and absolute passthrough, the nonexistent-path refusal, and the agreement between the resolve list and the validate list. End-to-end: set with `../../nais/unleash` from this repo, `config show` reports the absolute path, `--unset` with the same relative string removes it.