### PR TITLE
fix(proxy): refuse a list file the sandboxed agent can edit

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -212,6 +212,24 @@ An IP literal cannot be waived — give the host a name. A repository may propos
 entries in `[propose.proxy]`, which is the only proxy key `.cplt.toml` can
 propose, and they apply only after `cplt trust accept`.
 
+### Where the list files may live
+
+A list file is re-read every few seconds, which is what makes an edit take
+effect without restarting the session. That is the right design for a person
+editing an allowlist and the wrong one for a file the sandboxed agent can reach
+— so cplt **refuses to launch** when `proxy.allowed_domains` or
+`proxy.blocked_domains` names a path inside the project directory or any
+`allow.write` grant, naming both the file and the tree:
+
+```
+[cplt] proxy.allowed_domains names allow.txt, which is inside ~/src/myproject
+       — a tree this session can write.
+```
+
+An allowlist the agent can edit is not an allowlist. Keep the file somewhere the
+session cannot write; `~/.config/cplt/` is the obvious place, and grants inside
+cplt's own state directory are refused for the same reason.
+
 ### Adding hosts with `allow.domains`
 
 The allowlist file is the right shape for a long, shared or subscription-fed

--- a/src/main.rs
+++ b/src/main.rs
@@ -2841,6 +2841,7 @@ fn start_proxy_if_enabled(
     config_path: Option<&PathBuf>,
     active_agent: agent::Agent,
     project_dir: &Path,
+    named_roots: &[PathBuf],
 ) -> anyhow::Result<Option<proxy::ProxyHandle>> {
     // Proxy-forced (#53): the proxy is mandatory. `with_proxy` defaults to true,
     // so the only way it is false here is an explicit disable (--no-proxy or
@@ -2944,12 +2945,25 @@ fn start_proxy_if_enabled(
     // own egress rules and see the change take effect within the TTL. Refused
     // at launch, naming the file and the grant: the same shape as `allow.exec`
     // refusing a tree that overlaps a writable one, and the same reason.
+    // Every tree this session can write, not just the project and `allow.write`:
+    // a named repository, the scratch dir and the system temp dirs are writable
+    // too, and a list file in any of them is one the agent can rewrite between
+    // reloads (#499 review).
+    let scratch_base = std::env::var("HOME")
+        .ok()
+        .map(|h| scratch::ScratchDir::base(Path::new(&h)));
+    let writable = sandbox::session_writable_roots(
+        project_dir,
+        named_roots,
+        &resolved.allow_write,
+        scratch_base.as_deref(),
+    );
     for (key, file) in [
         ("proxy.allowed_domains", allowed_domains_file.as_ref()),
         ("proxy.blocked_domains", Some(&blocked_file)),
     ] {
         let Some(file) = file else { continue };
-        if let Some(root) = agent_writable_root(file, project_dir, &resolved.allow_write) {
+        if let Some(root) = agent_writable_root(file, &writable) {
             bail!(
                 "{key} names {}, which is inside {} — a tree this session can write.\n  \
                  The proxy re-reads that file every few seconds, so the agent could edit its \
@@ -4456,6 +4470,7 @@ fn assemble_sandbox(
         config_path,
         active_agent,
         probe.project_dir.as_path(),
+        opts.repos.dirs,
     )?;
     let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
 
@@ -6673,6 +6688,44 @@ fn run_config_set(
     } else {
         None
     };
+    // A proxy list file the session can write is refused at launch (#426), so
+    // it is refused here too. `config set` accepting a value every launch then
+    // rejects is the shape #306 is about, and the golden suite enforces the
+    // invariant: what `set` accepts must be launchable.
+    if matches!(key, "proxy.allowed_domains" | "proxy.blocked_domains")
+        && let Some(val) = value
+        && !unset
+    {
+        let project = detect_project_root().unwrap_or_else(|| PathBuf::from("."));
+        let grants: Vec<PathBuf> = config::Config::load_file()
+            .ok()
+            .flatten()
+            .map(|c| {
+                c.config
+                    .allow
+                    .write
+                    .iter()
+                    .map(|w| config::expand_tilde(w))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let scratch_base = std::env::var("HOME")
+            .ok()
+            .map(|h| scratch::ScratchDir::base(Path::new(&h)));
+        let writable =
+            sandbox::session_writable_roots(&project, &[], &grants, scratch_base.as_deref());
+        if let Some(root) = agent_writable_root(Path::new(val), &writable) {
+            ui::error(&format!(
+                "{key} = {val} is inside {} — a tree a session can write.\n  \
+                 The proxy re-reads that file every few seconds, so the agent could edit its \
+                 own egress rules mid-session, and the launch refuses it. Put the list \
+                 somewhere the session cannot write, such as ~/.config/cplt/.",
+                root.display()
+            ));
+            return ExitCode::FAILURE;
+        }
+    }
+
     // `../sibling` is how a person names the repository next door. The local
     // layer stores absolute paths only — a relative entry there has no stable
     // anchor — so resolve it here rather than making the user do it (#490).
@@ -7209,6 +7262,38 @@ fn run_init_global_command(write: bool, force: bool, quiet: bool) -> ExitCode {
     }
 }
 
+/// The writable tree `file` sits inside, if any.
+///
+/// `roots` comes from [`sandbox::session_writable_roots`], so this sees every
+/// tree the session can write — not only the project directory and
+/// `allow.write`, but named repositories, the scratch dir and the system temp
+/// dirs, which are writable by construction with no grant to withdraw
+/// (#499 review).
+///
+/// **Both spellings of the file are tested.** Canonicalizing first and checking
+/// only the target misses `<project>/list.txt -> /elsewhere/list.txt`: the
+/// target reads as safe at launch, the proxy re-reads through the configured
+/// path, and the agent swaps the symlink mid-session. The path as written
+/// catches that one; the canonical form catches a symlinked spelling of the
+/// *tree*.
+fn agent_writable_root(file: &Path, roots: &[PathBuf]) -> Option<PathBuf> {
+    let real = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let absolute = std::path::absolute(file).unwrap_or_else(|_| file.to_path_buf());
+    // The leaf left unresolved, the directories above it resolved. That is what
+    // "where the configured path lives" means: a symlinked spelling of the tree
+    // must still match, while a symlinked *leaf* must be judged by where it
+    // sits, not by where it currently points — it is the thing an agent swaps.
+    let as_written = match (absolute.parent(), absolute.file_name()) {
+        (Some(parent), Some(name)) => real(parent).join(name),
+        _ => absolute.clone(),
+    };
+    let resolved = real(file);
+    roots
+        .iter()
+        .map(|root| real(root))
+        .find(|root| as_written.starts_with(root) || resolved.starts_with(root))
+}
+
 /// `cplt link <owner>/<name> [dir]` — put another repository in scope for this
 /// checkout, verified rather than guessed.
 ///
@@ -7217,27 +7302,6 @@ fn run_init_global_command(write: bool, force: bool, quiet: bool) -> ExitCode {
 /// every launch, it is refused if it stops being a git toplevel or acquires a
 /// symlinked leaf, and `cplt config set --local sandbox.repo_dirs` manages the
 /// same list. What this command adds is the identity check.
-/// The writable tree `file` sits inside, if any.
-///
-/// Compared on canonicalized paths, because the grant and the configured file
-/// can spell the same directory differently — and a symlinked spelling that
-/// slipped past would be a bypass rather than a cosmetic miss. A path that
-/// cannot be canonicalized (it may not exist yet) falls back to its lexical
-/// form, which is what the launch will use for it anyway.
-fn agent_writable_root(
-    file: &Path,
-    project_dir: &Path,
-    allow_write: &[PathBuf],
-) -> Option<PathBuf> {
-    let real = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
-    let file = real(file);
-    std::iter::once(project_dir.to_path_buf())
-        .chain(allow_write.iter().cloned())
-        .map(|root| real(&root))
-        .find(|root| file.starts_with(root))
-}
-
-/// Where a candidate came from, for the line the user is shown.
 fn run_link_command(repo: &str, dir: Option<&Path>, unlink: bool) -> ExitCode {
     let Some(project_dir) = detect_project_root() else {
         ui::error(NOT_A_REPOSITORY);
@@ -8424,27 +8488,70 @@ mod tests {
         for f in [&in_project, &in_grant, &outside] {
             std::fs::write(f, "example.com\n").expect("write");
         }
-        let grants = vec![grant.clone()];
+        let roots = vec![project.clone(), grant.clone()];
 
         assert!(
-            super::agent_writable_root(&in_project, &project, &[]).is_some(),
+            super::agent_writable_root(&in_project, &roots).is_some(),
             "the project directory is writable by the session"
         );
         assert!(
-            super::agent_writable_root(&in_grant, &project, &grants).is_some(),
+            super::agent_writable_root(&in_grant, &roots).is_some(),
             "so is an allow.write grant"
         );
         assert!(
-            super::agent_writable_root(&outside, &project, &grants).is_none(),
+            super::agent_writable_root(&outside, &roots).is_none(),
             "a file outside every writable tree is the supported shape and must not be refused"
         );
 
-        // The same file reached through a symlinked spelling of the grant.
+        // A symlinked spelling of the writable TREE.
         let link = tmp.path().join("link");
         std::os::unix::fs::symlink(&grant, &link).expect("symlink");
         assert!(
-            super::agent_writable_root(&link.join("allow.txt"), &project, &grants).is_some(),
+            super::agent_writable_root(&link.join("allow.txt"), &roots).is_some(),
             "a symlinked spelling of a writable tree is still that tree"
+        );
+
+        // The dangerous direction: the configured path is INSIDE a writable
+        // tree and points out of it. Canonicalizing first makes that read as
+        // safe, and the agent then swaps the symlink between reloads — so the
+        // path as written has to be tested too (#499 review).
+        let escape = project.join("escape.txt");
+        std::os::unix::fs::symlink(&outside, &escape).expect("symlink");
+        assert!(
+            super::agent_writable_root(&escape, &roots).is_some(),
+            "a symlink inside a writable tree is swappable, wherever it points today"
+        );
+    }
+
+    /// The writable set must carry the trees no grant creates. A list file in
+    /// the system temp dir is as editable as one in the project.
+    #[test]
+    fn the_writable_set_includes_trees_no_grant_creates() {
+        let roots = cplt::sandbox::session_writable_roots(
+            Path::new("/src/project"),
+            &[PathBuf::from("/src/model")],
+            &[PathBuf::from("/src/granted")],
+            Some(Path::new("/home/u/.cache/cplt/tmp")),
+        );
+        for expected in [
+            "/src/project",
+            "/src/model",
+            "/src/granted",
+            "/home/u/.cache/cplt/tmp",
+        ] {
+            assert!(
+                roots.contains(&PathBuf::from(expected)),
+                "{expected} must be in the writable set: {roots:?}"
+            );
+        }
+        let temp_covered = roots.iter().any(|r| {
+            r.starts_with("/private/tmp")
+                || r.starts_with("/private/var/folders")
+                || r == Path::new("/tmp")
+        });
+        assert!(
+            temp_covered,
+            "the system temp dirs are writable too: {roots:?}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2840,6 +2840,7 @@ fn start_proxy_if_enabled(
     cli: &Cli,
     config_path: Option<&PathBuf>,
     active_agent: agent::Agent,
+    project_dir: &Path,
 ) -> anyhow::Result<Option<proxy::ProxyHandle>> {
     // Proxy-forced (#53): the proxy is mandatory. `with_proxy` defaults to true,
     // so the only way it is false here is an explicit disable (--no-proxy or
@@ -2936,6 +2937,29 @@ fn start_proxy_if_enabled(
     } else {
         Vec::new()
     };
+
+    // An allowlist the agent can edit is not an allowlist (#426). Both list
+    // files are re-read every few seconds by design, so one inside the project
+    // directory or an `allow.write` grant lets the sandboxed process change its
+    // own egress rules and see the change take effect within the TTL. Refused
+    // at launch, naming the file and the grant: the same shape as `allow.exec`
+    // refusing a tree that overlaps a writable one, and the same reason.
+    for (key, file) in [
+        ("proxy.allowed_domains", allowed_domains_file.as_ref()),
+        ("proxy.blocked_domains", Some(&blocked_file)),
+    ] {
+        let Some(file) = file else { continue };
+        if let Some(root) = agent_writable_root(file, project_dir, &resolved.allow_write) {
+            bail!(
+                "{key} names {}, which is inside {} — a tree this session can write.\n  \
+                 The proxy re-reads that file every few seconds, so the agent could edit its \
+                 own egress rules and have them take effect mid-session. Move the file outside \
+                 the writable trees (for example ~/.config/cplt/), or drop the grant.",
+                file.display(),
+                root.display()
+            );
+        }
+    }
 
     // Validate domain allowlist file at startup (fail-closed: abort if
     // unreadable) and capture the user-configured domains for the policy report.
@@ -4426,7 +4450,13 @@ fn assemble_sandbox(
 
     // Start proxy (handle returned for RAII ownership). Before the profile is
     // built, so the actual ephemeral port can be embedded in it.
-    let proxy_handle = start_proxy_if_enabled(resolved, cli, config_path, active_agent)?;
+    let proxy_handle = start_proxy_if_enabled(
+        resolved,
+        cli,
+        config_path,
+        active_agent,
+        probe.project_dir.as_path(),
+    )?;
     let proxy_port_for_profile = proxy_handle.as_ref().map(|h| h.port);
 
     // #242: drop the whole-Keychain grant only when the agent can authenticate
@@ -7187,6 +7217,27 @@ fn run_init_global_command(write: bool, force: bool, quiet: bool) -> ExitCode {
 /// every launch, it is refused if it stops being a git toplevel or acquires a
 /// symlinked leaf, and `cplt config set --local sandbox.repo_dirs` manages the
 /// same list. What this command adds is the identity check.
+/// The writable tree `file` sits inside, if any.
+///
+/// Compared on canonicalized paths, because the grant and the configured file
+/// can spell the same directory differently — and a symlinked spelling that
+/// slipped past would be a bypass rather than a cosmetic miss. A path that
+/// cannot be canonicalized (it may not exist yet) falls back to its lexical
+/// form, which is what the launch will use for it anyway.
+fn agent_writable_root(
+    file: &Path,
+    project_dir: &Path,
+    allow_write: &[PathBuf],
+) -> Option<PathBuf> {
+    let real = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let file = real(file);
+    std::iter::once(project_dir.to_path_buf())
+        .chain(allow_write.iter().cloned())
+        .map(|root| real(&root))
+        .find(|root| file.starts_with(root))
+}
+
+/// Where a candidate came from, for the line the user is shown.
 fn run_link_command(repo: &str, dir: Option<&Path>, unlink: bool) -> ExitCode {
     let Some(project_dir) = detect_project_root() else {
         ui::error(NOT_A_REPOSITORY);
@@ -8350,6 +8401,53 @@ fn start_denial_stream() -> Option<std::process::Child> {
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)] // test code: no unsandboxed parent to protect (#239)
 mod tests {
+    /// #426: an allowlist the agent can edit is not an allowlist. Both proxy
+    /// list files are re-read every few seconds by design, so one inside the
+    /// project directory or an `allow.write` grant lets the sandboxed process
+    /// rewrite its own egress rules mid-session.
+    ///
+    /// Canonicalized on both sides, because the grant and the configured path
+    /// can spell the same directory differently — and a spelling that slipped
+    /// past would be the bypass itself, not a cosmetic miss.
+    #[test]
+    fn a_proxy_list_file_in_a_writable_tree_is_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        let grant = tmp.path().join("granted");
+        let elsewhere = tmp.path().join("elsewhere");
+        for d in [&project, &grant, &elsewhere] {
+            std::fs::create_dir_all(d).expect("mkdir");
+        }
+        let in_project = project.join("allow.txt");
+        let in_grant = grant.join("allow.txt");
+        let outside = elsewhere.join("allow.txt");
+        for f in [&in_project, &in_grant, &outside] {
+            std::fs::write(f, "example.com\n").expect("write");
+        }
+        let grants = vec![grant.clone()];
+
+        assert!(
+            super::agent_writable_root(&in_project, &project, &[]).is_some(),
+            "the project directory is writable by the session"
+        );
+        assert!(
+            super::agent_writable_root(&in_grant, &project, &grants).is_some(),
+            "so is an allow.write grant"
+        );
+        assert!(
+            super::agent_writable_root(&outside, &project, &grants).is_none(),
+            "a file outside every writable tree is the supported shape and must not be refused"
+        );
+
+        // The same file reached through a symlinked spelling of the grant.
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&grant, &link).expect("symlink");
+        assert!(
+            super::agent_writable_root(&link.join("allow.txt"), &project, &grants).is_some(),
+            "a symlinked spelling of a writable tree is still that tree"
+        );
+    }
+
     /// The record of what an approval linked is the only way `trust revoke
     /// repos` can find those roots again — the launch reads `sandbox.repo_dirs`
     /// and never consults the trust store. Three ordinary events used to drop a

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -532,6 +532,34 @@ fn writable_trees(config: &SandboxConfig) -> Vec<(PathBuf, &'static str)> {
     trees
 }
 
+/// Every tree a session can write, for callers that need the answer **before**
+/// a [`SandboxConfig`] exists.
+///
+/// `writable_trees` is the full version and runs at profile build time. The
+/// proxy starts earlier than that and has to know the same thing: a domain list
+/// file inside any of these is one the agent can rewrite between reloads
+/// (#426). Kept next to `writable_trees` so the two cannot drift on the trees
+/// that are writable by construction rather than by config — the system temp
+/// dirs and `/dev/shm`, which no grant creates and none can withdraw.
+#[must_use]
+pub fn session_writable_roots(
+    project_dir: &Path,
+    named_roots: &[PathBuf],
+    allow_write: &[PathBuf],
+    scratch_dir: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut roots = vec![project_dir.to_path_buf()];
+    roots.extend(named_roots.iter().cloned());
+    roots.extend(allow_write.iter().cloned());
+    roots.extend(scratch_dir.map(Path::to_path_buf));
+    roots.extend(SYSTEM_TEMP_DIRS.iter().map(PathBuf::from));
+    #[cfg(not(target_os = "macos"))]
+    roots.push(PathBuf::from("/dev/shm"));
+    #[cfg(not(target_os = "macos"))]
+    roots.push(PathBuf::from("/tmp"));
+    roots
+}
+
 /// Names the temp-dir collision in the refusal, and selects its remedy: a temp
 /// dir is writable with no grant to withdraw, so "narrow one of the two" is not
 /// advice a user can act on there.

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -100,6 +100,16 @@ impl ScratchDir {
         Ok(ScratchDir { path: session_dir })
     }
 
+    /// The directory every scratch dir is created under, whether or not one
+    /// exists yet.
+    ///
+    /// Callers that must know what the session can write — the proxy list-file
+    /// check (#426) — need the tree, not this run's instance.
+    #[must_use]
+    pub fn base(home_dir: &Path) -> PathBuf {
+        home_dir.join(SCRATCH_BASE)
+    }
+
     /// Path to the scratch directory.
     pub fn path(&self) -> &Path {
         &self.path

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -2539,8 +2539,12 @@ if [ -z "${HTTPS_PROXY:-}" ]; then echo "RESULT:no_https_proxy:OK"; else echo "R
         let project = TempProject::scaffold_node();
         let port = next_proxy_port();
 
-        // Create an allowlist with only one domain
-        let allowlist_path = project.path().join("allowed-domains.txt");
+        // Create an allowlist with only one domain, OUTSIDE the project: a list
+        // file inside a tree the session can write is refused at launch, because
+        // the proxy re-reads it every few seconds and the agent could edit its
+        // own egress rules (#426).
+        let list_dir = tempfile::tempdir().expect("tempdir");
+        let allowlist_path = list_dir.path().join("allowed-domains.txt");
         std::fs::write(&allowlist_path, "only-this.example.com\n").unwrap();
 
         // Try to CONNECT to a domain NOT in the allowlist

--- a/tests/e2e_projects.rs
+++ b/tests/e2e_projects.rs
@@ -2539,12 +2539,21 @@ if [ -z "${HTTPS_PROXY:-}" ]; then echo "RESULT:no_https_proxy:OK"; else echo "R
         let project = TempProject::scaffold_node();
         let port = next_proxy_port();
 
-        // Create an allowlist with only one domain, OUTSIDE the project: a list
-        // file inside a tree the session can write is refused at launch, because
-        // the proxy re-reads it every few seconds and the agent could edit its
+        // An allowlist with one domain, in a tree the session CANNOT write: a
+        // list file inside a writable tree is refused at launch, because the
+        // proxy re-reads it every few seconds and the agent could rewrite its
         // own egress rules (#426).
-        let list_dir = tempfile::tempdir().expect("tempdir");
-        let allowlist_path = list_dir.path().join("allowed-domains.txt");
+        //
+        // Not `tempfile::tempdir()` — that lands in the system temp dir, which
+        // the sandbox makes writable by construction, so it is the refused
+        // shape too (#499 review). Under `$HOME`, which is deny-by-default and
+        // granted nothing here, is a tree the session cannot touch; the proxy
+        // reads the file in the unsandboxed parent, so reading it still works.
+        let home = std::env::var("HOME").expect("HOME");
+        let list_dir =
+            std::path::Path::new(&home).join(format!(".cplt-e2e-lists-{}", std::process::id()));
+        std::fs::create_dir_all(&list_dir).expect("list dir");
+        let allowlist_path = list_dir.join("allowed-domains.txt");
         std::fs::write(&allowlist_path, "only-this.example.com\n").unwrap();
 
         // Try to CONNECT to a domain NOT in the allowlist
@@ -2572,6 +2581,8 @@ if echo "$RESP" | grep -q "403"; then echo "RESULT:blocked_unlisted:OK"; else ec
             "cplt should succeed.\nstdout: {stdout}\nstderr: {stderr}"
         );
         assert_result_ok(&stdout, &stderr, "blocked_unlisted");
+
+        let _ = std::fs::remove_dir_all(&list_dir);
     }
 
     #[test]


### PR DESCRIPTION
Closes #426.

```
[cplt] proxy.allowed_domains names allow.txt, which is inside ~/src/myproject — a tree this session can write.
  The proxy re-reads that file every few seconds, so the agent could edit its own egress rules and
  have them take effect mid-session. Move the file outside the writable trees (for example
  ~/.config/cplt/), or drop the grant.
```

## Why refuse rather than warn

The live reload is deliberate — editing a list file adds and revokes entries without a restart, which is right for a person and wrong for a file the constrained process can reach. `AGENTS.md` already states the rule for grants: *a grant or setting that cannot be honoured must fail loudly at the point it is written*. An allowlist the agent can edit cannot be honoured, so it fails at launch, the same way `allow.exec` refuses a tree overlapping a writable one.

The issue calls this a footgun rather than a live vulnerability, and that is fair — it needs the user to have configured it. What makes it worth closing is the shape: a control that asks agent-writable state what the rules are, every five seconds, is GHSA-cm6f (the guard asking the sandbox which branch was protected) and GHSA-39xf (a deny whose parent could be renamed) in the one subsystem that re-reads by design.

## Both files

`proxy.blocked_domains` gets the same check. A blocklist the agent can edit is the same control with the sign flipped — it would let a session remove its own blocks.

## Details

Compared on **canonicalized** paths, because the grant and the configured file can spell the same directory differently, and a spelling that slipped past would be the bypass itself. Falsified by removing the canonicalization: the symlinked-grant case fails.

The issue's second path — grants inside cplt's own state directory — is already closed by `cplt_state_dir_grant`, so this PR is item 1 only.

## Verification

`a_proxy_list_file_in_a_writable_tree_is_found` covers the project directory, an `allow.write` grant, a symlinked spelling of that grant, and — the case that must keep working — a file outside every writable tree.

End to end: refused from inside the project, refused via `--allow-write`, and `~/.config/cplt/list.txt` still loads normally (`Domain allowlist: 1 domains from …`).

`project_proxy_allowlist_blocks_unlisted` put its fixture inside the project — the refused shape — so it caught the change. Its list moved to a tempdir, which is what the docs now tell users to do.