### PR TITLE
feat(link): name the repository, let cplt find and verify the checkout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,9 +231,13 @@ Where it looks, in order: beside the launch repository; then across the forge
 directory, so `nais/unleash` is findable from `navikt/cplt` in a
 `<host>/<org>/<repo>` layout; then the origin of each directory beside the
 launch repository, capped, which finds a clone in a differently-named
-directory. A directory inside the launch repository is never a candidate — that
-tree is agent-writable, so a checkout planted there would be a repository of
-the agent's choosing wearing the right name.
+directory. A directory that resolves inside the launch repository is never a
+candidate — that tree is agent-writable, so a checkout planted there would be a
+repository of the agent's choosing wearing the right name. That check runs on
+the resolved path, so a symlinked sibling pointing back into the project does
+not get around it. Note the sibling directory itself is only as trustworthy as
+your machine: one `--project-dir <parent>` launch makes every directory beside
+the repository writable from the sandbox.
 
 Every candidate has its `origin` read by the trusted git **outside** the
 sandbox and must match the name you asked for. A directory called
@@ -251,7 +255,13 @@ instead. Linked worktrees of the chosen checkout are counted, not listed — the
 share one `.git`, so they all report the same origin.
 
 `cplt link <owner>/<name> --unlink` removes it again, so a root can be dropped
-by the name it was added under.
+by the name it was added under. It matches on the recorded directory's origin
+where it can read one, and falls back to the directory's own name where it
+cannot — a deleted directory has no identity to read, and neither does one whose
+`.git/config` was rewritten since. Without that fallback the entries most worth
+removing would be the ones the command refused to find. If more than one entry
+answers, it names them and removes none; `cplt config set --local
+sandbox.repo_dirs <DIR> --unset` is always available.
 
 What this writes is an ordinary `sandbox.repo_dirs` entry, so everything below
 applies to it unchanged. What it adds is the identity check. And note the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,9 @@ cplt --repo-dir libs/sykepenger-model exec -- ./gradlew build
 
 # Persisted for this checkout, so every later launch picks it up with no flag
 cplt config set --local sandbox.repo_dirs ~/src/spleis/libs/sykepenger-model
+
+# Or name the repository and let cplt find and verify the checkout
+cplt link navikt/sykepenger-model
 ```
 
 The startup summary then lists what is in scope, and where each entry came
@@ -212,6 +215,50 @@ table.
 `config set` takes `-g`, `-l` and `-r` for `--global`, `--local` and `--repo`.
 The long forms are used throughout this document because they say which file is
 being written.
+
+### Naming a repository instead of a path
+
+`cplt link` takes the repository, finds the checkout, and checks it really is
+that repository before writing the path:
+
+```bash
+cplt link navikt/sykepenger-model
+# [cplt] navikt/sykepenger-model → /Users/you/src/sykepenger-model
+#        (beside this repository, origin verified)
+```
+
+Where it looks, in order: beside the launch repository; then across the forge
+directory, so `nais/unleash` is findable from `navikt/cplt` in a
+`<host>/<org>/<repo>` layout; then the origin of each directory beside the
+launch repository, capped, which finds a clone in a differently-named
+directory. A directory inside the launch repository is never a candidate — that
+tree is agent-writable, so a checkout planted there would be a repository of
+the agent's choosing wearing the right name.
+
+Every candidate has its `origin` read by the trusted git **outside** the
+sandbox and must match the name you asked for. A directory called
+`sykepenger-model` that is some other repository is not linked, and a directory
+you name yourself is checked too:
+
+```bash
+cplt link navikt/sykepenger-model ~/elsewhere/model    # verified, not assumed
+```
+
+If two equally good candidates verify, cplt refuses and names both rather than
+picking. A directory named after the repository beats one matched only by its
+origin, and the weaker matches are printed so you can link one of those
+instead. Linked worktrees of the chosen checkout are counted, not listed — they
+share one `.git`, so they all report the same origin.
+
+`cplt link <owner>/<name> --unlink` removes it again, so a root can be dropped
+by the name it was added under.
+
+What this writes is an ordinary `sandbox.repo_dirs` entry, so everything below
+applies to it unchanged. What it adds is the identity check. And note the
+limit: **"origin verified" describes the moment you ran the command.** On Linux
+an agent can rewrite `.git/config` in any tree it was granted, and Landlock
+cannot carve that file out of a writable root — which is why the link is stored
+and re-validated as a path, never re-resolved from the name.
 
 ### Relative paths are resolved when you set them
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod gh_proxy;
 pub mod git;
 pub mod gradle_init;
 pub mod init;
+pub mod link;
 pub mod proxy;
 pub mod repo_config;
 pub mod sandbox;

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,0 +1,644 @@
+//! Finding a repository on this machine from its `<owner>/<name>` identity.
+//!
+//! `cplt link navikt/sykepenger-model` is the whole of it today: the user names
+//! a repository, cplt finds the checkout, verifies it really is that repository,
+//! and writes the path into the per-checkout local config as a named root.
+//!
+//! The verification is the load-bearing part, and it is why this is a module
+//! rather than three lines in `main`. A directory with a matching *name* is not
+//! the repository: someone with `~/src/foo` unrelated to `navikt/foo` must not
+//! have it linked, and a tree an earlier session could write is a tree whose
+//! `.git/config` an earlier session could have pointed anywhere. So every
+//! candidate has its origin read by the **trusted git in the unsandboxed
+//! parent**, and the result must normalise to the identity asked for.
+//!
+//! What that verification is worth is bounded, and the bound is worth stating:
+//! on Linux the agent can rewrite `.git/config` in any tree it was granted, and
+//! Landlock cannot carve that file out of a writable root. "Origin verified" is
+//! a statement about this moment, made parent-side. It is not a continuing
+//! property of the linked tree — which is why the link is written as a path the
+//! user is shown, and re-validated as a path on every launch, rather than
+//! re-resolved from the identity each time.
+
+use std::path::{Path, PathBuf};
+
+/// How many sibling directories may have their origin read when no directory
+/// name matched. Bounded because this is the only step that pays a git call per
+/// directory rather than per candidate.
+const ORIGIN_SCAN_LIMIT: usize = 50;
+
+/// Where a candidate came from, for the line the user is shown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Found {
+    /// Beside the launch repository.
+    Sibling,
+    /// `<host>/<org>/<repo>`, the layout `~/go/src/github.com/navikt/cplt` has.
+    SameForge,
+    /// Name did not match; the origin did.
+    RenamedClone,
+    /// The user named the directory themselves.
+    Named,
+}
+
+impl Found {
+    /// How strong the evidence is. A directory named after the repository is
+    /// evidence in itself; a directory matched only by the origin it claims is
+    /// weaker, and there are usually several — every linked worktree of a
+    /// repository reports the same origin, because they share one config.
+    fn rank(self) -> u8 {
+        match self {
+            Self::Sibling | Self::Named => 0,
+            Self::SameForge => 1,
+            Self::RenamedClone => 2,
+        }
+    }
+
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::Sibling => "beside this repository",
+            Self::SameForge => "under the same forge directory",
+            Self::RenamedClone => "in a directory with a different name, matched by origin",
+            Self::Named => "at the directory you named",
+        }
+    }
+}
+
+/// A verified checkout of the requested repository.
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    pub dir: PathBuf,
+    pub how: Found,
+    /// Other *separate* checkouts that also verified as this repository — a
+    /// different clone, not another worktree of this one. Reported, never
+    /// silently discarded: one of them may be the one the user meant.
+    pub also: Vec<Candidate>,
+    /// How many linked worktrees of the chosen checkout were also matched.
+    /// Counted rather than listed: they share one `.git`, so they all report
+    /// the same origin, and a repository with thirty worktrees would otherwise
+    /// print thirty lines that are all the same repository.
+    pub worktrees: usize,
+}
+
+/// Why a resolution did not produce exactly one repository.
+#[derive(Debug)]
+pub enum ResolveError {
+    /// The identity is not `<owner>/<name>`.
+    BadIdentity(String),
+    /// Nothing on this machine verified as that repository.
+    NotFound {
+        /// The paths tried by name, deduplicated.
+        searched: Vec<PathBuf>,
+        /// How many further directories had their origin read.
+        scanned: usize,
+    },
+    /// More than one did. Never guessed between: one of them is the wrong tree,
+    /// and the wrong tree is a project-grade write+exec grant.
+    Ambiguous(Vec<Candidate>),
+    /// No trusted git in the parent, so no origin can be read at all.
+    NoTrustedGit,
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadIdentity(s) => write!(
+                f,
+                "{s:?} is not a repository identity. Name it as <owner>/<name>, \
+                 for example navikt/cplt."
+            ),
+            Self::NotFound { searched, scanned } => {
+                writeln!(f, "No checkout of that repository was found. Looked at:")?;
+                for dir in searched {
+                    writeln!(f, "  {}", dir.display())?;
+                }
+                if *scanned > 0 {
+                    // The scan reads origins, so naming every directory would be
+                    // a wall of paths that are not the answer.
+                    writeln!(
+                        f,
+                        "  ...and the origin of {scanned} other director{} beside it",
+                        if *scanned == 1 { "y" } else { "ies" }
+                    )?;
+                }
+                write!(
+                    f,
+                    "Name the directory if it is somewhere else:\n  \
+                     cplt link <owner>/<name> <dir>"
+                )
+            }
+            Self::Ambiguous(found) => {
+                writeln!(
+                    f,
+                    "More than one checkout claims to be that repository, so cplt is not \
+                     picking one:"
+                )?;
+                for c in found {
+                    writeln!(f, "  {} ({})", c.dir.display(), c.how.describe())?;
+                }
+                write!(
+                    f,
+                    "Name the one you mean:\n  cplt link <owner>/<name> <dir>"
+                )
+            }
+            Self::NoTrustedGit => write!(
+                f,
+                "No trusted git binary in the parent environment, so no repository's \
+                 identity can be verified. Name the directory instead:\n  \
+                 cplt link <owner>/<name> <dir>"
+            ),
+        }
+    }
+}
+
+/// Whether `identity` is a `<owner>/<name>` this may be used to build paths from.
+///
+/// The identity reaches path construction — `<parent>/<name>` — and in the
+/// proposal form of this feature (#491) it is text a repository's committed
+/// config chose. `..` and `/` in the wrong places would have cplt run git in a
+/// directory of that file's choosing and print the path back to the operator.
+#[must_use]
+pub fn is_valid_identity(identity: &str) -> bool {
+    let mut parts = identity.split('/');
+    let (Some(owner), Some(name), None) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    [owner, name].iter().all(|part| {
+        !part.is_empty()
+            && *part != "."
+            && *part != ".."
+            && part
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+    })
+}
+
+/// The `<owner>/<name>` a checkout's origin says it is, read parent-side.
+fn identity_of(real_git: &Path, dir: &Path) -> Option<String> {
+    crate::gh_proxy::detect_current_repo(real_git, dir).ok()
+}
+
+/// The `.git` a checkout shares with its linked worktrees, canonicalized.
+///
+/// Two directories with the same one are the same repository seen twice, not
+/// two clones — and every worktree reports the repository's origin, since the
+/// config lives in the shared directory.
+fn common_dir(dir: &Path) -> Option<PathBuf> {
+    crate::git::command(dir, &["rev-parse", "--git-common-dir"])
+        .and_then(|mut c| c.output().ok())
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|p| std::fs::canonicalize(dir.join(p.trim())).ok())
+}
+
+/// Whether `dir` is a git toplevel — the directory itself, not somewhere inside
+/// a repository.
+fn is_toplevel(dir: &Path) -> bool {
+    crate::git::command(dir, &["rev-parse", "--show-toplevel"])
+        .and_then(|mut c| c.output().ok())
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|top| std::fs::canonicalize(top.trim()).ok())
+        .is_some_and(|top| top == dir)
+}
+
+/// Verify one directory really is `identity`, and return it if so.
+fn verify(real_git: &Path, dir: &Path, identity: &str, how: Found) -> Option<Candidate> {
+    let dir = std::fs::canonicalize(dir).ok()?;
+    if !is_toplevel(&dir) {
+        return None;
+    }
+    let found = identity_of(real_git, &dir)?;
+    crate::gh_proxy::repos_match(&found, identity).then_some(Candidate {
+        dir,
+        how,
+        also: Vec::new(),
+        worktrees: 0,
+    })
+}
+
+/// Directories to try by name, in the order they are tried.
+///
+/// Not "everywhere under `$HOME`": a scan that wide is slow, surprising, and
+/// reads trees the user never associated with this project.
+fn name_candidates(project_dir: &Path, identity: &str) -> Vec<(PathBuf, Found)> {
+    let (owner, name) = identity.split_once('/').unwrap_or(("", identity));
+    let mut out = Vec::new();
+
+    if let Some(parent) = project_dir.parent() {
+        out.push((parent.join(name), Found::Sibling));
+        // `<host>/<org>/<repo>`: the Go layout, and anyone who mirrors it. The
+        // grandparent is the forge directory, so a repository in another org is
+        // one directory across rather than nowhere.
+        if let Some(forge) = parent.parent() {
+            out.push((forge.join(owner).join(name), Found::SameForge));
+        }
+    }
+
+    out
+}
+
+/// Sibling directories whose origin is worth reading when no name matched.
+fn origin_scan_dirs(project_dir: &Path, home: &Path) -> Vec<PathBuf> {
+    let Some(parent) = project_dir.parent() else {
+        return Vec::new();
+    };
+    // A parent that is `$HOME` (or another unsafe root) would turn this into the
+    // broad home scan this deliberately is not.
+    if crate::is_unsafe_root(parent, home) {
+        return Vec::new();
+    }
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return Vec::new();
+    };
+    let mut dirs: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir() && p != project_dir)
+        .collect();
+    dirs.sort();
+    dirs.truncate(ORIGIN_SCAN_LIMIT);
+    dirs
+}
+
+/// Find the one checkout of `identity` on this machine.
+///
+/// Every candidate from every step is collected before a verdict, rather than
+/// stopping at the first hit: with stop-at-first, a tree that verifies at an
+/// early step silently beats the real repository at a later one, and one of the
+/// two is a write+exec grant over the wrong directory.
+///
+/// # Errors
+/// See [`ResolveError`]: a malformed identity, nothing found, more than one
+/// found, or no trusted git to verify with.
+pub fn resolve(project_dir: &Path, home: &Path, identity: &str) -> Result<Candidate, ResolveError> {
+    if !is_valid_identity(identity) {
+        return Err(ResolveError::BadIdentity(identity.to_string()));
+    }
+    let Some(real_git) = crate::git::trusted_git() else {
+        return Err(ResolveError::NoTrustedGit);
+    };
+
+    let by_name = name_candidates(project_dir, identity);
+    // The sibling and same-forge paths coincide when the launch repository is in
+    // the proposed owner's directory, and a path listed twice reads as two
+    // places having been tried.
+    let mut searched: Vec<PathBuf> = by_name.iter().map(|(p, _)| p.clone()).collect();
+    searched.dedup();
+    let mut scanned = 0usize;
+    let mut found: Vec<Candidate> = Vec::new();
+
+    for (dir, how) in by_name {
+        // A candidate inside the launch repository is refused, not verified: that
+        // tree is agent-writable, so a checkout planted there last session would
+        // be a repository of the agent's choosing wearing the right name.
+        if dir.starts_with(project_dir) {
+            continue;
+        }
+        if let Some(c) = verify(real_git, &dir, identity, how) {
+            found.push(c);
+        }
+    }
+
+    // Always, not only when the name search came up empty. Stopping early would
+    // let a decoy with the right *name* silently beat the real checkout in a
+    // differently-named directory — and one of those two is a write+exec grant
+    // over the wrong tree. This costs one `git config` per sibling directory,
+    // capped, on a command a person runs by hand.
+    for dir in origin_scan_dirs(project_dir, home) {
+        if dir.starts_with(project_dir) {
+            continue;
+        }
+        scanned += 1;
+        if let Some(c) = verify(real_git, &dir, identity, Found::RenamedClone) {
+            found.push(c);
+        }
+    }
+
+    // A sibling matched by name is also reached by the scan; the same directory
+    // twice is one candidate, not an ambiguity.
+    found.sort_by(|a, b| a.dir.cmp(&b.dir));
+    found.dedup_by(|a, b| a.dir == b.dir);
+
+    if found.is_empty() {
+        return Err(ResolveError::NotFound { searched, scanned });
+    }
+
+    // Ambiguity is refused only among equally good matches. Two directories
+    // *named* after the repository are a genuine "which one did you mean";
+    // a named one plus three that merely claim the same origin is the ordinary
+    // shape of a repository with linked worktrees, and refusing that would make
+    // the command unusable for anyone who uses them.
+    //
+    // The weaker matches are printed rather than dropped, because the ranking is
+    // a heuristic and the operator is the one who knows.
+    let best = found.iter().map(|c| c.how.rank()).min().unwrap_or(0);
+    let (mut top, rest): (Vec<Candidate>, Vec<Candidate>) =
+        found.into_iter().partition(|c| c.how.rank() == best);
+
+    if top.len() > 1 {
+        top.extend(rest);
+        return Err(ResolveError::Ambiguous(top));
+    }
+    let mut winner = top.remove(0);
+    let shared = common_dir(&winner.dir);
+    let (mine, others): (Vec<Candidate>, Vec<Candidate>) = rest
+        .into_iter()
+        .partition(|c| shared.is_some() && common_dir(&c.dir) == shared);
+    winner.worktrees = mine.len();
+    winner.also = others;
+    Ok(winner)
+}
+
+/// Verify a directory the user named themselves.
+///
+/// The path is theirs, so it is not searched for — but it is still checked
+/// against the identity, because "I meant this one" and "this one is that
+/// repository" are different claims and only the second makes the link mean
+/// what it says.
+///
+/// # Errors
+/// If no trusted git is available, or the directory is not that repository.
+pub fn verify_named(dir: &Path, identity: &str) -> Result<Candidate, String> {
+    if !is_valid_identity(identity) {
+        return Err(ResolveError::BadIdentity(identity.to_string()).to_string());
+    }
+    let real_git =
+        crate::git::trusted_git().ok_or_else(|| ResolveError::NoTrustedGit.to_string())?;
+    let canonical =
+        std::fs::canonicalize(dir).map_err(|e| format!("Cannot resolve {}: {e}", dir.display()))?;
+    if !is_toplevel(&canonical) {
+        return Err(format!(
+            "{} is not the toplevel of a git repository.",
+            canonical.display()
+        ));
+    }
+    match identity_of(real_git, &canonical) {
+        Some(found) if crate::gh_proxy::repos_match(&found, identity) => Ok(Candidate {
+            dir: canonical,
+            how: Found::Named,
+            also: Vec::new(),
+            worktrees: 0,
+        }),
+        Some(found) => Err(format!(
+            "{} is {found}, not {identity}.\n  \
+             Link it as itself if that is what you meant:\n    cplt link {found}",
+            canonical.display()
+        )),
+        None => Err(format!(
+            "Could not read a GitHub origin for {}, so cplt cannot confirm it is {identity}.\n  \
+             A fork, a repository with no `origin`, or a non-GitHub remote all look like this.",
+            canonical.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A repository at `dir` whose origin is `identity`, using the real git so
+    /// the tests exercise the same reader the resolver does.
+    #[allow(clippy::disallowed_methods)] // test fixture: PATH is the harness's, not an agent's
+    fn make_repo(dir: &Path, identity: &str) {
+        std::fs::create_dir_all(dir).expect("mkdir");
+        let url = format!("git@github.com:{identity}.git");
+        for args in [
+            vec!["init", "-q"],
+            vec!["remote", "add", "origin", url.as_str()],
+        ] {
+            let ok = std::process::Command::new("git")
+                .args(&args)
+                .current_dir(dir)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .expect("git runs")
+                .success();
+            assert!(ok, "git {args:?} failed");
+        }
+    }
+
+    /// Run git in `dir`, asserting success.
+    #[allow(clippy::disallowed_methods)] // test fixture: PATH is the harness's, not an agent's
+    fn git_in(dir: &Path, args: &[&str]) {
+        let ok = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@e.x")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@e.x")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("git runs")
+            .success();
+        assert!(ok, "git {args:?} failed");
+    }
+
+    /// The identity reaches path construction, and in #491 it is text a
+    /// repository's committed config chose. `..` there would have cplt run git
+    /// in a directory that file picked and print the path to the operator.
+    #[test]
+    fn an_identity_that_is_not_owner_slash_name_is_refused() {
+        for good in ["navikt/cplt", "nais/unleash", "a/b", "org.x/repo-1_2"] {
+            assert!(is_valid_identity(good), "{good} should be accepted");
+        }
+        for bad in [
+            "../../etc",
+            "navikt/../../etc",
+            "navikt",
+            "navikt/cplt/extra",
+            "/navikt/cplt",
+            "navikt/",
+            "",
+            "..",
+            "nav ikt/cplt",
+            "navikt/./cplt",
+        ] {
+            assert!(!is_valid_identity(bad), "{bad:?} must be refused");
+        }
+    }
+
+    /// The everyday case: the repository next door.
+    #[test]
+    fn a_sibling_is_found_and_its_origin_checked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        make_repo(&root.join("sykepenger-model"), "navikt/sykepenger-model");
+
+        let found = resolve(&project, &root, "navikt/sykepenger-model").expect("resolves");
+        assert_eq!(found.dir, root.join("sykepenger-model"));
+        assert_eq!(found.how, Found::Sibling);
+    }
+
+    /// A directory with the right name and a different origin is NOT the
+    /// repository. Without this check, `~/src/foo` unrelated to `navikt/foo`
+    /// becomes a write+exec grant over the wrong tree.
+    #[test]
+    fn a_matching_name_with_a_different_origin_is_not_it() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        make_repo(
+            &root.join("sykepenger-model"),
+            "someone-else/sykepenger-model",
+        );
+
+        let err = resolve(&project, &root, "navikt/sykepenger-model").expect_err("must refuse");
+        assert!(matches!(err, ResolveError::NotFound { .. }), "{err}");
+    }
+
+    /// `<host>/<org>/<repo>`: a repository in another organisation is one
+    /// directory across, not nowhere.
+    #[test]
+    fn a_repository_in_another_org_is_found_across_the_forge_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let forge = tmp
+            .path()
+            .canonicalize()
+            .expect("canonical")
+            .join("github.com");
+        let project = forge.join("navikt").join("cplt");
+        make_repo(&project, "navikt/cplt");
+        make_repo(&forge.join("nais").join("unleash"), "nais/unleash");
+
+        let found = resolve(&project, tmp.path(), "nais/unleash").expect("resolves");
+        assert_eq!(found.dir, forge.join("nais").join("unleash"));
+        assert_eq!(found.how, Found::SameForge);
+    }
+
+    /// A clone in a differently-named directory is still findable, by origin.
+    #[test]
+    fn a_renamed_clone_is_matched_by_its_origin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        make_repo(&root.join("model-wip"), "navikt/sykepenger-model");
+
+        // A home elsewhere: the origin scan is skipped when the directory it
+        // would read is the home directory itself.
+        let found =
+            resolve(&project, &root.join("home"), "navikt/sykepenger-model").expect("resolves");
+        assert_eq!(found.dir, root.join("model-wip"));
+        assert_eq!(found.how, Found::RenamedClone);
+    }
+
+    /// Two trees with equally good claims: one of them is the wrong tree, and
+    /// the wrong tree is a project-grade write+exec grant. Refused, never
+    /// guessed between.
+    #[test]
+    fn equally_good_candidates_are_refused_rather_than_picked_between() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        // Neither is named after the repository, so neither claim is stronger.
+        make_repo(&root.join("model-wip"), "navikt/sykepenger-model");
+        make_repo(&root.join("model-old"), "navikt/sykepenger-model");
+
+        let err = resolve(&project, &root.join("home"), "navikt/sykepenger-model")
+            .expect_err("must refuse");
+        match err {
+            ResolveError::Ambiguous(found) => assert_eq!(found.len(), 2, "{found:?}"),
+            other => panic!("expected an ambiguity refusal, got {other}"),
+        }
+    }
+
+    /// A directory *named* after the repository is evidence a directory that
+    /// merely claims the same origin does not have. The weaker match is
+    /// reported rather than dropped — the ranking is a heuristic, and a user
+    /// with a decoy beside their checkout should be told it is there.
+    #[test]
+    fn a_weaker_match_does_not_block_the_link_but_is_reported() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        make_repo(&root.join("sykepenger-model"), "navikt/sykepenger-model");
+        make_repo(&root.join("decoy"), "navikt/sykepenger-model");
+
+        let found = resolve(&project, &root.join("home"), "navikt/sykepenger-model")
+            .expect("the named one wins");
+        assert_eq!(found.dir, root.join("sykepenger-model"));
+        assert_eq!(
+            found.also.iter().map(|c| &c.dir).collect::<Vec<_>>(),
+            vec![&root.join("decoy")],
+            "the other claim must be shown, not swallowed"
+        );
+    }
+
+    /// Every linked worktree shares one config, so they all report the same
+    /// origin. Counting them keeps `cplt link` usable for anyone who uses
+    /// worktrees, without pretending they are separate clones.
+    #[test]
+    fn worktrees_of_the_chosen_checkout_are_counted_not_listed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        let model = root.join("sykepenger-model");
+        make_repo(&model, "navikt/sykepenger-model");
+        // A worktree needs a commit to branch from.
+        std::fs::write(model.join("seed"), "x").expect("seed");
+        git_in(&model, &["add", "seed"]);
+        git_in(&model, &["commit", "-qm", "init"]);
+        git_in(
+            &model,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                root.join("model-hotfix").to_str().expect("utf8"),
+                "-b",
+                "hotfix",
+            ],
+        );
+
+        let found = resolve(&project, &root.join("home"), "navikt/sykepenger-model")
+            .expect("the main checkout wins");
+        assert_eq!(found.dir, model);
+        assert_eq!(found.worktrees, 1, "the worktree is counted");
+        assert!(found.also.is_empty(), "and not reported as another clone");
+    }
+
+    /// The launch repository is agent-writable, so a checkout planted inside it
+    /// is a repository of the agent's choosing wearing the right name.
+    #[test]
+    fn a_candidate_inside_the_launch_repository_is_never_taken() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        make_repo(&project.join("sykepenger-model"), "navikt/sykepenger-model");
+
+        let err = resolve(&project, &root, "navikt/sykepenger-model").expect_err("must refuse");
+        assert!(matches!(err, ResolveError::NotFound { .. }), "{err}");
+    }
+
+    /// A directory the user named is still checked: "I meant this one" and
+    /// "this one is that repository" are different claims.
+    #[test]
+    fn a_named_directory_is_verified_too() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let other = root.join("something-else");
+        make_repo(&other, "someone-else/thing");
+
+        let err = verify_named(&other, "navikt/sykepenger-model").expect_err("must refuse");
+        assert!(
+            err.contains("someone-else/thing"),
+            "the error must name what it actually is: {err}"
+        );
+        verify_named(&other, "someone-else/thing").expect("its own identity verifies");
+    }
+}

--- a/src/link.rs
+++ b/src/link.rs
@@ -203,8 +203,27 @@ fn is_toplevel(dir: &Path) -> bool {
 }
 
 /// Verify one directory really is `identity`, and return it if so.
-fn verify(real_git: &Path, dir: &Path, identity: &str, how: Found) -> Option<Candidate> {
+///
+/// The containment check is here, **after** `canonicalize`, and not at the
+/// caller. Checked on the path as written, a sibling symlink
+/// `../sykepenger-model -> <project>/planted` passes it, resolves into the
+/// project tree, verifies against a planted origin, and wins the strongest
+/// rank — so cplt would report "origin verified" for a directory the agent
+/// authored while the user believes the real repository is in scope. Found by
+/// review of #495 and reproduced.
+fn verify(
+    real_git: &Path,
+    dir: &Path,
+    project_dir: &Path,
+    identity: &str,
+    how: Found,
+) -> Option<Candidate> {
     let dir = std::fs::canonicalize(dir).ok()?;
+    let project_dir =
+        std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
+    if dir.starts_with(&project_dir) {
+        return None;
+    }
     if !is_toplevel(&dir) {
         return None;
     }
@@ -289,13 +308,7 @@ pub fn resolve(project_dir: &Path, home: &Path, identity: &str) -> Result<Candid
     let mut found: Vec<Candidate> = Vec::new();
 
     for (dir, how) in by_name {
-        // A candidate inside the launch repository is refused, not verified: that
-        // tree is agent-writable, so a checkout planted there last session would
-        // be a repository of the agent's choosing wearing the right name.
-        if dir.starts_with(project_dir) {
-            continue;
-        }
-        if let Some(c) = verify(real_git, &dir, identity, how) {
+        if let Some(c) = verify(real_git, &dir, project_dir, identity, how) {
             found.push(c);
         }
     }
@@ -306,11 +319,8 @@ pub fn resolve(project_dir: &Path, home: &Path, identity: &str) -> Result<Candid
     // over the wrong tree. This costs one `git config` per sibling directory,
     // capped, on a command a person runs by hand.
     for dir in origin_scan_dirs(project_dir, home) {
-        if dir.starts_with(project_dir) {
-            continue;
-        }
         scanned += 1;
-        if let Some(c) = verify(real_git, &dir, identity, Found::RenamedClone) {
+        if let Some(c) = verify(real_git, &dir, project_dir, identity, Found::RenamedClone) {
             found.push(c);
         }
     }
@@ -332,9 +342,15 @@ pub fn resolve(project_dir: &Path, home: &Path, identity: &str) -> Result<Candid
     //
     // The weaker matches are printed rather than dropped, because the ranking is
     // a heuristic and the operator is the one who knows.
-    let best = found.iter().map(|c| c.how.rank()).min().unwrap_or(0);
+    // A directory whose `.git` is elsewhere is a linked worktree — or a decoy
+    // holding nothing but a `gitdir:` pointer at the real repository, which
+    // reads as one. Either way the main checkout is the better answer, so it
+    // outranks them before the name-vs-origin ranking is consulted.
+    let is_main = |c: &Candidate| common_dir(&c.dir).is_some_and(|g| g == c.dir.join(".git"));
+    let rank = |c: &Candidate| (u8::from(!is_main(c)), c.how.rank());
+    let best = found.iter().map(&rank).min().unwrap_or((0, 0));
     let (mut top, rest): (Vec<Candidate>, Vec<Candidate>) =
-        found.into_iter().partition(|c| c.how.rank() == best);
+        found.into_iter().partition(|c| rank(c) == best);
 
     if top.len() > 1 {
         top.extend(rest);
@@ -359,7 +375,7 @@ pub fn resolve(project_dir: &Path, home: &Path, identity: &str) -> Result<Candid
 ///
 /// # Errors
 /// If no trusted git is available, or the directory is not that repository.
-pub fn verify_named(dir: &Path, identity: &str) -> Result<Candidate, String> {
+pub fn verify_named(dir: &Path, project_dir: &Path, identity: &str) -> Result<Candidate, String> {
     if !is_valid_identity(identity) {
         return Err(ResolveError::BadIdentity(identity.to_string()).to_string());
     }
@@ -367,6 +383,18 @@ pub fn verify_named(dir: &Path, identity: &str) -> Result<Candidate, String> {
         crate::git::trusted_git().ok_or_else(|| ResolveError::NoTrustedGit.to_string())?;
     let canonical =
         std::fs::canonicalize(dir).map_err(|e| format!("Cannot resolve {}: {e}", dir.display()))?;
+    // Same rule as the search, for the same reason: a tree inside the launch
+    // repository is agent-writable, so linking it grants nothing new and
+    // vouches for an identity a previous session could have written.
+    let project = std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
+    if canonical.starts_with(&project) {
+        return Err(format!(
+            "{} is inside the launch repository, which is already in scope — and is \
+             writable from the sandbox, so a checkout there may be one a previous \
+             session created.",
+            canonical.display()
+        ));
+    }
     if !is_toplevel(&canonical) {
         return Err(format!(
             "{} is not the toplevel of a git repository.",
@@ -390,6 +418,63 @@ pub fn verify_named(dir: &Path, identity: &str) -> Result<Candidate, String> {
              A fork, a repository with no `origin`, or a non-GitHub remote all look like this.",
             canonical.display()
         )),
+    }
+}
+
+/// What `--unlink` should do with the recorded roots.
+#[derive(Debug, PartialEq)]
+pub enum Unlink {
+    /// Remove exactly this entry, as it is written in the config.
+    Remove(String),
+    /// Nothing recorded here is that repository.
+    NoMatch,
+    /// Several are. Removing "the" one would be a guess about which.
+    Several(Vec<String>),
+}
+
+/// Choose which recorded `sandbox.repo_dirs` entry `--unlink` removes.
+///
+/// `identity_of` reads a directory's origin; it is a parameter so this is
+/// testable without a git tree, and so the caller supplies the trusted binary.
+///
+/// Falls back to the directory's own name when no origin matches. Origin alone
+/// cannot remove the entries that most need removing: a directory that has been
+/// deleted or moved has no identity to read, and on Linux an agent can rewrite
+/// `.git/config` in a tree it was granted — so the strict form would answer "no
+/// repository linked here is navikt/foo" while the write+exec grant on that
+/// tree quietly stays. The name is weaker evidence, but this only ever removes
+/// a grant, and the entry it removes is printed.
+pub fn choose_unlink(
+    entries: &[String],
+    identity: &str,
+    identity_of: impl Fn(&Path) -> Option<String>,
+) -> Unlink {
+    let by_origin: Vec<&String> = entries
+        .iter()
+        .filter(|entry| {
+            identity_of(&crate::config::expand_tilde(entry))
+                .is_some_and(|found| crate::gh_proxy::repos_match(&found, identity))
+        })
+        .collect();
+
+    let chosen = if by_origin.is_empty() {
+        let name = identity.split('/').next_back().unwrap_or(identity);
+        entries
+            .iter()
+            .filter(|entry| {
+                Path::new(entry.as_str())
+                    .file_name()
+                    .is_some_and(|leaf| leaf.eq_ignore_ascii_case(name))
+            })
+            .collect()
+    } else {
+        by_origin
+    };
+
+    match chosen.as_slice() {
+        [] => Unlink::NoMatch,
+        [one] => Unlink::Remove((*one).clone()),
+        many => Unlink::Several(many.iter().map(|s| (*s).clone()).collect()),
     }
 }
 
@@ -439,6 +524,61 @@ mod tests {
             .expect("git runs")
             .success();
         assert!(ok, "git {args:?} failed");
+    }
+
+    /// `--unlink` by name has to work in the cases that matter most: a
+    /// directory that no longer exists has no origin to read, and on Linux an
+    /// agent can rewrite `.git/config` in a tree it was granted. Matching on
+    /// origin alone would answer "nothing linked here is navikt/foo" while the
+    /// write+exec grant stayed.
+    #[test]
+    fn unlink_falls_back_to_the_directory_name_when_no_origin_answers() {
+        let entries = vec![
+            "/src/sykepenger-model".to_string(),
+            "/src/spleis-testdata".to_string(),
+        ];
+        let none = |_: &Path| None;
+
+        assert_eq!(
+            choose_unlink(&entries, "navikt/sykepenger-model", none),
+            Unlink::Remove("/src/sykepenger-model".to_string())
+        );
+        assert_eq!(
+            choose_unlink(&entries, "navikt/not-linked", none),
+            Unlink::NoMatch
+        );
+    }
+
+    /// The origin is the stronger evidence and wins when it is readable — a
+    /// clone in a renamed directory is removed by the repository's name.
+    #[test]
+    fn unlink_prefers_the_origin_over_the_directory_name() {
+        let entries = vec![
+            "/src/model-wip".to_string(),
+            "/src/sykepenger-model".to_string(),
+        ];
+        let origins = |dir: &Path| {
+            (dir == Path::new("/src/model-wip")).then(|| "navikt/sykepenger-model".to_string())
+        };
+
+        assert_eq!(
+            choose_unlink(&entries, "navikt/sykepenger-model", origins),
+            Unlink::Remove("/src/model-wip".to_string()),
+            "the directory that IS the repository, not the one merely named after it"
+        );
+    }
+
+    /// Two checkouts of one repository, both linked. Removing "the" one is a
+    /// guess about which, and the answer is the operator's.
+    #[test]
+    fn unlink_refuses_when_several_answer_to_the_name() {
+        let entries = vec!["/src/model-a".to_string(), "/src/model-b".to_string()];
+        let both = |_: &Path| Some("navikt/sykepenger-model".to_string());
+
+        match choose_unlink(&entries, "navikt/sykepenger-model", both) {
+            Unlink::Several(many) => assert_eq!(many.len(), 2, "{many:?}"),
+            other => panic!("expected a refusal, got {other:?}"),
+        }
     }
 
     /// The identity reaches path construction, and in #491 it is text a
@@ -613,16 +753,48 @@ mod tests {
 
     /// The launch repository is agent-writable, so a checkout planted inside it
     /// is a repository of the agent's choosing wearing the right name.
+    ///
+    /// Written as a **symlinked sibling**, because that is the only way a
+    /// candidate path lands inside the project: the search builds
+    /// `<parent>/<name>`, never a path under the project, so a plainly-nested
+    /// decoy is never even generated and a test using one passes with the
+    /// containment check deleted. That is what the first version of this test
+    /// did (#495 review), and why the check now runs after `canonicalize`.
     #[test]
-    fn a_candidate_inside_the_launch_repository_is_never_taken() {
+    fn a_symlinked_sibling_resolving_into_the_project_is_refused() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().canonicalize().expect("canonical");
         let project = root.join("spleis");
         make_repo(&project, "navikt/spleis");
-        make_repo(&project.join("sykepenger-model"), "navikt/sykepenger-model");
+        let planted = project.join("planted");
+        make_repo(&planted, "navikt/sykepenger-model");
+        std::os::unix::fs::symlink(&planted, root.join("sykepenger-model")).expect("symlink");
 
-        let err = resolve(&project, &root, "navikt/sykepenger-model").expect_err("must refuse");
-        assert!(matches!(err, ResolveError::NotFound { .. }), "{err}");
+        let err = resolve(&project, &root.join("home"), "navikt/sykepenger-model")
+            .expect_err("must refuse");
+        assert!(
+            matches!(err, ResolveError::NotFound { .. }),
+            "a tree the agent could have written must not be linked as a repository: {err}"
+        );
+    }
+
+    /// The same rule for a directory the user names by hand — otherwise the
+    /// search refuses what the explicit form accepts.
+    #[test]
+    fn a_named_directory_inside_the_project_is_refused_too() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonical");
+        let project = root.join("spleis");
+        make_repo(&project, "navikt/spleis");
+        let planted = project.join("vendor").join("model");
+        make_repo(&planted, "navikt/sykepenger-model");
+
+        let err =
+            verify_named(&planted, &project, "navikt/sykepenger-model").expect_err("must refuse");
+        assert!(
+            err.contains("inside the launch repository"),
+            "and say why: {err}"
+        );
     }
 
     /// A directory the user named is still checked: "I meant this one" and
@@ -634,11 +806,13 @@ mod tests {
         let other = root.join("something-else");
         make_repo(&other, "someone-else/thing");
 
-        let err = verify_named(&other, "navikt/sykepenger-model").expect_err("must refuse");
+        let err = verify_named(&other, &root.join("spleis"), "navikt/sykepenger-model")
+            .expect_err("must refuse");
         assert!(
             err.contains("someone-else/thing"),
             "the error must name what it actually is: {err}"
         );
-        verify_named(&other, "someone-else/thing").expect("its own identity verifies");
+        verify_named(&other, &root.join("spleis"), "someone-else/thing")
+            .expect("its own identity verifies");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7262,11 +7262,29 @@ fn run_link_command(repo: &str, dir: Option<&Path>, unlink: bool) -> ExitCode {
 
 /// Remove the named root that is `identity`.
 fn unlink_by_identity(project_dir: &Path, identity: &str) -> ExitCode {
-    let linked: Vec<String> = config::load_local(project_dir)
-        .ok()
-        .flatten()
-        .map(|l| l.config.sandbox.repo_dirs.clone())
-        .unwrap_or_default();
+    // Validated before it reaches any message: `--unlink` takes the same
+    // identity the other forms do, and an unvalidated string is printed back to
+    // the terminal.
+    if !cplt::link::is_valid_identity(identity) {
+        ui::error(&format!(
+            "{identity:?} is not a repository identity. Name it as <owner>/<name>, \
+             for example navikt/cplt."
+        ));
+        return ExitCode::FAILURE;
+    }
+
+    // A local config that cannot be read is an error, not an empty list. The
+    // launch fails loudly on the same file; answering "nothing is linked" here
+    // would tell the user their roots are gone when they are unreadable.
+    let linked: Vec<String> = match config::load_local(project_dir) {
+        Ok(loaded) => loaded
+            .map(|l| l.config.sandbox.repo_dirs.clone())
+            .unwrap_or_default(),
+        Err(e) => {
+            ui::error(&format!("Cannot read this checkout's local config: {e}"));
+            return ExitCode::FAILURE;
+        }
+    };
 
     if linked.is_empty() {
         ui::error("No repositories are linked for this checkout.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7197,7 +7197,7 @@ fn run_link_command(repo: &str, dir: Option<&Path>, unlink: bool) -> ExitCode {
     }
 
     let found = match dir {
-        Some(named) => match cplt::link::verify_named(named, repo) {
+        Some(named) => match cplt::link::verify_named(named, &project_dir, repo) {
             Ok(c) => c,
             Err(e) => {
                 ui::error(&e);
@@ -7260,60 +7260,51 @@ fn run_link_command(repo: &str, dir: Option<&Path>, unlink: bool) -> ExitCode {
     )
 }
 
-/// Remove the named root whose origin is `identity`.
+/// Remove the named root that is `identity`.
 fn unlink_by_identity(project_dir: &Path, identity: &str) -> ExitCode {
-    let Some(real_git) = cplt::git::trusted_git() else {
-        ui::error(
-            "No trusted git binary in the parent environment, so no repository's identity \
-             can be read. Remove it by path:\n  \
-             cplt config set --local sandbox.repo_dirs <DIR> --unset",
-        );
-        return ExitCode::FAILURE;
-    };
     let linked: Vec<String> = config::load_local(project_dir)
         .ok()
         .flatten()
         .map(|l| l.config.sandbox.repo_dirs.clone())
         .unwrap_or_default();
 
-    let matching: Vec<&String> = linked
-        .iter()
-        .filter(|entry| {
-            let dir = config::expand_tilde(entry);
-            cplt::gh_proxy::detect_current_repo(real_git, &dir)
-                .is_ok_and(|found| cplt::gh_proxy::repos_match(&found, identity))
-        })
-        .collect();
+    if linked.is_empty() {
+        ui::error("No repositories are linked for this checkout.");
+        return ExitCode::FAILURE;
+    }
 
-    match matching.as_slice() {
-        [] => {
-            ui::error(&format!(
-                "No repository linked here is {identity}.\n  \
-                 What is linked: cplt config get sandbox.repo_dirs"
-            ));
-            ExitCode::FAILURE
-        }
-        [entry] => run_config_set(
+    let read_identity = |dir: &Path| {
+        cplt::git::trusted_git().and_then(|git| cplt::gh_proxy::detect_current_repo(git, dir).ok())
+    };
+
+    match cplt::link::choose_unlink(&linked, identity, read_identity) {
+        cplt::link::Unlink::Remove(entry) => run_config_set(
             "sandbox.repo_dirs",
-            Some(entry),
+            Some(&entry),
             false,
             true,
             false,
             false,
             true,
         ),
-        // Two checkouts of one repository, both linked. Removing "the" one would
-        // be a guess about which.
-        many => {
+        cplt::link::Unlink::NoMatch => {
+            // The recorded list, not a pointer at another command: the user is
+            // here because they do not know what is linked.
             ui::error(&format!(
-                "{} checkouts of {identity} are linked here, so cplt is not picking one:\n  {}\n  \
+                "Nothing linked here is {identity}. Linked:\n  {}\n  \
+                 Remove one by path:\n    \
+                 cplt config set --local sandbox.repo_dirs <DIR> --unset",
+                linked.join("\n  ")
+            ));
+            ExitCode::FAILURE
+        }
+        cplt::link::Unlink::Several(many) => {
+            ui::error(&format!(
+                "More than one linked repository answers to {identity}, so cplt is not \
+                 picking one:\n  {}\n  \
                  Remove the one you mean:\n    \
                  cplt config set --local sandbox.repo_dirs <DIR> --unset",
-                many.len(),
-                many.iter()
-                    .map(|s| s.as_str())
-                    .collect::<Vec<_>>()
-                    .join("\n  ")
+                many.join("\n  ")
             ));
             ExitCode::FAILURE
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,6 +741,30 @@ QUICK START:
     #[command(name = "update-lists")]
     UpdateLists,
 
+    /// Put another repository in scope for this checkout, by name.
+    ///
+    /// `cplt link navikt/sykepenger-model` finds the checkout on this machine,
+    /// verifies its origin really is that repository, and records the path in
+    /// this project's local config as a named root. Equivalent to working out
+    /// the path yourself and running `cplt config set --local
+    /// sandbox.repo_dirs <dir>` — the difference is that cplt checks the
+    /// directory is the repository you named.
+    ///
+    /// A named root gets read, write AND execute, like the project directory.
+    /// Use `--allow-write` for a tree you only need to edit.
+    Link {
+        /// The repository, as `<owner>/<name>` (e.g. `navikt/cplt`).
+        repo: String,
+
+        /// The directory, when cplt should not go looking. Still verified
+        /// against the identity.
+        dir: Option<PathBuf>,
+
+        /// Remove the link instead of adding it.
+        #[arg(long)]
+        unlink: bool,
+    },
+
     /// Manage per-repo trust for .cplt.toml permissions.
     ///
     /// Shows, approves, or revokes trust for sandbox permissions
@@ -3270,6 +3294,7 @@ fn run(mut cli: Cli) -> anyhow::Result<ExitCode> {
             },
             Command::Update { check, force } => run_update(check, force),
             Command::UpdateLists => run_update_lists(),
+            Command::Link { repo, dir, unlink } => run_link_command(&repo, dir.as_deref(), unlink),
             Command::Trust { action } => run_trust_command(action),
             Command::Init {
                 write,
@@ -7143,6 +7168,153 @@ fn run_init_global_command(write: bool, force: bool, quiet: bool) -> ExitCode {
         }
         cplt::init::GlobalInitResult::WriteFailed(path, err) => {
             eprintln!("error: failed to write {}: {err}", path.display());
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// `cplt link <owner>/<name> [dir]` — put another repository in scope for this
+/// checkout, verified rather than guessed.
+///
+/// The write is an ordinary `sandbox.repo_dirs` entry in the local layer, so
+/// everything that already applies to one applies here: it is re-validated on
+/// every launch, it is refused if it stops being a git toplevel or acquires a
+/// symlinked leaf, and `cplt config set --local sandbox.repo_dirs` manages the
+/// same list. What this command adds is the identity check.
+fn run_link_command(repo: &str, dir: Option<&Path>, unlink: bool) -> ExitCode {
+    let Some(project_dir) = detect_project_root() else {
+        ui::error(NOT_A_REPOSITORY);
+        return ExitCode::FAILURE;
+    };
+    let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
+
+    if unlink {
+        // By identity, so a root can be dropped by the name it was added under
+        // — the path is an implementation detail the user should not have to
+        // remember. Resolution is not needed: the recorded paths are read and
+        // the one whose origin matches is removed.
+        return unlink_by_identity(&project_dir, repo);
+    }
+
+    let found = match dir {
+        Some(named) => match cplt::link::verify_named(named, repo) {
+            Ok(c) => c,
+            Err(e) => {
+                ui::error(&e);
+                return ExitCode::FAILURE;
+            }
+        },
+        None => match cplt::link::resolve(&project_dir, &home, repo) {
+            Ok(c) => c,
+            Err(e) => {
+                ui::error(&e.to_string());
+                return ExitCode::FAILURE;
+            }
+        },
+    };
+
+    ui::info(&format!(
+        "{repo} → {} ({}, origin verified)",
+        found.dir.display(),
+        found.how.describe()
+    ));
+    if found.worktrees > 0 {
+        let n = found.worktrees;
+        eprintln!(
+            "  {}{n} linked worktree{} of it {} on this machine; this is the main checkout.{}",
+            ui::color(ui::DIM),
+            if n == 1 { "" } else { "s" },
+            if n == 1 { "is" } else { "are" },
+            ui::color(ui::RESET)
+        );
+    }
+    if !found.also.is_empty() {
+        // A separate clone of the same repository. Named rather than hidden:
+        // the choice between them is the operator's, and this is where they
+        // learn there was one.
+        eprintln!(
+            "  {}Also matched: {}{}",
+            ui::color(ui::DIM),
+            found
+                .also
+                .iter()
+                .map(|c| c.dir.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            ui::color(ui::RESET)
+        );
+        eprintln!(
+            "  {}Link one of those instead with: cplt link {repo} <dir>{}",
+            ui::color(ui::DIM),
+            ui::color(ui::RESET)
+        );
+    }
+    run_config_set(
+        "sandbox.repo_dirs",
+        Some(&found.dir.to_string_lossy()),
+        false,
+        false,
+        false,
+        false,
+        true,
+    )
+}
+
+/// Remove the named root whose origin is `identity`.
+fn unlink_by_identity(project_dir: &Path, identity: &str) -> ExitCode {
+    let Some(real_git) = cplt::git::trusted_git() else {
+        ui::error(
+            "No trusted git binary in the parent environment, so no repository's identity \
+             can be read. Remove it by path:\n  \
+             cplt config set --local sandbox.repo_dirs <DIR> --unset",
+        );
+        return ExitCode::FAILURE;
+    };
+    let linked: Vec<String> = config::load_local(project_dir)
+        .ok()
+        .flatten()
+        .map(|l| l.config.sandbox.repo_dirs.clone())
+        .unwrap_or_default();
+
+    let matching: Vec<&String> = linked
+        .iter()
+        .filter(|entry| {
+            let dir = config::expand_tilde(entry);
+            cplt::gh_proxy::detect_current_repo(real_git, &dir)
+                .is_ok_and(|found| cplt::gh_proxy::repos_match(&found, identity))
+        })
+        .collect();
+
+    match matching.as_slice() {
+        [] => {
+            ui::error(&format!(
+                "No repository linked here is {identity}.\n  \
+                 What is linked: cplt config get sandbox.repo_dirs"
+            ));
+            ExitCode::FAILURE
+        }
+        [entry] => run_config_set(
+            "sandbox.repo_dirs",
+            Some(entry),
+            false,
+            true,
+            false,
+            false,
+            true,
+        ),
+        // Two checkouts of one repository, both linked. Removing "the" one would
+        // be a guess about which.
+        many => {
+            ui::error(&format!(
+                "{} checkouts of {identity} are linked here, so cplt is not picking one:\n  {}\n  \
+                 Remove the one you mean:\n    \
+                 cplt config set --local sandbox.repo_dirs <DIR> --unset",
+                many.len(),
+                many.iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            ));
             ExitCode::FAILURE
         }
     }


### PR DESCRIPTION
The first piece of #491, and the one its review confirmed can land before #206 — user-initiated, reads no `.cplt.toml`, writes no trust entry. (#206 has since landed anyway, in #494.)

```
$ cplt link navikt/sykepenger-model
[cplt] navikt/sykepenger-model → /Users/you/src/sykepenger-model (beside this repository, origin verified)
[cplt] sandbox.repo_dirs = [/Users/you/src/sykepenger-model]
```

Today the user has to work out the path themselves and remember `cplt config set --local sandbox.repo_dirs`. What this adds beyond convenience is the check that the directory *is* the repository.

## Where it looks

1. Beside the launch repository — one `stat`, and the overwhelmingly common layout.
2. Across the forge directory, for `<host>/<org>/<repo>` (the Go layout): this is what makes `nais/unleash` findable from `navikt/cplt`.
3. The origin of each sibling directory, capped at 50 — a clone in a renamed directory.

`$HOME` at large is never scanned, and a parent that is itself an unsafe root is skipped rather than walked. A directory **inside** the launch repository is never a candidate: that tree is agent-writable, so a checkout planted there is a repository of the agent's choosing wearing the right name.

## Why verification, and what it is worth

A matching name is not identity. Someone with an unrelated `~/src/foo` must not have it linked when a project names `navikt/foo` — that would be a project-grade **write and execute** grant over the wrong tree. So every candidate has `remote.origin.url` read by the trusted git **in the unsandboxed parent** (`detect_current_repo`, which strips `GIT_*` and ignores global config), compared with `repos_match` so `owner/name` is case-insensitive the way GitHub is.

The bound is stated in the docs rather than left implied: on Linux an agent can rewrite `.git/config` in any tree it was granted and Landlock cannot carve that file out of a writable root, so **"origin verified" describes the moment the command ran**. It is not a continuing property of the tree — which is why the link is stored and re-validated as a path, never re-resolved from the name.

## Two things the design review forced, and one reality did

- **Collect every candidate before deciding.** Stop-at-first lets a tree that verifies at an early step silently beat the real repository found at a later one.
- **Validate the identity as `<owner>/<name>` before building paths from it.** User input today; in #491 it is text a committed config chose, and `repos = ["../../.."]` would otherwise have cplt run git in a directory that file picked.
- **Rank the evidence.** Running this against my own machine found 34 linked worktrees of `navikt/copilot`, all reporting the same origin, because worktrees share one config. Pure "refuse any ambiguity" makes the command unusable for anyone who uses worktrees. So: a directory *named* after the repository outranks one matched only by origin; equally good candidates are still refused and both named; worktrees of the winner are counted, and a genuinely separate clone is printed so the operator can link that one instead.

## Verification

Nine unit tests, each a scenario rather than a restatement: sibling found; matching name with a **different** origin not found; cross-org via the forge directory; renamed clone by origin; equally good candidates refused; weaker match reported but not blocking; worktrees counted not listed; a candidate inside the launch repository never taken; a user-named directory still verified, with the error naming what the directory actually is.

Manually against real checkouts: `navikt/copilot` (sibling, 34 worktrees counted), `nais/unleash` (across the forge dir), a non-existent repo (bounded "looked at" list), `../../etc` (refused as an identity), and `--unlink` round-tripping both.

`cargo test`, clippy, and `--target x86_64-unknown-linux-gnu --all-targets` clean.

## Not in this PR

`[propose] repos` — a repository proposing links by identity — which is the rest of #491 and carries the trust questions its review recorded. This is the resolver those need, landed on its own so the search order can be wrong in public before a repository's config depends on it.