### PR TITLE
feat(repo-config): a project may propose the repositories it spans, by name

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,56 @@ table.
 The long forms are used throughout this document because they say which file is
 being written.
 
+### A project can name the repositories it spans
+
+A `.cplt.toml` may say which repositories a session usually needs:
+
+```toml
+[propose]
+repos = ["navikt/sykepenger-model", "navikt/spleis-testdata"]
+```
+
+Identities, never paths. The repository states what the *project* is; your
+machine decides where those repositories live. A committed `.cplt.toml` cannot
+point cplt at a directory of its choosing — the most it can do is put a name in
+front of you.
+
+Approving is what turns names into paths, and it is a separate, explicit step:
+
+```
+$ cplt trust accept repos
+[cplt] sandbox.repo_dirs = [/Users/you/src/sykepenger-model]
+[cplt] navikt/spleis-testdata: not linked
+  No checkout of that repository was found. Looked at: ...
+```
+
+Each identity is resolved and origin-verified exactly as `cplt link` does, and
+one that is not on your machine is reported, never fetched: cloning a
+repository named by a config file is a much larger decision than linking one
+you already have. Approving again re-links anything missing, so a repository
+you clone later needs no re-approval dance.
+
+`cplt trust revoke repos` removes the roots that approval created — and only
+those. A root you added yourself with `cplt link` or `config set --local` stays,
+because it is yours.
+
+Three properties worth knowing:
+
+- **An unapproved proposal grants nothing.** It shows up in the launch summary
+  naming the repositories, so you learn the link exists to be made, and that is
+  all it does.
+- **`--accept-repo-config` cannot approve it.** That flag approves for one run
+  and persists nothing; linking a repository is persistent. It is the one
+  proposal the flag skips.
+- **An uncommitted `.cplt.toml` cannot propose repositories at all.** It is a
+  grant, so it needs the audit trail a commit gives — see the repo-config
+  security model above.
+
+The approval binds to the path it resolved, which is then re-validated on every
+launch like any other named root. cplt does not re-resolve the identity each
+time: a later directory rename would otherwise redirect a grant you approved
+for a specific tree.
+
 ### Naming a repository instead of a path
 
 `cplt link` takes the repository, finds the checkout, and checks it really is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,7 +230,10 @@ machine decides where those repositories live. A committed `.cplt.toml` cannot
 point cplt at a directory of its choosing — the most it can do is put a name in
 front of you.
 
-Approving is what turns names into paths, and it is a separate, explicit step:
+**What approving grants is not small.** Each linked repository becomes a named
+root: read, write **and execute** on that whole tree, the same posture as the
+project directory. A repository proposing five repositories is asking for five
+of those. Approving is therefore a separate, explicit step:
 
 ```
 $ cplt trust accept repos
@@ -245,9 +248,14 @@ repository named by a config file is a much larger decision than linking one
 you already have. Approving again re-links anything missing, so a repository
 you clone later needs no re-approval dance.
 
-`cplt trust revoke repos` removes the roots that approval created — and only
-those. A root you added yourself with `cplt link` or `config set --local` stays,
-because it is yours.
+`cplt trust revoke repos` removes the roots recorded at approval time, matched
+by path — and only those. A root you added yourself with `cplt link` or
+`config set --local` stays, because it is yours: if a proposal names a
+repository you had already linked, approving says so and leaves it alone rather
+than taking ownership of it. `cplt trust` lists what an approval linked, which
+is what revoke acts on; a recorded root that is no longer in your config is
+reported rather than assumed gone, because revoke cannot tell removed from
+renamed.
 
 Three properties worth knowing:
 
@@ -265,6 +273,21 @@ The approval binds to the path it resolved, which is then re-validated on every
 launch like any other named root. cplt does not re-resolve the identity each
 time: a later directory rename would otherwise redirect a grant you approved
 for a specific tree.
+
+**"Origin verified" describes the moment you approved.** On Linux an agent can
+rewrite `.git/config` in any tree it was already granted, and Landlock cannot
+carve that file out of a writable root — so a tree a previous session could
+write can claim to be the repository a proposal names. If the real checkout is
+absent, that claim is what gets linked, and the verification line will say so.
+It grants nothing the previous session did not already have, but it can make
+you believe the real repository is in scope when it is not. This matters more
+here than for `cplt link`, because what is being verified was chosen by a
+committed file rather than typed by you.
+
+Limits worth knowing: a second checkout of the same repository cannot approve
+`repos` at all, because trust is stored per origin; a fork reads as "not found",
+since its `origin` is the fork; a repository with no `origin`, or with only
+`upstream`, is invisible; and a monorepo can only be named whole.
 
 ### Naming a repository instead of a path
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -600,6 +600,15 @@ mod tests {
             "..",
             "nav ikt/cplt",
             "navikt/./cplt",
+            // Two components, and one of them walks up. `name_candidates` joins
+            // the name onto the parent directory, so this is the shape that
+            // reaches `parent.join("..")` — and it is the one the earlier list
+            // missed, because every other bad case was refused by the arity
+            // check alone (#496 review).
+            "navikt/..",
+            "../cplt",
+            "./cplt",
+            "navikt/.",
         ] {
             assert!(!is_valid_identity(bad), "{bad:?} must be refused");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2440,7 +2440,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             unapproved_proposals.len()
         ));
         for key in &unapproved_proposals {
-            match propose_key_detail(&repo_propose, key) {
+            match repo_config::propose_key_detail(&repo_propose, key) {
                 Some(detail) => eprintln!(
                     "  {}○{} {key}: {detail}",
                     ui::color(ui::YELLOW),
@@ -7793,7 +7793,7 @@ no longer apply"
         );
         println!();
         for &key in &pending {
-            let detail = propose_key_detail(&loaded.config.propose, key);
+            let detail = repo_config::propose_key_detail(&loaded.config.propose, key);
             if let Some(d) = detail {
                 println!("  {yellow}•{nc} {key}: {d}");
             } else {
@@ -7909,33 +7909,6 @@ fn warn_repo_config_discrepancy(project_dir: &std::path::Path) {
     }
     if let Some(msg) = state.explain() {
         ui::warn(&msg);
-    }
-}
-
-/// Format the proposed values for a key for display.
-fn propose_key_detail(propose: &repo_config::ProposeSection, key: &str) -> Option<String> {
-    match key {
-        "allow.read" if !propose.allow.read.is_empty() => Some(format!("{:?}", propose.allow.read)),
-        "allow.write" if !propose.allow.write.is_empty() => {
-            Some(format!("{:?}", propose.allow.write))
-        }
-        "allow.ports" if !propose.allow.ports.is_empty() => {
-            Some(format!("{:?}", propose.allow.ports))
-        }
-        "allow.localhost" if !propose.allow.localhost.is_empty() => {
-            Some(format!("{:?}", propose.allow.localhost))
-        }
-        "proxy.allow_private_domains" if !propose.proxy.allow_private_domains.is_empty() => {
-            Some(format!("{:?}", propose.proxy.allow_private_domains))
-        }
-        // Named, not counted: "repos" alone says nothing about what approving
-        // it would put in scope, and this is the one proposal whose effect is a
-        // whole other repository being read, written and executed in.
-        "repos" if !propose.repos.is_empty() => Some(format!(
-            "{} (each resolved and origin-verified on this machine)",
-            propose.repos.join(", ")
-        )),
-        _ => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2440,7 +2440,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             unapproved_proposals.len()
         ));
         for key in &unapproved_proposals {
-            match repo_config::propose_key_detail(&repo_propose, key) {
+            match repo_config::propose_key_detail(&repo_propose, key, Some(5)) {
                 Some(detail) => eprintln!(
                     "  {}○{} {key}: {detail}",
                     ui::color(ui::YELLOW),
@@ -7486,6 +7486,19 @@ fn trust_show(project_dir: &std::path::Path, loaded: &repo_config::LoadedRepoCon
         && !entry.accepted.approved_at.is_empty()
     {
         println!();
+        // The roots this approval created, which no other command showed. They
+        // are read/write/execute grants over whole other repositories, and the
+        // record is what `trust revoke repos` acts on — so it has to be
+        // inspectable (#496 review).
+        if !entry.accepted.linked.is_empty() {
+            println!(
+                "{blue}[cplt]{nc}  {green}Linked by this approval{nc} (read+write+exec, removed by `cplt trust revoke repos`):"
+            );
+            for repo in &entry.accepted.linked {
+                println!("{blue}[cplt]{nc}    {} → {}", repo.identity, repo.path);
+            }
+            println!();
+        }
         println!(
             "{blue}[cplt]{nc}  Last approved: {}",
             entry.accepted.approved_at
@@ -7570,7 +7583,12 @@ fn link_proposed_repos(project_dir: &Path, repos: &[String]) -> Vec<trust::Linke
                     .flatten()
                     .is_some_and(|l| l.config.sandbox.repo_dirs.contains(&path));
                 if already {
-                    println!("  • {identity} → {path} (already linked)");
+                    // Recorded by nobody: the root was already there, so the
+                    // approval did not create it and revoking must not remove
+                    // it. Claiming it would make `trust revoke repos` delete a
+                    // root the user linked by hand (#496 review).
+                    println!("  • {identity} → {path} (already linked; left as yours)");
+                    continue;
                 } else if run_config_set(
                     "sandbox.repo_dirs",
                     Some(&path),
@@ -7603,6 +7621,25 @@ fn link_proposed_repos(project_dir: &Path, repos: &[String]) -> Vec<trust::Linke
     linked
 }
 
+/// Union two sets of approval-created roots, keyed by path.
+///
+/// Records outlive the proposal that created them on purpose. A repository that
+/// drops an identity from `[propose] repos`, or an identity that stops
+/// resolving, must not take the record with it — the root is still in the
+/// config, and the record is the only thing that lets `revoke` remove it.
+fn merge_linked(
+    prior: Vec<trust::LinkedRepo>,
+    fresh: Vec<trust::LinkedRepo>,
+) -> Vec<trust::LinkedRepo> {
+    let mut out = prior;
+    for repo in fresh {
+        if !out.iter().any(|existing| existing.path == repo.path) {
+            out.push(repo);
+        }
+    }
+    out
+}
+
 /// Remove the named roots an approval created, and only those.
 ///
 /// A root the user added by hand — with `cplt link` or `config set --local` —
@@ -7617,9 +7654,26 @@ fn unlink_approved_repos(project_dir: &Path, linked: &[trust::LinkedRepo]) {
         .unwrap_or_default();
 
     for repo in linked {
-        if !recorded.contains(&repo.path) {
-            continue; // Already gone; nothing to say.
-        }
+        // Compared expanded, not as written: the local layer stores `~/…`
+        // verbatim while an approval records the canonical path, so a raw
+        // string compare would silently skip a root that is right there and
+        // report success (#496 review).
+        let wanted = config::expand_tilde(&repo.path);
+        let Some(entry) = recorded.iter().find(|e| config::expand_tilde(e) == wanted) else {
+            // Not "already gone" — revoke cannot tell removed from renamed, and
+            // asserting the safe reading is how a live grant gets reported as
+            // withdrawn.
+            ui::warn(&format!(
+                "{} is recorded as linked for {} but is not in this checkout's config. \
+                 If it is still in scope, remove it by path.",
+                repo.path, repo.identity
+            ));
+            continue;
+        };
+        let repo = trust::LinkedRepo {
+            identity: repo.identity.clone(),
+            path: entry.clone(),
+        };
         println!("  • unlinking {} ({})", repo.identity, repo.path);
         run_config_set(
             "sandbox.repo_dirs",
@@ -7715,6 +7769,16 @@ fn trust_accept(
     let hash_mismatch = stored
         .as_ref()
         .is_some_and(|t| trust::approval_is_stale(&t.accepted.content_hash, &current_hash));
+    // Kept regardless of hash staleness, unlike the approved keys: a stale hash
+    // means "re-review the values", not "those roots stopped existing". Bound
+    // to the checkout the same way approvals are, so a foreign entry's roots are
+    // never adopted.
+    let prior_linked = stored
+        .as_ref()
+        .filter(|t| trust::approved_path_matches(t, project_dir))
+        .map(|t| t.accepted.linked.clone())
+        .unwrap_or_default();
+
     let carried = stored.filter(|t| {
         trust::approved_path_matches(t, project_dir)
             && !trust::approval_is_stale(&t.accepted.content_hash, &current_hash)
@@ -7765,14 +7829,36 @@ no longer apply"
             // A user who approved before the repositories were on disk — or who
             // deleted a root by hand — must be able to run this again and get
             // them linked. Idempotent: an entry already recorded says so.
+            // Only identities this approval never linked. "Approved before the
+            // repository was cloned" is a real case; "the user removed this root
+            // on purpose with `cplt link --unlink`" is a different one, and a
+            // record is what tells them apart. Without this, a bare
+            // `cplt trust accept` silently undoes a deliberate removal — in
+            // scripts too, since this runs before the terminal check.
+            let unlinked_yet: Vec<String> = loaded
+                .config
+                .propose
+                .repos
+                .iter()
+                .filter(|identity| {
+                    !carried.as_ref().is_some_and(|t| {
+                        t.accepted
+                            .linked
+                            .iter()
+                            .any(|l| l.identity.as_str() == identity.as_str())
+                    })
+                })
+                .cloned()
+                .collect();
+
             if carried
                 .as_ref()
                 .is_some_and(|t| trust::is_key_approved(t, "repos"))
-                && !loaded.config.propose.repos.is_empty()
+                && !unlinked_yet.is_empty()
             {
-                let linked = link_proposed_repos(project_dir, &loaded.config.propose.repos);
+                let fresh = link_proposed_repos(project_dir, &unlinked_yet);
                 let mut entry = carried.unwrap_or_default();
-                entry.accepted.linked = linked;
+                entry.accepted.linked = merge_linked(entry.accepted.linked.clone(), fresh);
                 if let Err(e) = trust::save_trust(project_dir, &entry) {
                     ui::error(&format!("Failed to save trust: {e}"));
                     return ExitCode::FAILURE;
@@ -7793,7 +7879,7 @@ no longer apply"
         );
         println!();
         for &key in &pending {
-            let detail = repo_config::propose_key_detail(&loaded.config.propose, key);
+            let detail = repo_config::propose_key_detail(&loaded.config.propose, key, None);
             if let Some(d) = detail {
                 println!("  {yellow}•{nc} {key}: {d}");
             } else {
@@ -7870,8 +7956,18 @@ no longer apply"
     // `repos` is not a value the launch applies — approving it performs the
     // linking, here. Done before the entry is saved, so a failure to resolve
     // leaves no approval claiming repositories are linked.
+    //
+    // MERGED into what is already recorded, never replacing it. A record is the
+    // only way `revoke` can find a root an approval created, so dropping one
+    // while the root stands strands a read/write/execute grant that no command
+    // can then withdraw (#496 review). Three ordinary events cause it: the
+    // proposal shrinks, an identity stops resolving, or the hash goes stale and
+    // the user approves some other key.
     if keys_to_accept.iter().any(|k| k == "repos") {
-        entry.accepted.linked = link_proposed_repos(project_dir, &loaded.config.propose.repos);
+        let fresh = link_proposed_repos(project_dir, &loaded.config.propose.repos);
+        entry.accepted.linked = merge_linked(prior_linked, fresh);
+    } else {
+        entry.accepted.linked = prior_linked;
     }
 
     // Save
@@ -7958,13 +8054,16 @@ fn trust_revoke(
     entry.accepted.keys.retain(|k| !keys.contains(k));
     let removed = before_len - entry.accepted.keys.len();
 
-    if keys.iter().any(|k| k == "repos") {
-        unlink_approved_repos(project_dir, &std::mem::take(&mut entry.accepted.linked));
-    }
-
     if removed == 0 {
         ui::info("No matching keys found to revoke.");
         return ExitCode::SUCCESS;
+    }
+
+    // After the early return, never before it: unlinking and then returning
+    // without saving leaves the roots gone from the config and still recorded
+    // as linked, so the next `trust accept` puts them back (#496 review).
+    if keys.iter().any(|k| k == "repos") {
+        unlink_approved_repos(project_dir, &std::mem::take(&mut entry.accepted.linked));
     }
 
     if entry.accepted.keys.is_empty() {
@@ -8261,6 +8360,40 @@ fn start_denial_stream() -> Option<std::process::Child> {
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)] // test code: no unsandboxed parent to protect (#239)
 mod tests {
+    /// The record of what an approval linked is the only way `trust revoke
+    /// repos` can find those roots again — the launch reads `sandbox.repo_dirs`
+    /// and never consults the trust store. Three ordinary events used to drop a
+    /// record while its root stood: the proposal shrinks, an identity stops
+    /// resolving, and a stale hash plus approving some other key (#496 review).
+    ///
+    /// This pins the merge that fixes all three. It does not cover the callers'
+    /// staleness handling, which the e2e does.
+    #[test]
+    fn a_record_of_a_linked_root_is_never_dropped_while_the_root_stands() {
+        let linked = |identity: &str, path: &str| super::trust::LinkedRepo {
+            identity: identity.to_string(),
+            path: path.to_string(),
+        };
+
+        let prior = vec![linked("navikt/a", "/src/a"), linked("navikt/b", "/src/b")];
+        // The proposal now names only `a`, so a fresh resolve produces one entry.
+        let fresh = vec![linked("navikt/a", "/src/a")];
+
+        let merged = super::merge_linked(prior, fresh);
+        assert_eq!(merged.len(), 2, "b's root is still linked: {merged:?}");
+        assert!(
+            merged.iter().any(|r| r.path == "/src/b"),
+            "and must stay revocable: {merged:?}"
+        );
+
+        // The same path from two identities is one root, not two records.
+        let merged = super::merge_linked(
+            vec![linked("navikt/a", "/src/a")],
+            vec![linked("navikt/renamed", "/src/a")],
+        );
+        assert_eq!(merged.len(), 1, "one root, one record: {merged:?}");
+    }
+
     /// The hand-written matcher must cover every pattern the profile denies.
     /// It cannot be derived from them — they are SBPL regex source and there is
     /// no regex engine linked — so this is the thing that stops the two

--- a/src/main.rs
+++ b/src/main.rs
@@ -2141,6 +2141,9 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
 
     // ── Load and apply per-repo config (.cplt.toml) ──────────────
     let mut unapproved_proposals: Vec<String> = Vec::new();
+    // Kept for the warning below, which names what each unapproved key would
+    // grant. `repos` in particular is opaque as a bare key name.
+    let mut repo_propose = repo_config::ProposeSection::default();
     match repo_config::load_repo_config(&project_dir) {
         Ok(Some(loaded)) => {
             if !resolved.quiet {
@@ -2181,9 +2184,14 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
 
             // Determine approved keys
             let approved_keys: Vec<String> = if cli.accept_repo_config {
-                // --accept-repo-config: approve everything
+                // --accept-repo-config approves for ONE run and persists
+                // nothing. `repos` is the opposite shape: approving it writes
+                // named roots into the local config, which outlives the run. A
+                // per-run flag must not leave a persistent grant behind, so it
+                // is the one proposal this flag cannot approve (#491).
                 repo_config::proposed_keys(&loaded.config.propose)
                     .iter()
+                    .filter(|key| **key != "repos")
                     .map(std::string::ToString::to_string)
                     .collect()
             } else {
@@ -2256,6 +2264,7 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
                 .collect();
             unapproved_proposals =
                 resolved.apply_repo_config(&loaded.config, &loaded.dir, &approved_refs);
+            repo_propose = loaded.config.propose.clone();
         }
         Ok(None) => {} // No .cplt.toml in HEAD — warn_repo_config_discrepancy explains why
         Err(e) => {
@@ -2431,7 +2440,14 @@ fn resolve_context(cli: &Cli, check_mode: bool) -> anyhow::Result<ResolvedContex
             unapproved_proposals.len()
         ));
         for key in &unapproved_proposals {
-            eprintln!("  {}○{} {key}", ui::color(ui::YELLOW), ui::color(ui::RESET));
+            match propose_key_detail(&repo_propose, key) {
+                Some(detail) => eprintln!(
+                    "  {}○{} {key}: {detail}",
+                    ui::color(ui::YELLOW),
+                    ui::color(ui::RESET)
+                ),
+                None => eprintln!("  {}○{} {key}", ui::color(ui::YELLOW), ui::color(ui::RESET)),
+            }
         }
         eprintln!(
             "  Run: {}cplt trust accept --all{}  (or select specific keys)",
@@ -7530,6 +7546,93 @@ fn trust_show(project_dir: &std::path::Path, loaded: &repo_config::LoadedRepoCon
     ExitCode::SUCCESS
 }
 
+/// Resolve and link the repositories a `.cplt.toml` proposes, and say what
+/// happened to each.
+///
+/// Approving is where the identities become paths. Each is resolved on this
+/// machine and its origin verified by the same code `cplt link` uses, so a
+/// repository can put a *name* in front of the user and only a path the user
+/// approved ever grants access.
+///
+/// A repository that is not on this machine is reported, not fetched: cloning a
+/// repository named by a config file is a much larger trust decision than
+/// linking one the user already has.
+fn link_proposed_repos(project_dir: &Path, repos: &[String]) -> Vec<trust::LinkedRepo> {
+    let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
+    let mut linked = Vec::new();
+
+    for identity in repos {
+        match cplt::link::resolve(project_dir, &home, identity) {
+            Ok(found) => {
+                let path = found.dir.to_string_lossy().into_owned();
+                let already = config::load_local(project_dir)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|l| l.config.sandbox.repo_dirs.contains(&path));
+                if already {
+                    println!("  • {identity} → {path} (already linked)");
+                } else if run_config_set(
+                    "sandbox.repo_dirs",
+                    Some(&path),
+                    false,
+                    false,
+                    false,
+                    false,
+                    true,
+                ) != ExitCode::SUCCESS
+                {
+                    // The write said why. Not recorded as linked, because it is
+                    // not: an approval must not claim a grant that is not there.
+                    continue;
+                }
+                linked.push(trust::LinkedRepo {
+                    identity: identity.clone(),
+                    path,
+                });
+            }
+            Err(e) => {
+                // One line per repository, then the reason indented: several
+                // failures in a row otherwise read as one paragraph.
+                ui::warn(&format!("{identity}: not linked"));
+                for line in e.to_string().lines() {
+                    eprintln!("  {line}");
+                }
+            }
+        }
+    }
+    linked
+}
+
+/// Remove the named roots an approval created, and only those.
+///
+/// A root the user added by hand — with `cplt link` or `config set --local` —
+/// is theirs, and revoking a repository's proposal must not take it away. That
+/// is why the approval records what it wrote rather than re-deriving it from
+/// the proposal, which may since have changed.
+fn unlink_approved_repos(project_dir: &Path, linked: &[trust::LinkedRepo]) {
+    let recorded: Vec<String> = config::load_local(project_dir)
+        .ok()
+        .flatten()
+        .map(|l| l.config.sandbox.repo_dirs.clone())
+        .unwrap_or_default();
+
+    for repo in linked {
+        if !recorded.contains(&repo.path) {
+            continue; // Already gone; nothing to say.
+        }
+        println!("  • unlinking {} ({})", repo.identity, repo.path);
+        run_config_set(
+            "sandbox.repo_dirs",
+            Some(&repo.path),
+            false,
+            true,
+            false,
+            false,
+            true,
+        );
+    }
+}
+
 fn trust_accept(
     project_dir: &std::path::Path,
     loaded: &repo_config::LoadedRepoConfig,
@@ -7657,6 +7760,25 @@ no longer apply"
             .collect();
 
         if pending.is_empty() {
+            // `repos` is the one proposal whose approval is an ACTION, not a
+            // value, so "already approved" is not the same as "already done".
+            // A user who approved before the repositories were on disk — or who
+            // deleted a root by hand — must be able to run this again and get
+            // them linked. Idempotent: an entry already recorded says so.
+            if carried
+                .as_ref()
+                .is_some_and(|t| trust::is_key_approved(t, "repos"))
+                && !loaded.config.propose.repos.is_empty()
+            {
+                let linked = link_proposed_repos(project_dir, &loaded.config.propose.repos);
+                let mut entry = carried.unwrap_or_default();
+                entry.accepted.linked = linked;
+                if let Err(e) = trust::save_trust(project_dir, &entry) {
+                    ui::error(&format!("Failed to save trust: {e}"));
+                    return ExitCode::FAILURE;
+                }
+                return ExitCode::SUCCESS;
+            }
             ui::info("All permissions are already approved.");
             return ExitCode::SUCCESS;
         }
@@ -7745,6 +7867,13 @@ no longer apply"
     // Pin content hash so changes to proposal values invalidate approval
     entry.accepted.content_hash = current_hash;
 
+    // `repos` is not a value the launch applies — approving it performs the
+    // linking, here. Done before the entry is saved, so a failure to resolve
+    // leaves no approval claiming repositories are linked.
+    if keys_to_accept.iter().any(|k| k == "repos") {
+        entry.accepted.linked = link_proposed_repos(project_dir, &loaded.config.propose.repos);
+    }
+
     // Save
     if let Err(e) = trust::save_trust(project_dir, &entry) {
         ui::error(&format!("Failed to save trust: {e}"));
@@ -7799,6 +7928,13 @@ fn propose_key_detail(propose: &repo_config::ProposeSection, key: &str) -> Optio
         "proxy.allow_private_domains" if !propose.proxy.allow_private_domains.is_empty() => {
             Some(format!("{:?}", propose.proxy.allow_private_domains))
         }
+        // Named, not counted: "repos" alone says nothing about what approving
+        // it would put in scope, and this is the one proposal whose effect is a
+        // whole other repository being read, written and executed in.
+        "repos" if !propose.repos.is_empty() => Some(format!(
+            "{} (each resolved and origin-verified on this machine)",
+            propose.repos.join(", ")
+        )),
         _ => None,
     }
 }
@@ -7810,10 +7946,17 @@ fn trust_revoke(
     all: bool,
 ) -> ExitCode {
     if all {
+        // Read before the entry is deleted: the paths an approval created live
+        // in it, and without them `repos` would be the only proposal key whose
+        // grant outlives its own revocation.
+        let linked = trust::load_trust(project_dir)
+            .map(|t| t.accepted.linked)
+            .unwrap_or_default();
         if let Err(e) = trust::revoke_trust(project_dir) {
             ui::error(&format!("Failed to revoke trust: {e}"));
             return ExitCode::FAILURE;
         }
+        unlink_approved_repos(project_dir, &linked);
         println!(
             "{}✓{} Revoked all trust for this repository.",
             ui::stdout_color(ui::GREEN),
@@ -7841,6 +7984,10 @@ fn trust_revoke(
     let before_len = entry.accepted.keys.len();
     entry.accepted.keys.retain(|k| !keys.contains(k));
     let removed = before_len - entry.accepted.keys.len();
+
+    if keys.iter().any(|k| k == "repos") {
+        unlink_approved_repos(project_dir, &std::mem::take(&mut entry.accepted.linked));
+    }
 
     if removed == 0 {
         ui::info("No matching keys found to revoke.");

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -734,6 +734,50 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
     keys
 }
 
+/// Format the proposed values for a key for display.
+pub fn propose_key_detail(propose: &ProposeSection, key: &str) -> Option<String> {
+    match key {
+        "allow.read" if !propose.allow.read.is_empty() => Some(format!("{:?}", propose.allow.read)),
+        "allow.write" if !propose.allow.write.is_empty() => {
+            Some(format!("{:?}", propose.allow.write))
+        }
+        "allow.ports" if !propose.allow.ports.is_empty() => {
+            Some(format!("{:?}", propose.allow.ports))
+        }
+        "allow.localhost" if !propose.allow.localhost.is_empty() => {
+            Some(format!("{:?}", propose.allow.localhost))
+        }
+        "proxy.allow_private_domains" if !propose.proxy.allow_private_domains.is_empty() => {
+            Some(format!("{:?}", propose.proxy.allow_private_domains))
+        }
+        // Named, not counted: "repos" alone says nothing about what approving
+        // it would put in scope, and this is the one proposal whose effect is a
+        // whole other repository being read, written and executed in.
+        // Named, but bounded. The list is a repository's committed text, and a
+        // file proposing two hundred repositories would otherwise print one
+        // 3 KB line — which is how the whole warning stops being read. The
+        // entries themselves cannot carry escapes: `validate_repo_config`
+        // refuses anything that is not `<owner>/<name>`.
+        "repos" if !propose.repos.is_empty() => {
+            const SHOWN: usize = 5;
+            let shown = propose
+                .repos
+                .iter()
+                .take(SHOWN)
+                .cloned()
+                .collect::<Vec<_>>();
+            let rest = propose.repos.len().saturating_sub(shown.len());
+            let listed = shown.join(", ");
+            Some(if rest == 0 {
+                format!("{listed} (each resolved and origin-verified on this machine)")
+            } else {
+                format!("{listed}, and {rest} more — see `cplt trust`")
+            })
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -958,6 +1002,34 @@ preset = \"full-trust\"\n",
 
         let cfg = parse_repo_config("[propose]\nrepos = [\"navikt/cplt\"]\n").expect("parses");
         validate_repo_config(&cfg).expect("an identity is the point of the key");
+    }
+
+    /// The launch names the repositories an unapproved `repos` would put in
+    /// scope, and the list is a repository's committed text. Bounded, because a
+    /// warning that prints a 3 KB line is a warning nobody reads.
+    #[test]
+    fn a_long_repos_proposal_is_summarised_not_dumped() {
+        let many: Vec<String> = (0..200).map(|i| format!("navikt/repo-{i}")).collect();
+        let cfg = parse_repo_config(&format!(
+            "[propose]\nrepos = [{}]\n",
+            many.iter()
+                .map(|r| format!("{r:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+        .expect("parses");
+        validate_repo_config(&cfg).expect("identities are valid");
+
+        let detail = propose_key_detail(&cfg.propose, "repos").expect("has a detail");
+        assert!(
+            detail.len() < 200,
+            "one line, not a wall: {} chars",
+            detail.len()
+        );
+        assert!(
+            detail.contains("and 195 more"),
+            "and it says how many: {detail}"
+        );
     }
 
     /// It is a grant — it puts another repository in read/write/exec scope — so

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -102,6 +102,22 @@ pub struct ProposeSection {
     #[serde(default)]
     pub pass_env: Vec<String>,
 
+    /// Repositories this project usually spans, as `<owner>/<name>` (#491).
+    ///
+    /// An identity, never a path: the repository states what the *project* is,
+    /// and the user's machine decides where that repository lives. Approving
+    /// resolves each one locally, verifies its origin, and records the path —
+    /// so what a repository can put in front of the user is a name, and what
+    /// grants access is a path the user approved.
+    ///
+    /// Unlike every other proposal, this one is not a value the launch applies.
+    /// `cplt trust accept repos` performs the linking; after that the entries
+    /// are ordinary `sandbox.repo_dirs` roots. Nothing here is consulted at
+    /// launch, which is also why `--accept-repo-config` cannot use it: a
+    /// per-run flag must not write a persistent grant.
+    #[serde(default)]
+    pub repos: Vec<String>,
+
     /// Proposed path/port expansions.
     #[serde(default)]
     pub allow: ProposeAllowSection,
@@ -148,6 +164,7 @@ impl ProposeSection {
             gh_guard,
             git_push_prevention,
             pass_env: _,
+            repos: _,
             allow: _,
             proxy: _,
             unknown: _,
@@ -549,6 +566,19 @@ fn validate_repo_config(config: &RepoConfig) -> Result<(), String> {
         crate::sandbox::validate_sbpl_path(&PathBuf::from(path))?;
     }
 
+    // `[propose] repos` entries are identities. The value reaches path
+    // construction on the user's machine — `<parent>/<name>` — so a `..` or a
+    // slash in the wrong place would have cplt look in a directory this file
+    // chose. Refused here, where the file is read, rather than at the resolver.
+    for repo in &config.propose.repos {
+        if !crate::link::is_valid_identity(repo) {
+            return Err(format!(
+                "propose.repos entry {repo:?} is not a repository identity. \
+                 Name repositories as <owner>/<name>, for example navikt/cplt."
+            ));
+        }
+    }
+
     // Validate deny env vars: must be non-empty alphanumeric/underscore identifiers
     for var in &config.deny.env {
         if var.is_empty() {
@@ -673,6 +703,9 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
         }
     }
 
+    if !propose.repos.is_empty() {
+        keys.push("repos");
+    }
     if !propose.allow.read.is_empty() {
         keys.push("allow.read");
     }
@@ -901,6 +934,38 @@ preset = \"full-trust\"\n",
         assert_eq!(loaded.source, RepoConfigSource::GitHead);
         assert_eq!(proposed_keys(&loaded.config.propose), vec!["allow_docker"]);
         assert!(!loaded.propose_dropped);
+    }
+
+    /// #491: a repository proposes *identities*, never paths. The value is
+    /// used to build paths on the user's machine, so a `..` or a stray slash
+    /// would have cplt look in a directory this file chose — and print the
+    /// result back to the operator as if it were a repository.
+    #[test]
+    fn a_proposed_repo_must_be_an_identity_not_a_path() {
+        for bad in [
+            "../../etc",
+            "navikt/../../etc",
+            "/absolute/path",
+            "navikt",
+            "navikt/cplt/extra",
+            "",
+        ] {
+            let cfg =
+                parse_repo_config(&format!("[propose]\nrepos = [\"{bad}\"]\n")).expect("parses");
+            let err = validate_repo_config(&cfg).expect_err("{bad} must be refused");
+            assert!(err.contains("identity"), "say what is wrong: {err}");
+        }
+
+        let cfg = parse_repo_config("[propose]\nrepos = [\"navikt/cplt\"]\n").expect("parses");
+        validate_repo_config(&cfg).expect("an identity is the point of the key");
+    }
+
+    /// It is a grant — it puts another repository in read/write/exec scope — so
+    /// an uncommitted file cannot make it (#206).
+    #[test]
+    fn proposed_repos_do_not_survive_an_uncommitted_file() {
+        let cfg = parse_repo_config("[propose]\nrepos = [\"navikt/cplt\"]\n").expect("parses");
+        assert!(cfg.propose.tightenings_only().repos.is_empty());
     }
 
     /// The deny sweep runs after cplt sets up the child's environment, so these

--- a/src/repo_config.rs
+++ b/src/repo_config.rs
@@ -735,7 +735,11 @@ pub fn proposed_keys(propose: &ProposeSection) -> Vec<&'static str> {
 }
 
 /// Format the proposed values for a key for display.
-pub fn propose_key_detail(propose: &ProposeSection, key: &str) -> Option<String> {
+pub fn propose_key_detail(
+    propose: &ProposeSection,
+    key: &str,
+    limit: Option<usize>,
+) -> Option<String> {
     match key {
         "allow.read" if !propose.allow.read.is_empty() => Some(format!("{:?}", propose.allow.read)),
         "allow.write" if !propose.allow.write.is_empty() => {
@@ -759,19 +763,21 @@ pub fn propose_key_detail(propose: &ProposeSection, key: &str) -> Option<String>
         // entries themselves cannot carry escapes: `validate_repo_config`
         // refuses anything that is not `<owner>/<name>`.
         "repos" if !propose.repos.is_empty() => {
-            const SHOWN: usize = 5;
-            let shown = propose
+            // `limit` is None where consent is being asked for: a prompt that
+            // elides part of what it is approving is not consent (#496 review).
+            let shown = limit.unwrap_or(propose.repos.len()).max(1);
+            let listed = propose
                 .repos
                 .iter()
-                .take(SHOWN)
+                .take(shown)
                 .cloned()
                 .collect::<Vec<_>>();
-            let rest = propose.repos.len().saturating_sub(shown.len());
-            let listed = shown.join(", ");
+            let rest = propose.repos.len().saturating_sub(listed.len());
+            let listed = listed.join(", ");
             Some(if rest == 0 {
                 format!("{listed} (each resolved and origin-verified on this machine)")
             } else {
-                format!("{listed}, and {rest} more — see `cplt trust`")
+                format!("{listed}, and {rest} more — run `cplt trust` for the full list")
             })
         }
         _ => None,
@@ -1020,7 +1026,7 @@ preset = \"full-trust\"\n",
         .expect("parses");
         validate_repo_config(&cfg).expect("identities are valid");
 
-        let detail = propose_key_detail(&cfg.propose, "repos").expect("has a detail");
+        let detail = propose_key_detail(&cfg.propose, "repos", Some(5)).expect("has a detail");
         assert!(
             detail.len() < 200,
             "one line, not a wall: {} chars",
@@ -1030,6 +1036,27 @@ preset = \"full-trust\"\n",
             detail.contains("and 195 more"),
             "and it says how many: {detail}"
         );
+    }
+
+    /// The consent prompt must show everything it asks for. Truncating there
+    /// would ask the operator to approve two hundred trees while showing five.
+    #[test]
+    fn without_a_limit_every_proposed_repository_is_named() {
+        let many: Vec<String> = (0..40).map(|i| format!("navikt/repo-{i}")).collect();
+        let cfg = parse_repo_config(&format!(
+            "[propose]\nrepos = [{}]\n",
+            many.iter()
+                .map(|r| format!("{r:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+        .expect("parses");
+
+        let detail = propose_key_detail(&cfg.propose, "repos", None).expect("has a detail");
+        for repo in &many {
+            assert!(detail.contains(repo.as_str()), "{repo} must be shown");
+        }
+        assert!(!detail.contains("more"), "and nothing elided: {detail}");
     }
 
     /// It is a grant — it puts another repository in read/write/exec scope — so

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -42,11 +42,35 @@ pub struct AcceptedProposals {
     /// When approval was last updated (ISO 8601).
     #[serde(default)]
     pub approved_at: String,
+    /// Repositories linked by approving `[propose] repos`, with the path each
+    /// identity resolved to at approval time (#491).
+    ///
+    /// Recorded so `cplt trust revoke repos` can remove exactly the roots this
+    /// approval created and leave the ones the user added by hand. Without it,
+    /// `repos` would be the only proposal key whose grant survives its own
+    /// revocation — the launch reads `sandbox.repo_dirs` and never consults the
+    /// trust store.
+    #[serde(default)]
+    pub linked: Vec<LinkedRepo>,
+
     /// SHA-256 hash of the proposal values at approval time.
     /// If the .cplt.toml proposals change, this hash won't match and
     /// approvals are invalidated (user must re-approve).
     #[serde(default)]
     pub content_hash: String,
+}
+
+/// One repository linked by an approval: the identity that was approved, and
+/// the path it resolved to on this machine.
+///
+/// The path is what the grant is. It is re-validated on every launch like any
+/// other named root, and never re-resolved from the identity — otherwise a
+/// later directory rename would silently redirect a grant the user approved for
+/// a specific tree.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct LinkedRepo {
+    pub identity: String,
+    pub path: String,
 }
 
 /// Compute a stable fingerprint for a repository.
@@ -636,6 +660,7 @@ mod tests {
                     "allow_jvm_attach".to_string(),
                 ],
                 approved_at: "2026-05-07T12:00:00Z".to_string(),
+                linked: Vec::new(),
                 content_hash: "a1b2c3d4e5f6a7b8".to_string(),
             },
         };
@@ -775,6 +800,7 @@ approved_at = "2026-05-01T12:00:00Z"
             gh_guard: _,
             git_push_prevention: _,
             pass_env: _,
+            repos: _,
             allow: _,
             proxy: _,
             unknown: _,

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -351,6 +351,7 @@ pub fn proposal_content_hash(propose: &crate::repo_config::ProposeSection) -> St
     // here simply hashes in its written order — stricter, never looser.
     let mut normalized = propose.clone();
     normalized.pass_env.sort_unstable();
+    normalized.repos.sort_unstable();
     normalized.allow.read.sort_unstable();
     normalized.allow.write.sort_unstable();
     normalized.allow.socket.sort_unstable();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3971,6 +3971,70 @@ paths = [
         let _ = std::fs::remove_dir_all(&mine);
     }
 
+    /// The user linked it first; the project happens to propose the same
+    /// repository. Approving must not take ownership of a root the user
+    /// created, because revoking would then delete it (#496 review).
+    #[test]
+    fn e2e_approving_does_not_claim_a_root_the_user_linked_first() {
+        let (repo, config_file) = make_trust_repo(
+            "propose-repos-claim",
+            "[propose]\nrepos = [\"navikt/e2e-claim\"]\n",
+        );
+        let _ = std::fs::remove_dir_all(config_file.parent().expect("cfg dir").join("trust"));
+        let parent = repo.parent().expect("parent").to_path_buf();
+        let model = parent.join("e2e-claim");
+        let _ = std::fs::remove_dir_all(&model);
+        std::fs::create_dir_all(&model).expect("mkdir");
+        for args in [
+            vec!["init", "--quiet"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:navikt/e2e-claim.git",
+            ],
+        ] {
+            let out = git_cmd(&model).args(&args).output().expect("git runs");
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+
+        // The user's own link, before any approval.
+        let out = trust_cmd(&repo, &config_file)
+            .args(["link", "navikt/e2e-claim"])
+            .output()
+            .expect("link runs");
+        assert!(
+            out.status.success(),
+            "hand link failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let out = trust_cmd(&repo, &config_file)
+            .args(["trust", "accept", "repos"])
+            .output()
+            .expect("accept runs");
+        assert!(out.status.success(), "accept failed");
+
+        let out = trust_cmd(&repo, &config_file)
+            .args(["trust", "revoke", "repos"])
+            .output()
+            .expect("revoke runs");
+        assert!(out.status.success(), "revoke failed");
+
+        let out = trust_cmd(&repo, &config_file)
+            .args(["config", "get", "sandbox.repo_dirs"])
+            .output()
+            .expect("get runs");
+        let roots = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            roots.contains("e2e-claim"),
+            "the user's root must survive revoking a proposal that merely named it: {roots}"
+        );
+
+        let _ = std::fs::remove_dir_all(&repo);
+        let _ = std::fs::remove_dir_all(&model);
+    }
+
     /// `--accept-repo-config` approves for one run and persists nothing.
     /// Linking a repository is persistent, so it is the one proposal the flag
     /// cannot approve.
@@ -4031,10 +4095,13 @@ paths = [
         // test passes even with the filter removed, because approving `repos`
         // for one run does nothing observable — the linking only ever happens
         // in `trust accept`. What the filter buys is that the user is told.
+        // Asserted on the identity, not the word "repos": "repositories"
+        // contains it, and a `Named repositories` header exists elsewhere, so
+        // the loose form could pass for the wrong reason (#496 review).
         let stderr = String::from_utf8_lossy(&out2_stderr);
         assert!(
-            stderr.contains("unapproved permission") && stderr.contains("repos"),
-            "the launch must report repos as still unapproved:\n{stderr}"
+            stderr.contains("unapproved permission") && stderr.contains("navikt/e2e-flag-model"),
+            "the launch must report the proposal as still unapproved:\n{stderr}"
         );
 
         let _ = std::fs::remove_dir_all(&repo);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3861,6 +3861,186 @@ paths = [
         cmd
     }
 
+    /// #491, the whole loop: a repository proposes another repository by name,
+    /// approving resolves and links it, and revoking removes exactly what the
+    /// approval created — never a root the user added themselves.
+    ///
+    /// The last part is the one worth a test: the launch reads
+    /// `sandbox.repo_dirs` and never consults the trust store, so without the
+    /// recorded provenance `repos` would be the only proposal whose grant
+    /// outlives its own revocation.
+    #[test]
+    fn e2e_propose_repos_links_on_approval_and_unlinks_on_revoke() {
+        let (repo, config_file) = make_trust_repo(
+            "propose-repos",
+            "[propose]\nrepos = [\"navikt/e2e-model\"]\n",
+        );
+        // The proposed repository, beside the launch one.
+        // The fixture directories are stable per label, so a previous run's
+        // trust entry would make this one skip the work it is testing.
+        let _ = std::fs::remove_dir_all(config_file.parent().expect("cfg dir").join("trust"));
+        let parent = repo.parent().expect("parent").to_path_buf();
+        let model = parent.join("e2e-model");
+        let _ = std::fs::remove_dir_all(&model);
+        std::fs::create_dir_all(&model).expect("mkdir");
+        for args in [
+            vec!["init", "--quiet"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:navikt/e2e-model.git",
+            ],
+        ] {
+            let out = git_cmd(&model).args(&args).output().expect("git runs");
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+        // And one the user links by hand, which revoking must not touch.
+        let mine = parent.join("e2e-mine");
+        let _ = std::fs::remove_dir_all(&mine);
+        std::fs::create_dir_all(&mine).expect("mkdir");
+        for args in [
+            vec!["init", "--quiet"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:navikt/e2e-mine.git",
+            ],
+        ] {
+            let out = git_cmd(&mine).args(&args).output().expect("git runs");
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+        let out = trust_cmd(&repo, &config_file)
+            .args(["link", "navikt/e2e-mine"])
+            .output()
+            .expect("link runs");
+        assert!(
+            out.status.success(),
+            "hand link failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let roots = |label: &str| {
+            let out = trust_cmd(&repo, &config_file)
+                .args(["config", "get", "sandbox.repo_dirs"])
+                .output()
+                .unwrap_or_else(|e| panic!("{label}: {e}"));
+            String::from_utf8_lossy(&out.stdout).into_owned()
+        };
+
+        assert!(
+            !roots("before").contains("e2e-model"),
+            "an unapproved proposal grants nothing"
+        );
+
+        let out = trust_cmd(&repo, &config_file)
+            .args(["trust", "accept", "repos"])
+            .output()
+            .expect("accept runs");
+        assert!(
+            out.status.success(),
+            "accept failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let after = roots("after accept");
+        assert!(after.contains("e2e-model"), "approval links it: {after}");
+        assert!(after.contains("e2e-mine"), "and leaves mine alone: {after}");
+
+        let out = trust_cmd(&repo, &config_file)
+            .args(["trust", "revoke", "repos"])
+            .output()
+            .expect("revoke runs");
+        assert!(
+            out.status.success(),
+            "revoke failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let after = roots("after revoke");
+        assert!(
+            !after.contains("e2e-model"),
+            "revoking must remove the grant it made, not only the approval: {after}"
+        );
+        assert!(
+            after.contains("e2e-mine"),
+            "and must not remove a root the user added: {after}"
+        );
+
+        let _ = std::fs::remove_dir_all(&repo);
+        let _ = std::fs::remove_dir_all(&model);
+        let _ = std::fs::remove_dir_all(&mine);
+    }
+
+    /// `--accept-repo-config` approves for one run and persists nothing.
+    /// Linking a repository is persistent, so it is the one proposal the flag
+    /// cannot approve.
+    #[test]
+    fn e2e_accept_repo_config_does_not_link_proposed_repos() {
+        require_sandbox!();
+        let (repo, config_file) = make_trust_repo(
+            "accept-flag-repos",
+            "[propose]\nrepos = [\"navikt/e2e-flag-model\"]\n",
+        );
+        let parent = repo.parent().expect("parent").to_path_buf();
+        let model = parent.join("e2e-flag-model");
+        let _ = std::fs::remove_dir_all(&model);
+        std::fs::create_dir_all(&model).expect("mkdir");
+        for args in [
+            vec!["init", "--quiet"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:navikt/e2e-flag-model.git",
+            ],
+        ] {
+            let out = git_cmd(&model).args(&args).output().expect("git runs");
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+
+        let out = trust_cmd(&repo, &config_file)
+            .args([
+                "--agent",
+                "shell",
+                "--yes",
+                "--no-validate",
+                "--accept-repo-config",
+                "--",
+                "-c",
+                "true",
+            ])
+            .output()
+            .expect("run");
+        assert!(
+            out.status.success(),
+            "launch failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let out2_stderr = out.stderr.clone();
+
+        let out = trust_cmd(&repo, &config_file)
+            .args(["config", "get", "sandbox.repo_dirs"])
+            .output()
+            .expect("get runs");
+        let roots = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !roots.contains("e2e-flag-model"),
+            "a per-run flag must not leave a persistent grant: {roots}"
+        );
+        // And the run must SAY the proposal is unapproved. Without this the
+        // test passes even with the filter removed, because approving `repos`
+        // for one run does nothing observable — the linking only ever happens
+        // in `trust accept`. What the filter buys is that the user is told.
+        let stderr = String::from_utf8_lossy(&out2_stderr);
+        assert!(
+            stderr.contains("unapproved permission") && stderr.contains("repos"),
+            "the launch must report repos as still unapproved:\n{stderr}"
+        );
+
+        let _ = std::fs::remove_dir_all(&repo);
+        let _ = std::fs::remove_dir_all(&model);
+    }
+
     #[test]
     fn e2e_trust_show_displays_proposals() {
         let (repo, config_file) = make_trust_repo(


### PR DESCRIPTION
Closes #491, on top of the resolver that landed in #495.

```toml
[propose]
repos = ["navikt/sykepenger-model", "navikt/spleis-testdata"]
```

```
$ cplt trust accept repos
[cplt] sandbox.repo_dirs = [/Users/you/src/sykepenger-model]
[cplt] navikt/spleis-testdata: not linked
  No checkout of that repository was found. Looked at: ...
```

## The shape of it

An **identity, never a path**. The repository states what the project is; the user's machine decides where those repositories live. That is what makes this allowable at all — the refusal it appears to contradict ("repo config cannot grant paths") is about paths, and `navikt/foo` is not one.

Approving is where names become paths, and it is the only place. Each identity is resolved and origin-verified by the same code `cplt link` uses. A repository that is not on the machine is reported, never fetched.

## Three consequences of approval being an *action*, not a value

- **`cplt trust revoke repos` unlinks what it linked.** The launch reads `sandbox.repo_dirs` and never consults the trust store, so without recorded provenance this would be the only proposal whose grant survives its own revocation. The approval records `{identity, path}` pairs and revoke removes exactly those — a root the user added with `cplt link` or `config set --local` is theirs and stays. Its adversarial review raised this on the design; it is the load-bearing piece of the implementation.
- **`--accept-repo-config` cannot approve it.** One-run flag, persistent grant: that pairing is #206's bypass class, and the reason this feature waited for #206 rather than merely citing it.
- **Re-approving re-links.** "Already approved" is not "already done" when approval is an action. A user who approved before cloning the repository, or who removed a root by hand, must be able to run it again. I found this because a test failed exactly that way, on a fixture that had an approval from a previous run.

## Also

The identity is validated in `validate_repo_config`, where the file is read, not at the resolver: the value reaches path construction on the user's machine and it is text a committed config chose. `repos` is a grant, so `tightenings_only` drops it — an uncommitted `.cplt.toml` cannot propose repositories, per #494. And the unapproved-permissions warning names the repositories, because `repos` as a bare key says nothing about what approving it would put in scope.

## Verification

Unit: identities not paths (six malformed forms refused), and `repos` dropped from an uncommitted file.

e2e: the full loop — unapproved grants nothing, approval links the proposed repository and leaves a hand-added root alone, revoke removes the approval's root and keeps the user's. Falsified by deleting the unlink call.

e2e: `--accept-repo-config` does not link, **and** the run still reports `repos` as unapproved. The first assertion alone was vacuous — approving `repos` for one run does nothing observable, since linking only happens in `trust accept` — so the test passed with the filter removed. The second assertion is what actually fails without it.

Manually, on scratch repositories: propose two repositories where one exists, approve, check the startup summary lists it as a new read/write/exec tree, add a hand-linked root, revoke, confirm only the approval's root went.

`cargo test`, clippy and `--target x86_64-unknown-linux-gnu --all-targets` clean.

## One thing deliberately not built

The design floated resolving proposals at launch to show "found at ../x, not yet linked". That costs a directory scan on every start to print a line, so the summary names the repositories without resolving them. Worth revisiting only if someone finds the unresolved line too vague.