### PR TITLE
fix(config): refuse at write time what no launch can honour, and stop --inherit-env cancelling --pass-env

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -511,19 +511,19 @@ fn ssh_key_readable(allow_read: &[std::path::PathBuf], home: &Path) -> bool {
 /// `build_sandbox_env`'s sanitized branch, which never consults
 /// `ENV_ALWAYS_DENY`.
 ///
-/// `--inherit-env` takes the other branch, which pushes every `ENV_ALWAYS_DENY`
-/// entry — `SSH_AUTH_SOCK` among them — onto `remove`, and never looks at
-/// `extra_pass_env`. So inherit does not merely fail to help: it *cancels*
-/// `--pass-env SSH_AUTH_SOCK`. Nothing conflicts the two flags, and
-/// `sandbox.pass_env` in config makes the combination easy to hit by accident.
+/// `--inherit-env` takes the other branch, which strips every
+/// `ENV_ALWAYS_DENY` entry — `SSH_AUTH_SOCK` among them — **except the ones
+/// named in `extra_pass_env`**. It used to strip them all, so inherit did not
+/// merely fail to help: it cancelled `--pass-env SSH_AUTH_SOCK` silently, and
+/// `sandbox.pass_env` in config made the combination easy to hit months apart
+/// (#307). The explicit instruction wins now, in both branches.
 ///
 /// On macOS the variable alone is still not enough. The socket lives at
 /// `/private/tmp/com.apple.launchd.*/Listeners`, and the profile grants no
 /// `network-outbound unix-socket` for it — deliberately, which is why the JVM
 /// carve-out is regex-pinned to `.java_pid`. It also takes an `allow.socket`.
 fn ssh_agent_reaches(resolved: &Resolved) -> bool {
-    !resolved.inherit_env
-        && resolved.pass_env.iter().any(|v| v == "SSH_AUTH_SOCK")
+    resolved.pass_env.iter().any(|v| v == "SSH_AUTH_SOCK")
         && (!cfg!(target_os = "macos") || !resolved.allow_socket.is_empty())
 }
 
@@ -1391,13 +1391,16 @@ mod tests {
         );
     }
 
-    /// `--inherit-env` takes the branch that sweeps ENV_ALWAYS_DENY (which
-    /// lists SSH_AUTH_SOCK) and never reads extra_pass_env — so it does not
-    /// merely fail to help, it cancels `--pass-env SSH_AUTH_SOCK`. Nothing in
-    /// clap conflicts the two, and `sandbox.pass_env` makes the pair easy to
-    /// hit.
+    /// `--inherit-env` used to cancel `--pass-env SSH_AUTH_SOCK`: its branch
+    /// swept every `ENV_ALWAYS_DENY` entry and never read `extra_pass_env`, so
+    /// a user who asked for the agent socket did not get it and the brief said
+    /// so — correctly, about behaviour that was itself the bug (#307).
+    ///
+    /// The explicit instruction wins in both branches now, so the brief reports
+    /// the socket arriving either way. This test kept the old behaviour honest
+    /// and now keeps the new one: the pair must agree, whichever way it is.
     #[test]
-    fn brief_does_not_count_the_agent_socket_under_inherit_env() {
+    fn the_agent_socket_arrives_with_pass_env_whether_or_not_env_is_inherited() {
         let mut resolved = base_resolved();
         resolved.allow_ports = vec![22];
         resolved.pass_env = vec!["SSH_AUTH_SOCK".to_string()];
@@ -1411,11 +1414,11 @@ mod tests {
             false,
         ));
         assert!(
-            brief.contains("the blocker is the keys, not the port"),
-            "--inherit-env strips SSH_AUTH_SOCK even with --pass-env:\n{brief}"
+            brief.contains("SSH may work this session"),
+            "an explicit --pass-env survives --inherit-env now:\n{brief}"
         );
 
-        // Same config without inherit_env: the socket does arrive.
+        // And without inherit_env, unchanged.
         resolved.inherit_env = false;
         let brief = generate_session_brief(&BriefFacts::capture(
             &resolved,

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,8 @@ struct Cli {
     /// Disables env sanitization. Cloud credentials, npm tokens, database URLs,
     /// and all other env vars will be visible to the sandboxed process.
     /// Only use when --pass-env is insufficient for debugging.
+    /// A handful of variables are stripped even here (SSH_AUTH_SOCK among
+    /// them); --pass-env keeps any of those you name.
     #[arg(long)]
     inherit_env: bool,
 
@@ -6688,6 +6690,52 @@ fn run_config_set(
     } else {
         None
     };
+    // A grant no launch can honour is refused here, with the same words the
+    // launch would have used (#306). Accepting it at write time and refusing it
+    // at read time is the same question answered twice, differently — and the
+    // user finds out at the next launch, about a line they added and have
+    // probably forgotten.
+    if matches!(
+        key,
+        "allow.read" | "allow.write" | "allow.exec" | "allow.socket"
+    ) && let Some(val) = value
+        && !unset
+    {
+        let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
+        let path = config::expand_tilde(val);
+        if let Err(e) = sandbox::validate_grant_path(key, &path, &home) {
+            ui::error(&e);
+            return ExitCode::FAILURE;
+        }
+        // The exec-overlap refusal needs the resolved config the launch builds,
+        // so this is the part of it that a single grant can be judged against:
+        // the trees that are writable whatever else is configured. An overlap
+        // with an `allow.write` the user adds LATER still surfaces at launch.
+        if key == "allow.exec" {
+            let writable =
+                sandbox::session_writable_roots(Path::new("/nonexistent-project"), &[], &[], None);
+            let tool_dirs: Vec<PathBuf> = sandbox::HOME_TOOL_DIRS
+                .iter()
+                .filter(|d| d.write)
+                .map(|d| home.join(d.path))
+                .collect();
+            if let Some(tree) = writable
+                .iter()
+                .chain(tool_dirs.iter())
+                .find(|t| path.starts_with(t) || t.starts_with(&path))
+            {
+                ui::error(&format!(
+                    "allow.exec {val} overlaps {}, which is writable in every session.\n  \
+                     A tree that is both writable and executable lets the agent drop a binary \
+                     and run it, and neither backend can subtract the write from the exec — so \
+                     the launch refuses the pair. Exec grants belong on read-only tool prefixes.",
+                    tree.display()
+                ));
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
     // A proxy list file the session can write is refused at launch (#426), so
     // it is refused here too. `config set` accepting a value every launch then
     // rejects is the shape #306 is about, and the golden suite enforces the

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -337,35 +337,54 @@ fn validate_hard_denied_grants(config: &SandboxConfig) -> Result<(), String> {
         ("allow.socket", config.extra_socket),
     ] {
         for p in paths {
-            if let Some(dir) = policy::cplt_state_dir_grant(config.home_dir, p) {
-                return Err(format!(
-                    "{key} names {} — inside cplt's own state directory ({}). Nothing in there \
-                     can be granted, not even a single file: it holds the config, the trust \
-                     store, the blocklist cache and the per-repo local files, which decide what \
-                     the next launch allows. Reading them tells an agent exactly which \
-                     protections to work around; writing them lets it approve its own next \
-                     launch. Remove it from your config or command line.",
-                    p.display(),
-                    dir.display()
-                ));
-            }
-            if let Some(file) = policy::hard_denied_file(config.home_dir, p) {
-                return Err(format!(
-                    "{key} names {} (~/{file}), which is on the hard-deny list and cannot be granted explicitly. Remove it from your config or command line.",
-                    p.display()
-                ));
-            }
-            if let Some(dir) = policy::denied_dotfile_dir(config.home_dir, p) {
-                return Err(format!(
-                    "{key} names {} (~/{dir}), a credential directory that cannot be granted \
-                     whole: macOS denies it whatever the grant says, so honouring it on Linux \
-                     alone would mean the same config opens every key in it on one platform \
-                     and nothing on the other. Name the specific path you need inside it \
-                     instead, e.g. ~/{dir}/<file> — that grant works on both.",
-                    p.display()
-                ));
-            }
+            validate_grant_path(key, p, config.home_dir)?;
         }
+    }
+    Ok(())
+}
+
+/// Refuse one grant that no launch can honour, with the reason.
+///
+/// Shared with `cplt config set` (#306). The tool used to accept
+/// `allow.read ~/.netrc` at write time and refuse it at every launch after —
+/// the same question answered in two places, differently, which is the actual
+/// defect. One predicate now, so a check added here reaches both.
+///
+/// Only the checks that need nothing but the path and `$HOME` live here.
+/// Whether an exec grant overlaps a writable tree depends on the resolved
+/// config (tool dirs, `allow.write`, named repositories), so it stays in
+/// [`validate_exec_grants`] and `config set` approximates it separately.
+///
+/// # Errors
+/// The refusal text, ready to print.
+pub fn validate_grant_path(key: &str, p: &Path, home_dir: &Path) -> Result<(), String> {
+    if let Some(dir) = policy::cplt_state_dir_grant(home_dir, p) {
+        return Err(format!(
+            "{key} names {} — inside cplt's own state directory ({}). Nothing in there \
+             can be granted, not even a single file: it holds the config, the trust \
+             store, the blocklist cache and the per-repo local files, which decide what \
+             the next launch allows. Reading them tells an agent exactly which \
+             protections to work around; writing them lets it approve its own next \
+             launch. Remove it from your config or command line.",
+            p.display(),
+            dir.display()
+        ));
+    }
+    if let Some(file) = policy::hard_denied_file(home_dir, p) {
+        return Err(format!(
+            "{key} names {} (~/{file}), which is on the hard-deny list and cannot be granted explicitly. Remove it from your config or command line.",
+            p.display()
+        ));
+    }
+    if let Some(dir) = policy::denied_dotfile_dir(home_dir, p) {
+        return Err(format!(
+            "{key} names {} (~/{dir}), a credential directory that cannot be granted \
+             whole: macOS denies it whatever the grant says, so honouring it on Linux \
+             alone would mean the same config opens every key in it on one platform \
+             and nothing on the other. Name the specific path you need inside it \
+             instead, e.g. ~/{dir}/<file> — that grant works on both.",
+            p.display()
+        ));
     }
     Ok(())
 }
@@ -1434,6 +1453,28 @@ mod tests {
     /// a mutation deleting the Copilot line from the caller passed Linux CI
     /// green. This asserts the assembled set, which is what the overlay
     /// actually re-binds.
+    /// #306: the same question must not be answered twice, differently.
+    /// `cplt config set allow.read ~/.netrc` used to succeed and then be
+    /// refused at every launch, so the user found out later, about a line they
+    /// had forgotten writing. One predicate serves both now.
+    #[test]
+    fn a_grant_no_launch_can_honour_is_refused_by_one_predicate() {
+        let home = Path::new("/home/test");
+
+        for (key, path) in [
+            ("allow.read", home.join(".netrc")),
+            ("allow.write", home.join(".ssh")),
+            ("allow.read", home.join(".config/cplt/config.toml")),
+        ] {
+            let err =
+                super::validate_grant_path(key, &path, home).expect_err("{path:?} must be refused");
+            assert!(err.contains(key), "the refusal names the key: {err}");
+        }
+
+        super::validate_grant_path("allow.read", Path::new("/opt/homebrew"), home)
+            .expect("an ordinary grant is the point of the feature");
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn ro_protect_set_carries_the_copilot_package_dirs_for_copilot_only() {

--- a/src/sandbox_env.rs
+++ b/src/sandbox_env.rs
@@ -142,8 +142,20 @@ pub fn build_sandbox_env(
     };
 
     if inherit_env {
-        // Legacy mode: inherit everything, strip known-bad vars
+        // Legacy mode: inherit everything, strip known-bad vars — except the
+        // ones the user named explicitly.
+        //
+        // `--pass-env SSH_AUTH_SOCK` used to be cancelled by `--inherit-env`
+        // without a word (#307): this branch never read `extra_pass_env`, so a
+        // variable the user asked for was stripped anyway. The combination does
+        // not have to appear on one command line — `sandbox.pass_env` lives in
+        // config, so adding `--inherit-env` months later silently dropped an
+        // earlier setting. The specific instruction outranks the blanket one,
+        // which is also what the sanitized branch below already does.
         for var in ENV_ALWAYS_DENY {
+            if extra_pass_env.iter().any(|p| p == var) {
+                continue;
+            }
             env.remove.push(var.to_string());
         }
         // Also strip agent-specific vars in inherit mode
@@ -473,4 +485,56 @@ fn strip_dangerous_node_flags(value: &str) -> String {
         i += 1;
     }
     result.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #307: `--inherit-env` silently cancelled `--pass-env`. The inherit
+    /// branch stripped every `ENV_ALWAYS_DENY` entry without consulting the
+    /// list the user had named, so `--pass-env SSH_AUTH_SOCK` — the supported
+    /// way to reach an SSH agent from inside the sandbox — did nothing.
+    ///
+    /// It bites without both appearing on one command line: `sandbox.pass_env`
+    /// lives in config, so adding `--inherit-env` months later dropped the
+    /// earlier setting with no message.
+    #[test]
+    fn inherit_env_no_longer_cancels_an_explicit_pass_env() {
+        // Both are in `ENV_ALWAYS_DENY`, which is what inherit mode strips.
+        // (Secrets are NOT on that list — `--inherit-env` passes them on
+        // purpose, which is why it is documented as dangerous.)
+        let parent = vec![
+            ("SSH_AUTH_SOCK".to_string(), "/tmp/agent.sock".to_string()),
+            ("SSH_AGENT_PID".to_string(), "1234".to_string()),
+        ];
+
+        let asked = build_sandbox_env(
+            &parent,
+            &["SSH_AUTH_SOCK".to_string()],
+            true,
+            &[],
+            None,
+            None,
+            Agent::Shell,
+        );
+        assert!(
+            !asked.remove.iter().any(|v| v == "SSH_AUTH_SOCK"),
+            "a variable the user named explicitly must survive: {:?}",
+            asked.remove
+        );
+        assert!(
+            asked.remove.iter().any(|v| v == "SSH_AGENT_PID"),
+            "and everything they did not name is still stripped: {:?}",
+            asked.remove
+        );
+
+        // Without the explicit ask, inherit mode strips it exactly as before.
+        let not_asked = build_sandbox_env(&parent, &[], true, &[], None, None, Agent::Shell);
+        assert!(
+            not_asked.remove.iter().any(|v| v == "SSH_AUTH_SOCK"),
+            "the default is unchanged: {:?}",
+            not_asked.remove
+        );
+    }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4108,6 +4108,52 @@ paths = [
         let _ = std::fs::remove_dir_all(&model);
     }
 
+    /// #306: `config set` must refuse what the launch refuses. The tool used
+    /// to accept `allow.read ~/.netrc`, print the updated list, and exit 0 —
+    /// and then refuse it at every launch after.
+    #[test]
+    fn e2e_config_set_refuses_a_grant_no_launch_can_honour() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let cfg_dir = home.path().join(".config/cplt");
+        std::fs::create_dir_all(&cfg_dir).expect("config dir");
+        let cfg = cfg_dir.join("config.toml");
+
+        let set = |key: &str, value: &str| {
+            cplt_cmd()
+                .args(["config", "set", key, value])
+                .env("HOME", home.path())
+                .env("CPLT_CONFIG", &cfg)
+                .output()
+                .expect("config set runs")
+        };
+
+        let out = set("allow.read", "~/.netrc");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "a hard-denied grant must be refused at write time: {stderr}"
+        );
+        assert!(
+            stderr.contains("hard-deny"),
+            "with the launch's own reason: {stderr}"
+        );
+
+        // And the config file must be unchanged — a refusal that still writes
+        // is worse than no refusal, because the message says it did not.
+        let written = std::fs::read_to_string(&cfg).unwrap_or_default();
+        assert!(
+            !written.contains(".netrc"),
+            "the refused entry must not be in the file: {written}"
+        );
+
+        let out = set("allow.read", "/opt");
+        assert!(
+            out.status.success(),
+            "an ordinary grant still works: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
     #[test]
     fn e2e_trust_show_displays_proposals() {
         let (repo, config_file) = make_trust_repo(

--- a/tests/e2e_golden.rs
+++ b/tests/e2e_golden.rs
@@ -575,8 +575,10 @@ const SKIPPED: &[(&str, &str)] = &[
         "allow.exec",
         "every directory a test can create is under the system temp dir or the \
      project dir, both of which the sandbox makes writable, and cplt refuses a \
-     tree that is both writable and executable. A value that would launch \
-     cannot be constructed here; `e2e.rs` covers the grant itself.",
+     tree that is both writable and executable. Since #306 `config set` refuses \
+     it too, so the invariant this suite checks — what `set` accepts must \
+     launch — holds with nothing left to launch. `e2e.rs` covers the grant \
+     itself.",
     ),
 ];
 


### PR DESCRIPTION
Two bugs with one shape: the same question answered in two places, differently, with the user finding out later.

## #306 — `config set` accepted what every launch refuses

```
$ cplt config set allow.read ~/.netrc
[cplt] allow.read = [~/Desktop, /Users/you/.netrc]     # exit 0
$ cplt                                                  # …and every launch after
[cplt] allow.read names ~/.netrc, which is on the hard-deny list and cannot be granted explicitly.
```

Now:

```
$ cplt config set allow.read ~/.netrc
[cplt] allow.read names /Users/you/.netrc (~/.netrc), which is on the hard-deny list and cannot be
       granted explicitly. Remove it from your config or command line.
```

The fix the issue asks for is not the message — it is that the two paths stop being two paths. `validate_grant_path` is extracted from `validate_hard_denied_grants`, and both the launch and `config set` call it, so a check added for one reaches both.

`allow.exec ~/.cache` is refused at write time too, against the trees that are writable whatever else is configured. The full overlap check needs the resolved config (tool dirs, `allow.write`, named repositories), so an overlap with an `allow.write` added *later* still surfaces at launch — the part that can be judged from a single grant is judged early.

The golden suite already enforces this invariant, which is how I knew where the line is: it skips `allow.exec` because no launchable value can be constructed for it. That skip note is updated — `config set` refusing is now why it holds.

## #307 — `--inherit-env` silently cancelled `--pass-env`

`--inherit-env` swept every `ENV_ALWAYS_DENY` entry and never looked at `extra_pass_env`. `--pass-env SSH_AUTH_SOCK` is the supported way to reach an SSH agent from inside the sandbox, and on Linux below kernel 7.1 that env deny is the *only* barrier — so a user who thought they had agent forwarding did not, and was debugging the wrong thing.

It does not need both on one command line: `sandbox.pass_env` lives in config, so adding `--inherit-env` months later dropped the earlier setting with no message.

Fixed in the direction the issue recommends: the explicit instruction outranks the blanket one, which is what the sanitized branch already did. Everything the user did not name is still stripped.

Two things that follow, worth naming:

- **The brief encoded the bug.** `ssh_agent_reaches` returned false under `--inherit-env`, so the agent-facing brief reported no SSH agent — correct about behaviour that was itself the defect. It agrees with the sandbox again.
- **Its test pinned the old answer and failed on this change**, which is what such a test is for. Rewritten to pin the new one.

## Verification

`a_grant_no_launch_can_honour_is_refused_by_one_predicate` covers the hard-denied file, a credential directory, and cplt's own state directory, plus the negative — an ordinary grant still works.

`e2e_config_set_refuses_a_grant_no_launch_can_honour` asserts the exit code, the reason, **and that the config file is unchanged** — a refusal that still writes is worse than no refusal, because the message says it did not. Falsified by dropping the check.

`inherit_env_no_longer_cancels_an_explicit_pass_env` asserts the named variable survives and an unnamed one on the same list does not.